### PR TITLE
fix: improve --source flag error messages for dynamic fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Pika are documented in this file.
 
 ## [Unreleased]
 
+### Improved
+
+- **Better error messages for `--source` flag in dynamic fields** (pika-dbvv)
+  - Detects when user provides an enum value instead of a type name
+    - e.g., `"person" is a value in the "entity-type" enum, not a type name`
+  - Detects legacy path format usage and suggests correct syntax
+    - e.g., `Source "entity/person" uses path format. Use just the type name: "person"`
+  - Suggests similar type names for typos (using fuzzy matching)
+    - e.g., `Did you mean: project?`
+  - Lists available types when no close match exists
+  - Provides actionable hints for filtering by enum values
+
 ### Added
 
 - **`pika schema add-field` command** (pika-tev)

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -10,6 +10,7 @@ import {
   getEnumValues,
   getTypeNames,
   computeDefaultOutputDir,
+  resolveSourceType,
 } from '../lib/schema.js';
 import { resolveVaultDir } from '../lib/vault.js';
 import {
@@ -478,10 +479,13 @@ function buildFieldFromOptions(
       if (!options.source) {
         throw new Error('--source is required for dynamic type');
       }
-      if (!schema.types.has(options.source)) {
-        throw new Error(`Source type "${options.source}" does not exist`);
+      
+      // Use resolveSourceType for better error messages
+      const resolution = resolveSourceType(schema, options.source);
+      if (!resolution.success) {
+        throw new Error(resolution.error);
       }
-      field.source = options.source;
+      field.source = resolution.typeName;
       
       // Format is optional, default to plain
       if (options.format) {


### PR DESCRIPTION
## Summary

Improves error messages when using `--source` flag with invalid values in `pika schema add-field` command. This addresses a P1 schema tooling issue where error messages were confusing and unhelpful.

## Changes

- **Enum value confusion detection**: When user provides an enum value (like `person` from `entity-type` enum) thinking it's a type name, the error now explains this and suggests using the parent type with a filter
- **Path format detection**: When user provides legacy path format (`entity/person`), explains that paths aren't supported and suggests using just the type name
- **Typo suggestions**: Uses Levenshtein distance to suggest similar type names (e.g., `projec` → `Did you mean: project?`)
- **Available types listing**: When no close match exists, lists all available types

## Examples

Before:
```
$ pika schema add-field task owner --type dynamic --source person
Error: Source type "person" does not exist
```

After:
```
$ pika schema add-field task owner --type dynamic --source person
Error: "person" is a value in the "entity-type" enum, not a type name.
Dynamic sources must reference types.
Available types: entity, task, project

Hint: If you want to filter by this enum value, set the source to the 
parent type and add a filter in the schema.
```

## Testing

- Added 6 integration tests in `schema-add-field.test.ts`
- Added 8 unit tests in `schema.test.ts` for `resolveSourceType()`
- All 1011 tests pass

Closes pika-dbvv