### PR TITLE
refactor: extract UserCancelledError to shared errors module

### DIFF
--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -29,17 +29,7 @@ import {
   ExitCodes,
 } from '../lib/output.js';
 import type { Schema, Field, BodySection } from '../types/schema.js';
-
-/**
- * Error thrown when user cancels an interactive prompt (Ctrl+C/Escape).
- * This allows cancellation to propagate cleanly without writing changes.
- */
-class UserCancelledError extends Error {
-  constructor() {
-    super('User cancelled');
-    this.name = 'UserCancelledError';
-  }
-}
+import { UserCancelledError } from '../lib/errors.js';
 
 interface EditCommandOptions {
   open?: boolean;

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -56,18 +56,7 @@ import {
   processTemplateBody,
 } from '../lib/template.js';
 import type { Schema, TypeDef, Field, BodySection, Template } from '../types/schema.js';
-
-/**
- * Error thrown when user cancels an interactive prompt (Ctrl+C/Escape).
- * This allows cancellation to propagate cleanly through the call stack
- * without creating side effects (like folders or partial files).
- */
-class UserCancelledError extends Error {
-  constructor() {
-    super('User cancelled');
-    this.name = 'UserCancelledError';
-  }
-}
+import { UserCancelledError } from '../lib/errors.js';
 
 interface NewCommandOptions {
   open?: boolean;

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -35,16 +35,7 @@ import {
   ExitCodes,
 } from '../lib/output.js';
 import type { Schema, Field, Template } from '../types/schema.js';
-
-/**
- * Error thrown when user cancels an interactive prompt (Ctrl+C/Escape).
- */
-class UserCancelledError extends Error {
-  constructor() {
-    super('User cancelled');
-    this.name = 'UserCancelledError';
-  }
-}
+import { UserCancelledError } from '../lib/errors.js';
 
 interface TemplateListOptions {
   output?: string;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared error types for ovault commands.
+ */
+
+/**
+ * Thrown when the user cancels an interactive prompt (Ctrl+C / Escape).
+ *
+ * Prompt functions in src/lib/prompt.ts return `null` on cancellation.
+ * Commands throw UserCancelledError to propagate cancellation up the call
+ * stack, where it's caught at the top level to print "Cancelled." and exit.
+ *
+ * @example
+ * ```ts
+ * const value = await promptInput('Enter name:');
+ * if (value === null) throw new UserCancelledError();
+ * ```
+ */
+export class UserCancelledError extends Error {
+  constructor() {
+    super('User cancelled');
+    this.name = 'UserCancelledError';
+  }
+}


### PR DESCRIPTION
## Summary

- Create `src/lib/errors.ts` with shared `UserCancelledError` class
- Remove duplicate class definitions from `new.ts`, `edit.ts`, and `template.ts`
- Import from the new shared module in all three command files

## Motivation

The `UserCancelledError` class was identically defined in 3 separate files. Consolidating to a single location:
- Reduces code duplication
- Provides a foundation for additional shared error types
- Makes the error handling pattern more discoverable

## Testing

- All 606 tests pass
- Verified `new`, `edit`, and `template` commands still handle cancellation correctly

Closes ovault-307