### PR TITLE
feat: add --open flag to search and list commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Pika are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`--open` flag for `search` and `list` commands** (pika-fkd)
+  - `pika search "My Note" --open` - Search for a note and open it in Obsidian/editor
+  - `pika list task --status=inbox --open` - Filter notes and pick one to open
+  - `--app <mode>` flag specifies how to open: obsidian (default), editor, system, print
+  - Respects `PIKA_DEFAULT_APP` environment variable
+  - Works with both name search and content search modes
+  - For `list`, uses picker when multiple results (in interactive mode)
+  - The `open` command is now an alias for `search --open` (kept for backward compatibility)
+
 ### Breaking Changes
 
 - **Removed `dynamic_sources` - use type-based sources instead** (pika-fqh)


### PR DESCRIPTION
## Summary

- Adds `--open` and `--app` flags to `search` command for opening notes after search
- Adds `--open` and `--app` flags to `list` command for opening notes from results  
- Makes `open` command an alias for `search --open` (kept for backward compatibility)

## Changes

### `pika search`
- New `--open` flag opens the selected note after search
- New `--app <mode>` flag specifies how to open (obsidian, editor, system, print)
- Works with both name search and content search modes
- Prompt text changes to "Select note to open" when `--open` is used

### `pika list`
- New `--open` flag opens a note from the results
- Uses picker when multiple results in interactive mode
- Opens first result directly in non-interactive mode
- New `--app <mode>` flag for controlling open behavior

### `pika open`
- Now documented as an alias for `search --open`
- Behavior unchanged for backward compatibility
- Help text updated to show equivalent search commands

## Examples

```bash
# Search and open
pika search "My Note" --open
pika search "My Note" --open --app editor

# List and open
pika list task --status=inbox --open
pika list idea --open --app system

# These are now equivalent
pika open "My Note"
pika search "My Note" --open
```

## Testing

- All 902 existing tests pass
- Typecheck passes
- Build succeeds

## Issue

Closes pika-fkd