### PR TITLE
feat: add pika schema add-field command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Pika are documented in this file.
 
 ### Added
 
+- **`pika schema add-field` command** (pika-tev)
+  - Add fields to existing types via CLI without editing schema.json directly
+  - Interactive mode: prompts for field name, prompt type, and relevant options
+  - Non-interactive mode: use `--type`, `--enum`, `--source`, `--value` flags with `--output json`
+  - Supports all prompt types: input, select, date, multi-input, dynamic, and fixed value
+  - Validates field names (lowercase, alphanumeric with hyphens)
+  - Prevents duplicate fields and overriding inherited fields
+  - Automatically updates field_order and validates the schema
+  - Shows inheritance notes when adding fields to parent types
+  - Example: `pika schema add-field task priority --type select --enum priority`
+
 - **PTY tests for schema add-type interactive wizard** (pika-h3xh)
   - Comprehensive coverage for the interactive type creation flow
   - Tests for all field wizard prompt types: input, select, date, multi-input, dynamic, fixed value

--- a/tests/ts/commands/schema-add-field.pty.test.ts
+++ b/tests/ts/commands/schema-add-field.pty.test.ts
@@ -1,0 +1,585 @@
+/**
+ * PTY-based integration tests for the `pika schema add-field` command.
+ *
+ * Tests the interactive wizard for adding fields to existing types, including:
+ * - Full interactive flow for each prompt type
+ * - Cancellation paths at each step
+ * - Field validation and error handling
+ * - Error cases (no enums for select, no types for dynamic)
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  withTempVault,
+  Keys,
+  readVaultFile,
+  shouldSkipPtyTests,
+  killAllPtyProcesses,
+} from '../lib/pty-helpers.js';
+
+// Skip PTY tests if running in CI without TTY support or node-pty is incompatible
+const describePty = shouldSkipPtyTests() ? describe.skip : describe;
+
+// Schema with existing types and enums for testing the wizard
+const WIZARD_SCHEMA = {
+  version: 2,
+  enums: {
+    status: ['open', 'closed'],
+    priority: ['low', 'medium', 'high'],
+  },
+  types: {
+    note: {
+      output_dir: 'Notes',
+      fields: {
+        status: { prompt: 'select', enum: 'status' },
+      },
+    },
+    task: {
+      extends: 'note',
+      output_dir: 'Tasks',
+    },
+    project: {
+      output_dir: 'Projects',
+    },
+  },
+};
+
+// Schema without enums (for testing select field error)
+const NO_ENUM_SCHEMA = {
+  version: 2,
+  enums: {},
+  types: {
+    note: {
+      output_dir: 'Notes',
+    },
+  },
+};
+
+// Schema without types for dynamic source (for testing dynamic field error)
+const MINIMAL_SCHEMA = {
+  version: 2,
+  enums: {
+    status: ['open', 'closed'],
+  },
+  types: {},
+};
+
+describePty('pika schema add-field PTY tests', () => {
+  // Clean up any orphaned PTY processes after each test
+  afterEach(() => {
+    killAllPtyProcesses();
+  });
+
+  // ==========================================================================
+  // Full Interactive Flow
+  // ==========================================================================
+  describe('full interactive flow', () => {
+    it('should add an input field interactively', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project'],
+        async (proc, vaultPath) => {
+          // Field name prompt
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('description');
+
+          // Prompt type selection
+          await proc.waitFor('Prompt type');
+          proc.write('1'); // input (text)
+
+          // Required prompt
+          await proc.waitFor('Required');
+          proc.write('n');
+
+          // Default value prompt
+          await proc.waitFor('Default value');
+          proc.write(Keys.ENTER); // blank
+
+          // Wait for success
+          await proc.waitFor('Added field');
+          await proc.waitForExit(5000);
+
+          // Verify schema was updated
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.project.fields.description).toEqual({
+            prompt: 'input',
+            required: false,
+          });
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should add a select field with enum selection', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('mypriority');
+
+          await proc.waitFor('Prompt type');
+          proc.write('2'); // select (enum)
+
+          // Enum selection - insertion order: status=1, priority=2
+          await proc.waitFor('Enum to use');
+          await proc.waitForStable(100);
+          proc.write('2'); // priority
+
+          await proc.waitFor('Required');
+          proc.write('n');
+
+          await proc.waitFor('Default value');
+          await proc.typeAndEnter('medium');
+
+          await proc.waitFor('Added field');
+          await proc.waitForExit(5000);
+
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.project.fields.mypriority).toMatchObject({
+            prompt: 'select',
+            enum: 'priority',
+            default: 'medium',
+          });
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should add a date field', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('due-date');
+
+          await proc.waitFor('Prompt type');
+          proc.write('3'); // date
+
+          await proc.waitFor('Required');
+          proc.write('y');
+
+          await proc.waitFor('Added field');
+          await proc.waitForExit(5000);
+
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.project.fields['due-date']).toMatchObject({
+            prompt: 'date',
+            required: true,
+          });
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should add a multi-input field', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('tags');
+
+          await proc.waitFor('Prompt type');
+          proc.write('4'); // multi-input (list)
+
+          await proc.waitFor('Required');
+          proc.write('n');
+
+          await proc.waitFor('Default value');
+          proc.write(Keys.ENTER);
+
+          await proc.waitFor('Added field');
+          await proc.waitForExit(5000);
+
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.project.fields.tags).toMatchObject({
+            prompt: 'multi-input',
+            required: false,
+          });
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should add a dynamic field with source and format', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'task'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('parent-project');
+
+          await proc.waitFor('Prompt type');
+          proc.write('5'); // dynamic (from other notes)
+
+          // Source type selection - insertion order: note=1, task=2, project=3
+          await proc.waitFor('Source type');
+          proc.write('3'); // project
+
+          // Link format: plain, wikilink, quoted-wikilink
+          await proc.waitFor('Link format');
+          proc.write('2'); // wikilink
+
+          await proc.waitFor('Required');
+          proc.write('n');
+
+          await proc.waitFor('Default value');
+          proc.write(Keys.ENTER);
+
+          await proc.waitFor('Added field');
+          await proc.waitForExit(5000);
+
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.task.fields['parent-project']).toMatchObject({
+            prompt: 'dynamic',
+            source: 'project',
+            format: 'wikilink',
+            required: false,
+          });
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should add a fixed value field', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('type');
+
+          await proc.waitFor('Prompt type');
+          proc.write('6'); // fixed value
+
+          await proc.waitFor('Fixed value');
+          await proc.typeAndEnter('project');
+
+          await proc.waitFor('Added field');
+          await proc.waitForExit(5000);
+
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.project.fields.type).toEqual({
+            value: 'project',
+          });
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should add a required field with no default prompt', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('name');
+
+          await proc.waitFor('Prompt type');
+          proc.write('1'); // input
+
+          await proc.waitFor('Required');
+          proc.write('y');
+
+          // Should not prompt for default when required
+          await proc.waitFor('Added field');
+          await proc.waitForExit(5000);
+
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.project.fields.name).toEqual({
+            prompt: 'input',
+            required: true,
+          });
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+  });
+
+  // ==========================================================================
+  // Field Name Pre-provided
+  // ==========================================================================
+  describe('field name provided as argument', () => {
+    it('should skip field name prompt when provided', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project', 'description'],
+        async (proc, vaultPath) => {
+          // Should go straight to prompt type
+          await proc.waitFor('Prompt type');
+          proc.write('1'); // input
+
+          await proc.waitFor('Required');
+          proc.write('n');
+
+          await proc.waitFor('Default value');
+          proc.write(Keys.ENTER);
+
+          await proc.waitFor('Added field');
+          await proc.waitForExit(5000);
+
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.project.fields.description).toBeDefined();
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+  });
+
+  // ==========================================================================
+  // Cancellation Paths
+  // ==========================================================================
+  describe('cancellation paths', () => {
+    it('should cancel cleanly at field name prompt', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          proc.write(Keys.CTRL_C);
+
+          await proc.waitForExit(5000);
+
+          // Schema should not have new field
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.project.fields).toBeUndefined();
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should cancel cleanly at prompt type selection', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('myfield');
+
+          await proc.waitFor('Prompt type');
+          proc.write(Keys.CTRL_C);
+
+          await proc.waitForExit(5000);
+
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.project.fields).toBeUndefined();
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should cancel cleanly at required prompt', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('myfield');
+
+          await proc.waitFor('Prompt type');
+          proc.write('1'); // input
+
+          await proc.waitFor('Required');
+          proc.write(Keys.CTRL_C);
+
+          await proc.waitForExit(5000);
+
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.project.fields).toBeUndefined();
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should cancel cleanly at enum selection', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('mystatus');
+
+          await proc.waitFor('Prompt type');
+          proc.write('2'); // select
+
+          await proc.waitFor('Enum to use');
+          proc.write(Keys.CTRL_C);
+
+          await proc.waitForExit(5000);
+
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.project.fields).toBeUndefined();
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should cancel cleanly at source type selection', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('parent');
+
+          await proc.waitFor('Prompt type');
+          proc.write('5'); // dynamic
+
+          await proc.waitFor('Source type');
+          proc.write(Keys.CTRL_C);
+
+          await proc.waitForExit(5000);
+
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.project.fields).toBeUndefined();
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should cancel cleanly at fixed value prompt', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('type');
+
+          await proc.waitFor('Prompt type');
+          proc.write('6'); // fixed value
+
+          await proc.waitFor('Fixed value');
+          proc.write(Keys.CTRL_C);
+
+          await proc.waitForExit(5000);
+
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.project.fields).toBeUndefined();
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+  });
+
+  // ==========================================================================
+  // Error Handling
+  // ==========================================================================
+  describe('error handling', () => {
+    it('should show error for non-existent type', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'nonexistent'],
+        async (proc) => {
+          await proc.waitFor('does not exist');
+          await proc.waitForExit(5000);
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should show error when selecting select field with no enums', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'note'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('status');
+
+          await proc.waitFor('Prompt type');
+          proc.write('2'); // select (enum)
+
+          // Should show error about no enums
+          await proc.waitFor('No enums defined');
+
+          await proc.waitForExit(5000);
+
+          // Schema should not have new field
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.note.fields).toBeUndefined();
+        },
+        { schema: NO_ENUM_SCHEMA }
+      );
+    }, 30000);
+
+    it('should allow dynamic field when at least one type exists', async () => {
+      // With only one type, dynamic source selection shows that one type
+      const schemaWithOneType = {
+        ...MINIMAL_SCHEMA,
+        types: {
+          note: { output_dir: 'Notes' },
+        },
+      };
+
+      await withTempVault(
+        ['schema', 'add-field', 'note'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Field name');
+          await proc.typeAndEnter('parent');
+
+          await proc.waitFor('Prompt type');
+          proc.write('5'); // dynamic
+
+          // Should show source type selection with 'note' as the only option
+          await proc.waitFor('Source type');
+          proc.write('1'); // note (only option)
+
+          await proc.waitFor('Link format');
+          proc.write('1'); // plain
+
+          await proc.waitFor('Required');
+          proc.write('n');
+
+          await proc.waitFor('Default value');
+          proc.write(Keys.ENTER);
+
+          await proc.waitFor('Added field');
+          await proc.waitForExit(5000);
+
+          const schemaContent = await readVaultFile(vaultPath, '.pika/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.types.note.fields.parent).toMatchObject({
+            prompt: 'dynamic',
+            source: 'note',
+          });
+        },
+        { schema: schemaWithOneType }
+      );
+    }, 30000);
+
+    it('should show error for duplicate field on same type', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'note', 'status'],
+        async (proc) => {
+          // status already exists on note
+          await proc.waitFor('already exists');
+          await proc.waitForExit(5000);
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should show error for inherited field', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'task', 'status'],
+        async (proc) => {
+          // status is inherited from note
+          await proc.waitFor('inherited');
+          await proc.waitForExit(5000);
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+
+    it('should show error for invalid field name', async () => {
+      await withTempVault(
+        ['schema', 'add-field', 'project', '123invalid'],
+        async (proc) => {
+          await proc.waitFor('must start with a lowercase letter');
+          await proc.waitForExit(5000);
+        },
+        { schema: WIZARD_SCHEMA }
+      );
+    }, 30000);
+  });
+});

--- a/tests/ts/commands/schema-add-field.test.ts
+++ b/tests/ts/commands/schema-add-field.test.ts
@@ -1,0 +1,517 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runCLI } from '../fixtures/setup.js';
+
+describe('schema add-field command', () => {
+  let tempVaultDir: string;
+
+  beforeEach(async () => {
+    // Create fresh vault for each test
+    tempVaultDir = await mkdtemp(join(tmpdir(), 'pika-addfield-'));
+    await mkdir(join(tempVaultDir, '.pika'), { recursive: true });
+    await writeFile(
+      join(tempVaultDir, '.pika', 'schema.json'),
+      JSON.stringify({
+        version: 2,
+        enums: {
+          status: ['open', 'closed'],
+          priority: ['low', 'medium', 'high'],
+        },
+        types: {
+          note: {
+            output_dir: 'Notes',
+            fields: {
+              status: { prompt: 'select', enum: 'status' },
+            },
+          },
+          task: {
+            extends: 'note',
+            output_dir: 'Tasks',
+            fields: {
+              due: { prompt: 'date' },
+            },
+          },
+          project: {
+            output_dir: 'Projects',
+          },
+        },
+      })
+    );
+  });
+
+  afterAll(async () => {
+    if (tempVaultDir) {
+      await rm(tempVaultDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('basic field creation (JSON mode)', () => {
+    it('should add an input field to a type', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'description', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.type).toBe('project');
+      expect(json.data.field).toBe('description');
+      expect(json.data.definition.prompt).toBe('input');
+
+      // Verify schema was updated
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.types.project.fields.description).toEqual({ prompt: 'input' });
+    });
+
+    it('should add a select field with enum', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'priority', '--type', 'select', '--enum', 'priority', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.definition.prompt).toBe('select');
+      expect(json.data.definition.enum).toBe('priority');
+
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.types.project.fields.priority).toEqual({
+        prompt: 'select',
+        enum: 'priority',
+      });
+    });
+
+    it('should add a date field', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'deadline', '--type', 'date', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.data.definition.prompt).toBe('date');
+
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.types.project.fields.deadline).toEqual({ prompt: 'date' });
+    });
+
+    it('should add a multi-input field', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'tags', '--type', 'multi-input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.data.definition.prompt).toBe('multi-input');
+
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.types.project.fields.tags).toEqual({ prompt: 'multi-input' });
+    });
+
+    it('should add a dynamic field with source and format', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'task', 'project', '--type', 'dynamic', '--source', 'project', '--format', 'wikilink', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.data.definition.prompt).toBe('dynamic');
+      expect(json.data.definition.source).toBe('project');
+      expect(json.data.definition.format).toBe('wikilink');
+
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.types.task.fields.project).toEqual({
+        prompt: 'dynamic',
+        source: 'project',
+        format: 'wikilink',
+      });
+    });
+
+    it('should add a fixed value field', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'type', '--type', 'fixed', '--value', 'project', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.data.definition.value).toBe('project');
+
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.types.project.fields.type).toEqual({ value: 'project' });
+    });
+
+    it('should add a required field', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'name', '--type', 'input', '--required', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.data.definition.required).toBe(true);
+
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.types.project.fields.name).toEqual({
+        prompt: 'input',
+        required: true,
+      });
+    });
+
+    it('should add a field with default value', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'status', '--type', 'select', '--enum', 'status', '--default', 'open', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.data.definition.default).toBe('open');
+
+      const schema = JSON.parse(await readFile(join(tempVaultDir, '.pika', 'schema.json'), 'utf-8'));
+      expect(schema.types.project.fields.status).toEqual({
+        prompt: 'select',
+        enum: 'status',
+        default: 'open',
+      });
+    });
+  });
+
+  describe('validation', () => {
+    it('should reject non-existent type', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'nonexistent', 'field', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('does not exist');
+    });
+
+    it('should reject duplicate field name on same type', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'note', 'status', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('already exists');
+    });
+
+    it('should reject overriding inherited field', async () => {
+      // task inherits from note, which has status field
+      const result = await runCLI(
+        ['schema', 'add-field', 'task', 'status', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('inherited');
+    });
+
+    it('should reject invalid field name starting with number', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', '123field', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('must start with a lowercase letter');
+    });
+
+    it('should reject field name with uppercase letters', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'MyField', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('must start with a lowercase letter');
+    });
+
+    it('should reject field name with underscores', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'my_field', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('must start with a lowercase letter');
+    });
+
+    it('should reject invalid prompt type', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'field', '--type', 'invalid', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('Invalid prompt type');
+    });
+
+    it('should reject select without --enum', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'priority', '--type', 'select', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('--enum is required');
+    });
+
+    it('should reject select with non-existent enum', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'field', '--type', 'select', '--enum', 'nonexistent', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('does not exist');
+    });
+
+    it('should reject dynamic without --source', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'parent', '--type', 'dynamic', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('--source is required');
+    });
+
+    it('should reject dynamic with non-existent source type', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'parent', '--type', 'dynamic', '--source', 'nonexistent', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('does not exist');
+    });
+
+    it('should reject fixed without --value', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'type', '--type', 'fixed', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('--value is required');
+    });
+
+    it('should reject invalid format value', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'parent', '--type', 'dynamic', '--source', 'note', '--format', 'invalid', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('Invalid format');
+    });
+
+    it('should require field name in JSON mode', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('Field name is required');
+    });
+
+    it('should require --type in JSON mode', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'field', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('--type is required');
+    });
+  });
+
+  describe('field names with hyphens', () => {
+    it('should allow field names with hyphens', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'due-date', '--type', 'date', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.field).toBe('due-date');
+    });
+  });
+
+  describe('field_order handling', () => {
+    it('should append to existing field_order', async () => {
+      // First, add field_order to the schema
+      const schemaPath = join(tempVaultDir, '.pika', 'schema.json');
+      const schema = JSON.parse(await readFile(schemaPath, 'utf-8'));
+      schema.types.project.fields = { existing: { prompt: 'input' } };
+      schema.types.project.field_order = ['existing'];
+      await writeFile(schemaPath, JSON.stringify(schema));
+
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'new-field', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const updatedSchema = JSON.parse(await readFile(schemaPath, 'utf-8'));
+      expect(updatedSchema.types.project.field_order).toEqual(['existing', 'new-field']);
+    });
+
+    it('should create field_order when adding second field', async () => {
+      // Add first field
+      await runCLI(
+        ['schema', 'add-field', 'project', 'first', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      // Add second field
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'second', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const schemaPath = join(tempVaultDir, '.pika', 'schema.json');
+      const schema = JSON.parse(await readFile(schemaPath, 'utf-8'));
+      expect(schema.types.project.field_order).toEqual(['first', 'second']);
+    });
+
+    it('should not create field_order for first field only', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'only-field', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const schemaPath = join(tempVaultDir, '.pika', 'schema.json');
+      const schema = JSON.parse(await readFile(schemaPath, 'utf-8'));
+      expect(schema.types.project.field_order).toBeUndefined();
+    });
+  });
+
+  describe('schema validation after add', () => {
+    it('should maintain valid schema after adding field', async () => {
+      await runCLI(
+        ['schema', 'add-field', 'project', 'description', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      const result = await runCLI(
+        ['schema', 'validate', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+    });
+
+    it('should show new field in schema show', async () => {
+      await runCLI(
+        ['schema', 'add-field', 'project', 'description', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      const result = await runCLI(
+        ['schema', 'show', 'project', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.fields.description).toBeDefined();
+      expect(json.fields.description.type).toBe('input');
+    });
+  });
+
+  describe('inheritance indication', () => {
+    it('should indicate when field affects child types', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'note', 'new-field', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.data.affectsChildTypes).toBe(true);
+    });
+
+    it('should indicate when field does not affect child types', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', 'new-field', '--type', 'input', '--output', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.data.affectsChildTypes).toBe(false);
+    });
+  });
+
+  describe('text mode output', () => {
+    it('should show error message in text mode', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'nonexistent', 'field', '--type', 'input'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('does not exist');
+    });
+
+    it('should show validation error in text mode', async () => {
+      const result = await runCLI(
+        ['schema', 'add-field', 'project', '123invalid', '--type', 'input'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('must start with a lowercase letter');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `pika schema add-field` command (pika-tev) which allows users to add fields to existing types via CLI without manually editing schema.json.

### Features

- **Interactive mode**: Prompts for field name, prompt type, and relevant options
- **Non-interactive mode**: Use `--type`, `--enum`, `--source`, `--value` flags with `--output json`
- **All prompt types supported**: input, select, date, multi-input, dynamic, fixed value
- **Early validation**: Field names checked before entering interactive mode
- **Duplicate/inherited detection**: Prevents overriding inherited fields or creating duplicates
- **Schema updates**: Automatically updates field_order and validates the result
- **Inheritance notes**: Shows when adding fields to parent types affects child types

### Usage Examples

```bash
# Interactive mode
pika schema add-field task

# Add select field with enum
pika schema add-field task priority --type select --enum priority --output json

# Add dynamic field with format
pika schema add-field task parent --type dynamic --source project --format wikilink

# Add fixed value field
pika schema add-field task type --type fixed --value task
```

### Testing

- 33 unit tests in `schema-add-field.test.ts`
- 20 PTY tests in `schema-add-field.pty.test.ts` covering:
  - Full interactive flow for each prompt type
  - Cancellation paths at each step
  - Error handling (non-existent type, no enums, duplicates, inherited fields)

Resolves: pika-tev