### PR TITLE
chore: complete ovault to pika rename (pika-cr7)

### DIFF
--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -23,34 +23,34 @@ Work should proceed in this order due to dependencies:
 #### Phase 1: The Big Rename + Refactor
 | Priority | Issue | Title | Blocked By |
 |----------|-------|-------|------------|
-| P0 | `ovault-zg8` | Rename ovault to pika | — |
-| P0 | `ovault-wbz` | Implement inheritance model | `ovault-zg8` |
+| P0 | `pika-cr7` | Rename ovault to pika | — |
+| P0 | `pika-wbz` | Implement inheritance model | `pika-cr7` |
 
 #### Phase 2: Core Inheritance Features
 After inheritance model is in place:
 | Priority | Issue | Title |
 |----------|-------|-------|
-| P1 | `ovault-9g9` | Implement ownership and folder computation |
-| P1 | `ovault-0k0` | Update tests for new schema format |
-| P1 | `ovault-taz` | Implement context field validation |
-| P1 | `ovault-ita` | Implement recursive type support |
-| P1 | `ovault-oa8` | Update audit for new type resolution |
+| P1 | `pika-9g9` | Implement ownership and folder computation |
+| P1 | `pika-0k0` | Update tests for new schema format |
+| P1 | `pika-taz` | Implement context field validation |
+| P1 | `pika-ita` | Implement recursive type support |
+| P1 | `pika-oa8` | Update audit for new type resolution |
 
 #### Phase 3: Schema Management CLI
 | Priority | Issue | Title |
 |----------|-------|-------|
-| P1 | `ovault-tsh` | Schema Management CLI |
-| P2 | `ovault-w2a` | `pika schema add-type` command |
-| P2 | `ovault-tev` | `pika schema add-field` command |
-| P2 | `ovault-1kr` | `pika schema enum` management |
+| P1 | `pika-tsh` | Schema Management CLI |
+| P2 | `pika-w2a` | `pika schema add-type` command |
+| P2 | `pika-tev` | `pika schema add-field` command |
+| P2 | `pika-1kr` | `pika schema enum` management |
 
 #### Phase 4: Polish
 | Priority | Issue | Title |
 |----------|-------|-------|
-| P2 | `ovault-3nd` | Schema migration system |
-| P2 | `ovault-fkd` | Finalize command surface |
-| P2 | `ovault-oay` | Template spawning with ownership |
-| P2 | `ovault-xy1` | Remove name_field, standardize on 'name' |
+| P2 | `pika-3nd` | Schema migration system |
+| P2 | `pika-fkd` | Finalize command surface |
+| P2 | `pika-oay` | Template spawning with ownership |
+| P2 | `pika-xy1` | Remove name_field, standardize on 'name' |
 
 ### v1.0 Exit Criteria
 
@@ -72,11 +72,11 @@ Make the schema useful for knowledge work.
 
 | Feature | Issue | Description |
 |---------|-------|-------------|
-| Neovim plugin | `ovault-tic` | Full CLI parity in Neovim |
-| LSP | `ovault-cd1` | Real-time schema validation in editors |
-| Dashboards | `ovault-f9u` | Saved queries, visibility into notes |
-| Link validation | `ovault-6f0` | Broken link detection in audit |
-| Command consolidation | `ovault-fkd` | Merge list/search/open |
+| Neovim plugin | `pika-tic` | Full CLI parity in Neovim |
+| LSP | `pika-0wp` | Real-time schema validation in editors |
+| Dashboards | `pika-f9u` | Saved queries, visibility into notes |
+| Link validation | `pika-6f0` | Broken link detection in audit |
+| Command consolidation | `pika-fkd` | Merge list/search/open |
 
 ### v2.0 Exit Criteria
 
@@ -96,8 +96,8 @@ Optional AI-powered features for automation.
 
 | Feature | Issue | Description |
 |---------|-------|-------------|
-| AI Ingest | `ovault-acd` | Extract tasks/ideas/entities from notes |
-| Entity matching | `ovault-h9o` | Link mentions to existing notes |
+| AI Ingest | `pika-acd` | Extract tasks/ideas/entities from notes |
+| Entity matching | `pika-h9o` | Link mentions to existing notes |
 | Agentic workflows | — | Run AI workflows from vault |
 | Cost tracking | — | Monitor AI spend |
 
@@ -114,8 +114,8 @@ Optional AI-powered features for automation.
 
 | Feature | Issue | Notes |
 |---------|-------|-------|
-| Recurrence | `ovault-yuq` | Recurring task creation |
-| Schema discovery | `ovault-onp` | Suggest schema from existing files |
+| Recurrence | `pika-yuq` | Recurring task creation |
+| Schema discovery | `pika-onp` | Suggest schema from existing files |
 | Obsidian plugin | — | If there's demand |
 
 ---

--- a/docs/technical/inheritance.md
+++ b/docs/technical/inheritance.md
@@ -624,9 +624,9 @@ Pika validates schemas on load:
 
 ---
 
-## Migration from ovault
+## Migration from Legacy Schema
 
-### Old Model (ovault)
+### Old Model (Legacy)
 
 ```json
 {
@@ -659,7 +659,7 @@ Pika validates schemas on load:
 
 ### Key Changes
 
-| ovault | Pika |
+| Legacy | New |
 |--------|------|
 | Nested `subtypes` | Flat types with `extends` |
 | `output_dir` explicit | Computed from hierarchy + ownership |

--- a/plans/archive/directory-modes.md
+++ b/plans/archive/directory-modes.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-ovault supports two directory organization patterns:
+pika supports two directory organization patterns:
 
 1. **Pooled** (default): All notes of a type live in one folder
 2. **Instance-grouped**: Notes are grouped under parent instances
@@ -63,11 +63,11 @@ Ideas/
 ### CLI Behavior
 
 ```bash
-ovault new objective/task
+pika new objective/task
 # Title: Fix bug #123
 # → Creates: Objectives/Tasks/Fix bug #123.md
 
-ovault list objective/task
+pika list objective/task
 # Lists all tasks from Objectives/Tasks/
 ```
 
@@ -152,7 +152,7 @@ For instance-grouped types, the **parent type is always the instance field** for
 When creating a subtype, the user specifies which parent instance it belongs to:
 
 ```bash
-ovault new draft/version --set draft="Q1 Blog Post"
+pika new draft/version --set draft="Q1 Blog Post"
 ```
 
 #### Parent Note (Index File)
@@ -169,13 +169,13 @@ This pattern works beautifully with the **Folder Notes** Obsidian plugin, which 
 For instance-grouped types, the **folder IS the entity**. The parent note is metadata for that entity.
 
 ```bash
-ovault list draft
+pika list draft
 # Lists all draft instances (folders):
 #   Q1 Blog Post
 #   Technical Guide
 #   Annual Report
 
-ovault list draft/version
+pika list draft/version
 # Lists all version files across all drafts
 ```
 
@@ -184,7 +184,7 @@ ovault list draft/version
 #### Creating a Parent Instance
 
 ```bash
-ovault new draft
+pika new draft
 # Title: Q1 Blog Post
 # Status: in-progress
 # → Creates: Drafts/Q1 Blog Post/Q1 Blog Post.md
@@ -193,7 +193,7 @@ ovault new draft
 #### Creating a Subtype
 
 ```bash
-ovault new draft/version
+pika new draft/version
 # No draft specified. Select or create a draft:
 #   1. Q1 Blog Post
 #   2. Technical Guide
@@ -201,27 +201,27 @@ ovault new draft/version
 # > 1
 # → Creates: Drafts/Q1 Blog Post/Draft v2.md
 
-ovault new draft/version --set draft="Q1 Blog Post"
+pika new draft/version --set draft="Q1 Blog Post"
 # → Creates: Drafts/Q1 Blog Post/Draft v3.md
 ```
 
 #### Listing Instances
 
 ```bash
-ovault list draft
+pika list draft
 # TYPE   NAME              STATUS        FILES
 # draft  Q1 Blog Post      in-progress   4
 # draft  Technical Guide   planning      2
 # draft  Annual Report     done          5
 
-ovault list draft --instances
+pika list draft --instances
 # Just instance names (for scripting)
 ```
 
 #### Listing Subtypes
 
 ```bash
-ovault list draft/version
+pika list draft/version
 # DRAFT            FILENAME        CANONICAL
 # Q1 Blog Post     Draft v1.md     false
 # Q1 Blog Post     Draft v2.md     true
@@ -393,7 +393,7 @@ This gives you the best of both worlds — project-specific files together, but 
 Directories are created based on schema `output_dir`:
 
 ```bash
-ovault new objective/task
+pika new objective/task
 # Creates Objectives/Tasks/ if it doesn't exist
 # Creates Objectives/Tasks/My Task.md
 ```
@@ -403,12 +403,12 @@ ovault new objective/task
 Instance directories are created when needed:
 
 ```bash
-ovault new draft --title "Q1 Blog Post"
+pika new draft --title "Q1 Blog Post"
 # Creates Drafts/ if it doesn't exist
 # Creates Drafts/Q1 Blog Post/ if it doesn't exist
 # Creates Drafts/Q1 Blog Post/Q1 Blog Post.md
 
-ovault new draft/version --set draft="Q1 Blog Post"
+pika new draft/version --set draft="Q1 Blog Post"
 # Drafts/Q1 Blog Post/ already exists
 # Creates Drafts/Q1 Blog Post/Draft v1.md
 ```
@@ -439,13 +439,13 @@ If you're moving from pooled to instance-grouped (or vice versa):
 
 ```bash
 # 1. Update schema
-ovault schema edit-type draft --dir-mode instance-grouped
+pika schema edit-type draft --dir-mode instance-grouped
 
 # 2. Check what needs to change
-ovault audit draft
+pika audit draft
 
 # 3. Bulk move files (future feature)
-ovault bulk draft/version --reorg
+pika bulk draft/version --reorg
 ```
 
 The `--reorg` flag would restructure files to match the new directory mode.

--- a/plans/archive/roadmap.md
+++ b/plans/archive/roadmap.md
@@ -1,4 +1,4 @@
-# ovault Roadmap
+# pika Roadmap
 
 > Schema-driven management for Obsidian vaults — evolving into a comprehensive CLI for structured note management, auditing, and agentic workflows.
 
@@ -6,7 +6,7 @@
 
 ## Vision
 
-ovault is a CLI tool that brings structure, consistency, and automation to Obsidian vaults. It provides:
+pika is a CLI tool that brings structure, consistency, and automation to Obsidian vaults. It provides:
 
 1. **Schema-driven note creation** — Types, subtypes, and fields defined in a central schema
 2. **Flexible organization** — Both pooled and instance-grouped directory structures
@@ -19,10 +19,10 @@ ovault is a CLI tool that brings structure, consistency, and automation to Obsid
 ## Current State (v1 — Shell)
 
 **Implemented:**
-- `ovault new [type]` — Interactive note creation with schema-driven frontmatter
-- `ovault edit <file>` — Edit existing frontmatter fields
-- `ovault list [options] <type>` — List/filter objects with table output
-- `ovault help` — Usage documentation
+- `pika new [type]` — Interactive note creation with schema-driven frontmatter
+- `pika edit <file>` — Edit existing frontmatter fields
+- `pika list [options] <type>` — List/filter objects with table output
+- `pika help` — Usage documentation
 - Hierarchical type/subtype navigation
 - Dynamic sources for field queries (e.g., active milestones)
 - Multi-vault support via `--vault` flag and `OVAULT_VAULT` env var
@@ -73,9 +73,9 @@ See: [features/directory-modes.md](features/directory-modes.md)
 ### 1.3 Open in Obsidian
 
 ```bash
-ovault open <file>                    # Open file in Obsidian
-ovault new idea --open                # Create and open
-ovault edit Tasks/My\ Task.md --open  # Edit and open
+pika open <file>                    # Open file in Obsidian
+pika new idea --open                # Create and open
+pika edit Tasks/My\ Task.md --open  # Edit and open
 ```
 
 Uses Obsidian's URI scheme: `obsidian://open?vault=NAME&file=PATH`
@@ -85,9 +85,9 @@ Uses Obsidian's URI scheme: `obsidian://open?vault=NAME&file=PATH`
 Full expression-based filtering compatible with Obsidian Bases:
 
 ```bash
-ovault list task --where "status == 'in-progress'"
-ovault list task --where "priority < 3 && !isEmpty(deadline)"
-ovault list task --where "deadline < today() + '7d'"
+pika list task --where "status == 'in-progress'"
+pika list task --where "priority < 3 && !isEmpty(deadline)"
+pika list task --where "deadline < today() + '7d'"
 ```
 
 See: [features/query-system.md](features/query-system.md)
@@ -95,9 +95,9 @@ See: [features/query-system.md](features/query-system.md)
 ### 1.5 Schema Show Command
 
 ```bash
-ovault schema show                    # Tree view of all types
-ovault schema show objective/task     # Show specific type definition
-ovault schema validate                # Validate schema structure
+pika schema show                    # Tree view of all types
+pika schema show objective/task     # Show specific type definition
+pika schema validate                # Validate schema structure
 ```
 
 ---
