### PR TITLE
feat: add pika schema enum management commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Pika are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Enum management commands** (pika-1kr)
+  - `pika schema enum list` - Show all enums with their values and field usage
+  - `pika schema enum add <name>` - Create a new enum (interactive or `--values` flag)
+  - `pika schema enum update <name>` - Modify enum values (`--add`, `--remove`, `--rename`)
+  - `pika schema enum delete <name>` - Delete an enum (refuses if in use, `--force` to override)
+  - Full JSON output support with `--output json` for all enum commands
+  - Validation: enum names must be alphanumeric with hyphens/underscores, values cannot contain commas or newlines
+  - Note: Enum changes only update schema.json; use `pika bulk` or `pika audit --fix` to update existing notes
+
 ### Breaking Changes
 
 - **Renamed project from ovault to pika**

--- a/src/lib/enum-utils.ts
+++ b/src/lib/enum-utils.ts
@@ -1,0 +1,244 @@
+/**
+ * Enum Utilities Module
+ * 
+ * Query and mutation functions for enum management.
+ * Query functions work with LoadedSchema (resolved).
+ * Mutation functions work with raw Schema (for writing).
+ */
+
+import type { LoadedSchema, Schema } from '../types/schema.js';
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/**
+ * Validate an enum value name.
+ * Returns error message if invalid, null if valid.
+ */
+export function validateEnumValue(value: string): string | null {
+  if (!value) return 'Value cannot be empty';
+  if (value !== value.trim()) return 'Value cannot have leading/trailing whitespace';
+  if (value.includes(',')) return 'Value cannot contain commas';
+  if (value.includes('\n')) return 'Value cannot contain newlines';
+  return null;
+}
+
+/**
+ * Validate an enum name.
+ * Returns error message if invalid, null if valid.
+ */
+export function validateEnumName(name: string): string | null {
+  if (!name) return 'Name cannot be empty';
+  if (name !== name.trim()) return 'Name cannot have leading/trailing whitespace';
+  if (!/^[a-z][a-z0-9_-]*$/i.test(name)) {
+    return 'Name must start with a letter and contain only letters, numbers, hyphens, and underscores';
+  }
+  return null;
+}
+
+// ============================================================================
+// Query Functions (work with LoadedSchema)
+// ============================================================================
+
+/**
+ * Information about where an enum is used.
+ */
+export interface EnumUsage {
+  typeName: string;
+  fieldName: string;
+}
+
+/**
+ * Get all places where an enum is used in the schema.
+ */
+export function getEnumUsage(schema: LoadedSchema, enumName: string): EnumUsage[] {
+  const usages: EnumUsage[] = [];
+  
+  for (const [typeName, typeDef] of schema.types) {
+    for (const [fieldName, field] of Object.entries(typeDef.fields)) {
+      if (field.enum === enumName) {
+        usages.push({ typeName, fieldName });
+      }
+    }
+  }
+  
+  return usages;
+}
+
+/**
+ * Check if an enum is currently in use by any field.
+ */
+export function isEnumInUse(schema: LoadedSchema, enumName: string): boolean {
+  return getEnumUsage(schema, enumName).length > 0;
+}
+
+/**
+ * Get all enum names from a loaded schema.
+ */
+export function getEnumNames(schema: LoadedSchema): string[] {
+  return Array.from(schema.enums.keys()).sort();
+}
+
+/**
+ * Check if an enum exists in the schema.
+ */
+export function enumExists(schema: LoadedSchema, enumName: string): boolean {
+  return schema.enums.has(enumName);
+}
+
+// ============================================================================
+// Mutation Functions (work with raw Schema)
+// ============================================================================
+
+/**
+ * Add a new enum to the schema.
+ * Returns a new schema object (does not mutate).
+ * Throws if enum already exists or values are invalid.
+ */
+export function addEnum(schema: Schema, name: string, values: string[]): Schema {
+  // Validate name
+  const nameError = validateEnumName(name);
+  if (nameError) throw new Error(nameError);
+  
+  // Check if exists
+  if (schema.enums && schema.enums[name]) {
+    throw new Error(`Enum "${name}" already exists`);
+  }
+  
+  // Validate values
+  if (values.length === 0) {
+    throw new Error('Enum must have at least one value');
+  }
+  
+  for (const value of values) {
+    const valueError = validateEnumValue(value);
+    if (valueError) throw new Error(`Invalid value "${value}": ${valueError}`);
+  }
+  
+  // Check for duplicates
+  const uniqueValues = new Set(values);
+  if (uniqueValues.size !== values.length) {
+    throw new Error('Enum values must be unique');
+  }
+  
+  return {
+    ...schema,
+    enums: {
+      ...schema.enums,
+      [name]: values,
+    },
+  };
+}
+
+/**
+ * Delete an enum from the schema.
+ * Returns a new schema object (does not mutate).
+ * Throws if enum doesn't exist.
+ */
+export function deleteEnum(schema: Schema, name: string): Schema {
+  if (!schema.enums || !schema.enums[name]) {
+    throw new Error(`Enum "${name}" does not exist`);
+  }
+  
+  const { [name]: _, ...remainingEnums } = schema.enums;
+  
+  return {
+    ...schema,
+    enums: remainingEnums,
+  };
+}
+
+/**
+ * Add a value to an existing enum.
+ * Returns a new schema object (does not mutate).
+ * Throws if enum doesn't exist or value already exists.
+ */
+export function addEnumValue(schema: Schema, enumName: string, value: string): Schema {
+  if (!schema.enums || !schema.enums[enumName]) {
+    throw new Error(`Enum "${enumName}" does not exist`);
+  }
+  
+  const valueError = validateEnumValue(value);
+  if (valueError) throw new Error(valueError);
+  
+  const existingValues = schema.enums[enumName];
+  if (existingValues.includes(value)) {
+    throw new Error(`Value "${value}" already exists in enum "${enumName}"`);
+  }
+  
+  return {
+    ...schema,
+    enums: {
+      ...schema.enums,
+      [enumName]: [...existingValues, value],
+    },
+  };
+}
+
+/**
+ * Remove a value from an enum.
+ * Returns a new schema object (does not mutate).
+ * Throws if enum doesn't exist, value doesn't exist, or would leave enum empty.
+ */
+export function removeEnumValue(schema: Schema, enumName: string, value: string): Schema {
+  if (!schema.enums || !schema.enums[enumName]) {
+    throw new Error(`Enum "${enumName}" does not exist`);
+  }
+  
+  const existingValues = schema.enums[enumName];
+  if (!existingValues.includes(value)) {
+    throw new Error(`Value "${value}" does not exist in enum "${enumName}"`);
+  }
+  
+  const newValues = existingValues.filter(v => v !== value);
+  if (newValues.length === 0) {
+    throw new Error(`Cannot remove last value from enum "${enumName}"`);
+  }
+  
+  return {
+    ...schema,
+    enums: {
+      ...schema.enums,
+      [enumName]: newValues,
+    },
+  };
+}
+
+/**
+ * Rename a value in an enum.
+ * Returns a new schema object (does not mutate).
+ * Throws if enum doesn't exist, old value doesn't exist, or new value already exists.
+ */
+export function renameEnumValue(
+  schema: Schema,
+  enumName: string,
+  oldValue: string,
+  newValue: string
+): Schema {
+  if (!schema.enums || !schema.enums[enumName]) {
+    throw new Error(`Enum "${enumName}" does not exist`);
+  }
+  
+  const valueError = validateEnumValue(newValue);
+  if (valueError) throw new Error(valueError);
+  
+  const existingValues = schema.enums[enumName];
+  if (!existingValues.includes(oldValue)) {
+    throw new Error(`Value "${oldValue}" does not exist in enum "${enumName}"`);
+  }
+  
+  if (existingValues.includes(newValue)) {
+    throw new Error(`Value "${newValue}" already exists in enum "${enumName}"`);
+  }
+  
+  const newValues = existingValues.map(v => v === oldValue ? newValue : v);
+  
+  return {
+    ...schema,
+    enums: {
+      ...schema.enums,
+      [enumName]: newValues,
+    },
+  };
+}

