### PR TITLE
feat: Add non-interactive JSON I/O mode for AI/scripting usage

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      jsep:
+        specifier: ^1.4.0
+        version: 1.4.0
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -824,6 +827,10 @@ packages:
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
+
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -1840,6 +1847,8 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+
+  jsep@1.4.0: {}
 
   kind-of@6.0.3: {}
 

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,0 +1,139 @@
+import chalk from 'chalk';
+
+/**
+ * Output mode for commands.
+ */
+export type OutputMode = 'text' | 'json';
+
+/**
+ * JSON output wrapper for success results.
+ */
+export interface JsonSuccess<T = unknown> {
+  success: true;
+  data?: T;
+  path?: string;
+  updated?: string[];
+  message?: string;
+}
+
+/**
+ * JSON output wrapper for error results.
+ */
+export interface JsonError {
+  success: false;
+  error: string;
+  errors?: Array<{
+    field: string;
+    value?: unknown;
+    message: string;
+    expected?: string[] | string;
+    suggestion?: string;
+  }>;
+  code?: number;
+}
+
+/**
+ * Combined JSON result type.
+ */
+export type JsonResult<T = unknown> = JsonSuccess<T> | JsonError;
+
+/**
+ * Exit codes for the CLI.
+ */
+export const ExitCodes = {
+  SUCCESS: 0,
+  VALIDATION_ERROR: 1,
+  IO_ERROR: 2,
+  SCHEMA_ERROR: 3,
+} as const;
+
+export type ExitCode = (typeof ExitCodes)[keyof typeof ExitCodes];
+
+/**
+ * Print output as JSON.
+ */
+export function printJson(data: JsonResult): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+/**
+ * Print a single-line JSON output.
+ */
+export function printJsonCompact(data: JsonResult): void {
+  console.log(JSON.stringify(data));
+}
+
+/**
+ * Create a success JSON response.
+ */
+export function jsonSuccess<T = unknown>(
+  options: Omit<JsonSuccess<T>, 'success'> = {}
+): JsonSuccess<T> {
+  return { success: true, ...options };
+}
+
+/**
+ * Create an error JSON response.
+ */
+export function jsonError(
+  error: string,
+  options: Omit<JsonError, 'success' | 'error'> = {}
+): JsonError {
+  return { success: false, error, ...options };
+}
+
+/**
+ * Exit with appropriate code and output.
+ */
+export function exitWithError(
+  message: string,
+  code: ExitCode = ExitCodes.VALIDATION_ERROR,
+  jsonMode: boolean = false
+): never {
+  if (jsonMode) {
+    printJson(jsonError(message, { code }));
+  } else {
+    console.error(chalk.red(message));
+  }
+  process.exit(code);
+}
+
+/**
+ * Exit with success output.
+ */
+export function exitWithSuccess<T = unknown>(
+  result: Omit<JsonSuccess<T>, 'success'>,
+  textMessage: string,
+  jsonMode: boolean = false
+): void {
+  if (jsonMode) {
+    printJson(jsonSuccess(result));
+  } else {
+    console.log(chalk.green(textMessage));
+  }
+}
+
+/**
+ * Determine output mode from command options.
+ */
+export function getOutputMode(options: { output?: string; json?: string }): OutputMode {
+  if (options.output === 'json' || options.json !== undefined) {
+    return 'json';
+  }
+  return 'text';
+}
+
+/**
+ * Check if we're in JSON output mode.
+ */
+export function isJsonMode(options: { output?: string; json?: string }): boolean {
+  return getOutputMode(options) === 'json';
+}
+
+/**
+ * Strip ANSI color codes from a string.
+ */
+export function stripColors(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, '');
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,417 @@
+import type { Schema, Field } from '../types/schema.js';
+import { getFieldsForType, getEnumValues } from './schema.js';
+
+/**
+ * Validation error types.
+ */
+export type ValidationErrorType =
+  | 'required_field_missing'
+  | 'invalid_enum_value'
+  | 'invalid_type'
+  | 'unknown_field'
+  | 'invalid_date';
+
+/**
+ * A single validation error with context.
+ */
+export interface ValidationError {
+  type: ValidationErrorType;
+  field: string;
+  value?: unknown;
+  message: string;
+  expected?: string[] | string;
+  suggestion?: string;
+}
+
+/**
+ * Result of validating frontmatter.
+ */
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+  warnings: ValidationError[];
+}
+
+/**
+ * Options for validation.
+ */
+export interface ValidationOptions {
+  /** If true, unknown fields generate errors. If false, they generate warnings. Default: false */
+  strictFields?: boolean;
+  /** If true, skip applying defaults. Default: false */
+  skipDefaults?: boolean;
+}
+
+/**
+ * Validate frontmatter against a schema type.
+ * Returns validation result with errors and warnings.
+ */
+export function validateFrontmatter(
+  schema: Schema,
+  typePath: string,
+  frontmatter: Record<string, unknown>,
+  options: ValidationOptions = {}
+): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationError[] = [];
+  const fields = getFieldsForType(schema, typePath);
+  const fieldNames = new Set(Object.keys(fields));
+  const providedFields = new Set(Object.keys(frontmatter));
+
+  // Check for required fields
+  for (const [fieldName, field] of Object.entries(fields)) {
+    const value = frontmatter[fieldName];
+    const hasValue = value !== undefined && value !== null && value !== '';
+
+    // Check required fields
+    if (field.required && !hasValue && field.default === undefined) {
+      errors.push({
+        type: 'required_field_missing',
+        field: fieldName,
+        message: `Required field missing: ${fieldName}`,
+        expected: getFieldExpected(schema, field),
+      });
+      continue;
+    }
+
+    // Validate enum fields
+    if (hasValue && field.enum) {
+      const enumValues = getEnumValues(schema, field.enum);
+      if (enumValues.length > 0 && !enumValues.includes(String(value))) {
+        const suggestion = suggestEnumValue(String(value), enumValues);
+        errors.push({
+          type: 'invalid_enum_value',
+          field: fieldName,
+          value,
+          message: `Invalid value for ${fieldName}: "${value}"`,
+          expected: enumValues,
+          suggestion: suggestion ? `Did you mean '${suggestion}'?` : undefined,
+        });
+      }
+    }
+
+    // Type checking
+    if (hasValue) {
+      const typeError = validateFieldType(fieldName, value, field);
+      if (typeError) {
+        errors.push(typeError);
+      }
+    }
+  }
+
+  // Check for unknown fields
+  for (const fieldName of providedFields) {
+    if (!fieldNames.has(fieldName)) {
+      const suggestion = suggestFieldName(fieldName, Array.from(fieldNames));
+      const error: ValidationError = {
+        type: 'unknown_field',
+        field: fieldName,
+        value: frontmatter[fieldName],
+        message: `Unknown field: ${fieldName}`,
+        suggestion: suggestion ? `Did you mean '${suggestion}'?` : undefined,
+      };
+      if (options.strictFields) {
+        errors.push(error);
+      } else {
+        warnings.push(error);
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * Apply defaults to frontmatter for missing fields.
+ */
+export function applyDefaults(
+  schema: Schema,
+  typePath: string,
+  frontmatter: Record<string, unknown>
+): Record<string, unknown> {
+  const result = { ...frontmatter };
+  const fields = getFieldsForType(schema, typePath);
+
+  for (const [fieldName, field] of Object.entries(fields)) {
+    const value = result[fieldName];
+    const hasValue = value !== undefined && value !== null && value !== '';
+
+    if (!hasValue && field.default !== undefined) {
+      result[fieldName] = field.default;
+    }
+
+    // Handle static values
+    if (!hasValue && field.value !== undefined) {
+      result[fieldName] = expandStaticValue(field.value);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Validate field type against expected types.
+ */
+function validateFieldType(
+  fieldName: string,
+  value: unknown,
+  field: Field
+): ValidationError | null {
+  // Handle array fields (multi-input)
+  if (field.prompt === 'multi-input' || field.list_format) {
+    // Accept both arrays and strings for list fields
+    if (!Array.isArray(value) && typeof value !== 'string') {
+      return {
+        type: 'invalid_type',
+        field: fieldName,
+        value,
+        message: `Invalid type for ${fieldName}: expected array or string, got ${typeof value}`,
+        expected: 'array or string',
+      };
+    }
+    return null;
+  }
+
+  // Date fields
+  if (field.prompt === 'date') {
+    if (typeof value !== 'string') {
+      return {
+        type: 'invalid_type',
+        field: fieldName,
+        value,
+        message: `Invalid type for ${fieldName}: expected date string, got ${typeof value}`,
+        expected: 'date string (YYYY-MM-DD)',
+      };
+    }
+    // Basic date format validation
+    const dateRegex = /^\d{4}-\d{2}-\d{2}([ T]\d{2}:\d{2}(:\d{2})?)?$/;
+    if (!dateRegex.test(value)) {
+      return {
+        type: 'invalid_date',
+        field: fieldName,
+        value,
+        message: `Invalid date format for ${fieldName}: "${value}"`,
+        expected: 'YYYY-MM-DD or YYYY-MM-DD HH:MM',
+      };
+    }
+    return null;
+  }
+
+  // String fields (most common)
+  // Allow strings, numbers, and booleans as they can be serialized
+  if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
+    return {
+      type: 'invalid_type',
+      field: fieldName,
+      value,
+      message: `Invalid type for ${fieldName}: expected string, got object`,
+      expected: 'string',
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Get expected values description for a field.
+ */
+function getFieldExpected(schema: Schema, field: Field): string[] | undefined {
+  if (field.enum) {
+    const values = getEnumValues(schema, field.enum);
+    if (values.length > 0) return values;
+  }
+  return undefined;
+}
+
+/**
+ * Expand special static values like $NOW and $TODAY.
+ */
+function expandStaticValue(value: string): string {
+  const now = new Date();
+
+  switch (value) {
+    case '$NOW':
+      return now.toISOString().slice(0, 16).replace('T', ' ');
+    case '$TODAY':
+      return now.toISOString().slice(0, 10);
+    default:
+      return value;
+  }
+}
+
+/**
+ * Calculate Levenshtein distance between two strings.
+ */
+function levenshteinDistance(a: string, b: string): number {
+  const aLen = a.length;
+  const bLen = b.length;
+  
+  // Create a 2D array with proper initialization
+  const matrix: number[][] = Array.from({ length: aLen + 1 }, () => 
+    Array.from({ length: bLen + 1 }, () => 0)
+  );
+
+  // Initialize first column
+  for (let i = 0; i <= aLen; i++) {
+    matrix[i]![0] = i;
+  }
+  
+  // Initialize first row
+  for (let j = 0; j <= bLen; j++) {
+    matrix[0]![j] = j;
+  }
+
+  // Fill in the rest of the matrix
+  for (let i = 1; i <= aLen; i++) {
+    for (let j = 1; j <= bLen; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        matrix[i]![j] = matrix[i - 1]![j - 1]!;
+      } else {
+        matrix[i]![j] = Math.min(
+          matrix[i - 1]![j - 1]! + 1, // substitution
+          matrix[i]![j - 1]! + 1,     // insertion
+          matrix[i - 1]![j]! + 1      // deletion
+        );
+      }
+    }
+  }
+
+  return matrix[aLen]![bLen]!;
+}
+
+/**
+ * Suggest a similar enum value using fuzzy matching.
+ */
+export function suggestEnumValue(
+  value: string,
+  allowed: string[]
+): string | undefined {
+  if (allowed.length === 0) return undefined;
+
+  const valueLower = value.toLowerCase();
+  let bestMatch: string | undefined;
+  let bestDistance = Infinity;
+
+  // First, try exact case-insensitive match
+  for (const option of allowed) {
+    if (option.toLowerCase() === valueLower) {
+      return option;
+    }
+  }
+
+  // Try prefix match
+  for (const option of allowed) {
+    if (option.toLowerCase().startsWith(valueLower)) {
+      return option;
+    }
+  }
+
+  // Try contains match
+  for (const option of allowed) {
+    if (option.toLowerCase().includes(valueLower) || 
+        valueLower.includes(option.toLowerCase())) {
+      return option;
+    }
+  }
+
+  // Fall back to Levenshtein distance
+  for (const option of allowed) {
+    const distance = levenshteinDistance(valueLower, option.toLowerCase());
+    // Threshold: at most 40% of the longer string's length
+    const maxDistance = Math.ceil(Math.max(value.length, option.length) * 0.4);
+    if (distance < bestDistance && distance <= maxDistance) {
+      bestDistance = distance;
+      bestMatch = option;
+    }
+  }
+
+  return bestMatch;
+}
+
+/**
+ * Suggest a similar field name using fuzzy matching.
+ */
+export function suggestFieldName(
+  field: string,
+  known: string[]
+): string | undefined {
+  if (known.length === 0) return undefined;
+
+  const fieldLower = field.toLowerCase();
+  let bestMatch: string | undefined;
+  let bestDistance = Infinity;
+
+  // First, try exact case-insensitive match
+  for (const option of known) {
+    if (option.toLowerCase() === fieldLower) {
+      return option;
+    }
+  }
+
+  // Fall back to Levenshtein distance
+  for (const option of known) {
+    const distance = levenshteinDistance(fieldLower, option.toLowerCase());
+    // Threshold: at most 2 characters different, or 40% of length
+    const maxDistance = Math.min(2, Math.ceil(option.length * 0.4));
+    if (distance < bestDistance && distance <= maxDistance) {
+      bestDistance = distance;
+      bestMatch = option;
+    }
+  }
+
+  return bestMatch;
+}
+
+/**
+ * Format validation errors for human-readable output.
+ */
+export function formatValidationErrors(errors: ValidationError[]): string {
+  if (errors.length === 0) return '';
+
+  const lines: string[] = ['Validation errors:'];
+  for (const error of errors) {
+    let line = `  - ${error.message}`;
+    if (error.expected && Array.isArray(error.expected)) {
+      const display = error.expected.length <= 5 
+        ? error.expected.join(', ')
+        : `${error.expected.slice(0, 5).join(', ')}... (${error.expected.length} options)`;
+      line += `\n    Expected: ${display}`;
+    }
+    if (error.suggestion) {
+      line += `\n    ${error.suggestion}`;
+    }
+    lines.push(line);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Convert validation result to JSON-friendly format.
+ */
+export function validationResultToJson(
+  result: ValidationResult
+): Record<string, unknown> {
+  return {
+    success: result.valid,
+    errors: result.errors.map(e => ({
+      field: e.field,
+      value: e.value,
+      message: e.message,
+      expected: e.expected,
+      suggestion: e.suggestion,
+    })),
+    warnings: result.warnings.length > 0 
+      ? result.warnings.map(w => ({
+          field: w.field,
+          value: w.value,
+          message: w.message,
+          suggestion: w.suggestion,
+        }))
+      : undefined,
+  };
+}

--- a/tests/ts/commands/json-io.test.ts
+++ b/tests/ts/commands/json-io.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { createTestVault, cleanupTestVault, runCLI } from '../fixtures/setup.js';
+
+describe('JSON I/O', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  describe('ovault new --json', () => {
+    it('should create a note with JSON frontmatter', async () => {
+      const result = await runCLI(
+        ['new', 'idea', '--json', '{"Idea name": "Test Idea", "status": "raw", "priority": "high"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.path).toContain('Ideas/Test Idea.md');
+
+      // Verify file exists
+      const filePath = join(vaultDir, json.path);
+      expect(existsSync(filePath)).toBe(true);
+
+      // Verify content
+      const content = await readFile(filePath, 'utf-8');
+      expect(content).toContain('status: raw');
+      expect(content).toContain('priority: high');
+    });
+
+    it('should error on missing required name field', async () => {
+      const result = await runCLI(
+        ['new', 'idea', '--json', '{"status": "raw"}'],  // missing 'Idea name'
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('name');
+    });
+
+    it('should error on invalid enum value', async () => {
+      const result = await runCLI(
+        ['new', 'idea', '--json', '{"Idea name": "Bad Idea", "status": "invalid-status"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.errors).toBeDefined();
+      expect(json.errors[0].field).toBe('status');
+    });
+
+    it('should provide suggestions for typos', async () => {
+      const result = await runCLI(
+        ['new', 'idea', '--json', '{"Idea name": "Typo Idea", "status": "rae"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.errors[0].suggestion).toContain('raw');
+    });
+
+    it('should apply defaults for missing optional fields', async () => {
+      const result = await runCLI(
+        ['new', 'idea', '--json', '{"Idea name": "Minimal Idea"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+
+      const filePath = join(vaultDir, json.path);
+      const content = await readFile(filePath, 'utf-8');
+      expect(content).toContain('status: raw'); // default value
+    });
+
+    it('should error on unknown type', async () => {
+      const result = await runCLI(
+        ['new', 'unknown-type', '--json', '{"Idea name": "Test"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('Unknown type');
+    });
+
+    it('should error on invalid JSON', async () => {
+      const result = await runCLI(
+        ['new', 'idea', '--json', '{invalid json}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('Invalid JSON');
+    });
+
+    it('should require type in JSON mode', async () => {
+      const result = await runCLI(
+        ['new', '--json', '{"Idea name": "No Type"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('required');
+    });
+  });
+
+  describe('ovault edit --json', () => {
+    it('should update a note with JSON patch', async () => {
+      const result = await runCLI(
+        ['edit', 'Ideas/Sample Idea.md', '--json', '{"status": "backlog"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.updated).toContain('status');
+
+      // Verify file was updated
+      const content = await readFile(join(vaultDir, 'Ideas/Sample Idea.md'), 'utf-8');
+      expect(content).toContain('status: backlog');
+    });
+
+    it('should preserve existing fields not in patch', async () => {
+      const result = await runCLI(
+        ['edit', 'Ideas/Sample Idea.md', '--json', '{"status": "backlog"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const content = await readFile(join(vaultDir, 'Ideas/Sample Idea.md'), 'utf-8');
+      expect(content).toContain('status: backlog');
+      expect(content).toContain('type: idea'); // preserved
+      expect(content).toContain('priority: medium'); // preserved
+    });
+
+    it('should remove field with null value', async () => {
+      const result = await runCLI(
+        ['edit', 'Ideas/Sample Idea.md', '--json', '{"priority": null}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const content = await readFile(join(vaultDir, 'Ideas/Sample Idea.md'), 'utf-8');
+      expect(content).not.toContain('priority:');
+    });
+
+    it('should validate merged result', async () => {
+      const result = await runCLI(
+        ['edit', 'Ideas/Sample Idea.md', '--json', '{"status": "invalid-status"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.errors[0].field).toBe('status');
+    });
+
+    it('should error on file not found', async () => {
+      const result = await runCLI(
+        ['edit', 'Ideas/Nonexistent.md', '--json', '{"status": "raw"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(2);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('not found');
+    });
+  });
+
+  describe('ovault list --output json', () => {
+    it('should output list as JSON array', async () => {
+      const result = await runCLI(
+        ['list', 'idea', '--output', 'json'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(Array.isArray(json)).toBe(true);
+      expect(json.length).toBe(2);
+      expect(json[0]._path).toBeDefined();
+      expect(json[0]._name).toBeDefined();
+      expect(json[0].type).toBe('idea');
+    });
+
+    it('should include all frontmatter fields', async () => {
+      const result = await runCLI(
+        ['list', 'idea', '--output', 'json'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      const idea = json.find((i: Record<string, unknown>) => i._name === 'Sample Idea');
+      expect(idea.status).toBe('raw');
+      expect(idea.priority).toBe('medium');
+    });
+
+    it('should return empty array for no matches', async () => {
+      const result = await runCLI(
+        ['list', 'idea', '--status=settled', '--output', 'json'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json).toEqual([]);
+    });
+
+    it('should apply filters in JSON mode', async () => {
+      const result = await runCLI(
+        ['list', 'idea', '--status=raw', '--output', 'json'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.length).toBe(1);
+      expect(json[0]._name).toBe('Sample Idea');
+    });
+
+    it('should error on unknown type in JSON mode', async () => {
+      const result = await runCLI(
+        ['list', 'unknown-type', '--output', 'json'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('Unknown type');
+    });
+  });
+
+  describe('ovault schema show --output json', () => {
+    it('should output type details as JSON', async () => {
+      const result = await runCLI(
+        ['schema', 'show', 'idea', '--output', 'json'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.type_path).toBe('idea');
+      expect(json.output_dir).toBe('Ideas');
+      expect(json.fields).toBeDefined();
+    });
+
+    it('should include resolved enum values', async () => {
+      const result = await runCLI(
+        ['schema', 'show', 'idea', '--output', 'json'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.fields.status.values).toContain('raw');
+      expect(json.fields.status.values).toContain('backlog');
+    });
+
+    it('should output full schema as JSON', async () => {
+      const result = await runCLI(
+        ['schema', 'show', '--output', 'json'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.types).toBeDefined();
+      expect(json.enums).toBeDefined();
+    });
+
+    it('should error on unknown type in JSON mode', async () => {
+      const result = await runCLI(
+        ['schema', 'show', 'unknown-type', '--output', 'json'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('Unknown type');
+    });
+  });
+
+  describe('ovault schema validate --output json', () => {
+    it('should return success for valid schema', async () => {
+      const result = await runCLI(
+        ['schema', 'validate', '--output', 'json'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+    });
+  });
+});

--- a/tests/ts/lib/validation.test.ts
+++ b/tests/ts/lib/validation.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateFrontmatter,
+  applyDefaults,
+  suggestEnumValue,
+  suggestFieldName,
+  formatValidationErrors,
+} from '../../../src/lib/validation.js';
+import type { Schema } from '../../../src/types/schema.js';
+
+const TEST_SCHEMA: Schema = {
+  version: 2,
+  shared_fields: {
+    status: {
+      prompt: 'select',
+      enum: 'status',
+      default: 'raw',
+      required: true,
+    },
+    tags: {
+      prompt: 'multi-input',
+      list_format: 'yaml-array',
+      default: [],
+    },
+  },
+  enums: {
+    status: ['raw', 'backlog', 'in-flight', 'settled'],
+    priority: ['low', 'medium', 'high'],
+  },
+  types: {
+    idea: {
+      dir_mode: 'pooled',
+      output_dir: 'Ideas',
+      name_field: 'Name',
+      shared_fields: ['status'],
+      frontmatter: {
+        type: { value: 'idea' },
+        priority: { prompt: 'select', enum: 'priority' },
+        deadline: { prompt: 'date' },
+      },
+    },
+    task: {
+      dir_mode: 'pooled',
+      output_dir: 'Tasks',
+      name_field: 'Name',
+      shared_fields: ['status', 'tags'],
+      frontmatter: {
+        type: { value: 'task' },
+        requiredField: { prompt: 'input', required: true },
+      },
+    },
+  },
+};
+
+describe('validation', () => {
+  describe('validateFrontmatter', () => {
+    it('should pass valid frontmatter', () => {
+      const result = validateFrontmatter(TEST_SCHEMA, 'idea', {
+        type: 'idea',
+        status: 'raw',
+        priority: 'high',
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should fail on invalid enum value', () => {
+      const result = validateFrontmatter(TEST_SCHEMA, 'idea', {
+        type: 'idea',
+        status: 'invalid-status',
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].type).toBe('invalid_enum_value');
+      expect(result.errors[0].field).toBe('status');
+    });
+
+    it('should suggest similar enum values', () => {
+      const result = validateFrontmatter(TEST_SCHEMA, 'idea', {
+        type: 'idea',
+        status: 'rae', // typo for 'raw'
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].suggestion).toContain('raw');
+    });
+
+    it('should fail on missing required field without default', () => {
+      const result = validateFrontmatter(TEST_SCHEMA, 'task', {
+        type: 'task',
+        status: 'raw',
+        // requiredField is missing
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.type === 'required_field_missing')).toBe(true);
+    });
+
+    it('should pass when required field has default', () => {
+      // status is required but has default
+      const result = validateFrontmatter(TEST_SCHEMA, 'idea', {
+        type: 'idea',
+        // status is missing but has default
+      });
+
+      // Should pass because status has a default
+      expect(result.valid).toBe(true);
+    });
+
+    it('should warn on unknown fields in non-strict mode', () => {
+      const result = validateFrontmatter(TEST_SCHEMA, 'idea', {
+        type: 'idea',
+        status: 'raw',
+        unknownField: 'value',
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0].type).toBe('unknown_field');
+    });
+
+    it('should fail on unknown fields in strict mode', () => {
+      const result = validateFrontmatter(
+        TEST_SCHEMA,
+        'idea',
+        {
+          type: 'idea',
+          status: 'raw',
+          unknownField: 'value',
+        },
+        { strictFields: true }
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].type).toBe('unknown_field');
+    });
+
+    it('should validate date format', () => {
+      const result = validateFrontmatter(TEST_SCHEMA, 'idea', {
+        type: 'idea',
+        status: 'raw',
+        deadline: 'not-a-date',
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].type).toBe('invalid_date');
+    });
+
+    it('should accept valid date format', () => {
+      const result = validateFrontmatter(TEST_SCHEMA, 'idea', {
+        type: 'idea',
+        status: 'raw',
+        deadline: '2024-01-15',
+      });
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should accept datetime format', () => {
+      const result = validateFrontmatter(TEST_SCHEMA, 'idea', {
+        type: 'idea',
+        status: 'raw',
+        deadline: '2024-01-15 14:30',
+      });
+
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('applyDefaults', () => {
+    it('should apply defaults for missing fields', () => {
+      const result = applyDefaults(TEST_SCHEMA, 'idea', {
+        priority: 'high',
+      });
+
+      expect(result.status).toBe('raw');
+      expect(result.priority).toBe('high');
+    });
+
+    it('should not override existing values', () => {
+      const result = applyDefaults(TEST_SCHEMA, 'idea', {
+        status: 'in-flight',
+      });
+
+      expect(result.status).toBe('in-flight');
+    });
+
+    it('should expand $TODAY value', () => {
+      const result = applyDefaults(TEST_SCHEMA, 'idea', {});
+      // type field has value: 'idea' which is static
+      expect(result.type).toBe('idea');
+    });
+  });
+
+  describe('suggestEnumValue', () => {
+    it('should return exact match with different case', () => {
+      expect(suggestEnumValue('RAW', ['raw', 'backlog'])).toBe('raw');
+    });
+
+    it('should return prefix match', () => {
+      expect(suggestEnumValue('back', ['raw', 'backlog'])).toBe('backlog');
+    });
+
+    it('should return close match by Levenshtein distance', () => {
+      expect(suggestEnumValue('bakclog', ['raw', 'backlog'])).toBe('backlog');
+    });
+
+    it('should return undefined for no close match', () => {
+      expect(suggestEnumValue('xyz', ['raw', 'backlog'])).toBeUndefined();
+    });
+
+    it('should handle in-progress style values', () => {
+      expect(suggestEnumValue('wip', ['draft', 'in-progress', 'done'])).toBeUndefined();
+      expect(suggestEnumValue('in-prog', ['draft', 'in-progress', 'done'])).toBe('in-progress');
+    });
+  });
+
+  describe('suggestFieldName', () => {
+    it('should return exact match with different case', () => {
+      expect(suggestFieldName('Status', ['status', 'priority'])).toBe('status');
+    });
+
+    it('should return close match', () => {
+      expect(suggestFieldName('statis', ['status', 'priority'])).toBe('status');
+    });
+
+    it('should return undefined for no close match', () => {
+      expect(suggestFieldName('foo', ['status', 'priority'])).toBeUndefined();
+    });
+  });
+
+  describe('formatValidationErrors', () => {
+    it('should format single error', () => {
+      const output = formatValidationErrors([
+        {
+          type: 'invalid_enum_value',
+          field: 'status',
+          value: 'bad',
+          message: 'Invalid value for status: "bad"',
+          expected: ['raw', 'backlog'],
+        },
+      ]);
+
+      expect(output).toContain('Validation errors:');
+      expect(output).toContain('Invalid value for status');
+      expect(output).toContain('raw, backlog');
+    });
+
+    it('should include suggestion when available', () => {
+      const output = formatValidationErrors([
+        {
+          type: 'invalid_enum_value',
+          field: 'status',
+          value: 'rae',
+          message: 'Invalid value',
+          suggestion: "Did you mean 'raw'?",
+        },
+      ]);
+
+      expect(output).toContain("Did you mean 'raw'?");
+    });
+
+    it('should return empty string for no errors', () => {
+      expect(formatValidationErrors([])).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `--json` flag to `ovault new` for non-interactive note creation
- Add `--json` flag to `ovault edit` with merge/patch semantics
- Add `--output json` flag to `ovault list` and `ovault schema` commands
- Implement structured validation with fuzzy matching suggestions

Closes issue ovault-xrg and all subtasks (xrg.1, xrg.2, xrg.3, xrg.4).

## New Files

- `src/lib/validation.ts` - Frontmatter validation with Levenshtein-based typo suggestions
- `src/lib/output.ts` - JSON output formatting utilities with exit codes

## Usage Examples

```bash
# Create notes non-interactively
ovault new idea --json '{"Idea name": "My Idea", "status": "raw"}'

# Edit with patch semantics (only updates provided fields)
ovault edit "Ideas/My Idea.md" --json '{"status": "backlog"}'

# Machine-readable list output
ovault list idea --output json

# Get type schema for AI understanding
ovault schema show idea --output json
```

## Test Results

All 192 tests pass (47 new tests added for JSON I/O functionality).