### PR TITLE
refactor: extract shared filter helpers from list and search commands

### DIFF
--- a/src/lib/expression.ts
+++ b/src/lib/expression.ts
@@ -81,6 +81,48 @@ export function matchesExpression(exprString: string, context: EvalContext): boo
   return Boolean(result);
 }
 
+/**
+ * Build evaluation context for expression filtering.
+ * Creates an EvalContext from a file path and its frontmatter.
+ */
+export async function buildEvalContext(
+  filePath: string,
+  vaultDir: string,
+  frontmatter: Record<string, unknown>
+): Promise<EvalContext> {
+  const { stat } = await import('fs/promises');
+  const { basename, dirname, relative } = await import('path');
+
+  const relativePath = relative(vaultDir, filePath);
+  const fileName = basename(filePath, '.md');
+  const folder = dirname(relativePath);
+
+  let fileInfo: EvalContext['file'] = {
+    name: fileName,
+    path: relativePath,
+    folder,
+    ext: '.md',
+  };
+
+  // Try to get file stats
+  try {
+    const stats = await stat(filePath);
+    fileInfo = {
+      ...fileInfo,
+      size: stats.size,
+      ctime: stats.birthtime,
+      mtime: stats.mtime,
+    };
+  } catch {
+    // Ignore stat errors
+  }
+
+  return {
+    frontmatter,
+    file: fileInfo,
+  };
+}
+
 // ============================================================================
 // Expression evaluators
 // ============================================================================


### PR DESCRIPTION
## Summary

- Extract `buildEvalContext()` from list.ts and search.ts to `src/lib/expression.ts`
- Add `applyFrontmatterFilters()` helper to `src/lib/query.ts` for combined simple/expression filtering
- Add comprehensive unit tests for both new functions

## Why

Both `list.ts` and `search.ts` had identical implementations of `buildEvalContext()` and very similar filtering logic. This refactoring:

1. **Reduces duplication** - ~137 lines removed, replaced with shared utilities
2. **Centralizes filter logic** - easier to maintain and extend
3. **Improves testability** - both functions now have direct unit tests

## Changes

| File | Change |
|------|--------|
| `src/lib/expression.ts` | Added `buildEvalContext()` function |
| `src/lib/query.ts` | Added `applyFrontmatterFilters()` helper and types |
| `src/commands/list.ts` | Now uses shared helpers |
| `src/commands/search.ts` | Now uses shared helpers |
| `tests/ts/lib/expression.test.ts` | Added 6 tests for `buildEvalContext` |
| `tests/ts/lib/query.test.ts` | Added 9 tests for `applyFrontmatterFilters` |

## Testing

All 670 tests pass (14 new tests added).

Closes ovault-dl5, ovault-qqu