### PR TITLE
Add --all flag and targeting safety gate to bulk command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Pika are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Targeting safety gate for `bulk` command** (pika-da6s)
+  - Bulk operations now require explicit targeting to prevent accidental vault-wide mutations
+  - Must specify `--where` filter(s) OR use `--all` flag before any operation runs
+  - Without targeting: `pika bulk idea --set x=y` now errors with:
+    `No files selected. Use --type, --path, --where, --text, or --all.`
+  - With targeting: `pika bulk idea --all --set x=y` or `pika bulk idea --where "status == 'x'" --set x=y`
+  - This implements the "two-gate safety model" from docs/product/cli-targeting.md:
+    1. **Targeting gate**: Must specify explicit scope (`--where` or `--all`)
+    2. **Execution gate**: Must use `--execute` to apply changes (existing behavior)
+  - Help text updated to document the safety model
+  - Note: Simple filters (`--status=raw`) are deprecated and do NOT satisfy the targeting gate
+
 ### Fixed
 
 - **`pika schema add-field meta` now works correctly** (pika-tsbb)

--- a/tests/ts/commands/relative-paths.test.ts
+++ b/tests/ts/commands/relative-paths.test.ts
@@ -209,9 +209,9 @@ describe('relative vault path handling', () => {
         relativeVaultPath,
         'bulk',
         'idea',
+        '--all',
         '--set',
         'status=backlog',
-        '--dry-run',
       ]);
 
       expect(result.exitCode).toBe(0);


### PR DESCRIPTION
## Summary

Implements the targeting safety gate from the two-gate safety model specified in `docs/product/cli-targeting.md`. This addresses issue `pika-da6s`.

### Changes

- Added `--all` flag to the bulk command to explicitly target all files of a type
- Added targeting gate check that requires explicit targeting before any operation
- Updated help text to document the two-gate safety model
- Updated tests to use `--all` where appropriate

### Two-Gate Safety Model

1. **Targeting gate** (new): Must specify `--where` filter(s) OR use `--all` flag
2. **Execution gate** (existing): Must use `--execute` to apply changes

### Examples

```bash
# Error: no targeting specified
pika bulk task --set status=done
# "No files selected. Use --type, --path, --where, --text, or --all."

# OK: filtered with --where
pika bulk task --where "status == 'active'" --set status=done

# OK: explicit --all targets all files of type
pika bulk task --all --set status=done
```

### Notes

- Simple filters (`--status=raw`) are deprecated and do NOT satisfy the targeting gate per product spec
- The error message mentions all 4 selectors from the unified targeting model, even those not yet implemented

## Testing

- Added 7 new tests for targeting gate behavior
- Updated 30+ existing tests to use `--all` flag
- All 1034 tests pass

Closes pika-da6s