### PR TITLE
Add ovault template delete command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to ovault are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`ovault template delete` command** (ovault-3gb)
+  - Delete templates via CLI: `ovault template delete <type> <name>`
+  - Interactive confirmation prompt (use `--force` to skip)
+  - JSON output mode with `--output json`
+  - Completes the template CRUD cycle (list, show, new, edit, delete)
+
 ### Breaking Changes
 
 - **Removed `name_field` from schema** (ovault-jxd)

--- a/tests/ts/commands/template.pty.test.ts
+++ b/tests/ts/commands/template.pty.test.ts
@@ -214,4 +214,76 @@ describePty('template command PTY tests', () => {
       );
     }, 15000);
   });
+
+  describe('template delete (interactive)', () => {
+    it('should delete template when confirmed with y', async () => {
+      await withTempVault(
+        ['template', 'delete', 'idea', 'default'],
+        async (proc, vaultPath) => {
+          const templatePath = join(vaultPath, '.ovault/templates/idea', 'default.md');
+          
+          // Verify file exists before delete
+          expect(existsSync(templatePath)).toBe(true);
+
+          // Wait for confirmation prompt
+          await proc.waitFor("Delete template 'default'", 10000);
+          proc.write('y');
+
+          // Wait for success message
+          await proc.waitFor('Deleted:', 5000);
+
+          // Verify file was deleted
+          expect(existsSync(templatePath)).toBe(false);
+        },
+        { files: [DEFAULT_IDEA_TEMPLATE], schema: TEST_SCHEMA }
+      );
+    }, 15000);
+
+    it('should not delete template when declined with n', async () => {
+      await withTempVault(
+        ['template', 'delete', 'idea', 'default'],
+        async (proc, vaultPath) => {
+          const templatePath = join(vaultPath, '.ovault/templates/idea', 'default.md');
+          
+          // Verify file exists before
+          expect(existsSync(templatePath)).toBe(true);
+
+          // Wait for confirmation prompt
+          await proc.waitFor("Delete template 'default'", 10000);
+          proc.write('n');
+
+          // Wait for cancellation message
+          await proc.waitFor('Cancelled', 5000);
+
+          // Verify file still exists
+          expect(existsSync(templatePath)).toBe(true);
+        },
+        { files: [DEFAULT_IDEA_TEMPLATE], schema: TEST_SCHEMA }
+      );
+    }, 15000);
+
+    it('should cancel delete on Ctrl+C', async () => {
+      await withTempVault(
+        ['template', 'delete', 'idea', 'default'],
+        async (proc, vaultPath) => {
+          const templatePath = join(vaultPath, '.ovault/templates/idea', 'default.md');
+          
+          // Verify file exists before
+          expect(existsSync(templatePath)).toBe(true);
+
+          // Wait for confirmation prompt
+          await proc.waitFor("Delete template 'default'", 10000);
+          
+          // Cancel with Ctrl+C
+          proc.write('\x03');
+
+          await proc.waitFor('Cancelled', 5000);
+
+          // Verify file still exists
+          expect(existsSync(templatePath)).toBe(true);
+        },
+        { files: [DEFAULT_IDEA_TEMPLATE], schema: TEST_SCHEMA }
+      );
+    }, 15000);
+  });
 });

--- a/tests/ts/commands/template.test.ts
+++ b/tests/ts/commands/template.test.ts
@@ -346,4 +346,89 @@ Body
       expect(json.error).toContain('Template not found');
     });
   });
+
+  describe('template delete', () => {
+    it('should delete a template with --force', async () => {
+      // First verify template exists
+      const templatePath = join(vaultDir, '.ovault/templates/idea', 'default.md');
+      expect(existsSync(templatePath)).toBe(true);
+
+      const result = await runCLI([
+        'template', 'delete', 'idea', 'default', '--force',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Deleted');
+      expect(result.stdout).toContain('.ovault/templates/idea/default.md');
+      
+      // Verify file was deleted
+      expect(existsSync(templatePath)).toBe(false);
+    });
+
+    it('should output JSON format on delete', async () => {
+      const result = await runCLI([
+        'template', 'delete', 'idea', 'default', '--force', '--output', 'json',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.path).toContain('.ovault/templates/idea/default.md');
+      expect(json.message).toContain('deleted');
+    });
+
+    it('should error on unknown template', async () => {
+      const result = await runCLI([
+        'template', 'delete', 'idea', 'nonexistent', '--force',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Template not found');
+    });
+
+    it('should error on unknown type', async () => {
+      const result = await runCLI([
+        'template', 'delete', 'nonexistent', 'default', '--force',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown type');
+    });
+
+    it('should output JSON error for unknown template', async () => {
+      const result = await runCLI([
+        'template', 'delete', 'idea', 'nonexistent', '--force', '--output', 'json',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('Template not found');
+    });
+
+    it('should output JSON error for unknown type', async () => {
+      const result = await runCLI([
+        'template', 'delete', 'nonexistent', 'default', '--force', '--output', 'json',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('Unknown type');
+    });
+
+    it('should delete nested subtype templates', async () => {
+      // Test with objective/task template (nested type)
+      const templatePath = join(vaultDir, '.ovault/templates/objective/task', 'default.md');
+      expect(existsSync(templatePath)).toBe(true);
+
+      const result = await runCLI([
+        'template', 'delete', 'objective/task', 'default', '--force',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Deleted');
+      expect(existsSync(templatePath)).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `ovault template delete <type> <name>` command to remove templates
- Includes interactive confirmation prompt (skippable with `--force`)
- Supports JSON output mode for scripting
- Completes the template CRUD cycle (list, show, new, edit, delete)

## Changes

- `src/commands/template.ts`: Add delete subcommand (~80 lines)
- `tests/ts/commands/template.test.ts`: Add 7 unit tests for delete
- `tests/ts/commands/template.pty.test.ts`: Add 3 PTY tests for interactive confirmation
- `CHANGELOG.md`: Document new feature

## Usage

```bash
# Delete with confirmation prompt
ovault template delete idea default
# Delete template 'default' for type 'idea'? [y/N] y
# ✓ Deleted: .ovault/templates/idea/default.md

# Skip confirmation
ovault template delete idea default --force

# JSON output
ovault template delete idea default --force --output json
# {"success":true,"path":".ovault/templates/idea/default.md","message":"Template deleted successfully"}
```

## Testing

All 768 tests pass (1 skipped - expected).

Closes ovault-3gb