### PR TITLE
refactor: consolidate file discovery logic (ovault-5jk)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to ovault are documented in this file.
 
 ### Changed
 
+- **Consolidated file discovery logic** (ovault-5jk)
+  - Moved duplicated file discovery functions from `audit/detection.ts` to shared `discovery.ts` module
+  - Single source of truth for `discoverManagedFiles`, `collectAllMarkdownFiles`, `findSimilarFiles`, etc.
+  - Added dedicated test suite for discovery module (31 tests)
+  - Reduces code duplication by ~200 lines
+
 - **Extracted `resolveAndPick` helper** (ovault-bjg)
   - DRYs up ~76 lines of duplicated query resolution + picker logic from `open` and `link` commands
   - Adds `exitWithResolutionError` helper for consistent error output with optional candidates list

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -34,9 +34,11 @@ import {
   runAudit,
   discoverManagedFiles,
   auditFile,
+} from '../lib/audit/detection.js';
+import {
   collectPooledFiles,
   collectInstanceGroupedFiles,
-} from '../lib/audit/detection.js';
+} from '../lib/discovery.js';
 import {
   runAutoFix,
   runInteractiveFix,

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -1,24 +1,20 @@
 /**
  * Audit detection logic.
  * 
- * This module handles file discovery and issue detection.
+ * This module handles issue detection for vault files.
+ * File discovery functions are imported from the shared discovery module.
  */
 
-import ignore, { type Ignore } from 'ignore';
-import { readdir, readFile } from 'fs/promises';
-import { join, dirname, basename } from 'path';
-import { existsSync } from 'fs';
+import { dirname, basename } from 'path';
 import {
   getTypeDefByPath,
-  hasSubtypes,
-  getSubtypeKeys,
   getFieldsForType,
   getEnumValues,
   resolveTypePathFromFrontmatter,
   getTypeFamilies,
 } from '../schema.js';
 import { parseNote } from '../frontmatter.js';
-import { getOutputDir, getDirMode } from '../vault.js';
+import { getOutputDir } from '../vault.js';
 import { suggestEnumValue, suggestFieldName } from '../validation.js';
 import type { Schema } from '../../types/schema.js';
 import {
@@ -32,6 +28,13 @@ import {
   isQuotedWikilink,
   extractWikilinkTarget,
 } from './types.js';
+
+// Import file discovery functions from shared module
+import {
+  discoverManagedFiles,
+  collectAllMarkdownFilenames,
+  findSimilarFiles,
+} from '../discovery.js';
 
 // ============================================================================
 // Main Audit Runner
@@ -81,241 +84,6 @@ export async function runAudit(
   }
 
   return results;
-}
-
-// ============================================================================
-// File Discovery
-// ============================================================================
-
-/**
- * Load and parse .gitignore file if it exists.
- */
-async function loadGitignore(vaultDir: string): Promise<Ignore | null> {
-  const gitignorePath = join(vaultDir, '.gitignore');
-  try {
-    const content = await readFile(gitignorePath, 'utf-8');
-    return ignore().add(content);
-  } catch {
-    return null; // No .gitignore or can't read it
-  }
-}
-
-/**
- * Get directories to exclude from vault-wide audit.
- * Combines defaults, schema config, and env var.
- */
-function getExcludedDirectories(schema: Schema): Set<string> {
-  const excluded = new Set<string>();
-  
-  // Always exclude .ovault
-  excluded.add('.ovault');
-  
-  // Add schema-configured exclusions
-  const schemaExclusions = schema.audit?.ignored_directories;
-  if (schemaExclusions) {
-    for (const dir of schemaExclusions) {
-      excluded.add(dir.replace(/\/$/, '')); // Normalize trailing slash
-    }
-  }
-  
-  // Add env var exclusions (comma-separated)
-  const envExclusions = process.env.OVAULT_AUDIT_EXCLUDE;
-  if (envExclusions) {
-    for (const dir of envExclusions.split(',')) {
-      const trimmed = dir.trim().replace(/\/$/, '');
-      if (trimmed) excluded.add(trimmed);
-    }
-  }
-  
-  return excluded;
-}
-
-/**
- * Recursively collect all markdown files in a directory.
- */
-async function collectAllMarkdownFiles(
-  dir: string,
-  baseDir: string,
-  excluded: Set<string>,
-  gitignore: Ignore | null
-): Promise<ManagedFile[]> {
-  const files: ManagedFile[] = [];
-  
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return files; // Directory doesn't exist or can't be read
-  }
-  
-  for (const entry of entries) {
-    const fullPath = join(dir, entry.name);
-    const relativePath = fullPath.slice(baseDir.length + 1); // +1 for leading slash
-    
-    // Check if this path should be excluded by explicit exclusions
-    const shouldExclude = Array.from(excluded).some(excl => 
-      relativePath === excl || relativePath.startsWith(excl + '/')
-    );
-    
-    if (shouldExclude) continue;
-    
-    // Skip hidden directories (starting with .)
-    if (entry.isDirectory() && entry.name.startsWith('.')) continue;
-    
-    // Check gitignore
-    if (gitignore && gitignore.ignores(relativePath)) continue;
-    
-    if (entry.isDirectory()) {
-      const subFiles = await collectAllMarkdownFiles(fullPath, baseDir, excluded, gitignore);
-      files.push(...subFiles);
-    } else if (entry.isFile() && entry.name.endsWith('.md')) {
-      files.push({
-        path: fullPath,
-        relativePath,
-      });
-    }
-  }
-  
-  return files;
-}
-
-/**
- * Collect all markdown filenames for stale reference checking.
- * Returns a set of basenames (without .md extension) for fast lookup.
- */
-async function collectAllMarkdownFilenames(vaultDir: string): Promise<Set<string>> {
-  const filenames = new Set<string>();
-  const excluded = new Set(['.ovault']);
-  const gitignore = await loadGitignore(vaultDir);
-  
-  const allFiles = await collectAllMarkdownFiles(vaultDir, vaultDir, excluded, gitignore);
-  for (const file of allFiles) {
-    // Add basename without extension
-    filenames.add(basename(file.relativePath, '.md'));
-    // Also add relative path without extension for path-based links
-    filenames.add(file.relativePath.replace(/\.md$/, ''));
-  }
-  
-  return filenames;
-}
-
-/**
- * Discover files to audit.
- * When no type is specified, scans the entire vault.
- * When a type is specified, only scans that type's directories.
- */
-export async function discoverManagedFiles(
-  schema: Schema,
-  vaultDir: string,
-  typePath?: string
-): Promise<ManagedFile[]> {
-  if (typePath) {
-    // Specific type - only check that type's files
-    return collectFilesForType(schema, vaultDir, typePath);
-  }
-  
-  // No type specified - scan entire vault
-  const excluded = getExcludedDirectories(schema);
-  const gitignore = await loadGitignore(vaultDir);
-  return collectAllMarkdownFiles(vaultDir, vaultDir, excluded, gitignore);
-}
-
-/**
- * Recursively collect files for a type path.
- */
-async function collectFilesForType(
-  schema: Schema,
-  vaultDir: string,
-  typePath: string
-): Promise<ManagedFile[]> {
-  const typeDef = getTypeDefByPath(schema, typePath);
-  if (!typeDef) return [];
-
-  if (hasSubtypes(typeDef)) {
-    // Recurse into subtypes
-    const files: ManagedFile[] = [];
-    for (const subtype of getSubtypeKeys(typeDef)) {
-      const subFiles = await collectFilesForType(schema, vaultDir, `${typePath}/${subtype}`);
-      files.push(...subFiles);
-    }
-    return files;
-  }
-
-  // Leaf type - collect files from output_dir
-  const outputDir = getOutputDir(schema, typePath);
-  if (!outputDir) return [];
-
-  const dirMode = getDirMode(schema, typePath);
-
-  if (dirMode === 'instance-grouped') {
-    return collectInstanceGroupedFiles(vaultDir, outputDir, typePath);
-  } else {
-    return collectPooledFiles(vaultDir, outputDir, typePath);
-  }
-}
-
-/**
- * Collect files from a pooled (flat) directory.
- */
-export async function collectPooledFiles(
-  vaultDir: string,
-  outputDir: string,
-  expectedType: string
-): Promise<ManagedFile[]> {
-  const fullDir = join(vaultDir, outputDir);
-  if (!existsSync(fullDir)) return [];
-
-  const files: ManagedFile[] = [];
-  const entries = await readdir(fullDir, { withFileTypes: true });
-
-  for (const entry of entries) {
-    if (entry.isFile() && entry.name.endsWith('.md')) {
-      const fullPath = join(fullDir, entry.name);
-      files.push({
-        path: fullPath,
-        relativePath: join(outputDir, entry.name),
-        expectedType,
-      });
-    }
-  }
-
-  return files;
-}
-
-/**
- * Collect files from instance-grouped directories.
- */
-export async function collectInstanceGroupedFiles(
-  vaultDir: string,
-  outputDir: string,
-  expectedType: string
-): Promise<ManagedFile[]> {
-  const fullDir = join(vaultDir, outputDir);
-  if (!existsSync(fullDir)) return [];
-
-  const files: ManagedFile[] = [];
-  const entries = await readdir(fullDir, { withFileTypes: true });
-
-  for (const entry of entries) {
-    if (entry.isDirectory()) {
-      const instanceDir = join(fullDir, entry.name);
-      const instanceFiles = await readdir(instanceDir, { withFileTypes: true });
-
-      for (const file of instanceFiles) {
-        if (file.isFile() && file.name.endsWith('.md')) {
-          const fullPath = join(instanceDir, file.name);
-          files.push({
-            path: fullPath,
-            relativePath: join(outputDir, entry.name, file.name),
-            expectedType,
-            instance: entry.name,
-          });
-        }
-      }
-    }
-  }
-
-  return files;
 }
 
 // ============================================================================
