### PR TITLE
Remove name_field, use standard 'name' field for JSON mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to ovault are documented in this file.
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **Removed `name_field` from schema** (ovault-jxd)
+  - The `name_field` property is no longer supported in schema definitions
+  - All types now use a standard `"name"` field in JSON mode payloads
+  - Interactive prompts show "Name:" for all types instead of custom labels
+  - **Migration required**: Remove all `name_field` entries from your `.ovault/schema.json`
+  - **JSON API change**: Use `{"name": "My Note"}` instead of `{"Task name": "My Note"}`
+
 ### Added
 
 - **Comprehensive integration tests for edit command** (ovault-deg)

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -45,10 +45,6 @@
           "type": "string",
           "description": "Directory path relative to vault root where files of this type are created"
         },
-        "name_field": {
-          "type": "string",
-          "description": "Label for the name prompt (default: 'Name')"
-        },
         "frontmatter": {
           "type": "object",
           "description": "Frontmatter field definitions in order",
@@ -83,10 +79,6 @@
           }
         },
         "output_dir": { "type": "string" },
-        "name_field": {
-          "type": "string",
-          "description": "Name field for type"
-        },
         "frontmatter": {
           "$ref": "#/definitions/typeDefinition/properties/frontmatter"
         },

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -91,12 +91,12 @@ Templates:
   ovault new task --no-template          # Skip templates, use schema only
 
 Non-interactive (JSON) mode:
-  ovault new idea --json '{"Name": "My Idea", "status": "raw"}'
-  ovault new objective/task --json '{"Name": "Fix bug", "status": "in-progress"}'
-  ovault new task --json '{"Name": "Bug"}' --template bug-report
+  ovault new idea --json '{"name": "My Idea", "status": "raw"}'
+  ovault new objective/task --json '{"name": "Fix bug", "status": "in-progress"}'
+  ovault new task --json '{"name": "Bug"}' --template bug-report
 
 Body sections (JSON mode):
-  ovault new task --json '{"Task name": "Fix bug", "_body": {"Steps": ["Step 1", "Step 2"]}}'
+  ovault new task --json '{"name": "Fix bug", "_body": {"Steps": ["Step 1", "Step 2"]}}'
   The _body field accepts section names as keys, with string or string[] values.
 
 Template Discovery:
@@ -326,11 +326,10 @@ async function createNoteFromJson(
     }
   }
 
-  // Get the name from the frontmatter
-  const nameField = typeDef.name_field ?? 'Name';
-  const itemName = frontmatter[nameField];
+  // Get the name from the frontmatter (always 'name')
+  const itemName = frontmatter['name'];
   if (!itemName || typeof itemName !== 'string') {
-    printJson(jsonError(`Missing or invalid name field: ${nameField}`));
+    printJson(jsonError(`Missing or invalid 'name' field`));
     process.exit(ExitCodes.VALIDATION_ERROR);
   }
 
