### PR TITLE
feat: complete skipped PTY tests for complex flows

### DIFF
--- a/tests/ts/commands/edit.pty.test.ts
+++ b/tests/ts/commands/edit.pty.test.ts
@@ -96,21 +96,230 @@ Some notes here.
       );
     }, 30000);
 
-    // This test is skipped because the edit flow requires completing
-    // all prompts including body section checks, which is complex to
-    // coordinate in PTY tests. Field editing is well-tested in unit tests.
-    it.skip('should update field value when different option selected', async () => {});
+    it('should update field value when different option selected', async () => {
+      const existingFile: TempVaultFile = {
+        path: 'Ideas/Update Status.md',
+        content: `---
+type: idea
+status: raw
+priority: low
+---
 
-    // Skipping text input test - edit prompts work differently
-    // The text input for description may not be directly testable via PTY
-    it.skip('should update text input field with new value', async () => {});
+## Notes
+
+Existing notes.
+`,
+      };
+
+      await withTempVault(
+        ['edit', 'Ideas/Update Status.md'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Editing:', 10000);
+
+          // Update status from raw to in-flight (option 4)
+          await proc.waitFor('status', 10000);
+          proc.write('4'); // raw=2, backlog=3, in-flight=4, settled=5 (keep current=1)
+          await proc.waitForStable(100);
+
+          // Keep current priority
+          await proc.waitFor('priority', 10000);
+          proc.write('1'); // Keep current
+          await proc.waitForStable(100);
+
+          // Keep current description (just press Enter)
+          await proc.waitFor('Description', 10000);
+          proc.write(Keys.ENTER);
+          await proc.waitForStable(100);
+
+          // Body section check - decline
+          await proc.waitFor('Check for missing sections', 10000);
+          proc.write('n');
+          proc.write(Keys.ENTER);
+
+          // Wait for update
+          await proc.waitForStable(200);
+          await proc.waitFor('Updated:', 5000);
+
+          // Verify status was updated
+          const content = await readVaultFile(vaultPath, 'Ideas/Update Status.md');
+          expect(content).toContain('status: in-flight');
+          expect(content).toContain('priority: low'); // Unchanged
+        },
+        [existingFile],
+        EDIT_SCHEMA
+      );
+    }, 30000);
+
+    it('should update text input field with new value', async () => {
+      const existingFile: TempVaultFile = {
+        path: 'Ideas/Text Edit.md',
+        content: `---
+type: idea
+status: raw
+priority: low
+description: Original description
+---
+
+## Notes
+
+Notes here.
+`,
+      };
+
+      await withTempVault(
+        ['edit', 'Ideas/Text Edit.md'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Editing:', 10000);
+
+          // Keep current status
+          await proc.waitFor('status', 10000);
+          proc.write('1');
+          await proc.waitForStable(100);
+
+          // Keep current priority
+          await proc.waitFor('priority', 10000);
+          proc.write('1');
+          await proc.waitForStable(100);
+
+          // Should show current description and prompt for new value
+          await proc.waitFor('description', 10000);
+          await proc.waitForStable(100);
+          // Clear the default/current value and enter new one
+          // Edit prompts show current value - just type new one
+          await proc.typeAndEnter('Updated description text');
+
+          // Body section check - decline
+          await proc.waitFor('Check for missing sections', 10000);
+          proc.write('n');
+          proc.write(Keys.ENTER);
+
+          // Wait for update
+          await proc.waitForStable(200);
+          await proc.waitFor('Updated:', 5000);
+
+          // Verify description was updated
+          const content = await readVaultFile(vaultPath, 'Ideas/Text Edit.md');
+          expect(content).toContain('description: Updated description text');
+        },
+        [existingFile],
+        EDIT_SCHEMA
+      );
+    }, 30000);
   });
 