@@ -662,96 +430,11 @@ function checkBodyStaleReferences(body: string, allFiles: Set<string>): AuditIss
   return issues;
 }
 
-/**
- * Find files with similar names to a target.
- * Uses simple string matching for now.
- */
-function findSimilarFiles(target: string, allFiles: Set<string>, maxResults = 5): string[] {
-  const targetLower = target.toLowerCase();
-  const results: { file: string; score: number }[] = [];
-  
-  for (const file of allFiles) {
-    const fileLower = file.toLowerCase();
-    const fileBasename = basename(file).toLowerCase();
-    
-    // Exact case-insensitive match (shouldn't happen if we're here, but just in case)
-    if (fileLower === targetLower) continue;
-    
-    // Calculate similarity score
-    let score = 0;
-    
-    // Prefix match
-    if (fileBasename.startsWith(targetLower) || targetLower.startsWith(fileBasename)) {
-      score += 50;
-    }
-    
-    // Contains match
-    if (fileBasename.includes(targetLower) || targetLower.includes(fileBasename)) {
-      score += 30;
-    }
-    
-    // Word overlap
-    const targetWords = targetLower.split(/[\s\-_]+/);
-    const fileWords = fileBasename.split(/[\s\-_]+/);
-    const overlap = targetWords.filter(w => fileWords.some(fw => fw.includes(w) || w.includes(fw)));
-    score += overlap.length * 10;
-    
-    // Levenshtein distance for short strings
-    if (targetLower.length < 20 && fileBasename.length < 20) {
-      const dist = levenshteinDistance(targetLower, fileBasename);
-      if (dist <= 3) {
-        score += (4 - dist) * 15;
-      }
-    }
-    
-    if (score > 0) {
-      results.push({ file, score });
-    }
-  }
-  
-  // Sort by score descending and return top results
-  results.sort((a, b) => b.score - a.score);
-  return results.slice(0, maxResults).map(r => r.file);
-}
-
-/**
- * Calculate Levenshtein distance between two strings.
- */
-function levenshteinDistance(a: string, b: string): number {
-  const aLen = a.length;
-  const bLen = b.length;
-  
-  const matrix: number[][] = Array.from({ length: aLen + 1 }, () => 
-    Array.from({ length: bLen + 1 }, () => 0)
-  );
-
-  for (let i = 0; i <= aLen; i++) {
-    matrix[i]![0] = i;
-  }
-  
-  for (let j = 0; j <= bLen; j++) {
-    matrix[0]![j] = j;
-  }
-
-  for (let i = 1; i <= aLen; i++) {
-    for (let j = 1; j <= bLen; j++) {
-      if (a[i - 1] === b[j - 1]) {
-        matrix[i]![j] = matrix[i - 1]![j - 1]!;
-      } else {
-        matrix[i]![j] = Math.min(
-          matrix[i - 1]![j - 1]! + 1,
-          matrix[i]![j - 1]! + 1,
-          matrix[i - 1]![j]! + 1
-        );
-      }
-    }
-  }
-
-  return matrix[aLen]![bLen]!;
-}
-
 // ============================================================================
 // Exports
 // ============================================================================
