### PR TITLE
feat(audit): add context field type validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ All notable changes to Pika are documented in this file.
     - `owned-wrong-location`: Owned note not in expected folder location
   - New schema field: `owned: true` on dynamic source fields declares child ownership
 
+- **Context field type validation in audit** (pika-taz)
+  - `pika audit` now validates that context fields (wikilink fields with `source` property) reference notes of the correct type
+  - New issue code: `invalid-source-type` - reports when a field references a note of the wrong type
+  - Example: If a task's `milestone` field has `source: "milestone"`, audit will error if it links to a task instead
+  - Supports parent types: `source: "objective"` accepts objectives and all descendants (task, milestone, etc.)
+  - Skips validation for legacy `dynamic_sources` (use type-based sources for validation)
+  - JSON output includes `expectedType` and `actualType` for debugging
+
 - **Custom plural names for folder computation** (pika-2e1)
   - Add `plural` property to type definitions for custom folder naming
   - Example: `"research": { "plural": "research" }` → folder is `research/` not `researches/`

--- a/src/lib/audit/output.ts
+++ b/src/lib/audit/output.ts
@@ -74,6 +74,8 @@ export function outputJsonResults(results: FileAuditResult[], summary: AuditSumm
         ...(i.similarFiles && { similarFiles: i.similarFiles }),
         ...(i.inBody !== undefined && { inBody: i.inBody }),
         ...(i.lineNumber !== undefined && { lineNumber: i.lineNumber }),
+        ...(i.expectedType && { expectedType: i.expectedType }),
+        ...(i.actualType && { actualType: i.actualType }),
       })),
     })),
     summary,

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -28,6 +28,7 @@ export type IssueCode =
   | 'type-mismatch'
   | 'format-violation'
   | 'stale-reference'
+  | 'invalid-source-type'
   | 'owned-note-referenced'
   | 'owned-wrong-location';
 
@@ -59,6 +60,10 @@ export interface AuditIssue {
   ownerPath?: string | undefined;
   /** For owned-note-referenced: the note that was improperly referenced */
   ownedNotePath?: string | undefined;
+  /** For invalid-source-type: the expected type(s) from field.source */
+  expectedType?: string | undefined;
+  /** For invalid-source-type: the actual type of the referenced note */
+  actualType?: string | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements validation for context fields (wikilink fields with `source` property) to ensure they reference notes of the correct type.

**Issue:** pika-taz

## Changes

- Add `invalid-source-type` issue code for type mismatches
- Add `buildNoteTypeMap()` for efficient type lookup during audit
- Validate context fields against their source type constraint
- Support parent types (`source: objective` accepts descendants like task, milestone)
- Skip validation for legacy `dynamic_sources` (to be migrated in pika-fqh)
- Include `expectedType`/`actualType` in JSON output for debugging

## Example

Schema:
```json
{
  "task": {
    "extends": "objective",
    "fields": {
      "milestone": {
        "prompt": "dynamic",
        "source": "milestone",
        "format": "wikilink"
      }
    }
  }
}
```

If a task incorrectly references another task as its milestone:
```yaml
type: task
milestone: "[[Some Task]]"  # Error: expects milestone, got task
```

Audit output:
```
objectives/tasks/Bad Ref.md
  ✗ Type mismatch: 'milestone' expects milestone, but 'Some Task' is task
```

## Testing

- Added comprehensive tests for context field validation
- Tests cover: type mismatches, correct types, parent types accepting descendants, stale references (skipped), legacy dynamic_sources (skipped), multiple values
- All 858 tests pass

## Follow-up

Created pika-fqh to migrate legacy `dynamic_sources` to type-based sources. Context validation currently skips legacy dynamic_sources for backward compatibility.