@@ -109,11 +109,11 @@ ovault schema validate                # Validate schema structure
 Validate files against schema and surface mismatches:
 
 ```bash
-ovault audit                      # Check all files (report only)
-ovault audit objective/task       # Check specific type
-ovault audit --fix                # Interactive repair mode
-ovault audit --fix --auto         # Automatic fixes where unambiguous
-ovault audit --strict             # Error on unknown fields
+pika audit                      # Check all files (report only)
+pika audit objective/task       # Check specific type
+pika audit --fix                # Interactive repair mode
+pika audit --fix --auto         # Automatic fixes where unambiguous
+pika audit --strict             # Error on unknown fields
 ```
 
 See: [features/audit-command.md](features/audit-command.md)
@@ -123,9 +123,9 @@ See: [features/audit-command.md](features/audit-command.md)
 Mass changes across filtered file sets:
 
 ```bash
-ovault bulk task --set status=done --where "status == 'in-progress'"
-ovault bulk idea --move Archive/Ideas --where "status == 'settled'"
-ovault bulk objective --rename old-field=new-field
+pika bulk task --set status=done --where "status == 'in-progress'"
+pika bulk idea --move Archive/Ideas --where "status == 'settled'"
+pika bulk objective --rename old-field=new-field
 ```
 
 Features:
@@ -145,9 +145,9 @@ See: [features/bulk-operations.md](features/bulk-operations.md)
 Markdown-based templates with defaults and body structure:
 
 ```bash
-ovault new task                           # Prompts for template if multiple
-ovault new task --template bug-report     # Use specific template
-ovault new task --default                 # Use default template
+pika new task                           # Prompts for template if multiple
+pika new task --template bug-report     # Use specific template
+pika new task --default                 # Use default template
 ```
 
 Templates live in `Templates/{type}/{subtype}/{name}.md`.
@@ -199,22 +199,22 @@ Full CLI for schema manipulation — never touch JSON directly:
 
 ```bash
 # Type management
-ovault schema add-type writing
-ovault schema edit-type writing
-ovault schema remove-type writing
+pika schema add-type writing
+pika schema edit-type writing
+pika schema remove-type writing
 
 # Field management
-ovault schema add-field deadline task
-ovault schema edit-field deadline task
+pika schema add-field deadline task
+pika schema edit-field deadline task
 
 # Enum management
-ovault schema add-enum priority
-ovault schema edit-enum status --add archived
-ovault schema edit-enum status --rename wip=in-progress
+pika schema add-enum priority
+pika schema edit-enum status --add archived
+pika schema edit-enum status --rename wip=in-progress
 
 # Migration
-ovault schema diff                # Show pending changes
-ovault schema apply               # Apply migrations to files
+pika schema diff                # Show pending changes
+pika schema apply               # Apply migrations to files
 ```
 
 See: [features/schema-management.md](features/schema-management.md)
@@ -237,17 +237,17 @@ Define recurring task/project creation:
 ```
 
 ```bash
-ovault recur list                 # Show configured recurrences
-ovault recur spawn                # Create due instances
-ovault recur spawn --dry-run      # Preview
+pika recur list                 # Show configured recurrences
+pika recur spawn                # Create due instances
+pika recur spawn --dry-run      # Preview
 ```
 
 ### 5.2 Output Formats
 
 ```bash
-ovault list task --format=json
-ovault list task --format=csv
-ovault list task --format=dataview
+pika list task --format=json
+pika list task --format=csv
+pika list task --format=dataview
 ```
 
 ---
@@ -259,23 +259,23 @@ ovault list task --format=dataview
 Schema types for managing AI assets:
 
 ```bash
-ovault new prompt --set model=claude-sonnet
-ovault new agent --set tools="web-search,summarize"
+pika new prompt --set model=claude-sonnet
+pika new agent --set tools="web-search,summarize"
 ```
 
 ### 6.2 Workflow Execution
 
 ```bash
-ovault run Workflows/blog-research.md --topic="AI agents"
-ovault run --status  # Show running/completed workflows
+pika run Workflows/blog-research.md --topic="AI agents"
+pika run --status  # Show running/completed workflows
 ```
 
 ### 6.3 Cost Tracking
 
 ```bash
-ovault costs                      # Spending summary
-ovault costs --period=week        # This week's usage
-ovault costs --workflow=research  # By workflow type
+pika costs                      # Spending summary
+pika costs --period=week        # This week's usage
+pika costs --workflow=research  # By workflow type
 ```
 
 See: [features/agentic-workflows.md](features/agentic-workflows.md)
@@ -289,8 +289,8 @@ See: [features/agentic-workflows.md](features/agentic-workflows.md)
 Broader markdown hygiene (separate from schema audit):
 
 ```bash
-ovault lint                   # Check all files
-ovault lint --fix             # Auto-fix where possible
+pika lint                   # Check all files
+pika lint --fix             # Auto-fix where possible
 ```
 
 Checks: broken wikilinks, orphan files, duplicate filenames, heading hierarchy
@@ -300,7 +300,7 @@ Checks: broken wikilinks, orphan files, duplicate filenames, heading hierarchy
 Generate Obsidian Bases queries from CLI filters:
 
 ```bash
-ovault base task --where "status == 'in-progress'" --where "scope == 'week'"
+pika base task --where "status == 'in-progress'" --where "scope == 'week'"
 # Outputs .base file or dataview query
 ```
 
@@ -340,7 +340,7 @@ ovault base task --where "status == 'in-progress'" --where "scope == 'week'"
 
 ### Schema Location
 
-`.ovault/schema.json` in vault root
+`.pika/schema.json` in vault root
 
 ### Key Design Decisions
 
@@ -350,7 +350,7 @@ ovault base task --where "status == 'in-progress'" --where "scope == 'week'"
 | Parent type = instance field | For instance-grouped, parent type names the instance |
 | Parent note for instances | Folder name matches parent note name (Folder Notes plugin compatible) |
 | Templates are markdown | Manage templates in Obsidian like any other note |
-| User manages git | ovault warns about dirty state but doesn't auto-commit |
+| User manages git | pika warns about dirty state but doesn't auto-commit |
 | Auto-apply deterministic migrations | Enum renames, field additions with defaults |
 | Prompt for non-deterministic | Field removal, type changes |
 

--- a/plans/archive/shared-fields.md
+++ b/plans/archive/shared-fields.md
@@ -142,7 +142,7 @@ With `frontmatter_order`, you can customize:
 Shared fields are prompted like any other field:
 
 ```bash
-ovault new idea
+pika new idea
 # Title: My Idea
 # Status: [inbox] backlog, planned, in-progress, done, cancelled
 # Scopes (comma-separated): personal, q1-2025
@@ -155,9 +155,9 @@ ovault new idea
 Shared fields are available for filtering and display:
 
 ```bash
-ovault list idea --where "status == 'in-progress'"
-ovault list --all --where "isEmpty(scopes)"
-ovault list task --fields status,title,deadline
+pika list idea --where "status == 'in-progress'"
+pika list --all --where "isEmpty(scopes)"
+pika list task --fields status,title,deadline
 ```
 
 ### Editing Notes
@@ -165,7 +165,7 @@ ovault list task --fields status,title,deadline
 Shared fields can be edited like any other:
 
 ```bash
-ovault edit Ideas/My\ Idea.md --set status=done
+pika edit Ideas/My\ Idea.md --set status=done
 ```
 
 ---
@@ -206,7 +206,7 @@ Audit should verify shared fields:
 ### Example Output
 
 ```bash
-ovault audit
+pika audit
 
 # Shared Field Issues:
 #   Ideas/Old Idea.md
@@ -220,7 +220,7 @@ ovault audit
 ### Auto-Fix
 
 ```bash
-ovault audit --fix --auto
+pika audit --fix --auto
 
 # Fixing shared field issues...
 #   Ideas/Old Idea.md
@@ -237,7 +237,7 @@ ovault audit --fix --auto
 ### Adding a Shared Field
 
 ```bash
-ovault schema add-shared-field priority
+pika schema add-shared-field priority
 
 # Field name: priority
 # Prompt type: select
@@ -260,7 +260,7 @@ ovault schema add-shared-field priority
 ### Modifying a Shared Field
 
 ```bash
-ovault schema edit-shared-field status --default planned
+pika schema edit-shared-field status --default planned
 
 # Updated default for 'status': inbox → planned
 # 
@@ -271,7 +271,7 @@ ovault schema edit-shared-field status --default planned
 ### Removing a Shared Field
 
 ```bash
-ovault schema remove-shared-field scopes
+pika schema remove-shared-field scopes
 
 # Warning: 'scopes' is used by 3 types:
 #   - idea
@@ -295,14 +295,14 @@ If you have existing per-type status fields:
 ### 1. Create Shared Field
 
 ```bash
-ovault schema add-shared-field status
+pika schema add-shared-field status
 # Define the canonical version
 ```
 
 ### 2. Audit Inconsistencies
 
 ```bash
-ovault audit --check-shared-migration status
+pika audit --check-shared-migration status
 
 # Status field migration analysis:
 #   
@@ -324,15 +324,15 @@ ovault audit --check-shared-migration status
 ### 3. Bulk Update
 
 ```bash
-ovault bulk task --set status=inbox --where "status == 'raw'" --execute
-ovault bulk task --set status=in-progress --where "status == 'in-flight'" --execute
-ovault bulk task --set status=done --where "status == 'complete'" --execute
+pika bulk task --set status=inbox --where "status == 'raw'" --execute
+pika bulk task --set status=in-progress --where "status == 'in-flight'" --execute
+pika bulk task --set status=done --where "status == 'complete'" --execute
 ```
 
 ### 4. Update Schema
 
 ```bash
-ovault schema edit-type task --use-shared-field status
+pika schema edit-type task --use-shared-field status
 # Removes type-specific status, adds to shared_fields list
 ```
 

--- a/plans/archive/typescript-migration.md
+++ b/plans/archive/typescript-migration.md
@@ -1,12 +1,12 @@
 # TypeScript Migration
 
-> Phase 0: Migrate ovault from Bash to TypeScript
+> Phase 0: Migrate pika from Bash to TypeScript
 
 ---
 
 ## Overview
 
-The current ovault implementation is written in Bash. While functional, this limits:
+The current pika implementation is written in Bash. While functional, this limits:
 
 - **Testing**: No good test framework for shell scripts
 - **Type Safety**: Easy to introduce bugs, hard to refactor
@@ -58,7 +58,7 @@ For vault operations (1K-10K files):
 ### Project Structure
 
 ```
-ovault/
+pika/
 ├── src/
 │   ├── index.ts              # CLI entry point
 │   ├── commands/
@@ -187,11 +187,11 @@ Given the codebase is ~1000 lines of shell (which translates to ~500-800 lines o
 
 ### Phase 0.3: Commands
 
-1. Port `ovault new` → `src/commands/new.ts`
-2. Port `ovault edit` → `src/commands/edit.ts`
-3. Port `ovault list` → `src/commands/list.ts`
-4. Add `ovault open` → `src/commands/open.ts`
-5. Add `ovault help` → handled by Commander
+1. Port `pika new` → `src/commands/new.ts`
+2. Port `pika edit` → `src/commands/edit.ts`
+3. Port `pika list` → `src/commands/list.ts`
+4. Add `pika open` → `src/commands/open.ts`
+5. Add `pika help` → handled by Commander
 
 ### Phase 0.4: Testing
 
@@ -215,30 +215,30 @@ The CLI interface remains the same, but with improved consistency:
 
 ```bash
 # Core commands
-ovault new <type>                    # Create new note
-ovault edit <file>                   # Edit existing note
-ovault list <type> [options]         # List notes
-ovault open <file>                   # Open in Obsidian
+pika new <type>                    # Create new note
+pika edit <file>                   # Edit existing note
+pika list <type> [options]         # List notes
+pika open <file>                   # Open in Obsidian
 
 # Audit & bulk (Phase 2)
-ovault audit [type] [options]        # Validate notes
-ovault bulk <type> [options]         # Mass operations
+pika audit [type] [options]        # Validate notes
+pika bulk <type> [options]         # Mass operations
 
 # Schema management (Phase 4)
-ovault schema show [type]            # View schema
-ovault schema validate               # Validate schema
-ovault schema add-type <name>        # Add type
-ovault schema add-field <name> <type># Add field
-ovault schema edit-enum <name>       # Modify enum
+pika schema show [type]            # View schema
+pika schema validate               # Validate schema
+pika schema add-type <name>        # Add type
+pika schema add-field <name> <type># Add field
+pika schema edit-enum <name>       # Modify enum
 
 # Templates (Phase 3)
-ovault template list [type]          # List templates
-ovault template new <type>           # Create template
+pika template list [type]          # List templates
+pika template new <type>           # Create template
 
 # Global options
