### PR TITLE
feat!: replace dynamic_sources with type-based source queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to Pika are documented in this file.
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **Removed `dynamic_sources` - use type-based sources instead** (pika-fqh)
+  - The `dynamic_sources` section in schema.json is no longer supported
+  - Schemas using `dynamic_sources` will error on load with a migration guide
+  - **Migration**: Replace `source: "dynamic_source_name"` with `source: "type_name"` on fields
+  - **Migration**: Move filter conditions from `dynamic_sources` to the field's `filter` property
+  
+  Before:
+  ```json
+  {
+    "dynamic_sources": {
+      "active_milestones": {
+        "dir": "Objectives/Milestones",
+        "filter": { "status": { "not_in": ["settled"] } }
+      }
+    },
+    "types": {
+      "task": {
+        "fields": {
+          "milestone": { "source": "active_milestones", "format": "wikilink" }
+        }
+      }
+    }
+  }
+  ```
+  
+  After:
+  ```json
+  {
+    "types": {
+      "task": {
+        "fields": {
+          "milestone": {
+            "source": "milestone",
+            "filter": { "status": { "not_in": ["settled"] } },
+            "format": "wikilink"
+          }
+        }
+      }
+    }
+  }
+  ```
+  
+  - Type-based sources automatically include descendant types (e.g., `source: "objective"` includes tasks, milestones)
+  - Owned notes are excluded from source queries (they cannot be referenced by other notes)
+  - Context field validation (`invalid-source-type` in audit) now works for all fields, not just type-based ones
+
 ### Added
 
 - **Enum management commands** (pika-1kr)
@@ -44,7 +92,6 @@ All notable changes to Pika are documented in this file.
   - New issue code: `invalid-source-type` - reports when a field references a note of the wrong type
   - Example: If a task's `milestone` field has `source: "milestone"`, audit will error if it links to a task instead
   - Supports parent types: `source: "objective"` accepts objectives and all descendants (task, milestone, etc.)
-  - Skips validation for legacy `dynamic_sources` (use type-based sources for validation)
   - JSON output includes `expectedType` and `actualType` for debugging
 
 - **Custom plural names for folder computation** (pika-2e1)

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -9,7 +9,7 @@ import {
   getEnumValues,
 } from '../lib/schema.js';
 import { parseNote, writeNote, generateBodySections } from '../lib/frontmatter.js';