--- a/src/lib/schema-writer.ts
+++ b/src/lib/schema-writer.ts
@@ -1,0 +1,51 @@
+/**
+ * Schema Writer Module
+ * 
+ * Handles reading and writing schema.json files safely.
+ * Unlike loadSchema() which resolves inheritance, this module works with
+ * raw JSON to preserve structure during mutations.
+ */
+
+import { readFile, writeFile, rename } from 'fs/promises';
+import { join } from 'path';
+import { PikaSchema, type Schema } from '../types/schema.js';
+
+const SCHEMA_PATH = '.pika/schema.json';
+
+/**
+ * Load the raw schema JSON from a vault directory.
+ * Returns the parsed JSON without resolving inheritance.
+ */
+export async function loadRawSchemaJson(vaultDir: string): Promise<Schema> {
+  const schemaPath = join(vaultDir, SCHEMA_PATH);
+  const content = await readFile(schemaPath, 'utf-8');
+  const json = JSON.parse(content) as unknown;
+  return PikaSchema.parse(json);
+}
+
+/**
+ * Write a schema to the vault, preserving formatting.
+ * Uses atomic write (temp file + rename) for safety.
+ */
+export async function writeSchema(vaultDir: string, schema: Schema): Promise<void> {
+  const schemaPath = join(vaultDir, SCHEMA_PATH);
+  const tempPath = join(vaultDir, SCHEMA_PATH + '.tmp');
+  
+  // Validate before writing
+  PikaSchema.parse(schema);
+  
+  // Write to temp file
+  const content = JSON.stringify(schema, null, 2) + '\n';
+  await writeFile(tempPath, content, 'utf-8');
+  
+  // Atomic rename
+  await rename(tempPath, schemaPath);
+}
+
+/**
+ * Validate that a schema is valid without writing it.
+ * Throws if invalid.
+ */
+export function validateSchema(schema: unknown): Schema {
+  return PikaSchema.parse(schema);
+}

