### PR TITLE
Add bulk command for mass frontmatter changes

### DIFF
--- a/src/commands/bulk.ts
+++ b/src/commands/bulk.ts
@@ -1,0 +1,443 @@
+/**
+ * Bulk command - mass changes across filtered file sets.
+ * 
+ * This command performs bulk operations on files matching filter criteria:
+ * - Set or clear field values
+ * - Rename fields (for migrations)
+ * - Delete fields
+ * - Append/remove from list fields
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import {
+  loadSchema,
+  getTypeDefByPath,
+  getTypeFamilies,
+  getEnumForField,
+  getEnumValues,
+} from '../lib/schema.js';
+import { resolveVaultDir } from '../lib/vault.js';
+import { parseFilters, validateFilters } from '../lib/query.js';
+import { printError } from '../lib/prompt.js';
+import {
+  printJson,
+  jsonError,
+  jsonSuccess,
+  ExitCodes,
+} from '../lib/output.js';
+import { buildOperation, formatChange } from '../lib/bulk/operations.js';
+import { executeBulk } from '../lib/bulk/execute.js';
+import type { BulkOperation, BulkResult, FileChange } from '../lib/bulk/types.js';
+import type { Schema } from '../types/schema.js';
+
+interface BulkCommandOptions {
+  set?: string[];
+  rename?: string[];
+  delete?: string[];
+  append?: string[];
+  remove?: string[];
+  where?: string[];
+  execute?: boolean;
+  backup?: boolean;
+  limit?: string;
+  verbose?: boolean;
+  quiet?: boolean;
+  output?: string;
+}
+
+export const bulkCommand = new Command('bulk')
+  .description('Mass changes across filtered file sets')
+  .addHelpText('after', `
+Operations:
+  --set <field>=<value>       Set field value
+  --set <field>=              Clear field (remove from frontmatter)
+  --rename <old>=<new>        Rename field
+  --delete <field>            Delete field
+  --append <field>=<value>    Append to list field
+  --remove <field>=<value>    Remove from list field
+
+Filters:
+  --field=value               Include where field equals value
+  --field=a,b                 Include where field equals a OR b
+  --field!=value              Exclude where field equals value
+  --field=                    Include where field is empty/missing
+  --field!=                   Include where field exists
+  --where "<expression>"      Filter expression (can repeat, ANDed)
+
+Execution:
+  --execute                   Actually apply changes (dry-run by default)
+  --backup                    Create backup before changes
+  --limit <n>                 Limit to n files
+
+Output:
+  --verbose                   Show detailed changes per file
+  --quiet                     Only show summary
+  --output json               JSON output for scripting
+
+Examples:
+  # Preview changes (dry-run)
+  ovault bulk task --set status=done --where "status == 'in-progress'"
+
+  # Apply changes
+  ovault bulk task --set status=done --where "status == 'in-progress'" --execute
+
+  # Multiple operations
+  ovault bulk task --set status=done --set "completion-date=2025-01-15" --execute
+
+  # Rename a field across all files
+  ovault bulk idea --rename old-field=new-field --execute
+
+  # Append to a list field
+  ovault bulk task --append tags=urgent --where "priority == 'high'" --execute
+
+  # Create backup before changes
+  ovault bulk task --set status=archived --execute --backup
+
+  # Using simple filters
+  ovault bulk task --status=done --set archived=true --execute
+  ovault bulk idea --priority=high,critical --set urgent=true --execute`)
+  .argument('<type>', 'Type path (e.g., idea, objective/task)')
+  .option('--set <field=value...>', 'Set field value (or clear with --set field=)')
+  .option('--rename <old=new...>', 'Rename field')
+  .option('--delete <field...>', 'Delete field')
+  .option('--append <field=value...>', 'Append to list field')
+  .option('--remove <field=value...>', 'Remove from list field')
+  .option('-w, --where <expression...>', 'Filter with expression (multiple are ANDed)')
+  .option('--execute', 'Actually apply changes (dry-run by default)')
+  .option('--backup', 'Create backup before changes')
+  .option('--limit <n>', 'Limit to n files')
+  .option('--verbose', 'Show detailed changes per file')
+  .option('--quiet', 'Only show summary')
+  .option('-o, --output <format>', 'Output format: text (default) or json')
+  .allowUnknownOption(true)
+  .action(async (typePath: string, options: BulkCommandOptions, cmd: Command) => {
+    const jsonMode = options.output === 'json';
+
+    try {
+      const parentOpts = cmd.parent?.opts() as { vault?: string } | undefined;
+      const vaultDir = resolveVaultDir(parentOpts ?? {});
+      const schema = await loadSchema(vaultDir);
+
+      // Validate type exists
+      const typeDef = getTypeDefByPath(schema, typePath);
+      if (!typeDef) {
+        const error = `Unknown type: ${typePath}`;
+        if (jsonMode) {
+          printJson(jsonError(error));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(error);
+        showAvailableTypes(schema);
+        process.exit(1);
+      }
+
+      // Parse simple filters from remaining arguments (--field=value syntax)
+      const filterArgs = cmd.args.slice(1); // Skip the type argument
+      const simpleFilters = parseFilters(filterArgs);
+
+      // Validate simple filters
+      if (simpleFilters.length > 0) {
+        const validation = validateFilters(schema, typePath, simpleFilters);
+        if (!validation.valid) {
+          if (jsonMode) {
+            printJson(jsonError(validation.errors.join('; ')));
+            process.exit(ExitCodes.VALIDATION_ERROR);
+          }
+          for (const error of validation.errors) {
+            printError(error);
+          }
+          process.exit(1);
+        }
+      }
+
+      // Build operations list
+      const operations: BulkOperation[] = [];
+      const validationErrors: string[] = [];
+
+      // Parse --set options
+      for (const arg of options.set ?? []) {
+        try {
+          const op = buildOperation('set', arg);
+          // Validate enum values for 'set' operations
+          if (op.type === 'set' && op.value !== undefined) {
+            const enumError = validateEnumValue(schema, typePath, op.field, op.value);
+            if (enumError) {
+              validationErrors.push(enumError);
+            }
+          }
+          operations.push(op);
+        } catch (err) {
+          validationErrors.push(err instanceof Error ? err.message : String(err));
+        }
+      }
+
+      // Parse --rename options
+      for (const arg of options.rename ?? []) {
+        try {
+          operations.push(buildOperation('rename', arg));
+        } catch (err) {
+          validationErrors.push(err instanceof Error ? err.message : String(err));
+        }
+      }
+
+      // Parse --delete options
+      for (const arg of options.delete ?? []) {
+        try {
+          operations.push(buildOperation('delete', arg));
+        } catch (err) {
+          validationErrors.push(err instanceof Error ? err.message : String(err));
+        }
+      }
+
+      // Parse --append options
+      for (const arg of options.append ?? []) {
+        try {
+          const op = buildOperation('append', arg);
+          // Validate enum values for 'append' operations
+          if (op.value !== undefined) {
+            const enumError = validateEnumValue(schema, typePath, op.field, op.value);
+            if (enumError) {
+              validationErrors.push(enumError);
+            }
+          }
+          operations.push(op);
+        } catch (err) {
+          validationErrors.push(err instanceof Error ? err.message : String(err));
+        }
+      }
+
+      // Parse --remove options
+      for (const arg of options.remove ?? []) {
+        try {
+          operations.push(buildOperation('remove', arg));
+        } catch (err) {
+          validationErrors.push(err instanceof Error ? err.message : String(err));
+        }
+      }
+
+      // Check for validation errors
+      if (validationErrors.length > 0) {
+        if (jsonMode) {
+          printJson(jsonError('Validation failed', { 
+            errors: validationErrors.map(e => ({ field: '', message: e }))
+          }));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        for (const err of validationErrors) {
+          printError(err);
+        }
+        process.exit(1);
+      }
+
+      // Check that at least one operation was specified
+      if (operations.length === 0) {
+        const error = 'No operations specified. Use --set, --rename, --delete, --append, or --remove.';
+        if (jsonMode) {
+          printJson(jsonError(error));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(error);
+        process.exit(1);
+      }
+
+      // Execute bulk operation
+      const limit = options.limit ? parseInt(options.limit, 10) : undefined;
+      if (options.limit && (isNaN(limit!) || limit! <= 0)) {
+        const error = 'Invalid --limit value: must be a positive integer';
+        if (jsonMode) {
+          printJson(jsonError(error));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(error);
+        process.exit(1);
+      }
+
+      const result = await executeBulk({
+        typePath,
+        operations,
+        whereExpressions: options.where ?? [],
+        simpleFilters,
+        execute: options.execute ?? false,
+        backup: options.backup ?? false,
+        ...(limit !== undefined && { limit }),
+        verbose: options.verbose ?? false,
+        quiet: options.quiet ?? false,
+        jsonMode,
+        vaultDir,
+        schema,
+      });
+
+      // Output results
+      if (jsonMode) {
+        outputJsonResult(result);
+      } else {
+        outputTextResult(result, options.verbose ?? false, options.quiet ?? false);
+      }
+
+      // Exit with error if there were failures
+      if (result.errors.length > 0) {
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (jsonMode) {
+        printJson(jsonError(message));
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+      printError(message);
+      process.exit(1);
+    }
+  });
+
+/**
+ * Validate that a value is valid for an enum field.
+ * Returns an error message if invalid, null if valid.
+ */
+function validateEnumValue(
+  schema: Schema,
+  typePath: string,
+  field: string,
+  value: unknown
+): string | null {
+  const enumName = getEnumForField(schema, typePath, field);
+  if (!enumName) {
+    return null; // Not an enum field
+  }
+
+  const enumValues = getEnumValues(schema, enumName);
+  if (enumValues.length === 0) {
+    return null; // Enum not defined
+  }
+
+  const strValue = String(value);
+  if (!enumValues.includes(strValue)) {
+    return `Invalid value '${strValue}' for field '${field}'. Valid values: ${enumValues.join(', ')}`;
+  }
+
+  return null;
+}
+
+/**
+ * Show available types.
+ */
+function showAvailableTypes(schema: Schema): void {
+  console.log('\nAvailable types:');
+  for (const family of getTypeFamilies(schema)) {
+    console.log(`  ${family}`);
+  }
+}
+
+/**
+ * Output result as JSON.
+ */
+function outputJsonResult(result: BulkResult): void {
+  const jsonOutput = {
+    success: result.errors.length === 0,
+    dryRun: result.dryRun,
+    totalFiles: result.totalFiles,
+    filesModified: result.affectedFiles,
+    ...(result.backupPath && { backupPath: result.backupPath }),
+    changes: result.changes.map(fc => ({
+      file: fc.relativePath,
+      applied: fc.applied,
+      ...(fc.error && { error: fc.error }),
+      changes: fc.changes.map(c => ({
+        operation: c.operation,
+        field: c.field,
+        from: c.oldValue,
+        to: c.newValue,
+        ...(c.newField && { newField: c.newField }),
+      })),
+    })),
+    ...(result.errors.length > 0 && { errors: result.errors }),
+  };
+
+  printJson(result.errors.length === 0 
+    ? jsonSuccess({ data: jsonOutput })
+    : jsonError('Some operations failed', { errors: result.errors.map(e => ({ field: '', message: e })) })
+  );
+}
+
+/**
+ * Output result as text.
+ */
+function outputTextResult(result: BulkResult, verbose: boolean, quiet: boolean): void {
+  // Quiet mode - just summary
+  if (quiet) {
+    if (result.dryRun) {
+      console.log(`Would affect ${result.affectedFiles} files`);
+    } else {
+      console.log(chalk.green(`✓ Updated ${result.affectedFiles} files`));
+    }
+    return;
+  }
+
+  // Dry-run header
+  if (result.dryRun) {
+    console.log(chalk.yellow('Dry run - no changes will be made'));
+    console.log();
+  }
+
+  // Show backup path if created
+  if (result.backupPath) {
+    console.log(chalk.blue(`Backup created: ${result.backupPath}`));
+    console.log();
+  }
+
+  // No changes case
+  if (result.affectedFiles === 0) {
+    console.log('No files match the criteria.');
+    return;
+  }
+
+  // Show changes
+  if (result.dryRun) {
+    console.log(`Would affect ${result.affectedFiles} file${result.affectedFiles === 1 ? '' : 's'}:`);
+  } else if (!quiet) {
+    console.log(`Applying changes to ${result.affectedFiles} file${result.affectedFiles === 1 ? '' : 's'}...`);
+  }
+
+  for (const fileChange of result.changes) {
+    if (fileChange.changes.length === 0) continue;
+
+    if (verbose || result.dryRun) {
+      console.log(`  ${fileChange.relativePath}`);
+      for (const change of fileChange.changes) {
+        console.log(`    ${formatChange(change)}`);
+      }
+    } else {
+      // Non-verbose execute mode
+      const status = fileChange.applied 
+        ? chalk.green('✓') 
+        : (fileChange.error ? chalk.red('✗') : ' ');
+      console.log(`  ${status} ${fileChange.relativePath}`);
+      if (fileChange.error) {
+        console.log(`    ${chalk.red(fileChange.error)}`);
+      }
+    }
+  }
+
+  // Summary
+  console.log();
+  if (result.dryRun) {
+    console.log(`Run with ${chalk.cyan('--execute')} to apply changes.`);
+  } else {
+    console.log(chalk.green(`✓ Updated ${result.affectedFiles} files`));
+  }
+
+  // Show errors if any
+  if (result.errors.length > 0) {
+    console.log();
+    console.log(chalk.red(`Errors (${result.errors.length}):`));
+    for (const error of result.errors) {
+      console.log(`  ${chalk.red('•')} ${error}`);
+    }
+  }
+}
+
+// Re-export types for testing
+export type { BulkOperation, BulkResult, FileChange };
+export { executeBulk } from '../lib/bulk/execute.js';
+export { buildOperation, applyOperations, formatChange, formatValue } from '../lib/bulk/operations.js';
+export { createBackup, listBackups, restoreBackup } from '../lib/bulk/backup.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { listCommand } from './commands/list.js';
 import { openCommand } from './commands/open.js';
 import { schemaCommand } from './commands/schema.js';
 import { auditCommand } from './commands/audit.js';