-ovault --vault <path>                # Specify vault
-ovault --version                     # Show version
-ovault --help                        # Show help
+pika --vault <path>                # Specify vault
+pika --version                     # Show version
+pika --help                        # Show help
 ```
 
 ---
@@ -253,7 +253,7 @@ import { describe, it, expect } from 'vitest';
 import { loadSchema, getTypeConfig, getFieldsForType } from '../src/lib/schema';
 
 describe('loadSchema', () => {
-  it('should load and validate schema from .ovault/schema.json', async () => {
+  it('should load and validate schema from .pika/schema.json', async () => {
     const schema = await loadSchema('/path/to/vault');
     expect(schema.version).toBeGreaterThan(0);
     expect(schema.types).toBeDefined();
@@ -287,11 +287,11 @@ import { execSync } from 'child_process';
 import { mkdtemp, rm, readFile } from 'fs/promises';
 import { join } from 'path';
 
-describe('ovault new', () => {
+describe('pika new', () => {
   let testVault: string;
 
   beforeEach(async () => {
-    testVault = await mkdtemp('/tmp/ovault-test-');
+    testVault = await mkdtemp('/tmp/pika-test-');
     // Copy test fixtures
   });
 
@@ -301,7 +301,7 @@ describe('ovault new', () => {
 
   it('should create a new task with prompted fields', async () => {
     // Use expect-test or similar for CLI testing
-    const result = execSync(`ovault new objective/task --vault ${testVault}`, {
+    const result = execSync(`pika new objective/task --vault ${testVault}`, {
       input: 'Test Task\nmilestone-1\n',
     });
     
@@ -319,7 +319,7 @@ Migrate existing fixtures from `tests/fixtures/` and expand:
 tests/
 ├── fixtures/
 │   ├── vault/                    # Test vault with notes
-│   │   ├── .ovault/
+│   │   ├── .pika/
 │   │   │   └── schema.json
 │   │   ├── Ideas/
 │   │   ├── Objectives/
@@ -351,26 +351,26 @@ npm run build         # Build for production
 
 ```json
 {
-  "name": "ovault",
+  "name": "pika",
   "version": "2.0.0",
   "bin": {
-    "ovault": "./dist/index.js"
+    "pika": ".//dist/index.js"
   }
 }
 ```
 
 Users install with:
 ```bash
-npm install -g ovault
+npm install -g pika
 # or
-npx ovault new idea
+npx pika new idea
 ```
 
 ### Single Binary (Optional)
 
 Using Bun:
 ```bash
-bun build src/index.ts --compile --outfile ovault
+bun build src/index.ts --compile --outfile pika
 ```
 
 Or pkg:
@@ -389,10 +389,10 @@ npx pkg dist/index.js --targets node18-macos-arm64
 - [ ] Port frontmatter parsing (`lib/body.sh` → `lib/frontmatter.ts`)
 - [ ] Port list functionality (`lib/list.sh` → `lib/vault.ts`)
 - [ ] Port query parsing (`lib/query.sh` → `lib/query.ts`)
-- [ ] Port `ovault new` command
-- [ ] Port `ovault edit` command
-- [ ] Port `ovault list` command
-- [ ] Add `ovault open` command
+- [ ] Port `pika new` command
+- [ ] Port `pika edit` command
+- [ ] Port `pika list` command
+- [ ] Add `pika open` command
 - [ ] Port existing tests
 - [ ] Add new unit tests (>80% coverage)
 - [ ] Add integration tests

--- a/plans/features/agentic-workflows.md
+++ b/plans/features/agentic-workflows.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-ovault serves as a **harness** for AI agents, not an agent itself. It provides:
+pika serves as a **harness** for AI agents, not an agent itself. It provides:
 
 1. **Prompt/Agent storage** — Manage AI assets in the vault
 2. **Workflow definitions** — Multi-step AI pipelines
@@ -24,7 +24,7 @@ ovault serves as a **harness** for AI agents, not an agent itself. It provides:
            │                │              ▲
            ▼                ▼              │
 ┌─────────────────────────────────────────────────┐
-│                    ovault                        │
+│                    pika                        │
 │  • Reads workflow definitions                   │
 │  • Manages execution state                      │
 │  • Writes results back to vault                 │
@@ -81,7 +81,7 @@ You are a skilled summarizer. Given the following content, provide a concise sum
 {
   "types": {
     "prompt": {
-      "output_dir": ".ovault/prompts",
+      "output_dir": ".pika/prompts",
       "frontmatter": {
         "type": { "value": "prompt" },
         "model": {
@@ -118,7 +118,7 @@ Agents are notes that combine prompts with tools and configuration:
 ```yaml
 ---
 type: agent
-system-prompt: "[[.ovault/prompts/Research Assistant]]"
+system-prompt: "[[.pika/prompts/Research Assistant]]"
 tools:
   - web-search
   - summarize
@@ -170,16 +170,16 @@ max-cost: 0.50
 ## Steps
 
 1. **Search** → sources
-   Prompt: [[.ovault/prompts/Web Search]]
+   Prompt: [[.pika/prompts/Web Search]]
    Input: {topic}
    
 2. **Summarize** → summaries
-   Prompt: [[.ovault/prompts/Summarize Content]]
+   Prompt: [[.pika/prompts/Summarize Content]]
    Input: {sources}
    For each: source in sources
    
 3. **Synthesize** → summary
-   Prompt: [[.ovault/prompts/Synthesize Research]]
+   Prompt: [[.pika/prompts/Synthesize Research]]
    Input: {summaries}
 
 ## Config
