### PR TITLE
Enable additional strict tsconfig options

### DIFF
--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -155,11 +155,11 @@ async function editNoteFromJson(
       error: 'Validation failed',
       errors: validation.errors.map(e => ({
         field: e.field,
-        value: e.value,
         message: e.message,
-        expected: e.expected,
-        suggestion: e.suggestion,
         currentValue: frontmatter[e.field],
+        ...(e.value !== undefined && { value: e.value }),
+        ...(e.expected !== undefined && { expected: e.expected }),
+        ...(e.suggestion !== undefined && { suggestion: e.suggestion }),
       })),
     });
     process.exit(ExitCodes.VALIDATION_ERROR);

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -106,9 +106,10 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
         }
       }
 
+      const fields = options.fields?.split(',').map(f => f.trim());
       await listObjects(schema, vaultDir, typePath, {
         showPaths: options.paths ?? false,
-        fields: options.fields?.split(',').map(f => f.trim()),
+        ...(fields !== undefined && { fields }),
         filters,
         whereExpressions: options.where ?? [],
         jsonMode,

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -178,10 +178,10 @@ async function createNoteFromJson(
       error: 'Validation failed',
       errors: validation.errors.map(e => ({
         field: e.field,
-        value: e.value,
         message: e.message,
-        expected: e.expected,
-        suggestion: e.suggestion,
+        ...(e.value !== undefined && { value: e.value }),
+        ...(e.expected !== undefined && { expected: e.expected }),
+        ...(e.suggestion !== undefined && { suggestion: e.suggestion }),
       })),
     });
     process.exit(ExitCodes.VALIDATION_ERROR);
@@ -655,7 +655,7 @@ function getOutputDirForType(schema: Schema, typePath: string): string | undefin
   const segments = typePath.split('/').filter(Boolean);
   let outputDir: string | undefined;
 
-  type TypeLike = { output_dir?: string; subtypes?: Record<string, TypeLike> };
+  type TypeLike = { output_dir?: string | undefined; subtypes?: Record<string, TypeLike> | undefined };
   let current: TypeLike | undefined;
 
   for (let i = 0; i < segments.length; i++) {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -65,11 +65,12 @@ export function validateFrontmatter(
 
     // Check required fields
     if (field.required && !hasValue && field.default === undefined) {
+      const expected = getFieldExpected(schema, field);
       errors.push({
         type: 'required_field_missing',
         field: fieldName,
         message: `Required field missing: ${fieldName}`,
-        expected: getFieldExpected(schema, field),
+        ...(expected !== undefined && { expected }),
       });
       continue;
     }
@@ -85,7 +86,7 @@ export function validateFrontmatter(
           value,
           message: `Invalid value for ${fieldName}: "${value}"`,
           expected: enumValues,
-          suggestion: suggestion ? `Did you mean '${suggestion}'?` : undefined,
+          ...(suggestion && { suggestion: `Did you mean '${suggestion}'?` }),
         });
       }
     }
