### PR TITLE
fix: respect OVAULT_DEFAULT_APP for new command --open flag

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -60,7 +60,7 @@ interface NewCommandOptions {
 export const newCommand = new Command('new')
   .description('Create a new note (interactive type navigation if type omitted)')
   .argument('[type]', 'Type of note to create (e.g., idea, objective/task)')
-  .option('--open', 'Open the note in Obsidian after creation')
+  .option('--open', 'Open the note after creation (uses OVAULT_DEFAULT_APP or Obsidian)')
   .option('--json <frontmatter>', 'Create note non-interactively with JSON frontmatter')
   .option('--instance <name>', 'Parent instance name (for instance-grouped subtypes)')
   .addHelpText('after', `
@@ -68,7 +68,7 @@ Examples:
   ovault new                    # Interactive type selection
   ovault new idea               # Create an idea
   ovault new objective/task     # Create a task
-  ovault new draft --open       # Create and open in Obsidian
+  ovault new draft --open       # Create and open (respects OVAULT_DEFAULT_APP)
 
 Non-interactive (JSON) mode:
   ovault new idea --json '{"Name": "My Idea", "status": "raw"}'
@@ -103,10 +103,10 @@ or create a parent instance folder.`)
         
         printJson(jsonSuccess({ path: relative(vaultDir, filePath) }));
         
-        // Open in Obsidian if requested
+        // Open if requested (respects OVAULT_DEFAULT_APP)
         if (options.open && filePath) {
-          const { openInObsidian } = await import('./open.js');
-          await openInObsidian(vaultDir, filePath);
+          const { openNote } = await import('./open.js');
+          await openNote(vaultDir, filePath);
         }
         return;
       }
@@ -126,10 +126,10 @@ or create a parent instance folder.`)
 
       const filePath = await createNote(schema, vaultDir, resolvedPath, typeDef);
 
-      // Open in Obsidian if requested
+      // Open if requested (respects OVAULT_DEFAULT_APP)
       if (options.open && filePath) {
-        const { openInObsidian } = await import('./open.js');
-        await openInObsidian(vaultDir, filePath);
+        const { openNote } = await import('./open.js');
+        await openNote(vaultDir, filePath);
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -234,6 +234,34 @@ Note: Obsidian must be running for --app obsidian to work.
 // Helpers
 // ============================================================================
 
+/**
+ * Open a note using the configured app mode (respects OVAULT_DEFAULT_APP).
+ * This is the shared entry point for opening notes from other commands.
+ */
+export async function openNote(
+  vaultDir: string,
+  filePath: string,
+  jsonMode: boolean = false
+): Promise<void> {
+  const appMode = parseAppMode(undefined); // Uses OVAULT_DEFAULT_APP or defaults to obsidian
+
+  switch (appMode) {
+    case 'print':
+      console.log(filePath);
+      break;
+    case 'editor':
+      await openInEditor(filePath, jsonMode);
+      break;
+    case 'system':
+      await openWithSystem(filePath, jsonMode);
+      break;
+    case 'obsidian':
+    default:
+      await openInObsidian(vaultDir, filePath, jsonMode);
+      break;
+  }
+}
+
 function parseAppMode(value: string | undefined): AppMode {
   // Use explicit value, then env var, then default to obsidian
   const effectiveValue = value ?? process.env['OVAULT_DEFAULT_APP'];


### PR DESCRIPTION
## Summary

- The `--open` flag in the `new` command was hardcoded to always open in Obsidian
- Now uses a shared `openNote()` function that respects `OVAULT_DEFAULT_APP` environment variable
- Consistent behavior between `ovault open` and `ovault new --open`

## Changes

- Added `openNote()` export in `src/commands/open.ts` as a shared entry point
- Updated `src/commands/new.ts` to use `openNote()` instead of `openInObsidian()`
- Updated help text to reflect the new behavior