@@ -677,8 +676,7 @@ async function createPooledNote(
   const fullOutputDir = join(vaultDir, outputDir);
 
   // Prompt for name
-  const nameField = typeDef.name_field ?? 'Name';
-  const itemName = await promptRequired(nameField);
+  const itemName = await promptRequired('Name');
   if (itemName === null) {
     throw new UserCancelledError();
   }
@@ -724,8 +722,7 @@ async function createInstanceParent(
   }
 
   // Prompt for instance name
-  const nameField = typeDef.name_field ?? 'Name';
-  const instanceName = await promptRequired(nameField);
+  const instanceName = await promptRequired('Name');
   if (instanceName === null) {
     throw new UserCancelledError();
   }

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -145,7 +145,6 @@ function outputTypeDetailsJson(schema: Schema, typePath: string): void {
     type_path: typePath,
     output_dir: typeDef.output_dir,
     dir_mode: typeAsType.dir_mode,
-    name_field: typeDef.name_field ?? 'Name',
     filename: (typeDef as { filename?: string }).filename,
     fields: Object.fromEntries(
       Object.entries(fields).map(([name, field]) => [
@@ -179,7 +178,6 @@ function formatTypeForJson(
   const result: Record<string, unknown> = {
     output_dir: typeDef.output_dir,
     dir_mode: typeAsType.dir_mode,
-    name_field: typeDef.name_field,
   };
 
   // Add subtypes if present
@@ -335,9 +333,6 @@ function showTypeDetails(schema: Schema, typePath: string): void {
   }
   if ((typeDef as Type).dir_mode) {
     console.log(`  ${chalk.cyan('Dir Mode:')} ${(typeDef as Type).dir_mode}`);
-  }
-  if (typeDef.name_field) {
-    console.log(`  ${chalk.cyan('Name Field:')} ${typeDef.name_field}`);
   }
   if ((typeDef as { filename?: string }).filename) {
     console.log(`  ${chalk.cyan('Filename Pattern:')} ${(typeDef as { filename?: string }).filename}`);

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -51,7 +51,6 @@ export const SubtypeSchema: z.ZodType<Subtype, z.ZodTypeDef, SubtypeInput> = z.l
   z.object({
     output_dir: z.string().optional(),
     filename: z.string().optional(),
-    name_field: z.string().optional(),
     shared_fields: z.array(z.string()).optional(), // Opt-in to shared fields
     field_overrides: z.record(FieldOverrideSchema).optional(), // Override shared field properties
     frontmatter: z.record(FieldSchema).optional(),
@@ -65,7 +64,6 @@ export const SubtypeSchema: z.ZodType<Subtype, z.ZodTypeDef, SubtypeInput> = z.l
 export const TypeSchema = z.object({
   output_dir: z.string().optional(), // Optional for parent types with subtypes
   dir_mode: z.enum(['pooled', 'instance-grouped']).optional().default('pooled'),
-  name_field: z.string().optional(),
   shared_fields: z.array(z.string()).optional(), // Opt-in to shared fields
   field_overrides: z.record(FieldOverrideSchema).optional(), // Override shared field properties
   frontmatter: z.record(FieldSchema).optional(),
@@ -115,7 +113,6 @@ export type DynamicSource = z.infer<typeof DynamicSourceSchema>;
 export type Subtype = {
   output_dir?: string | undefined;
   filename?: string | undefined;
-  name_field?: string | undefined;
   shared_fields?: string[] | undefined;
   field_overrides?: Record<string, FieldOverride> | undefined;
   frontmatter?: Record<string, Field> | undefined;
@@ -127,7 +124,6 @@ export type Subtype = {
 export type SubtypeInput = {
   output_dir?: string | undefined;
   filename?: string | undefined;
-  name_field?: string | undefined;
   shared_fields?: string[] | undefined;
   field_overrides?: Record<string, FieldOverride> | undefined;
   frontmatter?: Record<string, Field> | undefined;

--- a/tests/fixtures/test_schema.json
+++ b/tests/fixtures/test_schema.json
@@ -17,7 +17,6 @@
       "subtypes": {
         "task": {
           "output_dir": "Objectives/Tasks",
-          "name_field": "Task name",
           "frontmatter": {
             "type": { "value": "objective" },
             "objective-type": { "value": "task" },
@@ -59,7 +58,6 @@
         },
         "milestone": {
           "output_dir": "Objectives/Milestones",
-          "name_field": "Milestone name",
           "frontmatter": {
             "type": { "value": "objective" },
             "objective-type": { "value": "milestone" },
@@ -82,7 +80,6 @@
     },
     "idea": {
       "output_dir": "Ideas",
-      "name_field": "Idea name",
       "frontmatter": {
         "type": { "value": "idea" },
         "status": { "prompt": "select", "enum": "status", "default": "raw" },
@@ -95,7 +92,6 @@
       "subtypes": {
         "person": {
           "output_dir": "Entities/People",
-          "name_field": "Person name",
           "frontmatter": {
             "type": { "value": "entity" },
             "entity-type": { "value": "person" }

--- a/tests/fixtures/vault/.ovault/schema.json
+++ b/tests/fixtures/vault/.ovault/schema.json
@@ -19,7 +19,6 @@
       "subtypes": {
         "task": {
           "output_dir": "Objectives/Tasks",
-          "name_field": "Task name",
           "frontmatter": {
             "type": { "value": "objective" },
             "objective-type": { "value": "task" },
@@ -61,7 +60,6 @@
         },
         "milestone": {
           "output_dir": "Objectives/Milestones",
-          "name_field": "Milestone name",
           "frontmatter": {
             "type": { "value": "objective" },
             "objective-type": { "value": "milestone" },
@@ -84,7 +82,6 @@
     },
     "idea": {
       "output_dir": "Ideas",
-      "name_field": "Idea name",
       "frontmatter": {
         "type": { "value": "idea" },
         "status": { "prompt": "select", "enum": "status", "default": "raw" },
@@ -98,7 +95,6 @@
       "subtypes": {
         "person": {
           "output_dir": "Entities/People",
-          "name_field": "Person name",
           "frontmatter": {
             "type": { "value": "entity" },
             "entity-type": { "value": "person" }

--- a/tests/ts/commands/audit-fix.pty.test.ts
+++ b/tests/ts/commands/audit-fix.pty.test.ts
@@ -31,7 +31,6 @@ const AUDIT_SCHEMA = {
   types: {
     idea: {
       output_dir: 'Ideas',
-      name_field: 'Idea name',
       frontmatter: {
         type: { value: 'idea' },
         status: { prompt: 'select', enum: 'status', default: 'raw', required: true },
@@ -43,7 +42,6 @@ const AUDIT_SCHEMA = {
       subtypes: {
         task: {
           output_dir: 'Tasks',
-          name_field: 'Task name',
           frontmatter: {
             type: { value: 'objective' },
             'objective-type': { value: 'task' },
@@ -188,7 +186,6 @@ Missing required status.
         types: {
           item: {
             output_dir: 'Items',
-            name_field: 'Item name',
             frontmatter: {
               type: { value: 'item' },
               category: { prompt: 'select', enum: 'status', required: true }, // No default
@@ -421,7 +418,6 @@ some: value
         types: {
           item: {
             output_dir: 'Items',
-            name_field: 'Item name',
             frontmatter: {
               type: { value: 'item' },
               link: { prompt: 'input', format: 'wikilink' },
@@ -515,7 +511,6 @@ Auto-fixable orphan.
         types: {
           item: {
             output_dir: 'Items',
-            name_field: 'Item name',
             frontmatter: {
               type: { value: 'item' },
               category: { prompt: 'select', enum: 'status', required: true },

--- a/tests/ts/commands/edit.pty.test.ts
+++ b/tests/ts/commands/edit.pty.test.ts
@@ -31,7 +31,6 @@ const EDIT_SCHEMA = {
   types: {
     idea: {
       output_dir: 'Ideas',
-      name_field: 'Idea name',
       frontmatter: {
         type: { value: 'idea' },
         status: { prompt: 'select', enum: 'status', default: 'raw' },

--- a/tests/ts/commands/json-io.test.ts
+++ b/tests/ts/commands/json-io.test.ts
@@ -18,7 +18,7 @@ describe('JSON I/O', () => {
   describe('ovault new --json', () => {
     it('should create a note with JSON frontmatter', async () => {
       const result = await runCLI(
-        ['new', 'idea', '--json', '{"Idea name": "Test Idea", "status": "raw", "priority": "high"}'],
+        ['new', 'idea', '--json', '{"name": "Test Idea", "status": "raw", "priority": "high"}'],
         vaultDir
       );
 
@@ -39,7 +39,7 @@ describe('JSON I/O', () => {
 
     it('should error on missing required name field', async () => {
       const result = await runCLI(
-        ['new', 'idea', '--json', '{"status": "raw"}'],  // missing 'Idea name'
+        ['new', 'idea', '--json', '{"status": "raw"}'],  // missing 'name'
         vaultDir
       );
 
@@ -51,7 +51,7 @@ describe('JSON I/O', () => {
 
     it('should error on invalid enum value', async () => {
       const result = await runCLI(
-        ['new', 'idea', '--json', '{"Idea name": "Bad Idea", "status": "invalid-status"}'],
+        ['new', 'idea', '--json', '{"name": "Bad Idea", "status": "invalid-status"}'],
         vaultDir
       );
 
@@ -64,7 +64,7 @@ describe('JSON I/O', () => {
 
     it('should provide suggestions for typos', async () => {
       const result = await runCLI(
-        ['new', 'idea', '--json', '{"Idea name": "Typo Idea", "status": "rae"}'],
+        ['new', 'idea', '--json', '{"name": "Typo Idea", "status": "rae"}'],
         vaultDir
       );
 
@@ -75,7 +75,7 @@ describe('JSON I/O', () => {
 
     it('should apply defaults for missing optional fields', async () => {
       const result = await runCLI(
-        ['new', 'idea', '--json', '{"Idea name": "Minimal Idea"}'],
+        ['new', 'idea', '--json', '{"name": "Minimal Idea"}'],
         vaultDir
       );
 
@@ -90,7 +90,7 @@ describe('JSON I/O', () => {
 
     it('should error on unknown type', async () => {
       const result = await runCLI(
-        ['new', 'unknown-type', '--json', '{"Idea name": "Test"}'],
+        ['new', 'unknown-type', '--json', '{"name": "Test"}'],
         vaultDir
       );
 
@@ -114,7 +114,7 @@ describe('JSON I/O', () => {
 
     it('should require type in JSON mode', async () => {
       const result = await runCLI(
-        ['new', '--json', '{"Idea name": "No Type"}'],
+        ['new', '--json', '{"name": "No Type"}'],
         vaultDir
       );
 
@@ -128,7 +128,7 @@ describe('JSON I/O', () => {
       it('should create note with body sections from _body field', async () => {
         const result = await runCLI(
           ['new', 'objective/task', '--json', JSON.stringify({
-            'Task name': 'Test Task',
+            'name': 'Test Task',
             _body: {
               Steps: ['Step 1', 'Step 2', 'Step 3'],
             },
@@ -151,7 +151,7 @@ describe('JSON I/O', () => {
       it('should handle string content for paragraphs section', async () => {
         const result = await runCLI(
           ['new', 'objective/task', '--json', JSON.stringify({
-            'Task name': 'Notes Task',
+            'name': 'Notes Task',
             _body: {
               Notes: 'This is a paragraph of notes about the task.',
             },
@@ -172,7 +172,7 @@ describe('JSON I/O', () => {
       it('should handle multiple body sections', async () => {
         const result = await runCLI(
           ['new', 'objective/task', '--json', JSON.stringify({
-            'Task name': 'Multi Section Task',
+            'name': 'Multi Section Task',
             _body: {
               Steps: ['Step A', 'Step B'],
               Notes: 'Important notes here',
@@ -197,7 +197,7 @@ describe('JSON I/O', () => {
       it('should error on unknown body section', async () => {
         const result = await runCLI(
           ['new', 'objective/task', '--json', JSON.stringify({
-            'Task name': 'Bad Section Task',
+            'name': 'Bad Section Task',
             _body: {
               UnknownSection: ['Item'],
             },
@@ -215,7 +215,7 @@ describe('JSON I/O', () => {
       it('should error when _body is not an object', async () => {
         const result = await runCLI(
           ['new', 'objective/task', '--json', JSON.stringify({
-            'Task name': 'Bad Body Task',
+            'name': 'Bad Body Task',
             _body: 'not an object',
           })],
           vaultDir
@@ -230,7 +230,7 @@ describe('JSON I/O', () => {
       it('should error when _body is an array', async () => {
         const result = await runCLI(
           ['new', 'objective/task', '--json', JSON.stringify({
-            'Task name': 'Array Body Task',
+            'name': 'Array Body Task',
             _body: ['not', 'valid'],
           })],
           vaultDir
@@ -245,7 +245,7 @@ describe('JSON I/O', () => {
       it('should handle empty _body object', async () => {
         const result = await runCLI(
           ['new', 'objective/task', '--json', JSON.stringify({
-            'Task name': 'Empty Body Task',
+            'name': 'Empty Body Task',
             _body: {},
           })],
           vaultDir
@@ -263,7 +263,7 @@ describe('JSON I/O', () => {
       it('should handle null _body', async () => {
         const result = await runCLI(
           ['new', 'objective/task', '--json', JSON.stringify({
-            'Task name': 'Null Body Task',
+            'name': 'Null Body Task',
             _body: null,
           })],
           vaultDir
@@ -277,7 +277,7 @@ describe('JSON I/O', () => {
       it('should not include _body in frontmatter', async () => {
         const result = await runCLI(
           ['new', 'objective/task', '--json', JSON.stringify({
-            'Task name': 'Body Not In FM',
+            'name': 'Body Not In FM',
             _body: {
               Steps: ['Step 1'],
             },

--- a/tests/ts/commands/new.pty.test.ts
+++ b/tests/ts/commands/new.pty.test.ts
@@ -43,7 +43,6 @@ const FULL_SCHEMA = {
       subtypes: {
         task: {
           output_dir: 'Tasks',
-          name_field: 'Task name',
           frontmatter: {
             type: { value: 'objective' },
             'objective-type': { value: 'task' },
@@ -58,7 +57,6 @@ const FULL_SCHEMA = {
         },
         milestone: {
           output_dir: 'Milestones',
-          name_field: 'Milestone name',
           frontmatter: {
             type: { value: 'objective' },
             'objective-type': { value: 'milestone' },
@@ -70,7 +68,6 @@ const FULL_SCHEMA = {
     },
     idea: {
       output_dir: 'Ideas',
-      name_field: 'Idea name',
       frontmatter: {
         type: { value: 'idea' },
         status: { prompt: 'select', enum: 'status', default: 'raw' },
@@ -92,7 +89,7 @@ describePty('ovault new command PTY tests', () => {
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Complete Flow Test');
 
           // Status selection - options: (skip), raw, backlog, in-flight, settled
@@ -139,7 +136,7 @@ status: in-flight
         ['new', 'objective/task'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Task name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Full Task Flow');
 
           // Status selection - (skip) uses default 'raw'
@@ -212,7 +209,7 @@ status: in-flight
           await proc.waitForStable(100);
 
           // Should now be at task name prompt
-          await proc.waitFor('Task name', 10000);
+          await proc.waitFor('Name', 10000);
 
           proc.write(Keys.CTRL_C);
         },
@@ -232,7 +229,7 @@ status: in-flight
           await proc.waitForStable(100);
 
           // Should now ask for idea name
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Type Nav Test');
 
           // Complete remaining prompts
@@ -259,7 +256,7 @@ status: in-flight
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
 
           // Type partial name then cancel
           await proc.typeText('Partial');
@@ -287,7 +284,7 @@ status: in-flight
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Complete name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Selection Cancel');
 
           // Wait for status selection
@@ -312,7 +309,7 @@ status: in-flight
         ['new', 'objective/task'],
         async (proc, vaultPath) => {
           // Complete frontmatter prompts
-          await proc.waitFor('Task name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Body Cancel Test');
 
           await proc.waitFor('status', 10000);
@@ -391,7 +388,7 @@ defaults:
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Should go directly to name prompt (no template selection)
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Template Default Test');
 
           // Template provides defaults for all fields, so creation happens immediately
@@ -460,7 +457,7 @@ defaults:
           await proc.waitForStable(100);
 
           // Now name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Multi Template Test');
 
           // Template provides defaults for all fields, creation happens immediately
@@ -502,7 +499,7 @@ Template body content
           await proc.waitForStable(100);
 
           // Name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('No Template Test');
 
           // Complete prompts - no defaults from template
@@ -530,7 +527,7 @@ Template body content
         ['new', 'idea'],
         async (proc) => {
           // Wait for name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Skip Option Test');
 
           // Status is not required, should show skip option
@@ -551,7 +548,7 @@ Template body content
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Default Via Skip');
 
           // Select skip for status (should use default 'raw')

--- a/tests/ts/commands/new.test.ts
+++ b/tests/ts/commands/new.test.ts
@@ -64,7 +64,7 @@ describe('new command', () => {
   describe('template flags (JSON mode)', () => {
     it('should error when --template specifies non-existent template', async () => {
       const result = await runCLI(
-        ['new', 'idea', '--json', '{"Idea name": "Test"}', '--template', 'nonexistent'],
+        ['new', 'idea', '--json', '{"name": "Test"}', '--template', 'nonexistent'],
         vaultDir
       );
 
@@ -76,7 +76,7 @@ describe('new command', () => {
 
     it('should error when --default but no default.md exists', async () => {
       const result = await runCLI(
-        ['new', 'objective/milestone', '--json', '{"Milestone name": "Test"}', '--default'],
+        ['new', 'objective/milestone', '--json', '{"name": "Test"}', '--default'],
         vaultDir
       );
 
@@ -89,7 +89,7 @@ describe('new command', () => {
     it('should create note with --template flag applying defaults', async () => {
       // bug-report template has defaults: status: backlog
       const result = await runCLI(
-        ['new', 'objective/task', '--json', '{"Task name": "Fix the bug"}', '--template', 'bug-report'],
+        ['new', 'objective/task', '--json', '{"name": "Fix the bug"}', '--template', 'bug-report'],
         vaultDir
       );
 
@@ -108,7 +108,7 @@ describe('new command', () => {
     it('should create note with --default flag', async () => {
       // default.md for idea has defaults: status: raw, priority: medium
       const result = await runCLI(
-        ['new', 'idea', '--json', '{"Idea name": "My Great Idea"}', '--default'],
+        ['new', 'idea', '--json', '{"name": "My Great Idea"}', '--default'],
         vaultDir
       );
 
@@ -127,7 +127,7 @@ describe('new command', () => {
       // Template defaults status: raw, priority: medium
       // JSON input overrides priority to high
       const result = await runCLI(
-        ['new', 'idea', '--json', '{"Idea name": "Override Test", "priority": "high"}', '--default'],
+        ['new', 'idea', '--json', '{"name": "Override Test", "priority": "high"}', '--default'],
         vaultDir
       );
 
@@ -142,7 +142,7 @@ describe('new command', () => {
 
     it('should use schema-only when --no-template specified', async () => {
       const result = await runCLI(
-        ['new', 'idea', '--json', '{"Idea name": "Schema Only", "status": "raw"}', '--no-template'],
+        ['new', 'idea', '--json', '{"name": "Schema Only", "status": "raw"}', '--no-template'],
         vaultDir
       );
 
@@ -159,7 +159,7 @@ describe('new command', () => {
 
     it('should substitute {title} in template body', async () => {
       const result = await runCLI(
-        ['new', 'idea', '--json', '{"Idea name": "Substitution Test"}', '--default'],
+        ['new', 'idea', '--json', '{"name": "Substitution Test"}', '--default'],
         vaultDir
       );
 

--- a/tests/ts/commands/relative-paths.pty.test.ts
+++ b/tests/ts/commands/relative-paths.pty.test.ts
@@ -26,7 +26,6 @@ const TEST_SCHEMA = {
   types: {
     idea: {
       output_dir: 'Ideas',
-      name_field: 'Idea name',
       frontmatter: {
         type: { value: 'idea' },
         status: { prompt: 'select', enum: 'status', default: 'raw' },
@@ -44,7 +43,7 @@ describePty('relative vault path PTY tests', () => {
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Relative Path Interactive Test');
 
           // Status selection - (skip) is first option, which uses default
@@ -77,7 +76,7 @@ describePty('relative vault path PTY tests', () => {
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Full Prompts Relative');
 
           // Status selection - select 'backlog' (option 3)
@@ -110,7 +109,7 @@ describePty('relative vault path PTY tests', () => {
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Complete the flow
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Path Display Test');
 
           await proc.waitFor('status', 10000);
@@ -163,7 +162,7 @@ describePty('relative vault path PTY tests', () => {
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
 
           // Type partial name then cancel
           await proc.typeText('Partial');

--- a/tests/ts/commands/relative-paths.test.ts
+++ b/tests/ts/commands/relative-paths.test.ts
@@ -133,7 +133,7 @@ describe('relative vault path handling', () => {
   describe('new command (JSON mode)', () => {
     it('should create note with relative vault path', async () => {
       const json = JSON.stringify({
-        'Idea name': 'Relative Path Test Idea',
+        'name': 'Relative Path Test Idea',
         status: 'raw',
         priority: 'low',
       });
@@ -151,7 +151,7 @@ describe('relative vault path handling', () => {
 
     it('should create subtype note with relative vault path', async () => {
       const json = JSON.stringify({
-        'Task name': 'Relative Path Test Task',
+        'name': 'Relative Path Test Task',
         status: 'backlog',
       });
       const result = await runCLI([
@@ -171,7 +171,7 @@ describe('relative vault path handling', () => {
 
     it('should report validation errors with relative vault path', async () => {
       const json = JSON.stringify({
-        'Idea name': 'Bad Idea',
+        'name': 'Bad Idea',
         status: 'invalid-status', // Invalid enum value
       });
       const result = await runCLI(['--vault', relativeVaultPath, 'new', 'idea', '--json', json]);
@@ -242,7 +242,6 @@ describe('edge cases', () => {
           types: {
             idea: {
               output_dir: 'Ideas',
-              name_field: 'Idea name',
               frontmatter: {
                 type: { value: 'idea' },
                 status: { prompt: 'select', enum: 'status' },

--- a/tests/ts/fixtures/setup.ts
+++ b/tests/ts/fixtures/setup.ts
@@ -53,7 +53,6 @@ export const TEST_SCHEMA = {
       subtypes: {
         task: {
           output_dir: 'Objectives/Tasks',
-          name_field: 'Task name',
           shared_fields: ['status', 'tags'],
           field_overrides: {
             status: { default: 'backlog' },
@@ -73,7 +72,6 @@ export const TEST_SCHEMA = {
         },
         milestone: {
           output_dir: 'Objectives/Milestones',
-          name_field: 'Milestone name',
           shared_fields: ['status'],
           frontmatter: {
             type: { value: 'objective' },
@@ -85,7 +83,6 @@ export const TEST_SCHEMA = {
     },
     idea: {
       output_dir: 'Ideas',
-      name_field: 'Idea name',
       shared_fields: ['status'],
       frontmatter: {
         type: { value: 'idea' },

--- a/tests/ts/lib/numberedSelect.pty.test.ts
+++ b/tests/ts/lib/numberedSelect.pty.test.ts
@@ -47,7 +47,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
 
       try {
         // Wait for the task name prompt
-        await proc.waitFor('Task name', 10000);
+        await proc.waitFor('Name', 10000);
 
         // Enter a task name
         proc.write('Test Task for PTY\r');
@@ -104,7 +104,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
 
       try {
         // Wait for task name prompt
-        await proc.waitFor('Task name', 10000);
+        await proc.waitFor('Name', 10000);
         proc.write('PTY Test Task\r');
 
         // Wait for milestone prompt
@@ -147,7 +147,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
 
       try {
         // Wait for task name prompt
-        await proc.waitFor('Task name', 10000);
+        await proc.waitFor('Name', 10000);
         proc.write('Abort Test\r');
 
         // Wait for milestone prompt (a select prompt)
@@ -225,7 +225,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
 
       try {
         // Get to milestone prompt
-        await proc.waitFor('Task name', 10000);
+        await proc.waitFor('Name', 10000);
         proc.write('Navigation Test\r');
         await proc.waitFor('milestone', 10000);
 
@@ -272,7 +272,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
       });
 
       try {
-        await proc.waitFor('Task name', 10000);
+        await proc.waitFor('Name', 10000);
         proc.write('Arrow Nav Test\r');
         await proc.waitFor('milestone', 10000);
 
@@ -321,7 +321,6 @@ describePty('NumberedSelectPrompt PTY tests', () => {
       types: {
         item: {
           output_dir: 'Items',
-          name_field: 'Item name',
           frontmatter: {
             type: { value: 'item' },
             category: { prompt: 'select', enum: 'category', required: true },
@@ -336,7 +335,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
         ['new', 'item'],
         async (proc) => {
           // Wait for name prompt
-          await proc.waitFor('Item name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Pagination Test');
 
           // Wait for category prompt (15 items, so pagination)
@@ -361,7 +360,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
         ['new', 'item'],
         async (proc) => {
           // Wait for name prompt
-          await proc.waitFor('Item name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Page Nav Test');
 
           // Wait for category prompt
@@ -393,7 +392,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
         ['new', 'item'],
         async (proc) => {
           // Wait for name prompt
-          await proc.waitFor('Item name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Prev Page Test');
 
           // Wait for category prompt
@@ -428,7 +427,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
         ['new', 'item'],
         async (proc) => {
           // Wait for name prompt
-          await proc.waitFor('Item name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Page 2 Select');
 
           // Wait for category prompt
@@ -460,7 +459,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
         ['new', 'item'],
         async (proc) => {
           // Wait for name prompt
-          await proc.waitFor('Item name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Last Page Test');
 
           // Wait for category prompt
@@ -492,7 +491,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
         ['new', 'item'],
         async (proc) => {
           // Wait for name prompt
-          await proc.waitFor('Item name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('First Page Test');
 
           // Wait for category prompt
@@ -520,7 +519,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
         ['new', 'item'],
         async (proc) => {
           // Wait for name prompt
-          await proc.waitFor('Item name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Equals Key Test');
 
           // Wait for category prompt
@@ -557,7 +556,6 @@ describePty('NumberedSelectPrompt PTY tests', () => {
         types: {
           item: {
             output_dir: 'Items',
-            name_field: 'Item name',
             frontmatter: {
               type: { value: 'item' },
               ref: { prompt: 'dynamic', source: 'nonexistent', format: 'wikilink' },
@@ -571,7 +569,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
         ['new', 'item'],
         async (proc) => {
           // Wait for name prompt
-          await proc.waitFor('Item name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Empty Test');
 
           // Should show message about no options
@@ -597,7 +595,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
 
       try {
         // Wait for task name prompt
-        await proc.waitFor('Task name', 10000);
+        await proc.waitFor('Name', 10000);
         proc.write('Escape Test\r');
 
         // Wait for milestone prompt

--- a/tests/ts/lib/prompt-confirm.pty.test.ts
+++ b/tests/ts/lib/prompt-confirm.pty.test.ts
@@ -31,7 +31,6 @@ const EDIT_TEST_SCHEMA = {
   types: {
     idea: {
       output_dir: 'Ideas',
-      name_field: 'Idea name',
       frontmatter: {
         type: { value: 'idea' },
         status: { prompt: 'select', enum: 'status', default: 'raw' },
@@ -67,7 +66,7 @@ Original content.
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
 
           // Enter name that matches existing file
           await proc.typeAndEnter('Confirm Test');
@@ -241,7 +240,7 @@ Original content.
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
 
           // Enter name that matches existing file
           await proc.typeAndEnter('Existing Idea');
@@ -289,7 +288,7 @@ Keep this content.
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
 
           // Enter name that matches existing file
           await proc.typeAndEnter('Keep This');

--- a/tests/ts/lib/prompt-input.pty.test.ts
+++ b/tests/ts/lib/prompt-input.pty.test.ts
@@ -35,7 +35,7 @@ describePty('Text Input Prompt PTY tests', () => {
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Wait for the name prompt (idea name is required)
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
 
           // Type a name and press Enter
           await proc.typeAndEnter('My Test Idea');
@@ -66,7 +66,7 @@ describePty('Text Input Prompt PTY tests', () => {
         ['new', 'idea'],
         async (proc) => {
           // Wait for the name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
 
           // Press Enter without typing anything
           proc.write(Keys.ENTER);
@@ -91,7 +91,7 @@ describePty('Text Input Prompt PTY tests', () => {
 
       try {
         // Wait for the name prompt
-        await proc.waitFor('Idea name', 10000);
+        await proc.waitFor('Name', 10000);
 
         // Press Ctrl+C to cancel
         proc.write(Keys.CTRL_C);
@@ -123,7 +123,6 @@ describePty('Text Input Prompt PTY tests', () => {
         types: {
           task: {
             output_dir: 'Tasks',
-            name_field: 'Task name',
             frontmatter: {
               type: { value: 'task' },
               deadline: { prompt: 'input', label: 'Deadline' },
@@ -137,7 +136,7 @@ describePty('Text Input Prompt PTY tests', () => {
         ['new', 'task'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Task name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Test Task');
 
           // Wait for deadline prompt (optional)
@@ -165,7 +164,6 @@ describePty('Text Input Prompt PTY tests', () => {
         types: {
           note: {
             output_dir: 'Notes',
-            name_field: 'Note name',
             frontmatter: {
               type: { value: 'note' },
               category: { prompt: 'input', label: 'Category', default: 'general' },
@@ -179,7 +177,7 @@ describePty('Text Input Prompt PTY tests', () => {
         ['new', 'note'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Note name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Test Note');
 
           // Wait for category prompt
@@ -210,7 +208,7 @@ describePty('Text Input Prompt PTY tests', () => {
         ['new', 'idea'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Idea name', 10000);
+          await proc.waitFor('Name', 10000);
 
           // Type some text, then backspace and correct
           await proc.typeText('Test Ideaa');

--- a/tests/ts/lib/prompt-multiinput.pty.test.ts
+++ b/tests/ts/lib/prompt-multiinput.pty.test.ts
@@ -36,7 +36,6 @@ const TASK_SCHEMA = {
   types: {
     task: {
       output_dir: 'Tasks',
-      name_field: 'Task name',
       frontmatter: {
         type: { value: 'task' },
         status: { prompt: 'select', enum: 'status', default: 'raw' },
@@ -71,7 +70,7 @@ describePty('Multi-Input Prompt PTY tests', () => {
         ['new', 'task'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Task name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Test Task');
 
           // Wait for status selection
@@ -108,7 +107,7 @@ describePty('Multi-Input Prompt PTY tests', () => {
         ['new', 'task'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Task name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Empty Steps Task');
 
           // Wait for status selection
@@ -143,7 +142,7 @@ describePty('Multi-Input Prompt PTY tests', () => {
         ['new', 'task'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Task name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Cancel Test');
 
           // Wait for status selection
@@ -181,7 +180,7 @@ describePty('Multi-Input Prompt PTY tests', () => {
         ['new', 'task'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Task name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Single Step Task');
 
           // Wait for status selection
@@ -214,7 +213,7 @@ describePty('Multi-Input Prompt PTY tests', () => {
         ['new', 'task'],
         async (proc, vaultPath) => {
           // Wait for name prompt
-          await proc.waitFor('Task name', 10000);
+          await proc.waitFor('Name', 10000);
           await proc.typeAndEnter('Whitespace Task');
 
           // Wait for status selection

--- a/tests/ts/lib/pty-helpers.ts
+++ b/tests/ts/lib/pty-helpers.ts
@@ -282,7 +282,7 @@ export class PtyProcess {
  * @example
  * ```ts
  * const proc = await spawnOvault(['new', 'objective/task'], { cwd: testVaultPath });
- * await proc.waitFor('Task name');
+ * await proc.waitFor('Name');
  * proc.write('My Task\r');
  * ```
  */
@@ -391,7 +391,6 @@ export const MINIMAL_SCHEMA = {
   types: {
     idea: {
       output_dir: 'Ideas',
-      name_field: 'Idea name',
       frontmatter: {
         type: { value: 'idea' },
         status: { prompt: 'select', enum: 'status', default: 'raw' },

--- a/tests/ts/lib/validation.test.ts
+++ b/tests/ts/lib/validation.test.ts
@@ -31,7 +31,6 @@ const TEST_SCHEMA: Schema = {
     idea: {
       dir_mode: 'pooled',
       output_dir: 'Ideas',
-      name_field: 'Name',
       shared_fields: ['status'],
       frontmatter: {
         type: { value: 'idea' },
@@ -42,7 +41,6 @@ const TEST_SCHEMA: Schema = {
     task: {
       dir_mode: 'pooled',
       output_dir: 'Tasks',
-      name_field: 'Name',
       shared_fields: ['status', 'tags'],
       frontmatter: {
         type: { value: 'task' },


### PR DESCRIPTION
## Summary

- Remove `name_field` schema property - all types now use standard `"name"` field in JSON mode
- Interactive prompts show "Name:" for all types instead of custom labels like "Task name"
- Simplifies JSON payloads for programmatic use: `{"name": "Fix bug"}` instead of `{"Task name": "Fix bug"}`

## Breaking Changes

- **Schema change**: Remove all `name_field` entries from `.ovault/schema.json`
- **JSON API change**: Use `{"name": "..."}` in JSON mode instead of type-specific names

## Migration

After updating ovault, edit your vault's `.ovault/schema.json` and remove all `name_field` lines.

Closes ovault-jxd