### PR TITLE
docs: add non-interactive usage examples to schema command help

### DIFF
--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -263,6 +263,15 @@ schemaCommand
   .option('-o, --output <format>', 'Output format: text (default) or json')
   .option('--extends <parent>', 'Parent type to extend')
   .option('--output-dir <dir>', 'Output directory for type files')
+  .addHelpText('after', `
+Examples:
+  # Non-interactive type creation (requires --output-dir):
+  pika schema add-type book --output-dir Books -o json
+  pika schema add-type entity --output-dir Entities
+  pika schema add-type person --extends entity --output-dir Entities/People -o json
+
+  # Interactive mode (prompts for options):
+  pika schema add-type book`)
   .action(async (name: string, options: AddTypeOptions, cmd: Command) => {
     const jsonMode = options.output === 'json';
 
@@ -633,6 +642,18 @@ schemaCommand
   .option('--format <format>', 'Link format: plain, wikilink, quoted-wikilink (for dynamic)')
   .option('--required', 'Mark field as required')
   .option('--default <value>', 'Default value')
+  .addHelpText('after', `
+Examples:
+  # Non-interactive field creation (requires --type flag):
+  pika schema add-field book title --type input --required -o json
+  pika schema add-field book status --type select --enum status -o json
+  pika schema add-field book author --type dynamic --source person --format wikilink -o json
+  pika schema add-field book edition --type fixed --value "1st" -o json
+  pika schema add-field book published --type date -o json
+  pika schema add-field book tags --type multi-input -o json
+
+  # Interactive mode (prompts for field definition):
+  pika schema add-field book title`)
   .action(async (typeName: string, fieldName: string | undefined, options: AddFieldOptions, cmd: Command) => {
     const jsonMode = options.output === 'json';
 


### PR DESCRIPTION
## Summary

- Adds Examples sections to `pika schema add-type --help` showing non-interactive usage
- Adds Examples sections to `pika schema add-field --help` covering all field types
- Both include `-o json` examples for AI/scripting workflows

## Problem

An AI agent tried `pika schema add-type place` and got stuck at an interactive prompt. The help text didn't document how to use the commands non-interactively.

## Solution

Added Examples sections showing:
- `add-type`: requires `--output-dir` for non-interactive mode
- `add-field`: requires `--type` flag for non-interactive mode, with examples for all 6 field types

This aligns with the "JSON mode for every command" and "no hidden modes" principles from vision.md.

## Testing

```bash
pnpm dev -- schema add-type --help
pnpm dev -- schema add-field --help
```

Closes pika-3r0a