+import { bulkCommand } from './commands/bulk.js';
 
 const program = new Command();
 
@@ -22,5 +23,6 @@ program.addCommand(listCommand);
 program.addCommand(openCommand);
 program.addCommand(schemaCommand);
 program.addCommand(auditCommand);
+program.addCommand(bulkCommand);
 
 program.parse();

--- a/src/lib/bulk/backup.ts
+++ b/src/lib/bulk/backup.ts
@@ -1,0 +1,183 @@
+/**
+ * Backup functionality for bulk operations.
+ */
+
+import { mkdir, readFile, writeFile, readdir, cp, stat } from 'fs/promises';
+import { join, dirname, relative } from 'path';
+import type { BackupManifest, BackupInfo } from './types.js';
+
+/**
+ * Get the backups directory path.
+ */
+function getBackupsDir(vaultDir: string): string {
+  return join(vaultDir, '.ovault', 'backups');
+}
+
+/**
+ * Generate a backup ID from the current timestamp.
+ */
+function generateBackupId(): string {
+  const now = new Date();
+  return now.toISOString()
+    .replace(/[:.]/g, '-')
+    .replace('T', 'T')
+    .slice(0, 19); // 2025-12-27T10-30-00
+}
+
+/**
+ * Create a backup of the specified files before bulk modification.
+ * 
+ * @param vaultDir - The vault directory path
+ * @param files - Array of absolute file paths to back up
+ * @param operation - Description of the operation for the manifest
+ * @returns The backup directory path
+ */
+export async function createBackup(
+  vaultDir: string,
+  files: string[],
+  operation: string
+): Promise<string> {
+  const backupId = generateBackupId();
+  const backupDir = join(getBackupsDir(vaultDir), backupId);
+  const filesDir = join(backupDir, 'files');
+
+  // Create backup directories
+  await mkdir(filesDir, { recursive: true });
+
+  // Copy each file, preserving relative paths
+  const relativeFiles: string[] = [];
+  for (const file of files) {
+    const relativePath = relative(vaultDir, file);
+    relativeFiles.push(relativePath);
+
+    const destPath = join(filesDir, relativePath);
+    await mkdir(dirname(destPath), { recursive: true });
+    await cp(file, destPath);
+  }
+
+  // Write manifest
+  const manifest: BackupManifest = {
+    timestamp: new Date().toISOString(),
+    operation,
+    files: relativeFiles,
+  };
+  await writeFile(
+    join(backupDir, 'manifest.json'),
+    JSON.stringify(manifest, null, 2)
+  );
+
+  return backupDir;
+}
+
+/**
+ * List available backups.
+ */
+export async function listBackups(vaultDir: string): Promise<BackupInfo[]> {
+  const backupsDir = getBackupsDir(vaultDir);
+
+  let entries: string[];
+  try {
+    entries = await readdir(backupsDir);
+  } catch {
+    // No backups directory
+    return [];
+  }
+
+  const backups: BackupInfo[] = [];
+  for (const entry of entries) {
+    const backupDir = join(backupsDir, entry);
+    const manifestPath = join(backupDir, 'manifest.json');
+
+    try {
+      const stats = await stat(backupDir);
+      if (!stats.isDirectory()) continue;
+
+      const manifestContent = await readFile(manifestPath, 'utf-8');
+      const manifest: BackupManifest = JSON.parse(manifestContent);
+
+      backups.push({
+        id: entry,
+        timestamp: new Date(manifest.timestamp),
+        operation: manifest.operation,
+        fileCount: manifest.files.length,
+        path: backupDir,
+      });
+    } catch {
+      // Skip invalid backup directories
+      continue;
+    }
+  }
+
+  // Sort by timestamp, newest first
+  backups.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+
+  return backups;
+}
+
+/**
+ * Restore files from a backup.
+ */
+export async function restoreBackup(
+  vaultDir: string,
+  backupId: string
+): Promise<{ restored: string[] }> {
+  const backupDir = join(getBackupsDir(vaultDir), backupId);
+  const manifestPath = join(backupDir, 'manifest.json');
+  const filesDir = join(backupDir, 'files');
+
+  // Read manifest
+  let manifest: BackupManifest;
+  try {
+    const content = await readFile(manifestPath, 'utf-8');
+    manifest = JSON.parse(content);
+  } catch {
+    throw new Error(`Backup not found: ${backupId}`);
+  }
+
+  // Restore each file
+  const restored: string[] = [];
+  for (const relativePath of manifest.files) {
+    const srcPath = join(filesDir, relativePath);
+    const destPath = join(vaultDir, relativePath);
+
+    try {
+      await mkdir(dirname(destPath), { recursive: true });
+      await cp(srcPath, destPath);
+      restored.push(relativePath);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to restore ${relativePath}: ${message}`);
+    }
+  }
+
+  return { restored };
+}
+
+/**
+ * Get backup info by ID.
+ */
+export async function getBackup(
+  vaultDir: string,
+  backupId: string
+): Promise<BackupInfo | null> {
+  const backupDir = join(getBackupsDir(vaultDir), backupId);
+  const manifestPath = join(backupDir, 'manifest.json');
+
+  try {
+    const stats = await stat(backupDir);
+    if (!stats.isDirectory()) return null;
+
+    const content = await readFile(manifestPath, 'utf-8');
+    const manifest: BackupManifest = JSON.parse(content);
+
+    return {
+      id: backupId,
+      timestamp: new Date(manifest.timestamp),
+      operation: manifest.operation,
+      fileCount: manifest.files.length,
+      path: backupDir,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/bulk/execute.ts
+++ b/src/lib/bulk/execute.ts
@@ -1,0 +1,214 @@
+/**
+ * Bulk execution orchestration.
+ */
+
+import { relative, dirname, basename } from 'path';
+import { stat } from 'fs/promises';
+import { parseNote, writeNote } from '../frontmatter.js';
+import { matchesExpression, type EvalContext } from '../expression.js';
+import { matchesAllFilters } from '../query.js';
+import { discoverManagedFiles } from '../audit/detection.js';
+import { applyOperations } from './operations.js';
+import { createBackup } from './backup.js';
+import type {
+  BulkOptions,
+  BulkResult,
+  FileChange,
+  BulkOperation,
+} from './types.js';
+
+/**
+ * Execute bulk operations on matching files.
+ */
+export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
+  const {
+    typePath,
+    operations,
+    whereExpressions,
+    simpleFilters,
+    execute,
+    backup,
+    limit,
+    vaultDir,
+    schema,
+  } = options;
+
+  const result: BulkResult = {
+    dryRun: !execute,
+    totalFiles: 0,
+    affectedFiles: 0,
+    changes: [],
+    errors: [],
+  };
+
+  // Discover files for the specified type
+  const files = await discoverManagedFiles(schema, vaultDir, typePath);
+  result.totalFiles = files.length;
+
+  // Filter and collect changes
+  const filesToModify: {
+    path: string;
+    relativePath: string;
+    frontmatter: Record<string, unknown>;
+    body: string;
+  }[] = [];
+
+  for (const file of files) {
+    try {
+      const { frontmatter, body } = await parseNote(file.path);
+
+      // Apply simple filters (--field=value syntax)
+      if (simpleFilters.length > 0) {
+        if (!matchesAllFilters(frontmatter, simpleFilters)) {
+          continue;
+        }
+      }
+
+      // Apply where expression filters
+      if (whereExpressions.length > 0) {
+        const context = await buildEvalContext(file.path, vaultDir, frontmatter);
+        const allMatch = whereExpressions.every(expr => {
+          try {
+            return matchesExpression(expr, context);
+          } catch {
+            return false;
+          }
+        });
+        if (!allMatch) continue;
+      }
+
+      // Calculate what would change - this may throw for conflicts like rename-to-existing
+      // Such errors should abort the entire operation (fail fast)
+      const { changes } = applyOperations({ ...frontmatter }, operations);
+      if (changes.length === 0) continue;
+
+      filesToModify.push({
+        path: file.path,
+        relativePath: file.relativePath,
+        frontmatter,
+        body,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // Check if this is an operation error (like rename conflict) - these abort
+      if (message.includes('Cannot rename') || message.includes('target field already exists')) {
+        throw new Error(`${file.relativePath}: ${message}`);
+      }
+      // Parse errors just get logged
+      result.errors.push(`Failed to parse ${file.relativePath}: ${message}`);
+    }
+  }
+
+  // Apply limit
+  const filesToProcess = limit ? filesToModify.slice(0, limit) : filesToModify;
+
+  // Create backup if requested and executing
+  if (execute && backup && filesToProcess.length > 0) {
+    const operationDesc = describeOperations(operations);
+    result.backupPath = await createBackup(
+      vaultDir,
+      filesToProcess.map(f => f.path),
+      operationDesc
+    );
+  }
+
+  // Process each file
+  for (const file of filesToProcess) {
+    const fileChange: FileChange = {
+      filePath: file.path,
+      relativePath: file.relativePath,
+      changes: [],
+      applied: false,
+    };
+
+    try {
+      const { modified, changes } = applyOperations({ ...file.frontmatter }, operations);
+      fileChange.changes = changes;
+
+      if (execute && changes.length > 0) {
+        await writeNote(file.path, modified, file.body);
+        fileChange.applied = true;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      fileChange.error = message;
+      result.errors.push(`Failed to modify ${file.relativePath}: ${message}`);
+    }
+
+    result.changes.push(fileChange);
+  }
+
+  result.affectedFiles = result.changes.filter(c => c.changes.length > 0).length;
+
+  return result;
+}
+
+/**
+ * Build evaluation context for expression filtering.
+ */
+async function buildEvalContext(
+  filePath: string,
+  vaultDir: string,
+  frontmatter: Record<string, unknown>
+): Promise<EvalContext> {
+  const relativePath = relative(vaultDir, filePath);
+  const fileName = basename(filePath, '.md');
+  const folder = dirname(relativePath);
+
+  let fileInfo: EvalContext['file'] = {
+    name: fileName,
+    path: relativePath,
+    folder,
+    ext: '.md',
+  };
+
+  // Try to get file stats
+  try {
+    const stats = await stat(filePath);
+    fileInfo = {
+      ...fileInfo,
+      size: stats.size,
+      ctime: stats.birthtime,
+      mtime: stats.mtime,
+    };
+  } catch {
+    // Ignore stat errors
+  }
+
+  return {
+    frontmatter,
+    file: fileInfo,
+  };
+}
+
+/**
+ * Generate a description of the operations for backup manifest.
+ */
+function describeOperations(operations: BulkOperation[]): string {
+  const parts: string[] = [];
+
+  for (const op of operations) {
+    switch (op.type) {
+      case 'set':
+        parts.push(`set ${op.field}=${String(op.value)}`);
+        break;
+      case 'clear':
+        parts.push(`clear ${op.field}`);
+        break;
+      case 'rename':
+        parts.push(`rename ${op.field}=${op.newField}`);
+        break;
+      case 'delete':
+        parts.push(`delete ${op.field}`);
+        break;
+      case 'append':
+        parts.push(`append ${op.field}=${String(op.value)}`);
+        break;
+      case 'remove':
+        parts.push(`remove ${op.field}=${String(op.value)}`);
+        break;
+    }
+  }
+
+  return `bulk ${parts.join(', ')}`;
+}

--- a/src/lib/bulk/operations.ts
+++ b/src/lib/bulk/operations.ts
@@ -1,0 +1,287 @@
+/**
+ * Bulk operation logic for modifying frontmatter.
+ */
+
+import type { BulkOperation, FieldChange, OperationType } from './types.js';
+
+/**
+ * Parse an operation argument like "field=value" or "old=new".
+ * Returns [field, value] or [oldField, newField] depending on context.
+ */
+export function parseOperationArg(arg: string): [string, string] {
+  const eqIndex = arg.indexOf('=');
+  if (eqIndex === -1) {
+    return [arg, ''];
+  }
+  return [arg.slice(0, eqIndex), arg.slice(eqIndex + 1)];
+}
+
+/**
+ * Parse a value string into the appropriate type.
+ * Handles:
+ * - Empty string → undefined (for clear)
+ * - "true" / "false" → boolean
+ * - Numeric strings → number
+ * - Everything else → string
+ */
+export function parseValue(value: string): unknown {
+  if (value === '') {
+    return undefined;
+  }
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  // Check if it's a number
+  const num = Number(value);
+  if (!isNaN(num) && value.trim() !== '') {
+    return num;
+  }
+  return value;
+}
+
+/**
+ * Apply a single operation to frontmatter and return the change.
+ * Returns null if no change was made.
+ */
+export function applySingleOperation(
+  frontmatter: Record<string, unknown>,
+  operation: BulkOperation
+): FieldChange | null {
+  const { type, field, value, newField } = operation;
+
+  switch (type) {
+    case 'set': {
+      const oldValue = frontmatter[field];
+      if (oldValue === value) {
+        return null; // No change
+      }
+      frontmatter[field] = value;
+      return {
+        operation: 'set',
+        field,
+        oldValue,
+        newValue: value,
+      };
+    }
+
+    case 'clear': {
+      if (!(field in frontmatter)) {
+        return null; // Nothing to clear
+      }
+      const oldValue = frontmatter[field];
+      delete frontmatter[field];
+      return {
+        operation: 'clear',
+        field,
+        oldValue,
+        newValue: undefined,
+      };
+    }
+
+    case 'rename': {
+      if (!newField) {
+        throw new Error(`Rename operation requires a new field name`);
+      }
+      if (!(field in frontmatter)) {
+        return null; // Nothing to rename
+      }
+      if (newField in frontmatter) {
+        throw new Error(`Cannot rename '${field}' to '${newField}': target field already exists`);
+      }
+      const oldValue = frontmatter[field];
+      delete frontmatter[field];
+      frontmatter[newField] = oldValue;
+      return {
+        operation: 'rename',
+        field,
+        oldValue,
+        newValue: oldValue,
+        newField,
+      };
+    }
+
+    case 'delete': {
+      if (!(field in frontmatter)) {
+        return null; // Nothing to delete
+      }
+      const oldValue = frontmatter[field];
+      delete frontmatter[field];
+      return {
+        operation: 'delete',
+        field,
+        oldValue,
+        newValue: undefined,
+      };
+    }
+
+    case 'append': {
+      const oldValue = frontmatter[field];
+      let newArray: unknown[];
+
+      if (Array.isArray(oldValue)) {
+        // Already an array, append to it
+        if (oldValue.includes(value)) {
+          return null; // Value already in array
+        }
+        newArray = [...oldValue, value];
+      } else if (oldValue === undefined || oldValue === null) {
+        // No existing value, create array with single item
+        newArray = [value];
+      } else {
+        // Scalar value, convert to array with old and new values
+        if (oldValue === value) {
+          return null; // Same value
+        }
+        newArray = [oldValue, value];
+      }
+
+      frontmatter[field] = newArray;
+      return {
+        operation: 'append',
+        field,
+        oldValue,
+        newValue: newArray,
+      };
+    }
+
+    case 'remove': {
+      const oldValue = frontmatter[field];
+      if (!Array.isArray(oldValue)) {
+        // Not an array, can't remove
+        if (oldValue === value) {
+          // Scalar equals the value, clear the field
+          delete frontmatter[field];
+          return {
+            operation: 'remove',
+            field,
+            oldValue,
+            newValue: undefined,
+          };
+        }
+        return null; // Nothing to remove
+      }
+
+      const newArray = oldValue.filter(item => item !== value);
+      if (newArray.length === oldValue.length) {
+        return null; // Value wasn't in array
+      }
+
+      // Keep empty array (per design decision)
+      frontmatter[field] = newArray;
+      return {
+        operation: 'remove',
+        field,
+        oldValue,
+        newValue: newArray,
+      };
+    }
+
+    default:
+      throw new Error(`Unknown operation type: ${type}`);
+  }
+}
+
+/**
+ * Apply multiple operations to frontmatter.
+ * Returns the modified frontmatter and list of changes.
+ */
+export function applyOperations(
+  frontmatter: Record<string, unknown>,
+  operations: BulkOperation[]
+): { modified: Record<string, unknown>; changes: FieldChange[] } {
+  // Work on a copy to avoid mutating the original
+  const modified = { ...frontmatter };
+  const changes: FieldChange[] = [];
+
+  for (const operation of operations) {
+    const change = applySingleOperation(modified, operation);
+    if (change) {
+      changes.push(change);
+    }
+  }
+
+  return { modified, changes };
+}
+
+/**
+ * Format a value for display.
+ */
+export function formatValue(value: unknown): string {
+  if (value === undefined || value === null) {
+    return '(empty)';
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return '[]';
+    }
+    return `[${value.join(', ')}]`;
+  }
+  return String(value);
+}
+
+/**
+ * Format a single field change for display.
+ */
+export function formatChange(change: FieldChange): string {
+  switch (change.operation) {
+    case 'set':
+      return `${change.field}: ${formatValue(change.oldValue)} → ${formatValue(change.newValue)}`;
+    case 'clear':
+    case 'delete':
+      return `${change.field}: ${formatValue(change.oldValue)} → (removed)`;
+    case 'rename':
+      return `${change.field} → ${change.newField}: ${formatValue(change.oldValue)}`;
+    case 'append':
+      return `${change.field}: ${formatValue(change.oldValue)} → ${formatValue(change.newValue)}`;
+    case 'remove':
+      return `${change.field}: ${formatValue(change.oldValue)} → ${formatValue(change.newValue)}`;
+    default:
+      return `${change.field}: unknown operation`;
+  }
+}
+
+/**
+ * Build a BulkOperation from CLI arguments.
+ */
+export function buildOperation(
+  type: OperationType,
+  arg: string
+): BulkOperation {
+  const [field, value] = parseOperationArg(arg);
+
+  switch (type) {
+    case 'set':
+      if (value === '') {
+        // --set field= means clear
+        return { type: 'clear', field };
+      }
+      return { type: 'set', field, value: parseValue(value) };
+
+    case 'rename':
+      if (!value) {
+        throw new Error(`Rename requires format: --rename old=new`);
+      }
+      return { type: 'rename', field, newField: value };
+
+    case 'delete':
+      return { type: 'delete', field };
+
+    case 'append':
+      if (value === '') {
+        throw new Error(`Append requires a value: --append field=value`);
+      }
+      return { type: 'append', field, value: parseValue(value) };
+
+    case 'remove':
+      if (value === '') {
+        throw new Error(`Remove requires a value: --remove field=value`);
+      }
+      return { type: 'remove', field, value: parseValue(value) };
+
+    default:
+      throw new Error(`Unknown operation type: ${type}`);
+  }
+}

--- a/src/lib/bulk/types.ts
+++ b/src/lib/bulk/types.ts
@@ -1,0 +1,101 @@
+/**
+ * Type definitions for bulk operations.
+ */
+
+import type { Schema } from '../../types/schema.js';
+
+/**
+ * Types of bulk operations.
+ */
+export type OperationType = 'set' | 'clear' | 'rename' | 'delete' | 'append' | 'remove';
+
+/**
+ * A single bulk operation to apply.
+ */
+export interface BulkOperation {
+  type: OperationType;
+  field: string;
+  value?: unknown;        // For set, append, remove
+  newField?: string;      // For rename
+}
+
+/**
+ * A change to a single field.
+ */
+export interface FieldChange {
+  operation: OperationType;
+  field: string;
+  oldValue: unknown;
+  newValue: unknown;
+  newField?: string;      // For rename operations
+}
+
+/**
+ * Changes to a single file.
+ */
+export interface FileChange {
+  filePath: string;
+  relativePath: string;
+  changes: FieldChange[];
+  applied: boolean;
+  error?: string;
+}
+
+/**
+ * Result of a bulk operation.
+ */
+export interface BulkResult {
+  dryRun: boolean;
+  totalFiles: number;
+  affectedFiles: number;
+  changes: FileChange[];
+  backupPath?: string;
+  errors: string[];
+}
+
+/**
+ * Simple filter (--field=value syntax).
+ */
+export interface SimpleFilter {
+  field: string;
+  operator: 'eq' | 'neq';
+  values: string[];
+}
+
+/**
+ * Options for bulk execution.
+ */
+export interface BulkOptions {
+  typePath: string;
+  operations: BulkOperation[];
+  whereExpressions: string[];
+  simpleFilters: SimpleFilter[];
+  execute: boolean;
+  backup: boolean;
+  limit?: number;
+  verbose: boolean;
+  quiet: boolean;
+  jsonMode: boolean;
+  vaultDir: string;
+  schema: Schema;
+}
+
+/**
+ * Backup manifest structure.
+ */
+export interface BackupManifest {
+  timestamp: string;
+  operation: string;
+  files: string[];
+}
+
+/**
+ * Information about a backup.
+ */
+export interface BackupInfo {
+  id: string;
+  timestamp: Date;
+  operation: string;
+  fileCount: number;
+  path: string;
+}

--- a/tests/ts/commands/bulk.test.ts
+++ b/tests/ts/commands/bulk.test.ts
@@ -1,0 +1,628 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createTestVault, cleanupTestVault, runCLI, TEST_SCHEMA } from '../fixtures/setup.js';
+import { parseNote } from '../../../src/lib/frontmatter.js';
+
+describe('bulk command', () => {
+  let vaultDir: string;
+
+  beforeAll(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterAll(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  describe('basic validation', () => {
+    it('should require a type argument', async () => {
+      const result = await runCLI(['bulk'], vaultDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("required");
+    });
+
+    it('should reject unknown type', async () => {
+      const result = await runCLI(['bulk', 'unknown', '--set', 'status=done'], vaultDir);
+      expect(result.exitCode).toBe(1);
+      // Error goes to stderr via printError
+      expect(result.stderr).toContain('Unknown type: unknown');
+    });
+
+    it('should require at least one operation', async () => {
+      const result = await runCLI(['bulk', 'idea'], vaultDir);
+      expect(result.exitCode).toBe(1);
+      // Error goes to stderr via printError
+      expect(result.stderr).toContain('No operations specified');
+    });
+
+    it('should validate enum values', async () => {
+      const result = await runCLI(['bulk', 'idea', '--set', 'status=invalid'], vaultDir);
+      expect(result.exitCode).toBe(1);
+      // Error goes to stderr via printError
+      expect(result.stderr).toContain("Invalid value 'invalid' for field 'status'");
+    });
+  });
+
+  describe('dry-run mode', () => {
+    it('should show what would change without modifying files', async () => {
+      const result = await runCLI(['bulk', 'idea', '--set', 'status=backlog'], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Dry run');
+      expect(result.stdout).toContain('Sample Idea.md');
+      expect(result.stdout).toContain('status: raw → backlog');
+      expect(result.stdout).toContain('--execute');
+
+      // Verify file wasn't changed
+      const { frontmatter } = await parseNote(join(vaultDir, 'Ideas', 'Sample Idea.md'));
+      expect(frontmatter.status).toBe('raw');
+    });
+
+    it('should show no changes when nothing matches', async () => {
+      const result = await runCLI(['bulk', 'idea', '--set', 'status=raw', '--where', "status == 'settled'"], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('No files match');
+    });
+  });
+
+  describe('--set operation', () => {
+    let tempVaultDir: string;
+
+    beforeEach(async () => {
+      tempVaultDir = await createTestVault();
+    });
+
+    afterEach(async () => {
+      await cleanupTestVault(tempVaultDir);
+    });
+
+    it('should set a single field', async () => {
+      const result = await runCLI(['bulk', 'idea', '--set', 'status=settled', '--execute'], tempVaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Updated 2 files');
+
+      // Verify files were changed
+      const { frontmatter: fm1 } = await parseNote(join(tempVaultDir, 'Ideas', 'Sample Idea.md'));
+      expect(fm1.status).toBe('settled');
+
+      const { frontmatter: fm2 } = await parseNote(join(tempVaultDir, 'Ideas', 'Another Idea.md'));
+      expect(fm2.status).toBe('settled');
+    });
+
+    it('should set multiple fields', async () => {
+      const result = await runCLI([
+        'bulk', 'idea',
+        '--set', 'status=settled',
+        '--set', 'priority=low',
+        '--execute'
+      ], tempVaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Updated 2 files');
+
+      const { frontmatter } = await parseNote(join(tempVaultDir, 'Ideas', 'Sample Idea.md'));
+      expect(frontmatter.status).toBe('settled');
+      expect(frontmatter.priority).toBe('low');
+    });
+
+    it('should clear a field with --set field=', async () => {
+      const result = await runCLI(['bulk', 'idea', '--set', 'priority=', '--execute'], tempVaultDir);
+      
+      expect(result.exitCode).toBe(0);
+
+      const { frontmatter } = await parseNote(join(tempVaultDir, 'Ideas', 'Sample Idea.md'));
+      expect(frontmatter.priority).toBeUndefined();
+    });
+
+    it('should allow setting arbitrary fields (not in schema)', async () => {
+      const result = await runCLI(['bulk', 'idea', '--set', 'custom-field=test', '--execute'], tempVaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Updated 2 files');
+
+      const { frontmatter } = await parseNote(join(tempVaultDir, 'Ideas', 'Sample Idea.md'));
+      expect(frontmatter['custom-field']).toBe('test');
+    });
+  });
+
+  describe('--rename operation', () => {
+    let tempVaultDir: string;
+
+    beforeEach(async () => {
+      tempVaultDir = await createTestVault();
+    });
+
+    afterEach(async () => {
+      await cleanupTestVault(tempVaultDir);
+    });
+
+    it('should rename a field', async () => {
+      // First add a field to rename
+      await runCLI(['bulk', 'idea', '--set', 'old-field=value', '--execute'], tempVaultDir);
+      
+      const result = await runCLI(['bulk', 'idea', '--rename', 'old-field=new-field', '--execute'], tempVaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Updated 2 files');
+
+      const { frontmatter } = await parseNote(join(tempVaultDir, 'Ideas', 'Sample Idea.md'));
+      expect(frontmatter['old-field']).toBeUndefined();
+      expect(frontmatter['new-field']).toBe('value');
+    });
+
+    it('should error when target field already exists', async () => {
+      const result = await runCLI(['bulk', 'idea', '--rename', 'status=priority', '--execute'], tempVaultDir);
+      
+      expect(result.exitCode).toBe(1);
+      // Error goes to stderr via printError
+      expect(result.stderr).toContain('target field already exists');
+    });
+  });
+
+  describe('--delete operation', () => {
+    let tempVaultDir: string;
+
+    beforeEach(async () => {
+      tempVaultDir = await createTestVault();
+    });
+
+    afterEach(async () => {
+      await cleanupTestVault(tempVaultDir);
+    });
+
+    it('should delete a field', async () => {
+      const result = await runCLI(['bulk', 'idea', '--delete', 'priority', '--execute'], tempVaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Updated 2 files');
+
+      const { frontmatter } = await parseNote(join(tempVaultDir, 'Ideas', 'Sample Idea.md'));
+      expect(frontmatter.priority).toBeUndefined();
+    });
+
+    it('should not fail when field does not exist', async () => {
+      const result = await runCLI(['bulk', 'idea', '--delete', 'nonexistent', '--execute'], tempVaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      // No files should be modified since field doesn't exist
+      expect(result.stdout).toContain('No files match');
+    });
+  });
+
+  describe('--append operation', () => {
+    let tempVaultDir: string;
+
+    beforeEach(async () => {
+      tempVaultDir = await createTestVault();
+    });
+
+    afterEach(async () => {
+      await cleanupTestVault(tempVaultDir);
+    });
+
+    it('should append to an existing array', async () => {
+      // First set tags as an array
+      await runCLI(['bulk', 'idea', '--set', 'tags=existing', '--execute'], tempVaultDir);
+      
+      const result = await runCLI(['bulk', 'idea', '--append', 'tags=newtag', '--execute'], tempVaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Updated 2 files');
+
+      const { frontmatter } = await parseNote(join(tempVaultDir, 'Ideas', 'Sample Idea.md'));
+      expect(frontmatter.tags).toContain('existing');
+      expect(frontmatter.tags).toContain('newtag');
+    });
+
+    it('should create array for new field', async () => {
+      const result = await runCLI(['bulk', 'idea', '--append', 'labels=first', '--execute'], tempVaultDir);
+      
+      expect(result.exitCode).toBe(0);
+
+      const { frontmatter } = await parseNote(join(tempVaultDir, 'Ideas', 'Sample Idea.md'));
+      expect(frontmatter.labels).toEqual(['first']);
+    });
+
+    it('should convert scalar to array when appending', async () => {
+      // First set a scalar value
+      await runCLI(['bulk', 'idea', '--set', 'scalar-field=first', '--execute'], tempVaultDir);
+      
+      const result = await runCLI(['bulk', 'idea', '--append', 'scalar-field=second', '--execute'], tempVaultDir);
+      
+      expect(result.exitCode).toBe(0);
+
+      const { frontmatter } = await parseNote(join(tempVaultDir, 'Ideas', 'Sample Idea.md'));
+      expect(frontmatter['scalar-field']).toEqual(['first', 'second']);
+    });
+  });
+
+  describe('--remove operation', () => {
+    let tempVaultDir: string;
+
+    beforeEach(async () => {
+      tempVaultDir = await createTestVault();
+      // Set up array field for testing
+      await writeFile(
+        join(tempVaultDir, 'Ideas', 'Sample Idea.md'),
+        `---
+type: idea
+status: raw
+priority: medium
+tags:
+  - one
+  - two
+  - three
+---
+`
+      );
+    });
+
+    afterEach(async () => {
+      await cleanupTestVault(tempVaultDir);
+    });
+
+    it('should remove item from array', async () => {
+      const result = await runCLI(['bulk', 'idea', '--remove', 'tags=two', '--execute', '--where', "contains(tags, 'two')"], tempVaultDir);
+      
+      expect(result.exitCode).toBe(0);
+
+      const { frontmatter } = await parseNote(join(tempVaultDir, 'Ideas', 'Sample Idea.md'));
+      expect(frontmatter.tags).toEqual(['one', 'three']);
+    });
+
+    it('should leave empty array after removing last item', async () => {
+      await writeFile(
+        join(tempVaultDir, 'Ideas', 'Single Tag.md'),
+        `---
+type: idea
+status: raw
+tags:
+  - only
+---
+`
+      );
+
+      const result = await runCLI(['bulk', 'idea', '--remove', 'tags=only', '--execute', '--where', "contains(tags, 'only')"], tempVaultDir);
+      
+      expect(result.exitCode).toBe(0);
+
+      const { frontmatter } = await parseNote(join(tempVaultDir, 'Ideas', 'Single Tag.md'));
+      expect(frontmatter.tags).toEqual([]);
+    });
+  });
+
+  describe('--where filtering', () => {
+    it('should filter by expression', async () => {
+      const result = await runCLI(['bulk', 'idea', '--set', 'status=settled', '--where', "status == 'raw'"], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Sample Idea.md');
+      expect(result.stdout).not.toContain('Another Idea.md'); // This one has backlog status
+    });
+
+    it('should combine multiple where expressions with AND', async () => {
+      const result = await runCLI([
+        'bulk', 'idea',
+        '--set', 'status=settled',
+        '--where', "status == 'backlog'",
+        '--where', "priority == 'high'"
+      ], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      // Only Another Idea matches both conditions
+      expect(result.stdout).toContain('Another Idea.md');
+      expect(result.stdout).not.toContain('Sample Idea.md');
+    });
+  });
+
+  describe('simple filters (--field=value syntax)', () => {
+    it('should filter with equality', async () => {
+      const result = await runCLI([
+        'bulk', 'idea',
+        '--status=raw',
+        '--set', 'priority=high'
+      ], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      // Only Sample Idea has status=raw
+      expect(result.stdout).toContain('Sample Idea.md');
+      expect(result.stdout).not.toContain('Another Idea.md');
+    });
+
+    it('should filter with negation', async () => {
+      const result = await runCLI([
+        'bulk', 'idea',
+        '--status!=raw',
+        '--set', 'priority=low'
+      ], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      // Only Another Idea has status!=raw (it's backlog)
+      expect(result.stdout).toContain('Another Idea.md');
+      expect(result.stdout).not.toContain('Sample Idea.md');
+    });
+
+    it('should filter with multiple values (OR)', async () => {
+      const result = await runCLI([
+        'bulk', 'idea',
+        '--status=raw,backlog',
+        '--set', 'test=value'
+      ], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      // Both files match (raw or backlog)
+      expect(result.stdout).toContain('Sample Idea.md');
+      expect(result.stdout).toContain('Another Idea.md');
+    });
+
+    it('should combine simple filters with AND', async () => {
+      const result = await runCLI([
+        'bulk', 'idea',
+        '--status=backlog',
+        '--priority=high',
+        '--set', 'test=value'
+      ], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      // Only Another Idea has both status=backlog AND priority=high
+      expect(result.stdout).toContain('Another Idea.md');
+      expect(result.stdout).not.toContain('Sample Idea.md');
+    });
+
+    it('should combine simple filters with --where expressions', async () => {
+      const result = await runCLI([
+        'bulk', 'idea',
+        '--status=backlog',
+        '--where', "priority == 'high'",
+        '--set', 'test=value'
+      ], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      // Only Another Idea matches both conditions
+      expect(result.stdout).toContain('Another Idea.md');
+      expect(result.stdout).not.toContain('Sample Idea.md');
+    });
+
+    it('should validate filter field names', async () => {
+      const result = await runCLI([
+        'bulk', 'idea',
+        '--nonexistent=value',
+        '--set', 'status=done'
+      ], vaultDir);
+      
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Unknown field 'nonexistent'");
+    });
+
+    it('should validate filter enum values', async () => {
+      const result = await runCLI([
+        'bulk', 'idea',
+        '--status=invalid',
+        '--set', 'priority=high'
+      ], vaultDir);
+      
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Invalid value 'invalid'");
+    });
+  });
+
+  describe('--limit option', () => {
+    it('should limit number of files affected', async () => {
+      const result = await runCLI(['bulk', 'idea', '--set', 'status=settled', '--limit', '1'], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Would affect 1 file');
+    });
+
+    it('should reject invalid limit', async () => {
+      const result = await runCLI(['bulk', 'idea', '--set', 'status=settled', '--limit', 'abc'], vaultDir);
+      
+      expect(result.exitCode).toBe(1);
+      // Error goes to stderr via printError
+      expect(result.stderr).toContain('Invalid --limit');
+    });
+  });
+
+  describe('--backup option', () => {
+    let tempVaultDir: string;
+
+    beforeEach(async () => {
+      tempVaultDir = await createTestVault();
+    });
+
+    afterEach(async () => {
+      await cleanupTestVault(tempVaultDir);
+    });
+
+    it('should create backup when --backup is specified', async () => {
+      const result = await runCLI(['bulk', 'idea', '--set', 'status=settled', '--execute', '--backup'], tempVaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Backup created');
+      expect(result.stdout).toContain('.ovault/backups');
+    });
+  });
+
+  describe('output modes', () => {
+    it('should output JSON with --output json', async () => {
+      const result = await runCLI(['bulk', 'idea', '--set', 'status=settled', '--output', 'json'], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.dryRun).toBe(true);
+      expect(json.data.filesModified).toBeGreaterThan(0);
+    });
+
+    it('should show minimal output with --quiet', async () => {
+      const result = await runCLI(['bulk', 'idea', '--set', 'status=settled', '--quiet'], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Would affect');
+      expect(result.stdout).not.toContain('Sample Idea.md');
+    });
+
+    it('should show detailed output with --verbose', async () => {
+      const result = await runCLI(['bulk', 'idea', '--set', 'status=settled', '--verbose'], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Sample Idea.md');
+      expect(result.stdout).toContain('status:');
+    });
+  });
+
+  describe('subtype handling', () => {
+    it('should work with subtypes', async () => {
+      const result = await runCLI(['bulk', 'objective/task', '--set', 'status=settled'], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Sample Task.md');
+    });
+
+    it('should work with parent type (affecting all subtypes)', async () => {
+      const result = await runCLI(['bulk', 'objective', '--set', 'status=settled'], vaultDir);
+      
+      expect(result.exitCode).toBe(0);
+      // Should show both task and milestone
+      expect(result.stdout).toContain('Sample Task.md');
+      expect(result.stdout).toContain('Active Milestone.md');
+    });
+  });
+});
+
+describe('bulk operations unit tests', () => {
+  describe('applyOperations', () => {
+    // Import dynamically in tests
+    let applyOperations: typeof import('../../../src/lib/bulk/operations.js')['applyOperations'];
+
+    beforeAll(async () => {
+      const mod = await import('../../../src/lib/bulk/operations.js');
+      applyOperations = mod.applyOperations;
+    });
+
+    it('should set field value', () => {
+      const fm = { existing: 'value' };
+      const { modified, changes } = applyOperations(fm, [
+        { type: 'set', field: 'new', value: 'test' }
+      ]);
+      
+      expect(modified.new).toBe('test');
+      expect(changes).toHaveLength(1);
+      expect(changes[0]?.operation).toBe('set');
+    });
+
+    it('should rename field', () => {
+      const fm = { old: 'value' };
+      const { modified, changes } = applyOperations(fm, [
+        { type: 'rename', field: 'old', newField: 'new' }
+      ]);
+      
+      expect(modified.old).toBeUndefined();
+      expect(modified.new).toBe('value');
+      expect(changes).toHaveLength(1);
+      expect(changes[0]?.operation).toBe('rename');
+    });
+
+    it('should throw when renaming to existing field', () => {
+      const fm = { old: 'value1', new: 'value2' };
+      expect(() => {
+        applyOperations(fm, [
+          { type: 'rename', field: 'old', newField: 'new' }
+        ]);
+      }).toThrow('target field already exists');
+    });
+
+    it('should delete field', () => {
+      const fm = { field: 'value' };
+      const { modified, changes } = applyOperations(fm, [
+        { type: 'delete', field: 'field' }
+      ]);
+      
+      expect(modified.field).toBeUndefined();
+      expect(changes).toHaveLength(1);
+    });
+
+    it('should append to array', () => {
+      const fm = { list: ['a', 'b'] };
+      const { modified } = applyOperations(fm, [
+        { type: 'append', field: 'list', value: 'c' }
+      ]);
+      
+      expect(modified.list).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should not append duplicate value', () => {
+      const fm = { list: ['a', 'b'] };
+      const { modified, changes } = applyOperations(fm, [
+        { type: 'append', field: 'list', value: 'a' }
+      ]);
+      
+      expect(modified.list).toEqual(['a', 'b']);
+      expect(changes).toHaveLength(0);
+    });
+
+    it('should remove from array', () => {
+      const fm = { list: ['a', 'b', 'c'] };
+      const { modified } = applyOperations(fm, [
+        { type: 'remove', field: 'list', value: 'b' }
+      ]);
+      
+      expect(modified.list).toEqual(['a', 'c']);
+    });
+
+    it('should leave empty array after removing last item', () => {
+      const fm = { list: ['only'] };
+      const { modified } = applyOperations(fm, [
+        { type: 'remove', field: 'list', value: 'only' }
+      ]);
+      
+      expect(modified.list).toEqual([]);
+    });
+  });
+
+  describe('buildOperation', () => {
+    let buildOperation: typeof import('../../../src/lib/bulk/operations.js')['buildOperation'];
+
+    beforeAll(async () => {
+      const mod = await import('../../../src/lib/bulk/operations.js');
+      buildOperation = mod.buildOperation;
+    });
+
+    it('should parse set operation', () => {
+      const op = buildOperation('set', 'field=value');
+      expect(op.type).toBe('set');
+      expect(op.field).toBe('field');
+      expect(op.value).toBe('value');
+    });
+
+    it('should parse clear operation', () => {
+      const op = buildOperation('set', 'field=');
+      expect(op.type).toBe('clear');
+      expect(op.field).toBe('field');
+    });
+
+    it('should parse rename operation', () => {
+      const op = buildOperation('rename', 'old=new');
+      expect(op.type).toBe('rename');
+      expect(op.field).toBe('old');
+      expect(op.newField).toBe('new');
+    });
+
+    it('should parse boolean values', () => {
+      const opTrue = buildOperation('set', 'field=true');
+      expect(opTrue.value).toBe(true);
+
+      const opFalse = buildOperation('set', 'field=false');
+      expect(opFalse.value).toBe(false);
+    });
+
+    it('should parse numeric values', () => {
+      const op = buildOperation('set', 'count=42');
+      expect(op.value).toBe(42);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `ovault bulk` command for mass changes across filtered file sets, completing the core functionality for Phase 2 (Audit & Bulk Operations).

## Features

### Operations
- `--set field=value` - Set field value
- `--set field=` - Clear field (remove from frontmatter)
- `--rename old=new` - Rename field
- `--delete field` - Delete field
- `--append field=value` - Append to list field
- `--remove field=value` - Remove from list field

### Filters (parity with `ovault list`)
- `--field=value` - Include where field equals value
- `--field=a,b` - Include where field equals a OR b
- `--field!=value` - Exclude where field equals value
- `--where "expression"` - Expression filters for complex queries

### Safety
- Dry-run by default (preview changes without applying)
- `--execute` flag to apply changes
- `--backup` creates timestamped backup before changes
- Fail-fast on conflicts (e.g., rename to existing field)

### Output
- `--verbose` - Detailed per-file changes
- `--quiet` - Summary only
- `--output json` - JSON output for scripting

## Examples

```bash
# Preview changes (dry-run)
ovault bulk task --set status=done --where "status == 'in-progress'"

# Apply with simple filter
ovault bulk task --status=done --set archived=true --execute

# Create backup before changes
ovault bulk task --set status=archived --execute --backup
```

## Testing

- 49 tests covering all operations, filters, output modes, and error cases
- All 327 tests passing

## Related Issues

- Closes ovault-bj7 (Implement ovault bulk command)
- Part of ovault-9xi (Phase 2: Audit & Bulk Operations)