@@ -206,22 +206,22 @@ model: claude-sonnet-4-20250514
 
 ```bash
 # Run workflow with inputs
-ovault run Workflows/research.md --topic "AI agents" --depth "comprehensive"
+pika run Workflows/research.md --topic "AI agents" --depth "comprehensive"
 
 # Dry run (show what would execute)
-ovault run Workflows/research.md --topic "AI agents" --dry-run
+pika run Workflows/research.md --topic "AI agents" --dry-run
 
 # Check running workflows
-ovault run --status
+pika run --status
 
 # Cancel running workflow
-ovault run --cancel <workflow-id>
+pika run --cancel <workflow-id>
 ```
 
 ### Execution Flow
 
 ```bash
-ovault run Workflows/research.md --topic "AI agents"
+pika run Workflows/research.md --topic "AI agents"
 
 # Starting workflow: Research: AI agents
 # 
@@ -287,7 +287,7 @@ status: completed
 
 ### Cost Storage
 
-Costs are logged to `.ovault/logs/costs.json`:
+Costs are logged to `.pika/logs/costs.json`:
 
 ```json
 {
@@ -314,7 +314,7 @@ Costs are logged to `.ovault/logs/costs.json`:
 
 ```bash
 # View spending summary
-ovault costs
+pika costs
 
 # Spending Summary
 # 
@@ -328,16 +328,16 @@ ovault costs
 #   analysis: $0.30
 
 # Filter by period
-ovault costs --period week
-ovault costs --period month
-ovault costs --period "2025-01"
+pika costs --period week
+pika costs --period month
+pika costs --period "2025-01"
 
 # Filter by workflow
-ovault costs --workflow research
+pika costs --workflow research
 
 # Set budget alerts
-ovault costs --set-alert daily=5.00
-ovault costs --set-alert monthly=50.00
+pika costs --set-alert daily=5.00
+pika costs --set-alert monthly=50.00
 ```
 
 ### Cost Limits
@@ -352,7 +352,7 @@ max-cost: 0.50
 ```
 
 ```bash
-ovault run Workflows/expensive.md
+pika run Workflows/expensive.md
 
 # Step 3/5: Analysis
 #   ⚠ Cost limit approaching: $0.45 / $0.50
@@ -368,8 +368,8 @@ ovault run Workflows/expensive.md
 Store API key securely:
 
 ```bash
-ovault config set openrouter-api-key <key>
-# Stored in ~/.ovault/config.json (not in vault)
+pika config set openrouter-api-key <key>
+# Stored in ~/.pika/config.json (not in vault)
 ```
 
 Or via environment:
@@ -509,7 +509,7 @@ Process lists with `for each`:
 ### Step Failure
 
 ```bash
-ovault run Workflows/research.md --topic "AI agents"
+pika run Workflows/research.md --topic "AI agents"
 
 # Step 2/3: Summarize
 #   ✗ Failed: API error (rate limit)
@@ -527,7 +527,7 @@ ovault run Workflows/research.md --topic "AI agents"
 ### Cost Overrun
 
 ```bash
-ovault run Workflows/expensive.md
+pika run Workflows/expensive.md
 
 # Step 4/5: Analysis
 #   ✗ Cost limit exceeded: $0.52 > $0.50
@@ -576,31 +576,31 @@ Step 3: Synthesize - Rate limit exceeded
 
 ```bash
 # Prompts
-ovault new prompt                     # Create prompt
-ovault list prompt                    # List prompts
-ovault run-prompt <prompt> --input "text"  # Test prompt
+pika new prompt                     # Create prompt
+pika list prompt                    # List prompts
+pika run-prompt <prompt> --input "text"  # Test prompt
 
 # Agents
-ovault new agent                      # Create agent
-ovault list agent                     # List agents
+pika new agent                      # Create agent
+pika list agent                     # List agents
 
 # Workflows
-ovault new workflow                   # Create workflow
-ovault list workflow                  # List workflows
-ovault run <workflow> [--inputs]      # Execute workflow
-ovault run --status                   # Show running workflows
-ovault run --cancel <id>              # Cancel workflow
-ovault run --dry-run                  # Preview execution
+pika new workflow                   # Create workflow
+pika list workflow                  # List workflows
+pika run <workflow> [--inputs]      # Execute workflow
+pika run --status                   # Show running workflows
+pika run --cancel <id>              # Cancel workflow
+pika run --dry-run                  # Preview execution
 
 # Costs
-ovault costs                          # Spending summary
-ovault costs --period <period>        # Filter by time
-ovault costs --workflow <name>        # Filter by workflow
-ovault costs --set-alert <limit>      # Set budget alert
+pika costs                          # Spending summary
+pika costs --period <period>        # Filter by time
+pika costs --workflow <name>        # Filter by workflow
+pika costs --set-alert <limit>      # Set budget alert
 
 # Config
-ovault config set openrouter-api-key <key>
-ovault config get openrouter-api-key
+pika config set openrouter-api-key <key>
+pika config get openrouter-api-key
 ```
 
 ---
@@ -628,9 +628,9 @@ schedule: "0 9 * * 1"  # Every Monday at 9am
 ```
 
 ```bash
-ovault schedule list
-ovault schedule enable <workflow>
-ovault schedule disable <workflow>
+pika schedule list
+pika schedule enable <workflow>
+pika schedule disable <workflow>
 ```
 
 ### Streaming
@@ -638,7 +638,7 @@ ovault schedule disable <workflow>
 Real-time output during execution:
 
 ```bash
-ovault run Workflows/writing.md --stream
+pika run Workflows/writing.md --stream
 # Shows output as it's generated
 ```
 

--- a/plans/features/ai-ingest.md
+++ b/plans/features/ai-ingest.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-The `ovault ingest` command uses AI to scan notes (especially daily notes, journals, meeting notes) and extract structured data:
+The `pika ingest` command uses AI to scan notes (especially daily notes, journals, meeting notes) and extract structured data:
 
 - **Tasks** — Action items, TODOs, things to do
 - **Ideas** — Creative thoughts, concepts, possibilities
@@ -24,7 +24,7 @@ This bridges the gap between free-form journaling and structured knowledge manag
                             │
                             ▼
 ┌─────────────────────────────────────────────────────────────┐
-│                   ovault ingest                              │
+│                   pika ingest                              │
 │  • Sends note + schema context to AI                        │
 │  • Receives structured extraction proposals                 │
 │  • Presents interactive approval flow                       │
@@ -45,29 +45,29 @@ This bridges the gap between free-form journaling and structured knowledge manag
 
 ```bash
 # Ingest a specific file
-ovault ingest "Daily Notes/2025-12-30.md"
+pika ingest "Daily Notes/2025-12-30.md"
 
 # Ingest multiple files
-ovault ingest "Daily Notes/2025-12-*.md"
+pika ingest "Daily Notes/2025-12-*.md"
 
 # Ingest all notes of a type
-ovault ingest --type daily-note
+pika ingest --type daily-note
 
 # Ingest notes marked for processing
-ovault ingest --pending
+pika ingest --pending
 
 # Dry run (show what would be extracted, don't prompt)
-ovault ingest "Daily Notes/2025-12-30.md" --dry-run
+pika ingest "Daily Notes/2025-12-30.md" --dry-run
 
 # Auto-accept high-confidence extractions
-ovault ingest "Daily Notes/2025-12-30.md" --auto
+pika ingest "Daily Notes/2025-12-30.md" --auto
 
 # JSON output for scripting
-ovault ingest "Daily Notes/2025-12-30.md" --output json
+pika ingest "Daily Notes/2025-12-30.md" --output json
 
 # Limit extraction types
-ovault ingest --extract tasks,ideas  # Skip entities
-ovault ingest --extract entities     # Only entities
+pika ingest --extract tasks,ideas  # Skip entities
+pika ingest --extract entities     # Only entities
 ```
 
 ---
@@ -176,10 +176,10 @@ ai-extractions:
 When the schema changes (new type added, fields modified), notes processed under an older schema version are marked `needs-review`:
 
 ```bash
-ovault schema add-type place
+pika schema add-type place
 # Notes with ai-schema-version < current marked for re-processing
 
-ovault ingest --pending
+pika ingest --pending
 # Finds notes with ai-process-stage: to-process OR needs-review
 ```
 
@@ -188,7 +188,7 @@ ovault ingest --pending
 ## Interactive Approval Flow
 
 ```bash
-ovault ingest "Daily Notes/2025-12-30.md"
+pika ingest "Daily Notes/2025-12-30.md"
 
 # Scanning Daily Notes/2025-12-30.md...
 # 
@@ -300,7 +300,7 @@ ovault ingest "Daily Notes/2025-12-30.md"
 For high-confidence extractions, `--auto` accepts automatically:
 
 ```bash
-ovault ingest "Daily Notes/2025-12-30.md" --auto
+pika ingest "Daily Notes/2025-12-30.md" --auto
 
 # Scanning Daily Notes/2025-12-30.md...
 # 
@@ -320,8 +320,8 @@ ovault ingest "Daily Notes/2025-12-30.md" --auto
 ### Confidence Thresholds
 
 ```bash
-ovault ingest --auto --threshold 0.7  # Lower threshold
-ovault ingest --auto --threshold 0.9  # Higher threshold
+pika ingest --auto --threshold 0.7  # Lower threshold
+pika ingest --auto --threshold 0.9  # Higher threshold
 ```
 
 Or configure in schema:
@@ -339,7 +339,7 @@ Or configure in schema:
 
 ## Entity Matching
 
-When AI extracts an entity, ovault searches for existing matches:
+When AI extracts an entity, pika searches for existing matches:
 
 ### Match Strategies
 
@@ -367,7 +367,7 @@ Select match or [n]ew entity:
 For scripting and integration:
 
 ```bash
-ovault ingest "Daily Notes/2025-12-30.md" --output json --dry-run
+pika ingest "Daily Notes/2025-12-30.md" --output json --dry-run
 ```
 
 ```json
@@ -413,20 +413,20 @@ Uses the same API infrastructure as agentic workflows (Phase 6):
 
 ```bash
 # Use OpenRouter (default)
-ovault ingest "note.md"
+pika ingest "note.md"
 
 # Use opencode run (leverages existing subscription)
-ovault ingest "note.md" --provider opencode
+pika ingest "note.md" --provider opencode
 
 # Direct Anthropic API
-ovault ingest "note.md" --provider anthropic
+pika ingest "note.md" --provider anthropic
 ```
 
 ### Model Selection
 
 ```bash
-ovault ingest "note.md" --model claude-3-5-haiku  # Fast, cheap
-ovault ingest "note.md" --model claude-sonnet-4   # Better quality
+pika ingest "note.md" --model claude-3-5-haiku  # Fast, cheap
+pika ingest "note.md" --model claude-sonnet-4   # Better quality
 ```
 
 Or configure default:
@@ -511,7 +511,7 @@ If AI returns malformed JSON:
 Ingest operations log to the same cost tracking system as workflows:
 
 ```bash
-ovault costs --command ingest
+pika costs --command ingest
 
 # Ingest Costs (last 7 days):
 #   
@@ -532,24 +532,24 @@ ovault costs --command ingest
 
 ```bash
 # Process yesterday's daily note each morning
-ovault ingest "Daily Notes/$(date -d yesterday +%Y-%m-%d).md"
+pika ingest "Daily Notes/$(date -d yesterday +%Y-%m-%d).md"
 ```
 
 ### Catch-Up Processing
 
 ```bash
 # Process all unprocessed daily notes
-ovault ingest --type daily-note --pending
+pika ingest --type daily-note --pending
 
 # Process last 7 days
-ovault ingest "Daily Notes/2025-12-2*.md" --auto
+pika ingest "Daily Notes/2025-12-2*.md" --auto
 ```
 
 ### Cron Integration
 
 ```bash
 # In crontab: process daily note at 9am
-0 9 * * * cd ~/vault && ovault ingest --type daily-note --pending --auto
+0 9 * * * cd ~/vault && pika ingest --type daily-note --pending --auto
 ```
 
 ---
@@ -605,18 +605,18 @@ ovault ingest "Daily Notes/2025-12-2*.md" --auto
 ### With Audit
 
 ```bash
-ovault audit --fix
+pika audit --fix
 # After fixing issues, suggests:
-# "3 notes have ai-process-stage: to-process. Run 'ovault ingest --pending'?"
+# "3 notes have ai-process-stage: to-process. Run 'pika ingest --pending'?"
 ```
 
 ### With Schema Changes
 
 ```bash
-ovault schema add-type place
+pika schema add-type place
 # "12 processed notes may contain place entities. Mark for re-processing? [Y/n]"
 
-ovault ingest --pending --extract entities
+pika ingest --pending --extract entities
 # Re-processes only entity extraction on marked notes
 ```
 
@@ -624,7 +624,7 @@ ovault ingest --pending --extract entities
 
 ```bash
 # Mark all daily notes for processing
-ovault bulk daily-note --set ai-process-stage=to-process
+pika bulk daily-note --set ai-process-stage=to-process
 ```
 
 ---
@@ -632,9 +632,9 @@ ovault bulk daily-note --set ai-process-stage=to-process
 ## CLI Reference
 
 ```bash
-ovault ingest <files...>              # Process specific files
-ovault ingest --type <type>           # Process all of a type
-ovault ingest --pending               # Process to-process/needs-review notes
+pika ingest <files...>              # Process specific files
+pika ingest --type <type>           # Process all of a type
+pika ingest --pending               # Process to-process/needs-review notes
 
 # Options
 --dry-run                             # Show extractions without prompting
@@ -654,7 +654,7 @@ ovault ingest --pending               # Process to-process/needs-review notes
 ### API Errors
 
 ```
-ovault ingest "note.md"
+pika ingest "note.md"
 
 # ✗ API error: Rate limit exceeded
 #   Retry in 60 seconds? [Y/n]
@@ -674,7 +674,7 @@ ai-partial-extractions:
 ```
 
 ```bash
-ovault ingest "note.md"
+pika ingest "note.md"
 # "Previous processing incomplete. Resume from extraction 3? [Y/n]"
 ```
 
@@ -687,7 +687,7 @@ ovault ingest "note.md"
 For sensitive vaults, support local models:
 
 ```bash
-ovault ingest "note.md" --provider ollama --model llama3
+pika ingest "note.md" --provider ollama --model llama3
 ```
 
 ### Content Filtering

--- a/plans/features/audit-command.md
+++ b/plans/features/audit-command.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-The `ovault audit` command validates files against the schema and reports issues:
+The `pika audit` command validates files against the schema and reports issues:
 
 - Missing required fields
 - Invalid enum values
@@ -21,12 +21,12 @@ The `ovault audit` command validates files against the schema and reports issues
 ## Command Syntax
 
 ```bash
-ovault audit                      # Check all files (report only)
-ovault audit objective/task       # Check specific type
-ovault audit --fix                # Interactive repair mode
-ovault audit --fix --auto         # Automatic fixes where unambiguous
-ovault audit --strict             # Error on unknown fields
-ovault audit --templates          # Also audit templates
+pika audit                      # Check all files (report only)
+pika audit objective/task       # Check specific type
+pika audit --fix                # Interactive repair mode
+pika audit --fix --auto         # Automatic fixes where unambiguous
+pika audit --strict             # Error on unknown fields
+pika audit --templates          # Also audit templates
 ```
 
 ---
@@ -150,7 +150,7 @@ Drafts/Q1 Blog Post/Research.md
 ### Default: Report Only
 
 ```bash
-ovault audit
+pika audit
 
 # Auditing vault...
 # 
@@ -171,13 +171,13 @@ ovault audit
 #   Total errors: 5
 #   Total warnings: 1
 # 
-# Run 'ovault audit --fix' to repair interactively.
+# Run 'pika audit --fix' to repair interactively.
 ```
 
 ### Interactive Fix Mode
 
 ```bash
-ovault audit --fix
+pika audit --fix
 
 # Auditing vault...
 # 
@@ -209,7 +209,7 @@ ovault audit --fix
 ### Auto-Fix Mode
 
 ```bash
-ovault audit --fix --auto
+pika audit --fix --auto
 
 # Auditing vault...
 # 
@@ -232,13 +232,13 @@ ovault audit --fix --auto
 #   Auto-fixed: 3 issues
 #   Manual review needed: 2 issues
 # 
-# Run 'ovault audit --fix' to address remaining issues.
+# Run 'pika audit --fix' to address remaining issues.
 ```
 
 ### Strict Mode
 
 ```bash
-ovault audit --strict
+pika audit --strict
 
 # Unknown fields are now errors:
 # 
@@ -255,26 +255,26 @@ ovault audit --strict
 ### By Type
 
 ```bash
-ovault audit objective/task      # Only tasks
-ovault audit objective           # Tasks and milestones
-ovault audit draft               # All draft instances
-ovault audit draft/version       # Only draft versions
+pika audit objective/task      # Only tasks
+pika audit objective           # Tasks and milestones
+pika audit draft               # All draft instances
+pika audit draft/version       # Only draft versions
 ```
 
 ### By Directory
 
 ```bash
-ovault audit --path "Objectives/Tasks/"
-ovault audit --path "Drafts/Q1 Blog Post/"
+pika audit --path "Objectives/Tasks/"
+pika audit --path "Drafts/Q1 Blog Post/"
 ```
 
 ### By Issue Type
 
 ```bash
-ovault audit --only missing-required
-ovault audit --only invalid-enum
-ovault audit --only unknown-field
-ovault audit --ignore unknown-field
+pika audit --only missing-required
+pika audit --only invalid-enum
+pika audit --only unknown-field
+pika audit --ignore unknown-field
 ```
 
 ---
@@ -304,8 +304,8 @@ These fields are always allowed (Obsidian native):
 ### Command-Line Override
 
 ```bash
-ovault audit --allow-field custom-field
-ovault audit --strict --allow-field custom-field
+pika audit --allow-field custom-field
+pika audit --strict --allow-field custom-field
 ```
 
 ---
@@ -341,23 +341,23 @@ ovault audit --strict --allow-field custom-field
 ### Pre-Bulk Check
 
 ```bash
-ovault bulk task --set status=done --where "status == 'in-progress'"
+pika bulk task --set status=done --where "status == 'in-progress'"
 # Warning: 3 files have audit issues that may affect this operation.
-# Run 'ovault audit objective/task' first? [Y/n]
+# Run 'pika audit objective/task' first? [Y/n]
 ```
 
 ### Post-Schema-Change
 
 ```bash
-ovault schema edit-enum status --rename wip=in-progress
-# Schema updated. Run 'ovault audit' to check for issues.
+pika schema edit-enum status --rename wip=in-progress
+# Schema updated. Run 'pika audit' to check for issues.
 ```
 
 ### CI/CD Integration
 
 ```bash
-ovault audit --format json > audit-report.json
-ovault audit --format junit > audit-report.xml
+pika audit --format json > audit-report.json
+pika audit --format junit > audit-report.xml
 ```
 
 ---
@@ -369,7 +369,7 @@ For instance-grouped types, additional checks:
 ### Parent Note Check
 
 ```bash
-ovault audit draft
+pika audit draft
 
 # Checking draft instances...
 # 
@@ -385,7 +385,7 @@ ovault audit draft
 ### Subtype Validation
 
 ```bash
-ovault audit draft/version
+pika audit draft/version
 
 # Checking draft/version files...
 # 

--- a/plans/features/bulk-operations.md
+++ b/plans/features/bulk-operations.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-The `ovault bulk` command performs mass changes across notes matching filter criteria:
+The `pika bulk` command performs mass changes across notes matching filter criteria:
 
 - Set or clear field values
 - Rename fields (for migrations)
@@ -19,7 +19,7 @@ The `ovault bulk` command performs mass changes across notes matching filter cri
 ## Command Syntax
 
 ```bash
-ovault bulk <type> [options]
+pika bulk <type> [options]
 
 # Operations
 --set <field>=<value>       # Set field value
@@ -50,7 +50,7 @@ ovault bulk <type> [options]
 All bulk operations are dry-run by default for safety:
 
 ```bash
-ovault bulk task --set status=done --where "status == 'in-progress'"
+pika bulk task --set status=done --where "status == 'in-progress'"
 
 # Dry run - no changes will be made
 # 
@@ -72,28 +72,28 @@ ovault bulk task --set status=done --where "status == 'in-progress'"
 
 ```bash
 # Set single field
-ovault bulk task --set status=done --where "status == 'in-progress'" --execute
+pika bulk task --set status=done --where "status == 'in-progress'" --execute
 
 # Set multiple fields
-ovault bulk task --set status=done --set "completion-date=$(date +%Y-%m-%d)" --where "status == 'in-progress'" --execute
+pika bulk task --set status=done --set "completion-date=$(date +%Y-%m-%d)" --where "status == 'in-progress'" --execute
 
 # Set with special values
-ovault bulk task --set deadline=today --where "isEmpty(deadline)" --execute
-ovault bulk task --set "milestone=[[Q1 Release]]" --where "type == 'task'" --execute
+pika bulk task --set deadline=today --where "isEmpty(deadline)" --execute
+pika bulk task --set "milestone=[[Q1 Release]]" --where "type == 'task'" --execute
 ```
 
 ### Clear Field
 
 ```bash
 # Remove field entirely
-ovault bulk task --set deadline= --where "status == 'done'" --execute
+pika bulk task --set deadline= --where "status == 'done'" --execute
 ```
 
 ### Rename Field
 
 ```bash
 # For schema migrations
-ovault bulk objective --rename old-field=new-field --execute
+pika bulk objective --rename old-field=new-field --execute
 
 # All affected files:
 #   Objectives/Tasks/Task A.md
@@ -104,14 +104,14 @@ ovault bulk objective --rename old-field=new-field --execute
 
 ```bash
 # Explicit deletion (same as --set field=)
-ovault bulk task --delete legacy-field --execute
+pika bulk task --delete legacy-field --execute
 ```
 
 ### Move Files
 
 ```bash
 # Move to different directory
-ovault bulk idea --move Archive/Ideas --where "status == 'settled'" --execute
+pika bulk idea --move Archive/Ideas --where "status == 'settled'" --execute
 
 # Output:
 #   Moving 15 files...
@@ -123,7 +123,7 @@ ovault bulk idea --move Archive/Ideas --where "status == 'settled'" --execute
 
 ```bash
 # Add tag to all matching files
-ovault bulk task --append tags=urgent --where "priority == 'critical'" --execute
+pika bulk task --append tags=urgent --where "priority == 'critical'" --execute
 
 # Before: tags: [bug]
 # After:  tags: [bug, urgent]
@@ -133,31 +133,31 @@ ovault bulk task --append tags=urgent --where "priority == 'critical'" --execute
 
 ```bash
 # Remove tag from files
-ovault bulk task --remove tags=legacy --where "contains(tags, 'legacy')" --execute
+pika bulk task --remove tags=legacy --where "contains(tags, 'legacy')" --execute
 ```
 
 ---
 
 ## Filter Expressions
 
-Filters use the same expression syntax as `ovault list`:
+Filters use the same expression syntax as `pika list`:
 
 ```bash
 # Simple equality
-ovault bulk task --set status=done --where "status == 'in-progress'"
+pika bulk task --set status=done --where "status == 'in-progress'"
 
 # Comparison operators
-ovault bulk task --set priority=high --where "priority < 2"
+pika bulk task --set priority=high --where "priority < 2"
 
 # Boolean logic
-ovault bulk task --set status=backlog --where "status == 'inbox' && isEmpty(deadline)"
+pika bulk task --set status=backlog --where "status == 'inbox' && isEmpty(deadline)"
 
 # Functions
-ovault bulk task --set status=overdue --where "deadline < today()"
-ovault bulk idea --move Archive/Ideas --where "contains(tags, 'archived')"
+pika bulk task --set status=overdue --where "deadline < today()"
+pika bulk idea --move Archive/Ideas --where "contains(tags, 'archived')"
 
 # Multiple --where (AND logic)
-ovault bulk task --set status=done --where "status == 'in-progress'" --where "scope == 'day'"
+pika bulk task --set status=done --where "status == 'in-progress'" --where "scope == 'day'"
 ```
 
 ---
@@ -167,20 +167,20 @@ ovault bulk task --set status=done --where "status == 'in-progress'" --where "sc
 ### Specific Type
 
 ```bash
-ovault bulk objective/task --set status=done ...
+pika bulk objective/task --set status=done ...
 ```
 
 ### Parent Type (All Subtypes)
 
 ```bash
-ovault bulk objective --set status=done ...
+pika bulk objective --set status=done ...
 # Affects both tasks and milestones
 ```
 
 ### All Types
 
 ```bash
-ovault bulk --all --set status=done --where "status == 'in-progress'" ...
+pika bulk --all --set status=done --where "status == 'in-progress'" ...
 # Warning: This affects ALL managed files. Are you sure? [y/N]
 ```
 
@@ -191,17 +191,17 @@ ovault bulk --all --set status=done --where "status == 'in-progress'" ...
 ### 1. Dry-Run by Default
 
 ```bash
-ovault bulk task --set status=done --where "status == 'in-progress'"
+pika bulk task --set status=done --where "status == 'in-progress'"
 # Shows what would change, doesn't change anything
 ```
 
 ### 2. Backup Option
 
 ```bash
-ovault bulk task --set status=done --where "status == 'in-progress'" --execute --backup
+pika bulk task --set status=done --where "status == 'in-progress'" --execute --backup
 
 # Creating backup...
-#   Backup saved to .ovault/backups/2025-01-15T10-30-00/
+#   Backup saved to .pika/backups/2025-01-15T10-30-00/
 # 
 # Applying changes...
 #   ✓ Updated 12 files
@@ -209,7 +209,7 @@ ovault bulk task --set status=done --where "status == 'in-progress'" --execute -
 
 Restore from backup:
 ```bash
-ovault backup restore 2025-01-15T10-30-00
+pika backup restore 2025-01-15T10-30-00
 # Restoring 12 files from backup...
 # ✓ Restored
 ```
@@ -217,7 +217,7 @@ ovault backup restore 2025-01-15T10-30-00
 ### 3. Git Status Warning
 
 ```bash
-ovault bulk task --set status=done --where "status == 'in-progress'" --execute
+pika bulk task --set status=done --where "status == 'in-progress'" --execute
 
 # ⚠ Warning: You have uncommitted changes in your vault.
 # Bulk operations will modify files. Consider committing first.
@@ -233,7 +233,7 @@ ovault bulk task --set status=done --where "status == 'in-progress'" --execute
 
 ```bash
 # Apply to first 5 matches only
-ovault bulk task --set status=done --where "status == 'in-progress'" --execute --limit 5
+pika bulk task --set status=done --where "status == 'in-progress'" --execute --limit 5
 
 # Updated 5 of 12 matching files.
 # Run without --limit to update remaining 7 files.
@@ -242,7 +242,7 @@ ovault bulk task --set status=done --where "status == 'in-progress'" --execute -
 ### 5. Confirmation for Large Operations
 
 ```bash
-ovault bulk task --set status=archived --execute
+pika bulk task --set status=archived --execute
 
 # This will modify 247 files.
 # Are you sure? [y/N]
@@ -255,7 +255,7 @@ ovault bulk task --set status=archived --execute
 When `--move` relocates files, wikilinks are automatically updated:
 
 ```bash
-ovault bulk idea --move Archive/Ideas --where "status == 'settled'" --execute
+pika bulk idea --move Archive/Ideas --where "status == 'settled'" --execute
 
 # Moving 5 files...
 #   Ideas/Old Idea 1.md → Archive/Ideas/Old Idea 1.md
@@ -295,7 +295,7 @@ If using Obsidian's "shortest path when possible" setting:
 ### Default (Interactive)
 
 ```bash
-ovault bulk task --set status=done --where "status == 'in-progress'" --execute
+pika bulk task --set status=done --where "status == 'in-progress'" --execute
 
 # Applying changes to 12 files...
 #   ✓ Objectives/Tasks/Task A.md
@@ -308,7 +308,7 @@ ovault bulk task --set status=done --where "status == 'in-progress'" --execute
 ### Verbose
 
 ```bash
-ovault bulk task --set status=done --where "status == 'in-progress'" --execute --verbose
+pika bulk task --set status=done --where "status == 'in-progress'" --execute --verbose
 
 # Applying changes...
 # 
@@ -326,7 +326,7 @@ ovault bulk task --set status=done --where "status == 'in-progress'" --execute -
 ### Quiet
 
 ```bash
-ovault bulk task --set status=done --where "status == 'in-progress'" --execute --quiet
+pika bulk task --set status=done --where "status == 'in-progress'" --execute --quiet
 
 # ✓ Updated 12 files
 ```
@@ -334,7 +334,7 @@ ovault bulk task --set status=done --where "status == 'in-progress'" --execute -
 ### JSON (for scripting)
 
 ```bash
-ovault bulk task --set status=done --where "status == 'in-progress'" --execute --format json
+pika bulk task --set status=done --where "status == 'in-progress'" --execute --format json
 
 # {
 #   "success": true,
@@ -353,21 +353,21 @@ ovault bulk task --set status=done --where "status == 'in-progress'" --execute -
 ### Operating on Parent Type
 
 ```bash
-ovault bulk draft --set status=archived --where "status == 'done'" --execute
+pika bulk draft --set status=archived --where "status == 'done'" --execute
 # Only affects parent notes (Drafts/X/X.md)
 ```
 
 ### Operating on Subtypes
 
 ```bash
-ovault bulk draft/version --set canonical=false --execute
+pika bulk draft/version --set canonical=false --execute
 # Affects all version files across all drafts
 ```
 
 ### Moving Entire Instances
 
 ```bash
-ovault bulk draft --move Archive/Drafts --where "status == 'archived'" --execute
+pika bulk draft --move Archive/Drafts --where "status == 'archived'" --execute
 
 # This will move entire draft instances (parent + subtypes):
 #   Drafts/Old Project/ → Archive/Drafts/Old Project/
@@ -386,44 +386,44 @@ ovault bulk draft --move Archive/Drafts --where "status == 'archived'" --execute
 
 ```bash
 # 1. Check current usage
-ovault list task --where "status == 'wip'" --count
+pika list task --where "status == 'wip'" --count
 # 47 files
 
 # 2. Bulk update
-ovault bulk task --set status=in-progress --where "status == 'wip'" --execute --backup
+pika bulk task --set status=in-progress --where "status == 'wip'" --execute --backup
 
 # 3. Update schema
-ovault schema edit-enum status --remove wip
+pika schema edit-enum status --remove wip
 ```
 
 ### Cleanup: Archive Old Items
 
 ```bash
 # Archive settled ideas
-ovault bulk idea --move Archive/Ideas --where "status == 'settled'" --execute
+pika bulk idea --move Archive/Ideas --where "status == 'settled'" --execute
 
 # Archive completed tasks older than 30 days
-ovault bulk task --move Archive/Tasks --where "status == 'done' && completion-date < today() - '30d'" --execute
+pika bulk task --move Archive/Tasks --where "status == 'done' && completion-date < today() - '30d'" --execute
 ```
 
 ### Tagging: Add Tags Based on Criteria
 
 ```bash
 # Tag all high-priority items
-ovault bulk task --append tags=priority --where "priority == 'high' || priority == 'critical'" --execute
+pika bulk task --append tags=priority --where "priority == 'high' || priority == 'critical'" --execute
 
 # Tag overdue items
-ovault bulk task --append tags=overdue --where "deadline < today() && status != 'done'" --execute
+pika bulk task --append tags=overdue --where "deadline < today() && status != 'done'" --execute
 ```
 
 ### Field Migration: Rename or Remove
 
 ```bash
 # Rename field across all types
-ovault bulk --all --rename assignee=owner --execute
+pika bulk --all --rename assignee=owner --execute
 
 # Remove deprecated field
-ovault bulk --all --delete legacy-notes --execute
+pika bulk --all --delete legacy-notes --execute
 ```
 
 ---
@@ -496,7 +496,7 @@ async function findWikilinks(
 ### Backup Structure
 
 ```
-.ovault/
+.pika/
   backups/
     2025-01-15T10-30-00/
       manifest.json           # What was backed up and why

--- a/plans/features/neovim-plugin.md
+++ b/plans/features/neovim-plugin.md
@@ -1,14 +1,14 @@
-# Neovim Plugin for ovault
+# Neovim Plugin for Pika
 
 > Native Neovim integration with full CLI feature parity
 
-**Beads Issue:** `ovault-tic`
+**Beads Issue:** `pika-tic`
 
 ---
 
 ## Overview
 
-A Neovim plugin (`ovault.nvim`) that brings the full power of ovault into the editor. The goal is **feature parity with the CLI** for human-usable operations, making Neovim a complete PKM (Personal Knowledge Management) environment.
+A Neovim plugin (`pika.nvim`) that brings the full power of pika into the editor. The goal is **feature parity with the CLI** for human-usable operations, making Neovim a complete PKM (Personal Knowledge Management) environment.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -21,7 +21,7 @@ A Neovim plugin (`ovault.nvim`) that brings the full power of ovault into the ed
                           │
                           ▼
 ┌─────────────────────────────────────────────────────────┐
-│                    ovault.nvim                           │
+│                    pika.nvim                             │
 │  • CLI wrapper (--json mode)                            │
 │  • Native Lua for hot paths                             │
 │  • UI component library                                 │
@@ -29,7 +29,7 @@ A Neovim plugin (`ovault.nvim`) that brings the full power of ovault into the ed
                           │
                           ▼
 ┌─────────────────────────────────────────────────────────┐
-│                    ovault CLI                            │
+│                    pika CLI                              │
 │  • JSON mode for all commands                           │
 │  • Single source of truth for logic                     │
 └─────────────────────────────────────────────────────────┘
@@ -52,7 +52,7 @@ A Neovim plugin (`ovault.nvim`) that brings the full power of ovault into the ed
 **Hybrid approach:**
 - **CLI with `--json`** for complex operations (new, edit, audit, bulk)
 - **Native Lua** for hot paths (search picker, list display, wikilink completion)
-- **Shared schema understanding** via parsed JSON from `ovault schema show --output json`
+- **Shared schema understanding** via parsed JSON from `pika schema show --output json`
 
 ---
 
@@ -60,15 +60,15 @@ A Neovim plugin (`ovault.nvim`) that brings the full power of ovault into the ed
 
 | CLI Command | Neovim Command | Implementation |
 |-------------|----------------|----------------|
-| `ovault new [type]` | `:OvaultNew [type]` | CLI + floating inputs |
-| `ovault edit <file>` | `:OvaultEdit` | CLI + floating inputs |
-| `ovault list <type>` | `:OvaultList <type>` | CLI + buffer/Telescope |
-| `ovault search <query>` | `:OvaultSearch` | CLI + Telescope |
-| `ovault open <file>` | `:OvaultOpen` | Native `:edit` |
-| `ovault audit` | `:OvaultAudit` | CLI + diagnostics |
-| `ovault bulk` | `:OvaultBulk` | CLI + preview buffer |
-| `ovault schema show` | `:OvaultSchema` | CLI + floating window |
-| `ovault template list` | `:OvaultTemplates` | CLI + Telescope |
+| `pika new [type]` | `:PikaNew [type]` | CLI + floating inputs |
+| `pika edit <file>` | `:PikaEdit` | CLI + floating inputs |
+| `pika list <type>` | `:PikaList <type>` | CLI + buffer/Telescope |
+| `pika search <query>` | `:PikaSearch` | CLI + Telescope |
+| `pika open <file>` | `:PikaOpen` | Native `:edit` |
+| `pika audit` | `:PikaAudit` | CLI + diagnostics |
+| `pika bulk` | `:PikaBulk` | CLI + preview buffer |
+| `pika schema show` | `:PikaSchema` | CLI + floating window |
+| `pika template list` | `:PikaTemplates` | CLI + Telescope |
 
 ---
 
@@ -77,11 +77,11 @@ A Neovim plugin (`ovault.nvim`) that brings the full power of ovault into the ed
 ### 1.1 Core Infrastructure
 
 ```lua
--- lua/ovault/init.lua
+-- lua/pika/init.lua
 local M = {}
 
 M.setup = function(opts)
-  -- Vault detection (find .ovault/schema.json)
+  -- Vault detection (find .pika/schema.json)
   -- CLI path configuration
   -- Keybinding setup
 end
@@ -91,44 +91,44 @@ return M
 
 **Deliverables:**
 - [ ] Plugin structure with lazy.nvim/packer support
-- [ ] Vault detection (walk up to find `.ovault/`)
-- [ ] CLI wrapper module (`lua/ovault/cli.lua`)
+- [ ] Vault detection (walk up to find `.pika/`)
+- [ ] CLI wrapper module (`lua/pika/cli.lua`)
 - [ ] JSON response parser
 - [ ] Error handling with `vim.notify`
 
 ### 1.2 Basic Commands
 
-**`:OvaultOpen [query]`** — Open note by name
-- Uses `ovault search --json` for resolution
+**`:PikaOpen [query]`** — Open note by name
+- Uses `pika search --json` for resolution
 - Falls back to Telescope if ambiguous
 - Direct `:edit` for exact match
 
-**`:OvaultList <type>`** — List notes in buffer
-- Calls `ovault list <type> --output json`
+**`:PikaList <type>`** — List notes in buffer
+- Calls `pika list <type> --output json`
 - Renders in scratch buffer or quickfix
 - Supports `--where` expressions
 
-**`:OvaultSchema`** — Show schema tree
-- Calls `ovault schema show`
+**`:PikaSchema`** — Show schema tree
+- Calls `pika schema show`
 - Floating window with type hierarchy
 
 ### 1.3 Telescope Integration
 
 ```lua
--- lua/telescope/_extensions/ovault.lua
+-- lua/telescope/_extensions/pika.lua
 return require("telescope").register_extension({
   exports = {
-    search = require("ovault.telescope.search"),
-    list = require("ovault.telescope.list"),
-    types = require("ovault.telescope.types"),
+    search = require("pika.telescope.search"),
+    list = require("pika.telescope.list"),
+    types = require("pika.telescope.types"),
   },
 })
 ```
 
 **Pickers:**
-- `Telescope ovault search` — Note search with wikilink output
-- `Telescope ovault list` — Filtered list with type selection
-- `Telescope ovault types` — Type hierarchy navigation
+- `Telescope pika search` — Note search with wikilink output
+- `Telescope pika list` — Filtered list with type selection
+- `Telescope pika types` — Type hierarchy navigation
 
 ---
 
@@ -139,7 +139,7 @@ return require("telescope").register_extension({
 Custom UI for schema-driven prompts:
 
 ```lua
--- lua/ovault/ui/input.lua
+-- lua/pika/ui/input.lua
 local M = {}
 
 -- Single line input with validation
@@ -161,7 +161,7 @@ end
 return M
 ```
 
-### 2.2 `:OvaultNew [type]`
+### 2.2 `:PikaNew [type]`
 
 Interactive note creation:
 
@@ -169,12 +169,12 @@ Interactive note creation:
 2. Navigate subtypes if needed
 3. Prompt for template if multiple available
 4. Show floating inputs for each field (respecting schema order)
-5. Call `ovault new <type> --json '{...}'`
+5. Call `pika new <type> --json '{...}'`
 6. Open created file
 
 **Flow diagram:**
 ```
-:OvaultNew
+:PikaNew
     │
     ├─► Type picker (Telescope)
     │       │
@@ -192,27 +192,27 @@ Interactive note creation:
     │   └── ... (dynamic fields)
     │       │
     │       ▼
-    └─► ovault new --json → :edit <path>
+    └─► pika new --json → :edit <path>
 ```
 
-### 2.3 `:OvaultEdit`
+### 2.3 `:PikaEdit`
 
 Edit frontmatter of current buffer:
 
 1. Detect type from frontmatter
 2. Show current values with edit prompts
-3. Call `ovault edit <path> --json '{...}'`
+3. Call `pika edit <path> --json '{...}'`
 4. Refresh buffer
 
 ---
 
 ## Phase 3: Advanced Features (Weeks 8-10)
 
-### 3.1 `:OvaultAudit` with Diagnostics
+### 3.1 `:PikaAudit` with Diagnostics
 
 ```lua
 -- Register diagnostic namespace
-local ns = vim.diagnostic.get_namespace("ovault")
+local ns = vim.diagnostic.get_namespace("pika")
 
 -- Run audit and populate diagnostics
 M.audit = function()
@@ -227,7 +227,7 @@ M.audit = function()
           and vim.diagnostic.severity.ERROR
           or vim.diagnostic.severity.WARN,
         message = issue.message,
-        source = "ovault",
+        source = "pika",
       })
     end
     vim.diagnostic.set(ns, bufnr, diagnostics)
@@ -238,25 +238,25 @@ end
 **Features:**
 - Populate `vim.diagnostic` for all open buffers
 - Quickfix list with all issues
-- `:OvaultAuditFix` for interactive fixing
+- `:PikaAuditFix` for interactive fixing
 
-### 3.2 `:OvaultBulk`
+### 3.2 `:PikaBulk`
 
 Bulk operations with preview:
 
 1. Show matching files in preview buffer
 2. Display proposed changes
 3. Confirm before execution
-4. Call `ovault bulk --execute`
+4. Call `pika bulk --execute`
 
 ### 3.3 Wikilink Completion
 
 ```lua
--- lua/ovault/completion.lua
+-- lua/pika/completion.lua
 -- Integrates with nvim-cmp or built-in completion
 
 -- Trigger on [[ 
--- Call ovault search --json with prefix
+-- Call pika search --json with prefix
 -- Return completion items with wikilink format
 ```
 
@@ -266,17 +266,17 @@ Bulk operations with preview:
 
 ### 4.1 Dashboard Integration
 
-Saved queries (linked issue: `ovault-48g`):
+Saved queries (linked issue: `pika-48g`):
 
 ```lua
-:OvaultDashboard           -- Show saved query list
-:OvaultDashboardSave       -- Save current list query
-:OvaultDashboardRun <name> -- Run saved query
+:PikaDashboard           -- Show saved query list
+:PikaDashboardSave       -- Save current list query
+:PikaDashboardRun <name> -- Run saved query
 ```
 
 ### 4.2 Formatted Table Output
 
-Better list display (linked issue: `ovault-hvf`):
+Better list display (linked issue: `pika-hvf`):
 
 - Aligned columns in buffer
 - Sortable headers
@@ -284,19 +284,19 @@ Better list display (linked issue: `ovault-hvf`):
 
 ### 4.3 Wikilink Insertion Picker
 
-Fuzzy finder for links (linked issue: `ovault-ng6`):
+Fuzzy finder for links (linked issue: `pika-ng6`):
 
 ```lua
-:OvaultLink           -- Insert [[wikilink]] at cursor
-:OvaultLinkVisual     -- Wrap selection in [[]]
+:PikaLink           -- Insert [[wikilink]] at cursor
+:PikaLinkVisual     -- Wrap selection in [[]]
 ```
 
 ### 4.4 Status Line Integration
 
 ```lua
 -- For lualine, etc.
-require("ovault").statusline()
--- Returns: "ovault: Tasks (12 active)"
+require("pika").statusline()
+-- Returns: "pika: Tasks (12 active)"
 ```
 
 ---
@@ -325,7 +325,7 @@ tests/
 ├── integration/
 │   ├── minimal_init.lua    -- Minimal plugin config
 │   ├── fixtures/           -- Test vault with schema
-│   ├── commands_spec.lua   -- :Ovault* commands
+│   ├── commands_spec.lua   -- :Pika* commands
 │   └── telescope_spec.lua  -- Picker behavior
 ```
 
@@ -357,7 +357,7 @@ nvim --headless -c "PlenaryBustedDirectory tests/integration"
 
 **Required:**
 - Neovim 0.9+ (for `vim.ui`, floating windows, diagnostics API)
-- `ovault` CLI installed and in PATH
+- `pika` CLI installed and in PATH
 
 **Optional:**
 - `telescope.nvim` — Enhanced pickers
@@ -369,9 +369,9 @@ nvim --headless -c "PlenaryBustedDirectory tests/integration"
 ## Configuration
 
 ```lua
-require("ovault").setup({
-  -- Path to ovault CLI (default: "ovault")
-  cli_path = "ovault",
+require("pika").setup({
+  -- Path to pika CLI (default: "pika")
+  cli_path = "pika",
   
   -- Vault path (default: auto-detect from cwd)
   vault_path = nil,
@@ -381,10 +381,10 @@ require("ovault").setup({
   
   -- Keymaps (default: none, user configures)
   keymaps = {
-    new = "<leader>on",
-    search = "<leader>os",
-    list = "<leader>ol",
-    edit = "<leader>oe",
+    new = "<leader>pn",
+    search = "<leader>ps",
+    list = "<leader>pl",
+    edit = "<leader>pe",
   },
   
   -- Open created notes automatically
@@ -405,7 +405,7 @@ require("ovault").setup({
 | Week | Milestone | Deliverables |
 |------|-----------|--------------|
 | 1 | Setup | Plugin structure, CLI wrapper, error handling |
-| 2 | Basic commands | `:OvaultOpen`, `:OvaultSchema` |
+| 2 | Basic commands | `:PikaOpen`, `:PikaSchema` |
 | 3 | Telescope | Search picker, type picker |
 | 4 | List command | Buffer display, quickfix |
 | 5 | UI components | Floating input, select, multi-input |
@@ -422,10 +422,10 @@ require("ovault").setup({
 
 ## Related Issues
 
-- `ovault-tic` — Parent issue: Create Neovim plugin for ovault integration
-- `ovault-ng6` — Fuzzy finder window for wikilink insertion
-- `ovault-hvf` — Formatted table output for list queries
-- `ovault-48g` — Dashboard integration for saved queries
+- `pika-tic` — Parent issue: Create Neovim plugin for pika integration
+- `pika-ng6` — Fuzzy finder window for wikilink insertion
+- `pika-hvf` — Formatted table output for list queries
+- `pika-48g` — Dashboard integration for saved queries
 
 ---
 
@@ -441,7 +441,7 @@ Detect Obsidian sync conflicts and surface them.
 
 ### Mobile Companion
 
-If ovault ever has a mobile story, the Neovim plugin could share config/saved queries.
+If pika ever has a mobile story, the Neovim plugin could share config/saved queries.
 
 ### LSP Integration
 

--- a/plans/features/query-system.md
+++ b/plans/features/query-system.md
@@ -6,12 +6,12 @@
 
 ## Overview
 
-ovault's query system provides powerful filtering capabilities compatible with Obsidian Bases. This enables:
+pika's query system provides powerful filtering capabilities compatible with Obsidian Bases. This enables:
 
-- Complex filters in `ovault list`
-- Conditions in `ovault bulk`
+- Complex filters in `pika list`
+- Conditions in `pika bulk`
 - Validation rules in templates
-- Future: `ovault base` for generating Bases queries
+- Future: `pika base` for generating Bases queries
 
 ---
 
@@ -21,34 +21,34 @@ ovault's query system provides powerful filtering capabilities compatible with O
 
 ```bash
 # Equality
-ovault list task --where "status == 'in-progress'"
-ovault list task --where "priority == 'high'"
+pika list task --where "status == 'in-progress'"
+pika list task --where "priority == 'high'"
 
 # Inequality
-ovault list task --where "status != 'done'"
+pika list task --where "status != 'done'"
 
 # Numeric comparison
-ovault list task --where "priority < 3"
-ovault list task --where "priority >= 2"
+pika list task --where "priority < 3"
+pika list task --where "priority >= 2"
 
 # String comparison (lexicographic)
-ovault list task --where "title < 'M'"
+pika list task --where "title < 'M'"
 ```
 
 ### Boolean Logic
 
 ```bash
 # AND
-ovault list task --where "status == 'in-progress' && priority == 'high'"
+pika list task --where "status == 'in-progress' && priority == 'high'"
 
 # OR
-ovault list task --where "status == 'done' || status == 'cancelled'"
+pika list task --where "status == 'done' || status == 'cancelled'"
 
 # NOT
-ovault list task --where "!isEmpty(deadline)"
+pika list task --where "!isEmpty(deadline)"
 
 # Grouped
-ovault list task --where "(status == 'inbox' || status == 'backlog') && priority == 'critical'"
+pika list task --where "(status == 'inbox' || status == 'backlog') && priority == 'critical'"
 ```
 
 ### Multiple --where Clauses
@@ -56,9 +56,9 @@ ovault list task --where "(status == 'inbox' || status == 'backlog') && priority
 Multiple `--where` flags are ANDed together:
 
 ```bash
-ovault list task --where "status == 'in-progress'" --where "priority == 'high'"
+pika list task --where "status == 'in-progress'" --where "priority == 'high'"
 # Equivalent to:
-ovault list task --where "status == 'in-progress' && priority == 'high'"
+pika list task --where "status == 'in-progress' && priority == 'high'"
 ```
 
 ---
@@ -136,8 +136,8 @@ Durations can be added/subtracted from dates:
 | `'30min'` | 30 minutes |
 
 ```bash
-ovault list task --where "deadline < today() + '7d'"
-ovault list task --where "file.mtime > now() - '24h'"
+pika list task --where "deadline < today() + '7d'"
+pika list task --where "file.mtime > now() - '24h'"
 ```
 
 ### Null/Empty Functions
@@ -173,9 +173,9 @@ ovault list task --where "file.mtime > now() - '24h'"
 Access frontmatter fields directly by name:
 
 ```bash
-ovault list task --where "status == 'done'"
-ovault list task --where "priority < 3"
-ovault list task --where "contains(tags, 'urgent')"
+pika list task --where "status == 'done'"
+pika list task --where "priority < 3"
+pika list task --where "contains(tags, 'urgent')"
 ```
 
 ### File Properties
@@ -193,8 +193,8 @@ Access file metadata via `file.*`:
 | `file.mtime` | Modification time |
 
 ```bash
-ovault list task --where "file.mtime > now() - '24h'"
-ovault list task --where "inFolder('Archive/')"
+pika list task --where "file.mtime > now() - '24h'"
+pika list task --where "inFolder('Archive/')"
 ```
 
 ### Nested Access
@@ -202,7 +202,7 @@ ovault list task --where "inFolder('Archive/')"
 For nested frontmatter (if supported):
 
 ```bash
-ovault list task --where "metadata.author == 'alice'"
+pika list task --where "metadata.author == 'alice'"
 ```
 
 ---
@@ -229,38 +229,38 @@ The query engine handles type coercion:
 
 ```bash
 # Overdue tasks
-ovault list task --where "deadline < today() && status != 'done'"
+pika list task --where "deadline < today() && status != 'done'"
 
 # High priority inbox items
-ovault list task --where "status == 'inbox' && (priority == 'high' || priority == 'critical')"
+pika list task --where "status == 'inbox' && (priority == 'high' || priority == 'critical')"
 
 # Recently modified
-ovault list --all --where "file.mtime > now() - '24h'"
+pika list --all --where "file.mtime > now() - '24h'"
 
 # Tasks without deadlines
-ovault list task --where "isEmpty(deadline) && status != 'done'"
+pika list task --where "isEmpty(deadline) && status != 'done'"
 
 # Tasks for this week
-ovault list task --where "scope == 'week' && status != 'done'"
+pika list task --where "scope == 'week' && status != 'done'"
 
 # Items with specific tag
-ovault list --all --where "contains(tags, 'review')"
+pika list --all --where "contains(tags, 'review')"
 
 # Drafts in progress
-ovault list draft --where "status == 'drafting' || status == 'revising'"
+pika list draft --where "status == 'drafting' || status == 'revising'"
 ```
 
 ### Bulk Operations
 
 ```bash
 # Mark overdue as urgent
-ovault bulk task --append tags=overdue --where "deadline < today() && status != 'done'" --execute
+pika bulk task --append tags=overdue --where "deadline < today() && status != 'done'" --execute
 
 # Archive old completed tasks
-ovault bulk task --move Archive/Tasks --where "status == 'done' && file.mtime < now() - '30d'" --execute
+pika bulk task --move Archive/Tasks --where "status == 'done' && file.mtime < now() - '30d'" --execute
 
 # Set default priority
-ovault bulk task --set priority=medium --where "isEmpty(priority)" --execute
+pika bulk task --set priority=medium --where "isEmpty(priority)" --execute
 ```
 
 ### Template Constraints
@@ -280,7 +280,7 @@ constraints:
 
 ## Bases Compatibility
 
-ovault queries align with Obsidian Bases syntax for easy mental model sharing:
+pika queries align with Obsidian Bases syntax for easy mental model sharing:
 
 ### Bases Syntax
 
@@ -293,16 +293,16 @@ filters:
         gte: 2
 ```
 
-### ovault Equivalent
+### pika Equivalent
 
 ```bash
-ovault list task --where "status == 'in-progress' && priority >= 2"
+pika list task --where "status == 'in-progress' && priority >= 2"
 ```
 
 ### Future: Base Generation
 
 ```bash
-ovault base task --where "status == 'in-progress'" --where "priority >= 2"
+pika base task --where "status == 'in-progress'" --where "priority >= 2"
 
 # Output:
 # filters:
@@ -319,7 +319,7 @@ ovault base task --where "status == 'in-progress'" --where "priority >= 2"
 ### Syntax Errors
 
 ```bash
-ovault list task --where "status = 'done'"
+pika list task --where "status = 'done'"
 # Error: Invalid operator '=' at position 7
 # Did you mean '=='?
 # 
@@ -330,7 +330,7 @@ ovault list task --where "status = 'done'"
 ### Unknown Fields
 
 ```bash
-ovault list task --where "stauts == 'done'"
+pika list task --where "stauts == 'done'"
 # Warning: Unknown field 'stauts'. Did you mean 'status'?
 # No results found.
 ```
@@ -338,7 +338,7 @@ ovault list task --where "stauts == 'done'"
 ### Type Errors
 
 ```bash
-ovault list task --where "deadline == 'not-a-date'"
+pika list task --where "deadline == 'not-a-date'"
 # Warning: Cannot compare date field 'deadline' with non-date value
 ```
 

--- a/plans/features/schema-management.md
+++ b/plans/features/schema-management.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-The `ovault schema` command provides full CLI control over the schema:
+The `pika schema` command provides full CLI control over the schema:
 
 - Explore types, fields, and enums
 - Add, edit, and remove types
@@ -21,40 +21,40 @@ The goal is to **never require direct JSON editing**.
 
 ```bash
 # Exploration
-ovault schema show                          # Tree view of all types
-ovault schema show objective/task           # Show specific type
-ovault schema validate                      # Validate schema structure
+pika schema show                          # Tree view of all types
+pika schema show objective/task           # Show specific type
+pika schema validate                      # Validate schema structure
 
 # Type management
-ovault schema add-type <name>               # Create new type
-ovault schema edit-type <name>              # Modify type settings
-ovault schema remove-type <name>            # Remove type
+pika schema add-type <name>               # Create new type
+pika schema edit-type <name>              # Modify type settings
+pika schema remove-type <name>            # Remove type
 
 # Subtype management
-ovault schema add-subtype <type> <name>     # Add subtype
-ovault schema edit-subtype <type/subtype>   # Modify subtype
-ovault schema remove-subtype <type/subtype> # Remove subtype
+pika schema add-subtype <type> <name>     # Add subtype
+pika schema edit-subtype <type/subtype>   # Modify subtype
+pika schema remove-subtype <type/subtype> # Remove subtype
 
 # Field management
-ovault schema add-field <name> <type>       # Add field to type
-ovault schema edit-field <name> <type>      # Modify field
-ovault schema remove-field <name> <type>    # Remove field
+pika schema add-field <name> <type>       # Add field to type
+pika schema edit-field <name> <type>      # Modify field
+pika schema remove-field <name> <type>    # Remove field
 
 # Shared fields
-ovault schema add-shared-field <name>       # Create shared field
-ovault schema edit-shared-field <name>      # Modify shared field
-ovault schema remove-shared-field <name>    # Remove shared field
+pika schema add-shared-field <name>       # Create shared field
+pika schema edit-shared-field <name>      # Modify shared field
+pika schema remove-shared-field <name>    # Remove shared field
 
 # Enum management
-ovault schema add-enum <name>               # Create new enum
-ovault schema edit-enum <name> [options]    # Modify enum
-ovault schema remove-enum <name>            # Remove enum
-ovault schema list-enums                    # List all enums
+pika schema add-enum <name>               # Create new enum
+pika schema edit-enum <name> [options]    # Modify enum
+pika schema remove-enum <name>            # Remove enum
+pika schema list-enums                    # List all enums
 
 # Migration
-ovault schema diff                          # Show pending migrations
-ovault schema apply                         # Apply migrations
-ovault schema history                       # Show migration history
+pika schema diff                          # Show pending migrations
+pika schema apply                         # Apply migrations
+pika schema history                       # Show migration history
 ```
 
 ---
@@ -64,7 +64,7 @@ ovault schema history                       # Show migration history
 ### Show All Types
 
 ```bash
-ovault schema show
+pika schema show
 
 # Schema v3
 # 
@@ -102,7 +102,7 @@ ovault schema show
 ### Show Specific Type
 
 ```bash
-ovault schema show objective/task
+pika schema show objective/task
 
 # Type: objective/task
 # 
@@ -128,7 +128,7 @@ ovault schema show objective/task
 ### Validate Schema
 
 ```bash
-ovault schema validate
+pika schema validate
 
 # Validating schema...
 # 
@@ -149,7 +149,7 @@ ovault schema validate
 ### Add Type
 
 ```bash
-ovault schema add-type project
+pika schema add-type project
 
 # Creating new type: project
 # 
@@ -202,7 +202,7 @@ ovault schema add-type project
 ### Edit Type
 
 ```bash
-ovault schema edit-type project
+pika schema edit-type project
 
 # Editing type: project
 # 
@@ -226,7 +226,7 @@ ovault schema edit-type project
 ### Remove Type
 
 ```bash
-ovault schema remove-type project
+pika schema remove-type project
 
 # ⚠ Warning: Removing type 'project'
 # 
@@ -241,7 +241,7 @@ ovault schema remove-type project
 # 
 # ✓ Removed type 'project'
 # 
-# Tip: Run 'ovault audit' to find orphaned files.
+# Tip: Run 'pika audit' to find orphaned files.
 ```
 
 ---
@@ -251,7 +251,7 @@ ovault schema remove-type project
 ### Add Field
 
 ```bash
-ovault schema add-field deadline task
+pika schema add-field deadline task
 
 # Adding field 'deadline' to objective/task
 # 
@@ -278,7 +278,7 @@ ovault schema add-field deadline task
 ### Edit Field
 
 ```bash
-ovault schema edit-field priority task
+pika schema edit-field priority task
 
 # Editing field 'priority' in objective/task
 # 
@@ -306,7 +306,7 @@ ovault schema edit-field priority task
 ### Remove Field
 
 ```bash
-ovault schema remove-field legacy-notes task
+pika schema remove-field legacy-notes task
 
 # ⚠ Warning: Removing field 'legacy-notes' from objective/task
 # 
@@ -320,7 +320,7 @@ ovault schema remove-field legacy-notes task
 # ✓ Removed field 'legacy-notes' from schema
 # 
 # Note: 23 files still have 'legacy-notes' field.
-# Run 'ovault bulk task --delete legacy-notes --execute' to remove from files.
+# Run 'pika bulk task --delete legacy-notes --execute' to remove from files.
 ```
 
 ---
@@ -330,7 +330,7 @@ ovault schema remove-field legacy-notes task
 ### Add Shared Field
 
 ```bash
-ovault schema add-shared-field priority
+pika schema add-shared-field priority
 
 # Creating shared field: priority
 # 
@@ -364,7 +364,7 @@ ovault schema add-shared-field priority
 ### Edit Shared Field
 
 ```bash
-ovault schema edit-shared-field status
+pika schema edit-shared-field status
 
 # Editing shared field: status
 # 
@@ -403,7 +403,7 @@ ovault schema edit-shared-field status
 ### Add Enum
 
 ```bash
-ovault schema add-enum scope
+pika schema add-enum scope
 
 # Creating enum: scope
 # 
@@ -416,7 +416,7 @@ ovault schema add-enum scope
 
 ```bash
 # Add value
-ovault schema edit-enum status --add archived
+pika schema edit-enum status --add archived
 
 # Adding 'archived' to enum 'status'
 # Current: inbox, backlog, planned, in-progress, done, cancelled
@@ -425,7 +425,7 @@ ovault schema edit-enum status --add archived
 # ✓ Added 'archived' to enum 'status'
 
 # Rename value
-ovault schema edit-enum status --rename in-flight=in-progress
+pika schema edit-enum status --rename in-flight=in-progress
 
 # Renaming in enum 'status': in-flight → in-progress
 # 
@@ -437,7 +437,7 @@ ovault schema edit-enum status --rename in-flight=in-progress
 # ✓ Renamed 'in-flight' to 'in-progress'
 
 # Remove value
-ovault schema edit-enum status --remove deprecated
+pika schema edit-enum status --remove deprecated
 
 # Removing 'deprecated' from enum 'status'
 # 
@@ -462,7 +462,7 @@ ovault schema edit-enum status --remove deprecated
 # ✓ Removed 'deprecated' from enum 'status'
 
 # Reorder values
-ovault schema edit-enum priority --reorder
+pika schema edit-enum priority --reorder
 
 # Current order: low, medium, high, critical
 # 
@@ -474,7 +474,7 @@ ovault schema edit-enum priority --reorder
 ### List Enums
 
 ```bash
-ovault schema list-enums
+pika schema list-enums
 
 # Enums:
 #   status      inbox, backlog, planned, in-progress, done, cancelled
@@ -497,14 +497,14 @@ ovault schema list-enums
 ### How It Works
 
 1. Schema changes that affect existing files create **pending migrations**
-2. `ovault schema diff` shows what migrations are pending
-3. `ovault schema apply` executes migrations
-4. Migrations are logged in `.ovault/migrations/`
+2. `pika schema diff` shows what migrations are pending
+3. `pika schema apply` executes migrations
+4. Migrations are logged in `.pika/migrations/`
 
 ### Schema Diff
 
 ```bash
-ovault schema diff
+pika schema diff
 
 # Pending migrations:
 # 
@@ -520,13 +520,13 @@ ovault schema diff
 #    Affects: 12 files
 #    Auto-applicable: no (needs replacement value)
 # 
-# Run 'ovault schema apply' to execute migrations.
+# Run 'pika schema apply' to execute migrations.
 ```
 
 ### Schema Apply
 
 ```bash
-ovault schema apply
+pika schema apply
 
 # Applying migrations...
 # 
@@ -603,7 +603,7 @@ The schema tracks version and migration history:
 ### View History
 
 ```bash
-ovault schema history
+pika schema history
 
 # Schema migration history:
 # 
@@ -633,7 +633,7 @@ ovault schema history
 ### Invalid Operation
 
 ```bash
-ovault schema remove-enum status
+pika schema remove-enum status
 
 # ✗ Cannot remove enum 'status'
 #   It is used by shared field 'status'
@@ -646,7 +646,7 @@ ovault schema remove-enum status
 ### Circular Reference
 
 ```bash
-ovault schema add-field parent task --type dynamic --source tasks
+pika schema add-field parent task --type dynamic --source tasks
 
 # ⚠ Warning: This creates a self-referential field
 #   'task.parent' references 'tasks' (which are tasks)
@@ -672,7 +672,7 @@ interface Schema {
 }
 
 async function loadSchema(vaultPath: string): Promise<Schema> {
-  const schemaPath = path.join(vaultPath, '.ovault', 'schema.json');
+  const schemaPath = path.join(vaultPath, '.pika', 'schema.json');
   const content = await fs.readFile(schemaPath, 'utf-8');
   const raw = JSON.parse(content);
   
@@ -691,7 +691,7 @@ async function saveSchema(vaultPath: string, schema: Schema): Promise<void> {
     description: currentMigrationDescription,
   });
   
-  const schemaPath = path.join(vaultPath, '.ovault', 'schema.json');
+  const schemaPath = path.join(vaultPath, '.pika', 'schema.json');
   await fs.writeFile(schemaPath, JSON.stringify(schema, null, 2));
 }
 ```

--- a/plans/features/template-system.md
+++ b/plans/features/template-system.md
@@ -263,15 +263,15 @@ Empty sections indicate expected content type:
 
 ```bash
 # Use default template
-ovault new task --default
+pika new task --default
 # → Uses Templates/objective/task/default.md
 
 # Specify template
-ovault new task --template bug-report
+pika new task --template bug-report
 # → Uses Templates/objective/task/bug-report.md
 
 # Interactive selection (if multiple templates)
-ovault new task
+pika new task
 # Multiple templates found:
 #   1. default
 #   2. bug-report
@@ -283,20 +283,20 @@ ovault new task
 
 ```bash
 # Skip template, use schema only
-ovault new task --no-template
+pika new task --no-template
 ```
 
 ### List Templates
 
 ```bash
-ovault template list
+pika template list
 # TYPE           TEMPLATE         DESCRIPTION
 # objective/task default          Standard task
 # objective/task bug-report       Bug report with reproduction steps
 # objective/task feature-request  Feature request with acceptance criteria
 # idea           default          Quick idea capture
 
-ovault template list task
+pika template list task
 # TEMPLATE         DESCRIPTION
 # default          Standard task
 # bug-report       Bug report with reproduction steps
@@ -377,7 +377,7 @@ Blog post for Builder.io about [topic].
 ### CLI Behavior
 
 ```bash
-ovault new draft --template builder-blog --set title="Q1 Feature Announcement"
+pika new draft --template builder-blog --set title="Q1 Feature Announcement"
 
 # Creating draft: Q1 Feature Announcement
 # 
@@ -487,7 +487,7 @@ Templates can **narrow** but not **loosen** schema requirements:
 ### On Load
 
 ```bash
-ovault template validate
+pika template validate
 
 # Validating templates...
 # 
@@ -503,7 +503,7 @@ ovault template validate
 
 ### On Use
 
-If a template has validation errors, `ovault new` will:
+If a template has validation errors, `pika new` will:
 1. Warn about the errors
 2. Offer to continue without template
 3. Or abort
@@ -515,7 +515,7 @@ If a template has validation errors, `ovault new` will:
 ### Create Template
 
 ```bash
-ovault template new task
+pika template new task
 # Template name: quick-task
 # Description: Fast task capture with minimal fields
 # 
@@ -535,7 +535,7 @@ Templates are just markdown files — edit in Obsidian or any editor.
 ### Audit Templates
 
 ```bash
-ovault audit --templates
+pika audit --templates
 
 # Template Issues:
 #   Templates/draft/version/old.md

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -46,7 +46,7 @@ describe('audit command', () => {
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-test-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-test-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       // Schema with a required field that has NO default
       const schemaWithRequired = {
@@ -95,7 +95,7 @@ priority: medium
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-test-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-test-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await writeFile(
         join(tempVaultDir, '.pika', 'schema.json'),
@@ -147,7 +147,7 @@ priority: medium
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-test-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-test-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await writeFile(
         join(tempVaultDir, '.pika', 'schema.json'),
@@ -221,7 +221,7 @@ tags:
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-test-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-test-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await writeFile(
         join(tempVaultDir, '.pika', 'schema.json'),
@@ -255,7 +255,7 @@ priority: medium
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-test-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-test-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await writeFile(
         join(tempVaultDir, '.pika', 'schema.json'),
@@ -307,7 +307,7 @@ status: raw
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-test-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-test-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await writeFile(
         join(tempVaultDir, '.pika', 'schema.json'),
@@ -367,7 +367,7 @@ priority: medium
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-test-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-test-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await writeFile(
         join(tempVaultDir, '.pika', 'schema.json'),
@@ -456,7 +456,7 @@ priority: medium
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-test-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-test-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await writeFile(
         join(tempVaultDir, '.pika', 'schema.json'),
@@ -513,7 +513,7 @@ priority: medium
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-fix-test-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-fix-test-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await writeFile(
         join(tempVaultDir, '.pika', 'schema.json'),
@@ -635,7 +635,7 @@ priority: medium
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-fix-test-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-fix-test-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await writeFile(
         join(tempVaultDir, '.pika', 'schema.json'),
@@ -688,7 +688,7 @@ priority: medium
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-vaultwide-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-vaultwide-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await writeFile(
         join(tempVaultDir, '.pika', 'schema.json'),
@@ -906,7 +906,7 @@ priority: medium
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-orphan-fix-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-orphan-fix-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await writeFile(
         join(tempVaultDir, '.pika', 'schema.json'),
@@ -1017,7 +1017,7 @@ title: Random note
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-allow-field-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-allow-field-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await writeFile(
         join(tempVaultDir, '.pika', 'schema.json'),
@@ -1096,7 +1096,7 @@ otherField: value
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-format-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-format-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       // Use schema with wikilink format field
       await writeFile(
@@ -1195,7 +1195,7 @@ milestone: "[[Q1 Release]]"
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-stale-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-stale-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await writeFile(
         join(tempVaultDir, '.pika', 'schema.json'),
@@ -1385,7 +1385,7 @@ Link with both: [[Missing Note#Section|Alias]]
     let tempVaultDir: string;
 
     beforeEach(async () => {
-      tempVaultDir = await mkdtemp(join(tmpdir(), 'ovault-audit-schema-allow-'));
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-audit-schema-allow-'));
       await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
       await mkdir(join(tempVaultDir, 'Ideas'), { recursive: true });
     });

--- a/tests/ts/commands/relative-paths.test.ts
+++ b/tests/ts/commands/relative-paths.test.ts
@@ -3,7 +3,7 @@
  *
  * These tests verify that all CLI commands work correctly when
  * the --vault option is given a relative path instead of an absolute path.
- * This is important because users may run ovault from various directories
+ * This is important because users may run pika from various directories
  * and use relative paths like `--vault ./my-vault` or `--vault ../vaults/work`.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';

--- a/tests/ts/lib/numberedSelect.pty.test.ts
+++ b/tests/ts/lib/numberedSelect.pty.test.ts
@@ -30,7 +30,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
 
   describe('number key selection', () => {
     it('should select immediately on number key press without re-rendering', async () => {
-      // This test verifies the fix for ovault-18j:
+      // This test verifies the fix for pika-18j:
       // "Numbered select prompt renders repeatedly when selecting options"
       //
       // The bug: pressing a number key caused the options to render again
@@ -180,7 +180,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
 
   describe('first render preserves prior output', () => {
     it('should not erase output printed before the prompt', async () => {
-      // This test verifies the fix from ovault-h4h description:
+      // This test verifies the fix from pika-h4h description:
       // "on first render, it called clearPrompt() which erased lines
       //  printed BEFORE the prompt started"
 
@@ -258,8 +258,8 @@ describePty('NumberedSelectPrompt PTY tests', () => {
       }
     }, 30000);
 
-    it('should not re-render excessively during arrow navigation (ovault-18j)', async () => {
-      // This test verifies the fix for ovault-18j:
+    it('should not re-render excessively during arrow navigation (pika-18j)', async () => {
+      // This test verifies the fix for pika-18j:
       // Arrow key navigation should use differential updates, only changing
       // the specific lines affected (old selection and new selection),
       // rather than clearing and re-rendering the entire prompt.


### PR DESCRIPTION
## Summary

Completes the rename from "ovault" to "pika" throughout the codebase:

- **Test files**: Updated temp directory prefixes (`ovault-audit-test-` → `pika-audit-test-`) and comments referencing old issue IDs
- **Roadmap**: Updated all issue references from `ovault-*` to `pika-*` format
- **Plan docs**: Updated all feature and archive plan docs to use pika naming
- **Technical docs**: Updated migration section in inheritance.md
- **Issue titles**: Renamed beads issues referencing "ovault" in their titles

## Changes

- 17 files changed
- All tests pass (817 passed)
- TypeScript compiles cleanly
- Build succeeds

## Closes

- pika-cr7 (Rename ovault to pika)

This unblocks Phase 1 work including pika-wbz (Implement inheritance model).