--- a/tests/ts/commands/schema-enum.test.ts
+++ b/tests/ts/commands/schema-enum.test.ts
@@ -1,0 +1,425 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createTestVault, cleanupTestVault, runCLI, TEST_SCHEMA } from '../fixtures/setup.js';
+
+describe('schema enum commands', () => {
+  let vaultDir: string;
+
+  beforeAll(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterAll(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  describe('enum list', () => {
+    it('should list all enums with values', async () => {
+      const result = await runCLI(['schema', 'enum', 'list'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('status');
+      expect(result.stdout).toContain('priority');
+      expect(result.stdout).toContain('raw');
+      expect(result.stdout).toContain('backlog');
+    });
+
+    it('should show usage information', async () => {
+      const result = await runCLI(['schema', 'enum', 'list'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      // Status is used by task, milestone, and idea
+      expect(result.stdout).toContain('Used by:');
+    });
+
+    it('should output JSON format', async () => {
+      const result = await runCLI(['schema', 'enum', 'list', '--output', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.enums).toBeInstanceOf(Array);
+      
+      const statusEnum = json.data.enums.find((e: { name: string }) => e.name === 'status');
+      expect(statusEnum).toBeDefined();
+      expect(statusEnum.values).toContain('raw');
+      expect(statusEnum.values).toContain('in-flight');
+    });
+
+    it('should show empty message when no enums', async () => {
+      // Create vault with no enums
+      const emptyVaultDir = await mkdtemp(join(tmpdir(), 'pika-noenum-'));
+      await mkdir(join(emptyVaultDir, '.pika'), { recursive: true });
+      await writeFile(
+        join(emptyVaultDir, '.pika', 'schema.json'),
+        JSON.stringify({ version: 2, types: { note: { output_dir: 'Notes' } } })
+      );
+
+      try {
+        const result = await runCLI(['schema', 'enum', 'list'], emptyVaultDir);
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('No enums defined');
+      } finally {
+        await rm(emptyVaultDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('enum add', () => {
+    let tempVaultDir: string;
+
+    beforeEach(async () => {
+      // Create fresh vault for each add test
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-enumadd-'));
+      await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.pika', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          enums: { existing: ['a', 'b'] },
+          types: { note: { output_dir: 'Notes' } },
+        })
+      );
+    });
+
+    afterAll(async () => {
+      if (tempVaultDir) {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should add enum with --values flag', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'add', 'severity', '--values', 'low,medium,high,critical'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Created enum "severity"');
+      expect(result.stdout).toContain('low');
+      expect(result.stdout).toContain('critical');
+
+      // Verify it was written to schema
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.enums.severity).toEqual(['low', 'medium', 'high', 'critical']);
+    });
+
+    it('should output JSON format', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'add', 'category', '--values', 'bug,feature', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.name).toBe('category');
+      expect(json.data.values).toEqual(['bug', 'feature']);
+    });
+
+    it('should reject duplicate enum name', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'add', 'existing', '--values', 'x,y'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('already exists');
+    });
+
+    it('should reject duplicate values', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'add', 'dups', '--values', 'a,b,a', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('unique');
+    });
+
+    it('should reject invalid enum name', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'add', '123invalid', '--values', 'a,b'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('must start with a letter');
+    });
+
+    it('should reject values containing commas', async () => {
+      // This tests that individual values are validated
+      // Since commas are the separator, "a,b" becomes ["a", "b"], both valid
+      // But we can test a value with just whitespace
+      const result = await runCLI(
+        ['schema', 'enum', 'add', 'spaces', '--values', ' , '],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('should require --values in JSON mode', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'add', 'novals', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('--values flag is required');
+    });
+  });
+
+  describe('enum update', () => {
+    let tempVaultDir: string;
+
+    beforeEach(async () => {
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-enumupd-'));
+      await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.pika', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          enums: { status: ['open', 'closed', 'pending'] },
+          types: { note: { output_dir: 'Notes' } },
+        })
+      );
+    });
+
+    afterAll(async () => {
+      if (tempVaultDir) {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should add value with --add', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'update', 'status', '--add', 'archived'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Added "archived"');
+
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.enums.status).toContain('archived');
+    });
+
+    it('should remove value with --remove', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'update', 'status', '--remove', 'pending'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Removed "pending"');
+
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.enums.status).not.toContain('pending');
+      expect(schema.enums.status).toContain('open');
+      expect(schema.enums.status).toContain('closed');
+    });
+
+    it('should rename value with --rename', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'update', 'status', '--rename', 'open=active'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Renamed "open" to "active"');
+
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.enums.status).not.toContain('open');
+      expect(schema.enums.status).toContain('active');
+    });
+
+    it('should show warning about updating notes on rename', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'update', 'status', '--rename', 'open=active'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('pika bulk');
+    });
+
+    it('should output JSON format', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'update', 'status', '--add', 'wip', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.values).toContain('wip');
+    });
+
+    it('should reject nonexistent enum', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'update', 'nonexistent', '--add', 'val'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('does not exist');
+    });
+
+    it('should reject adding duplicate value', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'update', 'status', '--add', 'open'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('already exists');
+    });
+
+    it('should reject removing nonexistent value', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'update', 'status', '--remove', 'nonexistent'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('does not exist');
+    });
+
+    it('should reject removing last value', async () => {
+      // First remove two values
+      await runCLI(['schema', 'enum', 'update', 'status', '--remove', 'open'], tempVaultDir);
+      await runCLI(['schema', 'enum', 'update', 'status', '--remove', 'pending'], tempVaultDir);
+
+      // Try to remove the last one
+      const result = await runCLI(
+        ['schema', 'enum', 'update', 'status', '--remove', 'closed'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('last value');
+    });
+
+    it('should require exactly one operation', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'update', 'status'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Specify one of');
+    });
+
+    it('should reject multiple operations', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'update', 'status', '--add', 'x', '--remove', 'open'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('only one of');
+    });
+  });
+
+  describe('enum delete', () => {
+    let tempVaultDir: string;
+
+    beforeEach(async () => {
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-enumdel-'));
+      await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.pika', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          enums: {
+            unused: ['a', 'b', 'c'],
+            used: ['x', 'y', 'z'],
+          },
+          types: {
+            note: {
+              output_dir: 'Notes',
+              fields: {
+                category: { prompt: 'select', enum: 'used' },
+              },
+            },
+          },
+        })
+      );
+    });
+
+    afterAll(async () => {
+      if (tempVaultDir) {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should delete unused enum', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'delete', 'unused'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Deleted enum "unused"');
+
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.enums.unused).toBeUndefined();
+      expect(schema.enums.used).toBeDefined();
+    });
+
+    it('should refuse to delete enum in use', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'delete', 'used'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Cannot delete');
+      expect(result.stderr).toContain('note.category');
+    });
+
+    it('should delete enum in use with --force', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'delete', 'used', '--force'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Deleted enum "used"');
+      expect(result.stdout).toContain('Warning');
+      expect(result.stdout).toContain('note.category');
+
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.enums.used).toBeUndefined();
+    });
+
+    it('should output JSON format', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'delete', 'unused', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.name).toBe('unused');
+    });
+
+    it('should reject nonexistent enum', async () => {
+      const result = await runCLI(
+        ['schema', 'enum', 'delete', 'nonexistent'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('does not exist');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements enum CRUD operations under `pika schema enum` for managing enums in the vault schema.

- `pika schema enum list` - Show all enums with their values and field usage
- `pika schema enum add <name>` - Create a new enum (interactive or `--values` flag)  
- `pika schema enum update <name>` - Modify values (`--add`, `--remove`, `--rename`)
- `pika schema enum delete <name>` - Delete enum (refuses if in use, `--force` to override)

## Key Design Decisions

1. **Schema-only updates**: Enum changes only modify `schema.json`. Notes with affected values should be updated via `pika bulk` or `pika audit --fix`. This keeps the command focused and consistent with existing patterns.

2. **Usage tracking**: `enum list` and `enum delete` show which fields reference each enum, helping users understand impact before making changes.

3. **Safety guards**: Delete refuses if enum is in use (with `--force` override), and rename/remove warn about notes that may need updating.

## New Files

- `src/lib/schema-writer.ts` - Atomic schema file read/write utilities
- `src/lib/enum-utils.ts` - Enum query and mutation functions  
- `tests/ts/commands/schema-enum.test.ts` - 27 tests covering all enum operations

## Testing

```bash
cd ../pika-enum-management
pnpm test  # All 899 tests pass
```

## Usage Examples

```bash
# List enums
pika schema enum list
pika schema enum list --output json

# Add enum
pika schema enum add severity --values "low,medium,high,critical"

# Update enum
pika schema enum update severity --add extreme
pika schema enum update severity --remove low
pika schema enum update severity --rename medium=moderate

# Delete enum
pika schema enum delete unused-enum
pika schema enum delete used-enum --force
```

Closes pika-1kr