### PR TITLE
fix: allow adding fields to implicit meta type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Pika are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`pika schema add-field meta` now works correctly** (pika-tsbb)
+  - Previously failed with `Type "meta" not found in raw schema` when meta was implicit
+  - Now creates the meta type definition in schema.json when adding a field to implicit meta
+  - Fields added to meta correctly inherit to all types as documented in type-system.md
+
 ### Improved
 
 - **Better error messages for `--source` flag in dynamic fields** (pika-dbvv)

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -714,10 +714,14 @@ schemaCommand
       // Load raw schema and add the field
       const rawSchema = await loadRawSchemaJson(vaultDir);
       
-      // Get the type definition (we already validated it exists)
-      const typeDef = rawSchema.types[typeName];
+      // Get the type definition, creating it if this is an implicit type (like meta)
+      // The type exists in the resolved schema (validated above) but may not exist
+      // in the raw schema if it's implicit (e.g., meta is created implicitly if not defined)
+      let typeDef = rawSchema.types[typeName];
       if (!typeDef) {
-        throw new Error(`Type "${typeName}" not found in raw schema`);
+        // Create an empty type definition for the implicit type
+        rawSchema.types[typeName] = {};
+        typeDef = rawSchema.types[typeName];
       }
       
       // Ensure the type has a fields object


### PR DESCRIPTION
## Summary

- Fixes `pika schema add-field meta` failing with `Type "meta" not found in raw schema`
- Now creates the meta type definition in schema.json when adding a field to implicit meta
- Fields added to meta correctly inherit to all types as documented

## Problem

The `add-field` command validates that a type exists in the *resolved* schema (which includes implicit `meta`), but then tries to access it in the *raw* schema where it doesn't exist if never explicitly defined.

## Solution

When adding a field to a type that exists in the resolved schema but not the raw schema (i.e., an implicit type like `meta`), create an empty type definition in the raw schema first.

## Testing

```bash
cd ../worktree-fix-meta-add-field
pnpm test -- schema-add-field
```

Or manually test with a vault:
```bash
pika schema add-field meta created --type date --output json
# Should succeed and add meta type with created field to schema.json
```

## Issue

Fixes: pika-tsbb