### PR TITLE
test: add tests for relative vault path handling

### DIFF
--- a/tests/ts/commands/relative-paths.pty.test.ts
+++ b/tests/ts/commands/relative-paths.pty.test.ts
@@ -1,0 +1,192 @@
+/**
+ * PTY-based tests for relative vault path handling.
+ *
+ * These tests verify that interactive commands work correctly when
+ * the vault is specified via a relative path.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  withTempVaultRelative,
+  vaultFileExists,
+  readVaultFile,
+  shouldSkipPtyTests,
+} from '../lib/pty-helpers.js';
+
+// Skip PTY tests if running in CI without TTY support or node-pty is incompatible
+const describePty = shouldSkipPtyTests() ? describe.skip : describe;
+
+// Schema for testing
+const TEST_SCHEMA = {
+  version: 1,
+  enums: {
+    status: ['raw', 'backlog', 'in-flight', 'settled'],
+    priority: ['low', 'medium', 'high'],
+  },
+  types: {
+    idea: {
+      output_dir: 'Ideas',
+      name_field: 'Idea name',
+      frontmatter: {
+        type: { value: 'idea' },
+        status: { prompt: 'select', enum: 'status', default: 'raw' },
+        priority: { prompt: 'select', enum: 'priority' },
+      },
+      frontmatter_order: ['type', 'status', 'priority'],
+    },
+  },
+};
+
+describePty('relative vault path PTY tests', () => {
+  describe('new command with relative vault path', () => {
+    it('should create note interactively with relative vault path', async () => {
+      await withTempVaultRelative(
+        ['new', 'idea'],
+        async (proc, vaultPath) => {
+          // Wait for name prompt
+          await proc.waitFor('Idea name', 10000);
+          await proc.typeAndEnter('Relative Path Interactive Test');
+
+          // Status selection - (skip) is first option, which uses default
+          await proc.waitFor('status', 10000);
+          proc.write('1'); // Skip - uses default 'raw'
+
+          // Priority selection - (skip)
+          await proc.waitFor('priority', 10000);
+          proc.write('1'); // Skip
+
+          // Wait for creation message
+          await proc.waitForStable(200);
+          await proc.waitFor('Created:', 5000);
+
+          // Verify file was created
+          const exists = await vaultFileExists(vaultPath, 'Ideas/Relative Path Interactive Test.md');
+          expect(exists).toBe(true);
+
+          // Verify content
+          const content = await readVaultFile(vaultPath, 'Ideas/Relative Path Interactive Test.md');
+          expect(content).toContain('type: idea');
+          expect(content).toContain('status: raw');
+        },
+        [],
+        TEST_SCHEMA
+      );
+    }, 30000);
+
+    it('should complete full prompts with relative vault path', async () => {
+      await withTempVaultRelative(
+        ['new', 'idea'],
+        async (proc, vaultPath) => {
+          // Wait for name prompt
+          await proc.waitFor('Idea name', 10000);
+          await proc.typeAndEnter('Full Prompts Relative');
+
+          // Status selection - select 'backlog' (option 3)
+          await proc.waitFor('status', 10000);
+          proc.write('3'); // Select 'backlog'
+
+          // Priority selection - select 'high' (option 4)
+          await proc.waitFor('priority', 10000);
+          proc.write('4'); // Select 'high'
+
+          // Wait for creation
+          await proc.waitForStable(200);
+          await proc.waitFor('Created:', 5000);
+
+          // Verify file exists with correct content
+          const exists = await vaultFileExists(vaultPath, 'Ideas/Full Prompts Relative.md');
+          expect(exists).toBe(true);
+
+          const content = await readVaultFile(vaultPath, 'Ideas/Full Prompts Relative.md');
+          expect(content).toContain('type: idea');
+          expect(content).toContain('status: backlog');
+          expect(content).toContain('priority: high');
+        },
+        [],
+        TEST_SCHEMA
+      );
+    }, 30000);
+
+    it('should show correct output paths with relative vault', async () => {
+      await withTempVaultRelative(
+        ['new', 'idea'],
+        async (proc, vaultPath) => {
+          // Complete the flow
+          await proc.waitFor('Idea name', 10000);
+          await proc.typeAndEnter('Path Display Test');
+
+          await proc.waitFor('status', 10000);
+          proc.write('1');
+
+          await proc.waitFor('priority', 10000);
+          proc.write('1');
+
+          await proc.waitForStable(200);
+          await proc.waitFor('Created:', 5000);
+
+          // The output should contain the file path
+          const output = proc.getOutput();
+          expect(output).toContain('Path Display Test');
+          expect(output).toContain('Created:');
+
+          // File should actually exist
+          const exists = await vaultFileExists(vaultPath, 'Ideas/Path Display Test.md');
+          expect(exists).toBe(true);
+        },
+        [],
+        TEST_SCHEMA
+      );
+    }, 30000);
+  });
+
+  describe('type navigation with relative vault path', () => {
+    it('should prompt for type with relative vault path', async () => {
+      await withTempVaultRelative(
+        ['new'],
+        async (proc) => {
+          // Should prompt for top-level type selection
+          await proc.waitFor('What would you like to create', 10000);
+
+          // Should show available types
+          const output = proc.getOutput();
+          expect(output).toContain('idea');
+
+          // Cancel
+          proc.write('\x03'); // Ctrl+C
+          await proc.waitForExit(5000);
+        },
+        [],
+        TEST_SCHEMA
+      );
+    }, 30000);
+  });
+
+  describe('cancellation with relative vault path', () => {
+    it('should cancel cleanly - no file created', async () => {
+      await withTempVaultRelative(
+        ['new', 'idea'],
+        async (proc, vaultPath) => {
+          // Wait for name prompt
+          await proc.waitFor('Idea name', 10000);
+
+          // Type partial name then cancel
+          await proc.typeText('Partial');
+          proc.write('\x03'); // Ctrl+C
+
+          // Wait for exit
+          await proc.waitForExit(5000);
+
+          // Should show cancellation
+          const output = proc.getOutput();
+          expect(output.includes('Cancelled') || output.includes('cancelled')).toBe(true);
+
+          // Verify no files created
+          const exists = await vaultFileExists(vaultPath, 'Ideas/Partial.md');
+          expect(exists).toBe(false);
+        },
+        [],
+        TEST_SCHEMA
+      );
+    }, 30000);
+  });
+});

--- a/tests/ts/commands/relative-paths.test.ts
+++ b/tests/ts/commands/relative-paths.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Integration tests for relative vault path handling.
+ *
+ * These tests verify that all CLI commands work correctly when
+ * the --vault option is given a relative path instead of an absolute path.
+ * This is important because users may run ovault from various directories
+ * and use relative paths like `--vault ./my-vault` or `--vault ../vaults/work`.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, rm, writeFile, mkdir } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { existsSync } from 'fs';
+import {
+  createTestVault,
+  cleanupTestVault,
+  runCLI,
+  getRelativeVaultPath,
+  PROJECT_ROOT,
+} from '../fixtures/setup.js';
+
+describe('relative vault path handling', () => {
+  let vaultDir: string;
+  let relativeVaultPath: string;
+
+  beforeAll(async () => {
+    vaultDir = await createTestVault();
+    // Get path relative to PROJECT_ROOT (where CLI runs from)
+    relativeVaultPath = getRelativeVaultPath(vaultDir);
+  });
+
+  afterAll(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  describe('list command', () => {
+    it('should work with relative --vault path', async () => {
+      const result = await runCLI(['--vault', relativeVaultPath, 'list', 'idea']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Sample Idea');
+      expect(result.stdout).toContain('Another Idea');
+    });
+
+    it('should work with subtypes using relative path', async () => {
+      const result = await runCLI(['--vault', relativeVaultPath, 'list', 'objective/task']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Sample Task');
+    });
+
+    it('should filter correctly with relative path', async () => {
+      const result = await runCLI(['--vault', relativeVaultPath, 'list', 'idea', '--status=raw']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Sample Idea');
+      expect(result.stdout).not.toContain('Another Idea');
+    });
+
+    it('should show paths correctly with relative vault', async () => {
+      const result = await runCLI(['--vault', relativeVaultPath, 'list', '--paths', 'idea']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Ideas/Sample Idea.md');
+    });
+  });
+
+  describe('search command', () => {
+    it('should work with relative --vault path', async () => {
+      // Use exact match to avoid ambiguous results
+      const result = await runCLI([
+        '--vault', relativeVaultPath, 'search', 'Sample Idea', '--picker', 'none',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Sample Idea');
+    });
+
+    it('should generate wikilinks with relative vault path', async () => {
+      const result = await runCLI([
+        '--vault', relativeVaultPath, 'search', '--wikilink', 'Sample Idea', '--picker', 'none',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('[[Sample Idea]]');
+    });
+
+    it('should show paths with relative vault path', async () => {
+      const result = await runCLI([
+        '--vault', relativeVaultPath, 'search', '--path', 'Sample Task', '--picker', 'none',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Objectives/Tasks/Sample Task.md');
+    });
+  });
+
+  describe('schema command', () => {
+    it('should load schema with relative vault path', async () => {
+      const result = await runCLI(['--vault', relativeVaultPath, 'schema', 'show']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('idea');
+      expect(result.stdout).toContain('objective');
+    });
+
+    it('should show type details with relative vault path', async () => {
+      const result = await runCLI(['--vault', relativeVaultPath, 'schema', 'show', 'idea']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('idea');
+      expect(result.stdout).toContain('Ideas');
+    });
+  });
+
+  describe('audit command', () => {
+    it('should audit with relative vault path', async () => {
+      const result = await runCLI(['--vault', relativeVaultPath, 'audit', 'idea']);
+
+      // Should succeed (exit 0) or report issues (exit 1), not crash
+      expect([0, 1]).toContain(result.exitCode);
+      // Should not have schema loading errors
+      expect(result.stderr).not.toContain('schema');
+    });
+
+    it('should audit all types with relative vault path', async () => {
+      const result = await runCLI(['--vault', relativeVaultPath, 'audit', '--all']);
+
+      expect([0, 1]).toContain(result.exitCode);
+    });
+  });
+
+  describe('new command (JSON mode)', () => {
+    it('should create note with relative vault path', async () => {
+      const json = JSON.stringify({
+        'Idea name': 'Relative Path Test Idea',
+        status: 'raw',
+        priority: 'low',
+      });
+      const result = await runCLI(['--vault', relativeVaultPath, 'new', 'idea', '--json', json]);
+
+      expect(result.exitCode).toBe(0);
+      // Parse JSON output - structure is { success: true, path: "..." }
+      const output = JSON.parse(result.stdout);
+      expect(output.success).toBe(true);
+      expect(output.path).toContain('Ideas/Relative Path Test Idea.md');
+
+      // Verify file was created
+      expect(existsSync(join(vaultDir, 'Ideas', 'Relative Path Test Idea.md'))).toBe(true);
+    });
+
+    it('should create subtype note with relative vault path', async () => {
+      const json = JSON.stringify({
+        'Task name': 'Relative Path Test Task',
+        status: 'backlog',
+      });
+      const result = await runCLI([
+        '--vault',
+        relativeVaultPath,
+        'new',
+        'objective/task',
+        '--json',
+        json,
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const output = JSON.parse(result.stdout);
+      expect(output.success).toBe(true);
+      expect(output.path).toContain('Objectives/Tasks/Relative Path Test Task.md');
+    });
+
+    it('should report validation errors with relative vault path', async () => {
+      const json = JSON.stringify({
+        'Idea name': 'Bad Idea',
+        status: 'invalid-status', // Invalid enum value
+      });
+      const result = await runCLI(['--vault', relativeVaultPath, 'new', 'idea', '--json', json]);
+
+      expect(result.exitCode).toBe(1);
+      const output = JSON.parse(result.stdout);
+      expect(output.success).toBe(false);
+    });
+  });
+
+  describe('template command', () => {
+    it('should list templates with relative vault path', async () => {
+      const result = await runCLI(['--vault', relativeVaultPath, 'template', 'list']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('idea');
+    });
+
+    it('should show template with relative vault path', async () => {
+      // template show requires both type and template name
+      const result = await runCLI([
+        '--vault', relativeVaultPath, 'template', 'show', 'idea', 'default',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('default');
+      expect(result.stdout).toContain('idea');
+    });
+  });
+
+  describe('bulk command', () => {
+    it('should preview bulk operation with relative vault path', async () => {
+      const result = await runCLI([
+        '--vault',
+        relativeVaultPath,
+        'bulk',
+        'idea',
+        '--set',
+        'status=backlog',
+        '--dry-run',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      // Dry run shows "Dry run - no changes will be made" instead of "Preview"
+      expect(result.stdout).toContain('Dry run');
+      expect(result.stdout).toContain('Would affect');
+    });
+  });
+});
+
+describe('edge cases', () => {
+  describe('vault path with spaces', () => {
+    let spacedVaultDir: string;
+
+    beforeAll(async () => {
+      // Create vault in temp dir with space in name
+      spacedVaultDir = await mkdtemp(join(tmpdir(), 'ovault test vault '));
+
+      // Create minimal vault structure
+      await mkdir(join(spacedVaultDir, '.ovault'), { recursive: true });
+      await mkdir(join(spacedVaultDir, 'Ideas'), { recursive: true });
+
+      await writeFile(
+        join(spacedVaultDir, '.ovault', 'schema.json'),
+        JSON.stringify({
+          version: 1,
+          enums: { status: ['raw', 'done'] },
+          types: {
+            idea: {
+              output_dir: 'Ideas',
+              name_field: 'Idea name',
+              frontmatter: {
+                type: { value: 'idea' },
+                status: { prompt: 'select', enum: 'status' },
+              },
+              frontmatter_order: ['type', 'status'],
+            },
+          },
+        })
+      );
+
+      await writeFile(
+        join(spacedVaultDir, 'Ideas', 'Spaced Idea.md'),
+        `---
+type: idea
+status: raw
+---
+`
+      );
+    });
+
+    afterAll(async () => {
+      await rm(spacedVaultDir, { recursive: true, force: true });
+    });
+
+    it('should handle vault path with spaces', async () => {
+      const relativePath = getRelativeVaultPath(spacedVaultDir);
+      const result = await runCLI(['--vault', relativePath, 'list', 'idea']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Spaced Idea');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should error gracefully for non-existent relative path', async () => {
+      const result = await runCLI(['--vault', './nonexistent/vault', 'list', 'idea']);
+
+      expect(result.exitCode).not.toBe(0);
+      // Should mention schema not found
+      expect(result.stderr.toLowerCase()).toMatch(/schema|not found|enoent/);
+    });
+
+    it('should error gracefully for invalid relative path', async () => {
+      const result = await runCLI(['--vault', '...///invalid', 'list', 'idea']);
+
+      expect(result.exitCode).not.toBe(0);
+    });
+  });
+});

--- a/tests/ts/fixtures/setup.ts
+++ b/tests/ts/fixtures/setup.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, rm, mkdir, writeFile, cp } from 'fs/promises';
-import { join } from 'path';
+import { join, relative } from 'path';
 import { tmpdir } from 'os';
 import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
@@ -7,8 +7,18 @@ import { dirname } from 'path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const PROJECT_ROOT = join(__dirname, '../../..');
+export const PROJECT_ROOT = join(__dirname, '../../..');
 const CLI_PATH = join(PROJECT_ROOT, 'dist/index.js');
+
+/**
+ * Get a relative path from the project root to the vault.
+ * Useful for testing CLI with relative --vault paths.
+ * @param vaultDir Absolute path to vault
+ * @returns Relative path from PROJECT_ROOT
+ */
+export function getRelativeVaultPath(vaultDir: string): string {
+  return relative(PROJECT_ROOT, vaultDir);
+}
 
 export const TEST_SCHEMA = {
   version: 2,

--- a/tests/ts/lib/vault.test.ts
+++ b/tests/ts/lib/vault.test.ts
@@ -54,6 +54,24 @@ describe('vault', () => {
       const result = resolveVaultDir({});
       expect(result).toBe(process.cwd());
     });
+
+    it('should preserve relative path from --vault option', () => {
+      delete process.env['OVAULT_VAULT'];
+      const result = resolveVaultDir({ vault: './my-vault' });
+      expect(result).toBe('./my-vault');
+    });
+
+    it('should preserve relative path from env var', () => {
+      process.env['OVAULT_VAULT'] = '../other-vault';
+      const result = resolveVaultDir({});
+      expect(result).toBe('../other-vault');
+    });
+
+    it('should preserve dotted relative path', () => {
+      delete process.env['OVAULT_VAULT'];
+      const result = resolveVaultDir({ vault: '../../some/nested/vault' });
+      expect(result).toBe('../../some/nested/vault');
+    });
   });
 
   describe('listFilesInDir', () => {


### PR DESCRIPTION
## Summary

- Add comprehensive test suite for relative vault path handling
- Verify all CLI commands work correctly when `--vault` is given a relative path
- Add PTY tests for interactive commands with relative vault paths

## Changes

**Test Infrastructure:**
- `tests/ts/fixtures/setup.ts`: Add `getRelativeVaultPath()` helper and export `PROJECT_ROOT`
- `tests/ts/lib/pty-helpers.ts`: Add `getRelativePath()` and `withTempVaultRelative()` helpers

**Unit Tests:**
- `tests/ts/lib/vault.test.ts`: Add 3 tests for `resolveVaultDir` with relative paths

**Integration Tests:**
- `tests/ts/commands/relative-paths.test.ts`: 20 tests covering:
  - `list` command with relative vault path
  - `search` command with relative vault path
  - `schema` command with relative vault path
  - `audit` command with relative vault path
  - `new` command (JSON mode) with relative vault path
  - `template` command with relative vault path
  - `bulk` command with relative vault path
  - Edge cases: vault paths with spaces, non-existent paths

**PTY Tests:**
- `tests/ts/commands/relative-paths.pty.test.ts`: 5 tests for interactive commands

## Testing

All 716 tests pass:
```
Test Files  32 passed (32)
Tests       716 passed | 1 skipped (717)
```

Closes ovault-ijd