+
+// Re-export discovery functions for backward compatibility with existing imports
+export { discoverManagedFiles } from '../discovery.js';
 
 export { type ManagedFile, type AuditRunOptions };

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -105,15 +105,8 @@ export interface FixSummary {
 // Internal Types
 // ============================================================================
 
-/**
- * Managed file with expected type context.
- */
-export interface ManagedFile {
-  path: string;
-  relativePath: string;
-  expectedType?: string;
-  instance?: string;
-}
+// Re-export ManagedFile from discovery module (single source of truth)
+export type { ManagedFile } from '../discovery.js';
 
 /**
  * Audit command options.

--- a/src/lib/bulk/execute.ts
+++ b/src/lib/bulk/execute.ts
@@ -7,7 +7,7 @@ import { stat } from 'fs/promises';
 import { parseNote, writeNote } from '../frontmatter.js';
 import { matchesExpression, type EvalContext } from '../expression.js';
 import { matchesAllFilters } from '../query.js';
-import { discoverManagedFiles } from '../audit/detection.js';
+import { discoverManagedFiles } from '../discovery.js';
 import { applyOperations } from './operations.js';
 import { createBackup } from './backup.js';
 import { executeBulkMove, findAllMarkdownFiles } from './move.js';

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -38,7 +38,7 @@ export interface ManagedFile {
 /**
  * Load and parse .gitignore file if it exists.
  */
-async function loadGitignore(vaultDir: string): Promise<Ignore | null> {
+export async function loadGitignore(vaultDir: string): Promise<Ignore | null> {
   const gitignorePath = join(vaultDir, '.gitignore');
   try {
     const content = await readFile(gitignorePath, 'utf-8');

--- a/tests/ts/lib/discovery.test.ts
+++ b/tests/ts/lib/discovery.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestVault, cleanupTestVault, TEST_SCHEMA } from '../fixtures/setup.js';
+import {
+  loadGitignore,
+  getExcludedDirectories,
+  collectAllMarkdownFiles,
+  collectAllMarkdownFilenames,
+  discoverManagedFiles,
+  collectFilesForType,
+  collectPooledFiles,
+  collectInstanceGroupedFiles,
+  findSimilarFiles,
+  levenshteinDistance,
+  type ManagedFile,
+} from '../../../src/lib/discovery.js';
+import type { Schema } from '../../../src/types/schema.js';
+import { writeFile, mkdir, rm } from 'fs/promises';
+import { join } from 'path';
+
+describe('Discovery', () => {
+  let vaultDir: string;
+  const schema: Schema = TEST_SCHEMA as unknown as Schema;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  describe('loadGitignore', () => {
+    it('should return null when no .gitignore exists', async () => {
+      const result = await loadGitignore(vaultDir);
+      expect(result).toBeNull();
+    });
+
+    it('should load and parse .gitignore file', async () => {
+      await writeFile(join(vaultDir, '.gitignore'), 'node_modules/\n*.log');
+      const result = await loadGitignore(vaultDir);
+      
+      expect(result).not.toBeNull();
+      expect(result!.ignores('node_modules/foo')).toBe(true);
+      expect(result!.ignores('error.log')).toBe(true);
+      expect(result!.ignores('Ideas/Test.md')).toBe(false);
+    });
+  });
+
+  describe('getExcludedDirectories', () => {
+    it('should always exclude .ovault', () => {
+      const excluded = getExcludedDirectories(schema);
+      expect(excluded.has('.ovault')).toBe(true);
+    });
+
+    it('should include schema-configured exclusions', () => {
+      const excluded = getExcludedDirectories(schema);
+      expect(excluded.has('Templates')).toBe(true);
+    });
+
+    it('should respect OVAULT_AUDIT_EXCLUDE env var', () => {
+      const originalEnv = process.env.OVAULT_AUDIT_EXCLUDE;
+      try {
+        process.env.OVAULT_AUDIT_EXCLUDE = 'Archive,Drafts/';
+        const excluded = getExcludedDirectories(schema);
+        expect(excluded.has('Archive')).toBe(true);
+        expect(excluded.has('Drafts')).toBe(true); // Trailing slash normalized
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.OVAULT_AUDIT_EXCLUDE;
+        } else {
+          process.env.OVAULT_AUDIT_EXCLUDE = originalEnv;
+        }
+      }
+    });
+  });
+
+  describe('collectAllMarkdownFiles', () => {
+    it('should collect all markdown files recursively', async () => {
+      const excluded = new Set<string>();
+      const files = await collectAllMarkdownFiles(vaultDir, vaultDir, excluded, null);
+      
+      const paths = files.map(f => f.relativePath);
+      expect(paths).toContain('Ideas/Sample Idea.md');
+      expect(paths).toContain('Ideas/Another Idea.md');
+      expect(paths).toContain('Objectives/Tasks/Sample Task.md');
+    });
+
+    it('should respect excluded directories', async () => {
+      const excluded = new Set(['Templates']);
+      const files = await collectAllMarkdownFiles(vaultDir, vaultDir, excluded, null);
+      
+      const paths = files.map(f => f.relativePath);
+      expect(paths.some(p => p.startsWith('Templates/'))).toBe(false);
+    });
+
+    it('should skip hidden directories', async () => {
+      await mkdir(join(vaultDir, '.hidden'), { recursive: true });
+      await writeFile(join(vaultDir, '.hidden', 'secret.md'), '---\ntype: idea\n---\n');
+      
+      const excluded = new Set<string>();
+      const files = await collectAllMarkdownFiles(vaultDir, vaultDir, excluded, null);
+      
+      const paths = files.map(f => f.relativePath);
+      expect(paths.some(p => p.includes('.hidden'))).toBe(false);
+    });
+
+    it('should respect gitignore patterns', async () => {
+      await writeFile(join(vaultDir, '.gitignore'), 'Ideas/');
+      const gitignore = await loadGitignore(vaultDir);
+      
+      const excluded = new Set<string>();
+      const files = await collectAllMarkdownFiles(vaultDir, vaultDir, excluded, gitignore);
+      
+      const paths = files.map(f => f.relativePath);
+      expect(paths.some(p => p.startsWith('Ideas/'))).toBe(false);
+    });
+  });
+
+  describe('collectAllMarkdownFilenames', () => {
+    it('should return basenames without extension', async () => {
+      const filenames = await collectAllMarkdownFilenames(vaultDir);
+      
+      expect(filenames.has('Sample Idea')).toBe(true);
+      expect(filenames.has('Sample Task')).toBe(true);
+    });
+
+    it('should return relative paths without extension', async () => {
+      const filenames = await collectAllMarkdownFilenames(vaultDir);
+      
+      expect(filenames.has('Ideas/Sample Idea')).toBe(true);
+      expect(filenames.has('Objectives/Tasks/Sample Task')).toBe(true);
+    });
+  });
+
+  describe('discoverManagedFiles', () => {
+    it('should scan entire vault when no type specified', async () => {
+      const files = await discoverManagedFiles(schema, vaultDir);
+      
+      const paths = files.map(f => f.relativePath);
+      expect(paths).toContain('Ideas/Sample Idea.md');
+      expect(paths).toContain('Objectives/Tasks/Sample Task.md');
+    });
+
+    it('should only scan specific type when type specified', async () => {
+      const files = await discoverManagedFiles(schema, vaultDir, 'idea');
+      
+      const paths = files.map(f => f.relativePath);
+      expect(paths).toContain('Ideas/Sample Idea.md');
+      expect(paths.some(p => p.startsWith('Objectives/'))).toBe(false);
+    });
+
+    it('should scan parent type with subtypes recursively', async () => {
+      const files = await discoverManagedFiles(schema, vaultDir, 'objective');
+      
+      const paths = files.map(f => f.relativePath);
+      expect(paths).toContain('Objectives/Tasks/Sample Task.md');
+      expect(paths).toContain('Objectives/Milestones/Active Milestone.md');
+    });
+
+    it('should include expected type in results', async () => {
+      const files = await discoverManagedFiles(schema, vaultDir, 'idea');
+      
+      expect(files.every(f => f.expectedType === 'idea')).toBe(true);
+    });
+  });
+
+  describe('collectFilesForType', () => {
+    it('should collect files for a specific leaf type', async () => {
+      const files = await collectFilesForType(schema, vaultDir, 'objective/task');
+      
+      expect(files.length).toBeGreaterThan(0);
+      expect(files[0]!.expectedType).toBe('objective/task');
+    });
+
+    it('should return empty for invalid type', async () => {
+      const files = await collectFilesForType(schema, vaultDir, 'nonexistent');
+      expect(files).toEqual([]);
+    });
+  });
+
+  describe('collectPooledFiles', () => {
+    it('should collect files from a flat directory', async () => {
+      const files = await collectPooledFiles(vaultDir, 'Ideas', 'idea');
+      
+      const paths = files.map(f => f.relativePath);
+      expect(paths).toContain('Ideas/Sample Idea.md');
+      expect(paths).toContain('Ideas/Another Idea.md');
+    });
+
+    it('should set expectedType on all files', async () => {
+      const files = await collectPooledFiles(vaultDir, 'Ideas', 'idea');
+      expect(files.every(f => f.expectedType === 'idea')).toBe(true);
+    });
+
+    it('should return empty for non-existent directory', async () => {
+      const files = await collectPooledFiles(vaultDir, 'Nonexistent', 'test');
+      expect(files).toEqual([]);
+    });
+  });
+
+  describe('collectInstanceGroupedFiles', () => {
+    it('should collect files from instance-grouped directories', async () => {
+      // Create an instance-grouped structure
+      await mkdir(join(vaultDir, 'Projects/ProjectA'), { recursive: true });
+      await mkdir(join(vaultDir, 'Projects/ProjectB'), { recursive: true });
+      await writeFile(join(vaultDir, 'Projects/ProjectA', 'Note1.md'), '---\ntype: note\n---\n');
+      await writeFile(join(vaultDir, 'Projects/ProjectB', 'Note2.md'), '---\ntype: note\n---\n');
+      
+      const files = await collectInstanceGroupedFiles(vaultDir, 'Projects', 'project');
+      
+      expect(files.length).toBe(2);
+      expect(files.some(f => f.instance === 'ProjectA')).toBe(true);
+      expect(files.some(f => f.instance === 'ProjectB')).toBe(true);
+    });
+
+    it('should set instance field correctly', async () => {
+      await mkdir(join(vaultDir, 'Projects/MyProject'), { recursive: true });
+      await writeFile(join(vaultDir, 'Projects/MyProject', 'Test.md'), '---\ntype: note\n---\n');
+      
+      const files = await collectInstanceGroupedFiles(vaultDir, 'Projects', 'project');
+      
+      const file = files.find(f => f.relativePath.includes('MyProject'));
+      expect(file).toBeDefined();
+      expect(file!.instance).toBe('MyProject');
+    });
+  });
+
+  describe('findSimilarFiles', () => {
+    it('should find exact prefix matches', () => {
+      const allFiles = new Set(['Sample Idea', 'Sample Task', 'Another Idea', 'Project Notes']);
+      const similar = findSimilarFiles('Sample', allFiles);
+      
+      expect(similar).toContain('Sample Idea');
+      expect(similar).toContain('Sample Task');
+    });
+
+    it('should find files containing the target', () => {
+      const allFiles = new Set(['My Idea', 'Your Idea', 'Task List', 'Notes']);
+      const similar = findSimilarFiles('Idea', allFiles);
+      
+      expect(similar).toContain('My Idea');
+      expect(similar).toContain('Your Idea');
+    });
+
+    it('should find Levenshtein-close matches', () => {
+      const allFiles = new Set(['Project', 'Projet', 'Product', 'Progress']);
+      const similar = findSimilarFiles('Projct', allFiles);
+      
+      // "Project" has distance 1 from "Projct"
+      expect(similar).toContain('Project');
+    });
+
+    it('should limit results to maxResults', () => {
+      const allFiles = new Set(['Test1', 'Test2', 'Test3', 'Test4', 'Test5', 'Test6', 'Test7']);
+      const similar = findSimilarFiles('Test', allFiles, 3);
+      
+      expect(similar.length).toBeLessThanOrEqual(3);
+    });
+
+    it('should not include exact case-insensitive matches', () => {
+      const allFiles = new Set(['sample', 'Sample Idea', 'sample task']);
+      const similar = findSimilarFiles('sample', allFiles);
+      
+      // 'sample' should not be in results since it's an exact match
+      expect(similar).not.toContain('sample');
+    });
+  });
+
+  describe('levenshteinDistance', () => {
+    it('should return 0 for identical strings', () => {
+      expect(levenshteinDistance('test', 'test')).toBe(0);
+    });
+
+    it('should return string length for empty comparison', () => {
+      expect(levenshteinDistance('test', '')).toBe(4);
+      expect(levenshteinDistance('', 'test')).toBe(4);
+    });
+
+    it('should calculate single character changes', () => {
+      expect(levenshteinDistance('test', 'tast')).toBe(1); // substitution
+      expect(levenshteinDistance('test', 'tests')).toBe(1); // insertion
+      expect(levenshteinDistance('tests', 'test')).toBe(1); // deletion
+    });
+
+    it('should calculate multiple character changes', () => {
+      expect(levenshteinDistance('kitten', 'sitting')).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Consolidates duplicated file discovery functions from `audit/detection.ts` into the shared `discovery.ts` module
- Reduces code duplication by ~200 lines
- Adds comprehensive test suite for the discovery module (31 tests)

## Changes

### Removed from `audit/detection.ts`:
- `loadGitignore` 
- `getExcludedDirectories`
- `collectAllMarkdownFiles`
- `collectAllMarkdownFilenames`
- `discoverManagedFiles`
- `collectFilesForType`
- `collectPooledFiles`
- `collectInstanceGroupedFiles`
- `findSimilarFiles`
- `levenshteinDistance`

All these functions now live in `discovery.ts` as the single source of truth.

### New test coverage:
- `loadGitignore` parsing
- `getExcludedDirectories` with schema config and env vars
- `collectAllMarkdownFiles` with exclusions, hidden dirs, gitignore
- `discoverManagedFiles` for vault-wide and type-specific scans
- `collectPooledFiles` and `collectInstanceGroupedFiles` for different dir modes
- `findSimilarFiles` fuzzy matching
- `levenshteinDistance` algorithm

## Testing

All 536 tests pass.

Closes ovault-5jk