### PR TITLE
Add integration tests for CLI commands

### DIFF
--- a/tests/ts/commands/list.test.ts
+++ b/tests/ts/commands/list.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createTestVault, cleanupTestVault, runCLI } from '../fixtures/setup.js';
+
+describe('list command', () => {
+  let vaultDir: string;
+
+  beforeAll(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterAll(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  describe('basic listing', () => {
+    it('should list ideas by name', async () => {
+      const result = await runCLI(['list', 'idea'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Sample Idea');
+      expect(result.stdout).toContain('Another Idea');
+    });
+
+    it('should list subtypes with slash notation', async () => {
+      const result = await runCLI(['list', 'objective/task'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Sample Task');
+    });
+
+    it('should list all subtypes when listing parent type', async () => {
+      const result = await runCLI(['list', 'objective'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Sample Task');
+      expect(result.stdout).toContain('Active Milestone');
+      expect(result.stdout).toContain('Settled Milestone');
+    });
+
+    it('should return empty for type with no files', async () => {
+      const result = await runCLI(['list', 'objective/milestone', '--status=raw'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('');
+    });
+
+    it('should sort results alphabetically', async () => {
+      const result = await runCLI(['list', 'idea'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout.split('\n');
+      const anotherIndex = lines.findIndex(l => l.includes('Another Idea'));
+      const sampleIndex = lines.findIndex(l => l.includes('Sample Idea'));
+      expect(anotherIndex).toBeLessThan(sampleIndex);
+    });
+  });
+
+  describe('--paths flag', () => {
+    it('should show file paths instead of names', async () => {
+      const result = await runCLI(['list', '--paths', 'idea'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Ideas/Sample Idea.md');
+      expect(result.stdout).toContain('Ideas/Another Idea.md');
+    });
+
+    it('should show nested paths for subtypes', async () => {
+      const result = await runCLI(['list', '--paths', 'objective/task'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Objectives/Tasks/Sample Task.md');
+    });
+  });
+
+  describe('--fields flag', () => {
+    it('should show single field in table format', async () => {
+      const result = await runCLI(['list', '--fields=status', 'idea'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('NAME');
+      expect(result.stdout).toContain('STATUS');
+      expect(result.stdout).toContain('raw');
+      expect(result.stdout).toContain('backlog');
+    });
+
+    it('should show multiple fields', async () => {
+      const result = await runCLI(['list', '--fields=status,priority', 'idea'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('STATUS');
+      expect(result.stdout).toContain('PRIORITY');
+      expect(result.stdout).toContain('medium');
+      expect(result.stdout).toContain('high');
+    });
+
+    it('should combine --paths with --fields', async () => {
+      const result = await runCLI(['list', '--paths', '--fields=status', 'idea'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('PATH');
+      expect(result.stdout).toContain('Ideas/');
+    });
+  });
+
+  describe('simple filters', () => {
+    it('should filter by equality', async () => {
+      const result = await runCLI(['list', 'idea', '--status=raw'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Sample Idea');
+      expect(result.stdout).not.toContain('Another Idea');
+    });
+
+    it('should filter by OR values', async () => {
+      const result = await runCLI(['list', 'idea', '--status=raw,backlog'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Sample Idea');
+      expect(result.stdout).toContain('Another Idea');
+    });
+
+    it('should filter by negation', async () => {
+      const result = await runCLI(['list', 'objective/milestone', '--status!=settled'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Active Milestone');
+      expect(result.stdout).not.toContain('Settled Milestone');
+    });
+  });
+
+  describe('--where expression filters', () => {
+    it('should filter with equality expression', async () => {
+      const result = await runCLI(['list', 'idea', '--where', "status == 'raw'"], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Sample Idea');
+      expect(result.stdout).not.toContain('Another Idea');
+    });
+
+    it('should filter with comparison expression', async () => {
+      const result = await runCLI(['list', 'idea', '--where', "priority == 'high'"], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Another Idea');
+      expect(result.stdout).not.toContain('Sample Idea');
+    });
+
+    it('should support multiple --where (AND logic)', async () => {
+      const result = await runCLI(
+        ['list', 'idea', '--where', "status == 'backlog'", '--where', "priority == 'high'"],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Another Idea');
+      expect(result.stdout).not.toContain('Sample Idea');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should error on unknown type', async () => {
+      const result = await runCLI(['list', 'nonexistent'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown type');
+    });
+
+    it('should error on invalid filter field', async () => {
+      const result = await runCLI(['list', 'idea', '--nonexistent=value'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown field');
+    });
+
+    it('should error on invalid enum value', async () => {
+      const result = await runCLI(['list', 'idea', '--status=invalid'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Invalid value');
+    });
+
+    it('should show usage when no type provided', async () => {
+      const result = await runCLI(['list'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain('Usage:');
+      expect(result.stdout).toContain('Available types:');
+    });
+  });
+});

--- a/tests/ts/commands/new.test.ts
+++ b/tests/ts/commands/new.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestVault, cleanupTestVault, runCLI } from '../fixtures/setup.js';
+
+// Note: The `new` command uses the `prompts` library which requires a TTY.
+// Interactive tests cannot be run via piped stdin.
+// This file tests error handling and validation only.
+// Full interactive testing would require mocking the prompts module.
+
+describe('new command', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  describe('type validation', () => {
+    it('should error on unknown type', async () => {
+      const result = await runCLI(['new', 'nonexistent'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown type');
+    });
+
+    it('should error on unknown subtype', async () => {
+      const result = await runCLI(['new', 'objective/nonexistent'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown type');
+    });
+
+    it('should error on deeply nested invalid path', async () => {
+      const result = await runCLI(['new', 'objective/task/invalid'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown type');
+    });
+  });
+
+  describe('help and usage', () => {
+    it('should show help with --help flag', async () => {
+      const result = await runCLI(['new', '--help'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Create a new note');
+      expect(result.stdout).toContain('Examples:');
+    });
+  });
+});

--- a/tests/ts/commands/open.test.ts
+++ b/tests/ts/commands/open.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createTestVault, cleanupTestVault, runCLI } from '../fixtures/setup.js';
+
+// Note: We can't test actually opening Obsidian as it requires the app.
+// This file tests error handling and validation only.
+// The actual URI building is tested via unit tests.
+
+describe('open command', () => {
+  let vaultDir: string;
+
+  beforeAll(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterAll(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  describe('error handling', () => {
+    it('should error on file not found', async () => {
+      const result = await runCLI(['open', 'nonexistent.md'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('File not found');
+    });
+
+    it('should error on nonexistent nested path', async () => {
+      const result = await runCLI(['open', 'Ideas/Does Not Exist.md'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('File not found');
+    });
+
+    it('should require a file argument', async () => {
+      const result = await runCLI(['open'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      // Commander shows usage error for missing required argument
+      expect(result.stderr).toContain('required');
+    });
+  });
+
+  describe('help and usage', () => {
+    it('should show help with --help flag', async () => {
+      const result = await runCLI(['open', '--help'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Open a note in Obsidian');
+      expect(result.stdout).toContain('Examples:');
+    });
+  });
+});

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { writeFile, rm, mkdir } from 'fs/promises';
+import { join } from 'path';
+import { mkdtemp } from 'fs/promises';
+import { tmpdir } from 'os';
+import { createTestVault, cleanupTestVault, runCLI } from '../fixtures/setup.js';
+
+describe('schema command', () => {
+  let vaultDir: string;
+
+  beforeAll(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterAll(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  describe('schema show (all types)', () => {
+    it('should show schema tree', async () => {
+      const result = await runCLI(['schema', 'show'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Schema Types');
+      expect(result.stdout).toContain('Types:');
+    });
+
+    it('should list all type families', async () => {
+      const result = await runCLI(['schema', 'show'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('objective');
+      expect(result.stdout).toContain('idea');
+    });
+
+    it('should show subtypes', async () => {
+      const result = await runCLI(['schema', 'show'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('task');
+      expect(result.stdout).toContain('milestone');
+    });
+
+    it('should show enums if defined', async () => {
+      const result = await runCLI(['schema', 'show'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Enums:');
+      expect(result.stdout).toContain('status');
+    });
+
+    it('should show shared fields if defined', async () => {
+      const result = await runCLI(['schema', 'show'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Shared Fields:');
+    });
+  });
+
+  describe('schema show <type>', () => {
+    it('should show type details for leaf type', async () => {
+      const result = await runCLI(['schema', 'show', 'idea'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Type: idea');
+      expect(result.stdout).toContain('Output Dir:');
+      expect(result.stdout).toContain('Ideas');
+      expect(result.stdout).toContain('Fields:');
+    });
+
+    it('should show fields for type', async () => {
+      const result = await runCLI(['schema', 'show', 'idea'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('type');
+      expect(result.stdout).toContain('status');
+      expect(result.stdout).toContain('priority');
+    });
+
+    it('should show subtype details with slash notation', async () => {
+      const result = await runCLI(['schema', 'show', 'objective/task'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Type: objective/task');
+      expect(result.stdout).toContain('Objectives/Tasks');
+    });
+
+    it('should show subtypes for parent type', async () => {
+      const result = await runCLI(['schema', 'show', 'objective'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Subtypes:');
+      expect(result.stdout).toContain('task');
+      expect(result.stdout).toContain('milestone');
+    });
+
+    it('should show body sections if defined', async () => {
+      const result = await runCLI(['schema', 'show', 'objective/task'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Body Sections:');
+      expect(result.stdout).toContain('Steps');
+      expect(result.stdout).toContain('Notes');
+    });
+
+    it('should error on unknown type', async () => {
+      const result = await runCLI(['schema', 'show', 'nonexistent'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown type');
+    });
+  });
+
+  describe('schema validate', () => {
+    it('should validate valid schema', async () => {
+      const result = await runCLI(['schema', 'validate'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Schema is valid');
+    });
+
+    it('should error on invalid schema', async () => {
+      // Create a vault with invalid schema
+      const invalidVaultDir = await mkdtemp(join(tmpdir(), 'ovault-invalid-'));
+      await mkdir(join(invalidVaultDir, '.ovault'), { recursive: true });
+      await writeFile(
+        join(invalidVaultDir, '.ovault', 'schema.json'),
+        JSON.stringify({ invalid: 'schema' })
+      );
+
+      try {
+        const result = await runCLI(['schema', 'validate'], invalidVaultDir);
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain('Schema validation failed');
+      } finally {
+        await rm(invalidVaultDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should error when schema file is missing', async () => {
+      // Create a vault with no schema
+      const noSchemaVaultDir = await mkdtemp(join(tmpdir(), 'ovault-noschema-'));
+
+      try {
+        const result = await runCLI(['schema', 'validate'], noSchemaVaultDir);
+
+        expect(result.exitCode).toBe(1);
+      } finally {
+        await rm(noSchemaVaultDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should error on malformed JSON', async () => {
+      // Create a vault with malformed JSON
+      const malformedVaultDir = await mkdtemp(join(tmpdir(), 'ovault-malformed-'));
+      await mkdir(join(malformedVaultDir, '.ovault'), { recursive: true });
+      await writeFile(
+        join(malformedVaultDir, '.ovault', 'schema.json'),
+        '{ invalid json'
+      );
+
+      try {
+        const result = await runCLI(['schema', 'validate'], malformedVaultDir);
+
+        expect(result.exitCode).toBe(1);
+      } finally {
+        await rm(malformedVaultDir, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds integration tests for CLI commands (list, schema, open, new) using vitest.

## Changes
- Add `runCLI` helper to test fixtures for spawning CLI and capturing output
- **list command** (20 tests): basic listing, `--paths`, `--fields`, filters, `--where`, errors
- **schema command** (15 tests): `show`, `show <type>`, `validate` success/error
- **open command** (4 tests): error handling and help
- **new command** (4 tests): type validation and help

## Test Results
```
Test Files  9 passed (9)
     Tests  145 passed (145)
```

## Notes
- Interactive commands (`new`, `edit`) have limited test coverage due to `prompts` library requiring TTY
- Full `edit` command tests deferred to follow-up issue

Closes ovault-doh

Co-Authored-By: Warp <agent@warp.dev>