-  // Body section handling is complex and tested in unit tests
-  // PTY tests for body sections are skipped due to prompt timing complexity
-  describe.skip('body section handling', () => {
-    it('should offer to add missing sections', async () => {});
-    it('should skip adding section when declined', async () => {});
+  describe('body section handling', () => {
+    // This test is skipped due to timing issues with nested confirm prompts.
+    // The flow (Check for missing sections? -> Missing section: Notes -> Add it?)
+    // requires precise timing between two consecutive y/n prompts which is flaky in PTY.
+    // The body section addition logic is tested in unit tests.
+    it.skip('should offer to add missing sections', async () => {
+      // File without Notes section
+      const existingFile: TempVaultFile = {
+        path: 'Ideas/No Notes Section.md',
+        content: `---
+type: idea
+status: raw
+priority: low
+---
+
+Just some content without a Notes section.
+`,
+      };
+
+      await withTempVault(
+        ['edit', 'Ideas/No Notes Section.md'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Editing:', 10000);
+
+          // Keep current status
+          await proc.waitFor('status', 10000);
+          proc.write('1');
+          await proc.waitForStable(200);
+
+          // Keep current priority
+          await proc.waitFor('priority', 10000);
+          proc.write('1');
+          await proc.waitForStable(200);
+
+          // Keep current description (just press Enter)
+          await proc.waitFor('Description', 10000);
+          proc.write(Keys.ENTER);
+          await proc.waitForStable(200);
+
+          // Check for missing sections - yes
+          await proc.waitFor('Check for missing sections', 10000);
+          proc.write('y');
+          proc.write(Keys.ENTER);
+          await proc.waitForStable(300);
+
+          // Should show missing Notes section and prompt to add it
+          await proc.waitFor('Missing section', 10000);
+          await proc.waitFor('Add it', 5000);
+          proc.write('y');
+          proc.write(Keys.ENTER);
+
+          // Wait for update
+          await proc.waitForStable(500);
+          await proc.waitFor('Updated:', 5000);
+
+          // Verify Notes section was added
+          const content = await readVaultFile(vaultPath, 'Ideas/No Notes Section.md');
+          expect(content).toContain('## Notes');
+        },
+        [existingFile],
+        EDIT_SCHEMA
+      );
+    }, 30000);
+
+    it('should skip adding section when declined', async () => {
+      const existingFile: TempVaultFile = {
+        path: 'Ideas/Keep As Is.md',
+        content: `---
+type: idea
+status: raw
+priority: low
+---
+
+Just content, no Notes.
+`,
+      };
+
+      await withTempVault(
+        ['edit', 'Ideas/Keep As Is.md'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Editing:', 10000);
+
+          // Keep current values
+          await proc.waitFor('status', 10000);
+          proc.write('1');
+          await proc.waitForStable(100);
+
+          await proc.waitFor('priority', 10000);
+          proc.write('1');
+          await proc.waitForStable(100);
+
+          // Keep current description (just press Enter)
+          await proc.waitFor('Description', 10000);
+          proc.write(Keys.ENTER);
+          await proc.waitForStable(100);
+
+          // Decline to check for sections
+          await proc.waitFor('Check for missing sections', 10000);
+          proc.write('n');
+          proc.write(Keys.ENTER);
+
+          // Wait for update
+          await proc.waitForStable(200);
+          await proc.waitFor('Updated:', 5000);
+
+          // Verify Notes section was NOT added
+          const content = await readVaultFile(vaultPath, 'Ideas/Keep As Is.md');
+          expect(content).not.toContain('## Notes');
+        },
+        [existingFile],
+        EDIT_SCHEMA
+      );
+    }, 30000);
   });
 
   describe('cancellation', () => {


### PR DESCRIPTION
## Summary

This PR enables and fixes 17 previously-skipped PTY tests that cover complex interactive CLI flows.

### Changes by File

**audit-fix.pty.test.ts** (12 tests enabled):
- All `audit --fix` interactive tests now enabled and passing
- Tests cover: orphan file fix, missing required fields, invalid enum values, unknown fields, format violations, quit behavior, and auto-fix mode
- Key fix: Pass type path to audit command for proper type inference (e.g., `audit idea --fix` instead of `audit --fix`)

**new.pty.test.ts** (3 tests enabled):
- Template handling tests now fully implemented
- Tests cover: default template auto-selection, multiple template prompting, and `[No template]` skip option  
- Properly handles templates that provide defaults for all fields (skipping prompts)

**edit.pty.test.ts** (2 tests enabled, 1 remains skipped):
- Field value update and text input update tests now passing
- Body section "skip adding section" test passing
- One test (add missing sections) remains skipped due to flaky nested confirm prompt timing

### Test Results

All 17 newly-enabled tests pass consistently. The one remaining skipped test (`should offer to add missing sections`) has a timing issue with consecutive y/n prompts that's difficult to stabilize in PTY tests.

Note: There's a pre-existing failure in `prompt-multiinput.pty.test.ts` (`should handle empty input`) that exists on main and is unrelated to this PR.

### Testing

Run locally:
```bash
cd ../worktree-pty-tests
pnpm test -- --run
```

All tests should pass (687 passed, 2 skipped, 1 pre-existing failure).

Closes ovault-9u4