-import { resolveVaultDir, queryDynamicSource, formatValue, isFile } from '../lib/vault.js';
+import { resolveVaultDir, queryByType, formatValue, isFile } from '../lib/vault.js';
 import {
   promptSelection,
   promptInput,
@@ -328,7 +328,7 @@ async function promptFieldEdit(
 
     case 'dynamic': {
       if (!field.source) return currentValue;
-      const dynamicOptions = await queryDynamicSource(schema, vaultDir, field.source);
+      const dynamicOptions = await queryByType(schema, vaultDir, field.source, field.filter);
       if (dynamicOptions.length === 0) {
         return currentValue;
       }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -15,7 +15,7 @@ import {
 import { writeNote, generateBodyWithContent, generateBodySections, mergeBodySectionContent, extractSectionItems, parseBodyInput } from '../lib/frontmatter.js';
 import {
   resolveVaultDir,
-  queryDynamicSource,
+  queryByType,
   formatValue,
   getDirMode,
   isInstanceGroupedSubtype,
@@ -1247,7 +1247,7 @@ async function promptField(
 
     case 'dynamic': {
       if (!field.source) return field.default;
-      const dynamicOptions = await queryDynamicSource(schema, vaultDir, field.source);
+      const dynamicOptions = await queryByType(schema, vaultDir, field.source, field.filter);
       if (dynamicOptions.length === 0) {
         printWarning(`No options available for ${fieldName}`);
         return field.default ?? '';

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -17,7 +17,7 @@ import {
   getTemplateDir,
   parseTemplate,
 } from '../lib/template.js';
-import { resolveVaultDir, queryDynamicSource, formatValue } from '../lib/vault.js';
+import { resolveVaultDir, queryByType, formatValue } from '../lib/vault.js';
 import { parseNote, writeNote } from '../lib/frontmatter.js';
 import {
   promptSelection,
@@ -700,7 +700,7 @@ async function promptFieldDefault(
 
     case 'dynamic': {
       if (!field.source) return undefined;
-      const dynamicOptions = await queryDynamicSource(schema, vaultDir, field.source);
+      const dynamicOptions = await queryByType(schema, vaultDir, field.source, field.filter);
       if (dynamicOptions.length === 0) return undefined;
       
       const options = ['(skip)', ...dynamicOptions];
@@ -1122,7 +1122,7 @@ async function promptFieldDefaultEdit(
 
     case 'dynamic': {
       if (!field.source) return currentValue;
-      const dynamicOptions = await queryDynamicSource(schema, vaultDir, field.source);
+      const dynamicOptions = await queryByType(schema, vaultDir, field.source, field.filter);
       if (dynamicOptions.length === 0) return currentValue;
       
       const options = ['(keep)', '(clear)', ...dynamicOptions];

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -514,12 +514,6 @@ function checkContextFieldSource(
   // Handle "any" source - no type restriction
   if (source === 'any') return issues;
   
-  // Check if source refers to a dynamic_source (legacy) - skip validation
-  // These will be migrated to type-based sources in a future update
-  if (schema.dynamicSources.has(source)) {
-    return issues;
-  }
-  
   // Check if source is a valid type
   const sourceType = schema.types.get(source);
   if (!sourceType) {

--- a/tests/fixtures/test_schema.json
+++ b/tests/fixtures/test_schema.json
@@ -4,14 +4,6 @@
     "status": ["raw", "backlog", "in-flight", "settled"],
     "priority": ["low", "medium", "high"]
   },
-  "dynamic_sources": {
-    "active_milestones": {
-      "dir": "Objectives/Milestones",
-      "filter": {
-        "status": { "not_in": ["settled"] }
-      }
-    }
-  },
   "types": {
     "objective": {
       "subtypes": {
@@ -27,7 +19,8 @@
             },
             "milestone": {
               "prompt": "dynamic",
-              "source": "active_milestones",
+              "source": "milestone",
+              "filter": { "status": { "not_in": ["settled"] } },
               "format": "quoted-wikilink"
             },
             "creation-date": { "value": "$NOW" },

--- a/tests/fixtures/vault/.pika/schema.json
+++ b/tests/fixtures/vault/.pika/schema.json
@@ -5,14 +5,6 @@
     "status": ["raw", "backlog", "in-flight", "settled"],
     "priority": ["low", "medium", "high"]
   },
-  "dynamic_sources": {
-    "active_milestones": {
-      "dir": "Objectives/Milestones",
-      "filter": {
-        "status": { "not_in": ["settled"] }
-      }
-    }
-  },
   "types": {
     "objective": {
       "output_dir": "Objectives",
@@ -29,7 +21,8 @@
             },
             "milestone": {
               "prompt": "dynamic",
-              "source": "active_milestones",
+              "source": "milestone",
+              "filter": { "status": { "not_in": ["settled"] } },
               "format": "quoted-wikilink"
             },
             "creation-date": { "value": "$NOW" },

--- a/tests/ts/commands/new.pty.test.ts
+++ b/tests/ts/commands/new.pty.test.ts
@@ -31,12 +31,6 @@ const FULL_SCHEMA = {
     status: ['raw', 'backlog', 'in-flight', 'settled'],
     priority: ['low', 'medium', 'high'],
   },
-  dynamic_sources: {
-    active_milestones: {
-      dir: 'Milestones',
-      filter: { status: { not_in: ['settled'] } },
-    },
-  },
   types: {
     objective: {
       output_dir: 'Objectives',
@@ -47,7 +41,12 @@ const FULL_SCHEMA = {
             type: { value: 'objective' },
             'objective-type': { value: 'task' },
             status: { prompt: 'select', enum: 'status', default: 'raw' },
-            milestone: { prompt: 'dynamic', source: 'active_milestones', format: 'quoted-wikilink' },
+            milestone: {
+              prompt: 'dynamic',
+              source: 'milestone',
+              filter: { status: { not_in: ['settled'] } },
+              format: 'quoted-wikilink',
+            },
           },
           frontmatter_order: ['type', 'objective-type', 'status', 'milestone'],
           body_sections: [

--- a/tests/ts/fixtures/setup.ts
+++ b/tests/ts/fixtures/setup.ts
@@ -39,14 +39,6 @@ export const TEST_SCHEMA = {
     status: ['raw', 'backlog', 'in-flight', 'settled'],
     priority: ['low', 'medium', 'high'],
   },
-  dynamic_sources: {
-    active_milestones: {
-      dir: 'Objectives/Milestones',
-      filter: {
-        status: { not_in: ['settled'] },
-      },
-    },
-  },
   types: {
     objective: {
       output_dir: 'Objectives',
@@ -60,7 +52,12 @@ export const TEST_SCHEMA = {
           frontmatter: {
             type: { value: 'objective' },
             'objective-type': { value: 'task' },
-            milestone: { prompt: 'dynamic', source: 'active_milestones', format: 'quoted-wikilink' },
+            milestone: {
+              prompt: 'dynamic',
+              source: 'milestone',
+              filter: { status: { not_in: ['settled'] } },
+              format: 'quoted-wikilink',
+            },
             'creation-date': { value: '$NOW' },
             deadline: { prompt: 'input', label: 'Deadline (YYYY-MM-DD)' },
           },

--- a/tests/ts/lib/numberedSelect.pty.test.ts
+++ b/tests/ts/lib/numberedSelect.pty.test.ts
@@ -543,22 +543,17 @@ describePty('NumberedSelectPrompt PTY tests', () => {
 
   describe('empty choice handling', () => {
     it('should handle empty choices gracefully', async () => {
-      // Schema with dynamic source that returns no results
+      // Schema with type-based source that returns no results (type doesn't exist)
       const emptySchema = {
         version: 1,
         enums: {},
-        dynamic_sources: {
-          nonexistent: {
-            dir: 'NonexistentDir',
-            filter: {},
-          },
-        },
         types: {
           item: {
             output_dir: 'Items',
             frontmatter: {
               type: { value: 'item' },
-              ref: { prompt: 'dynamic', source: 'nonexistent', format: 'wikilink' },
+              // Reference a type that doesn't exist - will return no results
+              ref: { prompt: 'dynamic', source: 'nonexistent_type', format: 'wikilink' },
             },
             frontmatter_order: ['type', 'ref'],
           },

--- a/tests/ts/lib/prompt-multiinput.pty.test.ts
+++ b/tests/ts/lib/prompt-multiinput.pty.test.ts
@@ -27,12 +27,6 @@ const TASK_SCHEMA = {
   enums: {
     status: ['raw', 'in-progress', 'done'],
   },
-  dynamic_sources: {
-    active_milestones: {
-      dir: 'Milestones',
-      filter: { status: { not_in: ['done'] } },
-    },
-  },
   types: {
     task: {
       output_dir: 'Tasks',


### PR DESCRIPTION
## Summary

This PR removes the legacy `dynamic_sources` system and replaces it with type-based source queries, completing issue pika-fqh.

### Breaking Change

Schemas using `dynamic_sources` will now error on load with a helpful migration guide. Users must migrate to type-based sources.

### Key Changes

- **New `queryByType()` function** - Queries notes by type name, including all descendant types, with optional filters
- **Field-level `filter` property** - Filter conditions are now defined directly on fields instead of in a separate `dynamic_sources` section
- **Removed `dynamic_sources`** from schema.json (both PikaSchema and LoadedSchema types)
- **Updated all commands** - `new`, `edit`, `template` now use `queryByType()` 
- **Improved audit validation** - Context field type validation now works universally

### Migration Example

Before:
```json
{
  "dynamic_sources": {
    "active_milestones": {
      "dir": "Objectives/Milestones",
      "filter": { "status": { "not_in": ["settled"] } }
    }
  },
  "fields": {
    "milestone": { "source": "active_milestones" }
  }
}
```

After:
```json
{
  "fields": {
    "milestone": {
      "source": "milestone",
      "filter": { "status": { "not_in": ["settled"] } }
    }
  }
}
```

### Benefits

- **Simpler schema** - No separate `dynamic_sources` section to maintain
- **Type-aware** - Source automatically includes descendant types (e.g., `source: "objective"` includes tasks, milestones)
- **Better validation** - Audit's `invalid-source-type` check now works for all context fields
- **Owned note exclusion** - Owned notes are automatically excluded from query results (they can't be referenced)

## Testing

All 902 tests pass. Updated test schemas and fixtures to use type-based sources.

Closes pika-fqh