### PR TITLE
fix: body sections now work alongside templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ All notable changes to ovault are documented in this file.
 
 ### Fixed
 
+- **Body sections skipped when using templates** 
+  - Previously, if a template had body content, schema-defined body_sections with prompts were completely skipped
+  - Now, promptable body_sections work alongside templates: existing template content is shown, then user is prompted for additional items
+  - Added items are appended to matching sections in the template
+  - Sections not in template are added at the end of the body
+  - Supports checkboxes, bullets, and paragraph content types
+
 - **Numbered select prompt flicker** (ovault-18j)
   - Arrow key navigation now uses differential updates instead of full re-render
   - Only the changed lines (old/new selection) are updated

--- a/tests/ts/lib/frontmatter.test.ts
+++ b/tests/ts/lib/frontmatter.test.ts
@@ -9,6 +9,8 @@ import {
   writeNote,
   generateBodySections,
   generateBodyWithContent,
+  extractSectionItems,
+  mergeBodySectionContent,
 } from '../../../src/lib/frontmatter.js';
 import { createTestVault, cleanupTestVault } from '../fixtures/setup.js';
 
@@ -142,6 +144,183 @@ Body content`;
       expect(body).toContain('## Steps');
       expect(body).toContain('- [ ] Step 1');
       expect(body).toContain('- [ ] Step 2');
+    });
+  });
+
+  describe('extractSectionItems', () => {
+    it('should extract checkboxes from a section', () => {
+      const templateBody = `## Steps
+
+- [ ] First step
+- [ ] Second step
+
+## Notes
+
+Some notes here
+`;
+      const items = extractSectionItems(templateBody, 'Steps', 'checkboxes');
+      expect(items).toEqual(['First step', 'Second step']);
+    });
+
+    it('should extract bullets from a section', () => {
+      const templateBody = `## Items
+
+- Item one
+- Item two
+- Item three
+
+## Other
+`;
+      const items = extractSectionItems(templateBody, 'Items', 'bullets');
+      expect(items).toEqual(['Item one', 'Item two', 'Item three']);
+    });
+
+    it('should extract paragraphs from a section', () => {
+      const templateBody = `## Description
+
+This is the first paragraph.
+This is the second paragraph.
+
+## Notes
+`;
+      const items = extractSectionItems(templateBody, 'Description', 'paragraphs');
+      expect(items).toEqual(['This is the first paragraph.', 'This is the second paragraph.']);
+    });
+
+    it('should return empty array if section not found', () => {
+      const templateBody = `## Steps
+
+- [ ] Step
+`;
+      const items = extractSectionItems(templateBody, 'Notes', 'paragraphs');
+      expect(items).toEqual([]);
+    });
+
+    it('should handle different heading levels', () => {
+      const templateBody = `### Steps
+
+- [ ] Deep step
+
+#### Notes
+`;
+      const items = extractSectionItems(templateBody, 'Steps', 'checkboxes');
+      expect(items).toEqual(['Deep step']);
+    });
+
+    it('should handle checked checkboxes', () => {
+      const templateBody = `## Steps
+
+- [x] Done step
+- [ ] Pending step
+`;
+      const items = extractSectionItems(templateBody, 'Steps', 'checkboxes');
+      expect(items).toEqual(['Done step', 'Pending step']);
+    });
+  });
+
+  describe('mergeBodySectionContent', () => {
+    it('should append items to existing section', () => {
+      const templateBody = `## Steps
+
+- [ ] Existing step
+
+## Notes
+
+`;
+      const sections = [
+        { title: 'Steps', level: 2, content_type: 'checkboxes' as const },
+      ];
+      const content = new Map([['Steps', ['New step one', 'New step two']]]);
+      
+      const result = mergeBodySectionContent(templateBody, sections, content);
+      
+      expect(result).toContain('- [ ] Existing step');
+      expect(result).toContain('- [ ] New step one');
+      expect(result).toContain('- [ ] New step two');
+      // New items should come after existing
+      expect(result.indexOf('Existing step')).toBeLessThan(result.indexOf('New step one'));
+    });
+
+    it('should add section at end if not in template', () => {
+      const templateBody = `## Notes
+
+Some notes
+`;
+      const sections = [
+        { title: 'Steps', level: 2, content_type: 'checkboxes' as const },
+      ];
+      const content = new Map([['Steps', ['New step']]]);
+      
+      const result = mergeBodySectionContent(templateBody, sections, content);
+      
+      expect(result).toContain('## Notes');
+      expect(result).toContain('Some notes');
+      expect(result).toContain('## Steps');
+      expect(result).toContain('- [ ] New step');
+      // New section should come after existing content
+      expect(result.indexOf('Some notes')).toBeLessThan(result.indexOf('## Steps'));
+    });
+
+    it('should handle multiple sections with content', () => {
+      const templateBody = `## Steps
+
+- [ ] Template step
+
+## Items
+
+- Template item
+`;
+      const sections = [
+        { title: 'Steps', level: 2, content_type: 'checkboxes' as const },
+        { title: 'Items', level: 2, content_type: 'bullets' as const },
+      ];
+      const content = new Map([
+        ['Steps', ['Added step']],
+        ['Items', ['Added item']],
+      ]);
+      
+      const result = mergeBodySectionContent(templateBody, sections, content);
+      
+      expect(result).toContain('- [ ] Template step');
+      expect(result).toContain('- [ ] Added step');
+      expect(result).toContain('- Template item');
+      expect(result).toContain('- Added item');
+    });
+
+    it('should preserve template body when no content to add', () => {
+      const templateBody = `## Steps
+
+- [ ] Existing step
+
+## Notes
+
+`;
+      const sections = [
+        { title: 'Steps', level: 2, content_type: 'checkboxes' as const },
+      ];
+      const content = new Map<string, string[]>();
+      
+      const result = mergeBodySectionContent(templateBody, sections, content);
+      
+      expect(result).toBe(templateBody);
+    });
+
+    it('should handle paragraphs content type', () => {
+      const templateBody = `## Description
+
+Existing description
+
+## Notes
+`;
+      const sections = [
+        { title: 'Description', level: 2, content_type: 'paragraphs' as const },
+      ];
+      const content = new Map([['Description', ['Added paragraph']]]);
+      
+      const result = mergeBodySectionContent(templateBody, sections, content);
+      
+      expect(result).toContain('Existing description');
+      expect(result).toContain('Added paragraph');
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes a bug where schema-defined `body_sections` with `prompt: "multi-input"` were completely skipped when a template was used.

## Changes

- When creating a note with both a template (with body) AND promptable body_sections:
  1. Template body content is displayed first, showing existing items in each section
  2. User is prompted for "Additional {prompt_label}" items
  3. Added items are appended to matching sections in the template body
  4. Sections not present in template are added at the end

- New helper functions in `src/lib/frontmatter.ts`:
  - `extractSectionItems()`: Parse existing items from template body by section title
  - `mergeBodySectionContent()`: Merge prompted content into template body

## Example Flow

**Before (broken):** User has a task template with `## Steps\n- [ ] Review PR` and schema has body_sections with `prompt: "multi-input"`. The CLI would skip the prompt entirely and just use the template body as-is.

**After (fixed):**
```
Steps (from template):
  - [ ] Review PR
Additional Steps (comma-separated): Deploy to staging, Update docs
```

Result includes both template content AND user additions:
```markdown
## Steps

- [ ] Review PR
- [ ] Deploy to staging
- [ ] Update docs
```

## Testing

- Added 11 new unit tests for `extractSectionItems()` and `mergeBodySectionContent()`
- All existing tests pass (456 passing, 63 skipped due to PTY issues)

## Related

- Logged PTY test environment issue as bug `ovault-ne9` (node-pty fails with posix_spawnp on current setup)