@@ -108,7 +109,7 @@ export function validateFrontmatter(
         field: fieldName,
         value: frontmatter[fieldName],
         message: `Unknown field: ${fieldName}`,
-        suggestion: suggestion ? `Did you mean '${suggestion}'?` : undefined,
+        ...(suggestion && { suggestion: `Did you mean '${suggestion}'?` }),
       };
       if (options.strictFields) {
         errors.push(error);

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -153,7 +153,7 @@ export function getOutputDir(
   let outputDir: string | undefined;
 
   // Walk through segments, keeping track of most recent output_dir
-  let current: { output_dir?: string; subtypes?: Record<string, unknown> } | undefined;
+  let current: { output_dir?: string | undefined; subtypes?: Record<string, unknown> | undefined } | undefined;
   
   for (let i = 0; i < segments.length; i++) {
     const segment = segments[i];

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -14,7 +14,7 @@ export const FieldSchema = z.object({
 });
 
 // Body section definition
-export const BodySectionSchema: z.ZodType<BodySection> = z.lazy(() =>
+export const BodySectionSchema: z.ZodType<BodySection, z.ZodTypeDef, BodySectionInput> = z.lazy(() =>
   z.object({
     title: z.string(),
     level: z.number().optional().default(2),
@@ -47,7 +47,7 @@ export const FieldOverrideSchema = z.object({
 });
 
 // Subtype definition (recursive via Type)
-export const SubtypeSchema: z.ZodType<Subtype> = z.lazy(() =>
+export const SubtypeSchema: z.ZodType<Subtype, z.ZodTypeDef, SubtypeInput> = z.lazy(() =>
   z.object({
     output_dir: z.string().optional(),
     filename: z.string().optional(),
@@ -88,24 +88,45 @@ export type Field = z.infer<typeof FieldSchema>;
 export type FieldOverride = z.infer<typeof FieldOverrideSchema>;
 export type BodySection = {
   title: string;
-  level?: number;
-  content_type?: 'none' | 'paragraphs' | 'bullets' | 'checkboxes';
-  prompt?: 'none' | 'multi-input';
-  prompt_label?: string;
-  children?: BodySection[];
+  level?: number | undefined;
+  content_type?: 'none' | 'paragraphs' | 'bullets' | 'checkboxes' | undefined;
+  prompt?: 'none' | 'multi-input' | undefined;
+  prompt_label?: string | undefined;
+  children?: BodySection[] | undefined;
+};
+// Input type for BodySection (allows missing level which gets defaulted)
+export type BodySectionInput = {
+  title: string;
+  level?: number | undefined;
+  content_type?: 'none' | 'paragraphs' | 'bullets' | 'checkboxes' | undefined;
+  prompt?: 'none' | 'multi-input' | undefined;
+  prompt_label?: string | undefined;
+  children?: BodySectionInput[] | undefined;
 };
 export type FilterCondition = z.infer<typeof FilterConditionSchema>;
 export type DynamicSource = z.infer<typeof DynamicSourceSchema>;
 export type Subtype = {
-  output_dir?: string;
-  filename?: string;
-  name_field?: string;
-  shared_fields?: string[];
-  field_overrides?: Record<string, FieldOverride>;
-  frontmatter?: Record<string, Field>;
-  frontmatter_order?: string[];
-  body_sections?: BodySection[];
-  subtypes?: Record<string, Subtype>;
+  output_dir?: string | undefined;
+  filename?: string | undefined;
+  name_field?: string | undefined;
+  shared_fields?: string[] | undefined;
+  field_overrides?: Record<string, FieldOverride> | undefined;
+  frontmatter?: Record<string, Field> | undefined;
+  frontmatter_order?: string[] | undefined;
+  body_sections?: BodySection[] | undefined;
+  subtypes?: Record<string, Subtype> | undefined;
+};
+// Input type for Subtype
+export type SubtypeInput = {
+  output_dir?: string | undefined;
+  filename?: string | undefined;
+  name_field?: string | undefined;
+  shared_fields?: string[] | undefined;
+  field_overrides?: Record<string, FieldOverride> | undefined;
+  frontmatter?: Record<string, Field> | undefined;
+  frontmatter_order?: string[] | undefined;
+  body_sections?: BodySectionInput[] | undefined;
+  subtypes?: Record<string, SubtypeInput> | undefined;
 };
 export type Type = z.infer<typeof TypeSchema>;
 export type Schema = z.infer<typeof OvaultSchema>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,10 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "allowUnreachableCode": false,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
Add three strict TypeScript compiler options:
- `allowUnreachableCode: false` - Error on unreachable code
- `exactOptionalPropertyTypes: true` - Distinguishes between undefined and missing optional properties
- `noImplicitOverride: true` - Requires override keyword for overriding class members

## Changes
- Updated `tsconfig.json` with the three new options
- Fixed 10 violations for `exactOptionalPropertyTypes` across 6 files by:
  - Conditionally omitting optional properties instead of setting to undefined
  - Adding `| undefined` to local TypeLike type aliases
  - Adding explicit input types for recursive Zod schemas

Closes ovault-4ex

Co-Authored-By: Warp <agent@warp.dev>