### PR TITLE
Remove v1 schema support and migrate to v2 flat type model

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -374,10 +374,11 @@ async function collectFilesForType(
   if (!typeDef) return [];
 
   if (hasSubtypes(typeDef)) {
-    // Recurse into subtypes
+    // Recurse into subtypes (children in v2)
     const files: string[] = [];
     for (const subtype of getSubtypeKeys(typeDef)) {
-      const subFiles = await collectFilesForType(schema, vaultDir, `${typePath}/${subtype}`);
+      // In v2, children are just type names, not paths
+      const subFiles = await collectFilesForType(schema, vaultDir, subtype);
       files.push(...subFiles);
     }
     return files;

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -622,25 +622,25 @@ async function resolveTypePath(
     typePath = selected;
   }
 
-  // Navigate through subtypes
+  // Navigate through subtypes (children in v2)
   let typeDef = getTypeDefByPath(schema, typePath);
-  let currentSegment = typePath.split('/').pop() ?? typePath;
+  let currentTypeName = typePath;
 
   while (typeDef && hasSubtypes(typeDef)) {
     const subtypes = getSubtypeKeys(typeDef);
-    const discLabel = discriminatorName(currentSegment);
+    const discLabel = discriminatorName(currentTypeName);
     const selected = await promptSelection(
-      `Select ${currentSegment} subtype (${discLabel}):`,
+      `Select ${currentTypeName} subtype (${discLabel}):`,
       subtypes
     );
     if (!selected) return undefined;
 
-    typePath = `${typePath}/${selected}`;
-    typeDef = getTypeDefByPath(schema, typePath);
-    currentSegment = selected;
+    // In v2, children are just type names, not paths
+    currentTypeName = selected;
+    typeDef = getTypeDefByPath(schema, currentTypeName);
   }
 
-  return typePath;
+  return currentTypeName;
 }
 
 /**

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -929,7 +929,7 @@ function outputTypeDetailsJson(schema: LoadedSchema, typePath: string): void {
  */
 function formatTypeForJson(
   schema: LoadedSchema,
-  typePath: string,
+  _typePath: string,
   typeDef: ResolvedType
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {
@@ -940,10 +940,11 @@ function formatTypeForJson(
   if (hasSubtypes(typeDef)) {
     result.subtypes = Object.fromEntries(
       getSubtypeKeys(typeDef).map(subtype => {
-        const childTypeDef = getTypeDefByPath(schema, `${typePath}/${subtype}`);
+        // In v2, children are just type names, not paths
+        const childTypeDef = getTypeDefByPath(schema, subtype);
         return [
           subtype,
-          childTypeDef ? formatTypeForJson(schema, `${typePath}/${subtype}`, childTypeDef) : {},
+          childTypeDef ? formatTypeForJson(schema, subtype, childTypeDef) : {},
         ];
       })
     );
@@ -1054,9 +1055,10 @@ function printTypeTree(
   // Show subtypes (children in new model)
   if (hasSubtypes(typeDef)) {
     for (const subtype of getSubtypeKeys(typeDef)) {
-      const subDef = getTypeDefByPath(schema, `${typePath}/${subtype}`);
+      // In v2, children are just type names, not paths
+      const subDef = getTypeDefByPath(schema, subtype);
       if (subDef) {
-        printTypeTree(schema, `${typePath}/${subtype}`, subDef, depth + 1);
+        printTypeTree(schema, subtype, subDef, depth + 1);
       }
     }
   }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -57,15 +57,7 @@ export const BodySectionSchema: z.ZodType<BodySection, z.ZodTypeDef, BodySection
   })
 );
 
-// ============================================================================
-// Dynamic Sources (Legacy - REMOVED, kept only for migration error messages)
-// ============================================================================
 
-// Dynamic source definition (legacy - for error detection only)
-export const DynamicSourceSchema = z.object({
-  dir: z.string(),
-  filter: z.record(FilterConditionSchema).optional(),
-});
 
 // ============================================================================
 // Type Definition (New Inheritance Model)
@@ -155,7 +147,6 @@ export type BodySectionInput = {
   children?: BodySectionInput[] | undefined;
 };
 export type FilterCondition = z.infer<typeof FilterConditionSchema>;
-export type DynamicSource = z.infer<typeof DynamicSourceSchema>;
 export type Type = z.infer<typeof TypeSchema>;
 export type Schema = z.infer<typeof PikaSchema>;
 
@@ -330,89 +321,4 @@ export interface Template {
   body: string;
 }
 
-// ============================================================================
-// Legacy Types (For Migration Support)
-// ============================================================================
 
-/**
- * Field override definition (legacy - for old shared_fields model).
- * @deprecated Use field inheritance instead
- */
-export const FieldOverrideSchema = z.object({
-  default: z.union([z.string(), z.array(z.string())]).optional(),
-  required: z.boolean().optional(),
-  label: z.string().optional(),
-});
-
-export type FieldOverride = z.infer<typeof FieldOverrideSchema>;
-
-/**
- * Legacy subtype definition (for v1 schema migration).
- * @deprecated Use flat types with 'extends' instead
- */
-export const LegacySubtypeSchema: z.ZodType<LegacySubtype, z.ZodTypeDef, LegacySubtypeInput> = z.lazy(() =>
-  z.object({
-    output_dir: z.string().optional(),
-    filename: z.string().optional(),
-    shared_fields: z.array(z.string()).optional(),
-    field_overrides: z.record(FieldOverrideSchema).optional(),
-    frontmatter: z.record(FieldSchema).optional(),
-    frontmatter_order: z.array(z.string()).optional(),
-    body_sections: z.array(BodySectionSchema).optional(),
-    subtypes: z.record(LegacySubtypeSchema).optional(),
-  })
-);
-
-/**
- * Legacy type definition (for v1 schema migration).
- * @deprecated Use flat types with 'extends' instead
- */
-export const LegacyTypeSchema = z.object({
-  output_dir: z.string().optional(),
-  dir_mode: z.enum(['pooled', 'instance-grouped']).optional().default('pooled'),
-  shared_fields: z.array(z.string()).optional(),
-  field_overrides: z.record(FieldOverrideSchema).optional(),
-  frontmatter: z.record(FieldSchema).optional(),
-  frontmatter_order: z.array(z.string()).optional(),
-  body_sections: z.array(BodySectionSchema).optional(),
-  subtypes: z.record(LegacySubtypeSchema).optional(),
-});
-
-/**
- * Legacy schema (v1 format with nested subtypes).
- * @deprecated Use PikaSchema (v2) instead
- */
-export const LegacyPikaSchema = z.object({
-  version: z.literal(1).optional(),
-  shared_fields: z.record(FieldSchema).optional(),
-  enums: z.record(z.array(z.string())).optional(),
-  dynamic_sources: z.record(DynamicSourceSchema).optional(),
-  types: z.record(LegacyTypeSchema),
-  audit: AuditConfigSchema.optional(),
-});
-
-export type LegacySubtype = {
-  output_dir?: string | undefined;
-  filename?: string | undefined;
-  shared_fields?: string[] | undefined;
-  field_overrides?: Record<string, FieldOverride> | undefined;
-  frontmatter?: Record<string, Field> | undefined;
-  frontmatter_order?: string[] | undefined;
-  body_sections?: BodySection[] | undefined;
-  subtypes?: Record<string, LegacySubtype> | undefined;
-};
-export type LegacySubtypeInput = {
-  output_dir?: string | undefined;
-  filename?: string | undefined;
-  shared_fields?: string[] | undefined;
-  field_overrides?: Record<string, FieldOverride> | undefined;
-  frontmatter?: Record<string, Field> | undefined;
-  frontmatter_order?: string[] | undefined;
-  body_sections?: BodySectionInput[] | undefined;
-  subtypes?: Record<string, LegacySubtypeInput> | undefined;
-};
-export type LegacyType = z.infer<typeof LegacyTypeSchema>;
-export type LegacySchema = z.infer<typeof LegacyPikaSchema>;
-
-// Type definition union for backward compatibility
-export type TypeDef = Type | LegacyType | LegacySubtype;

--- a/tests/fixtures/test_schema.json
+++ b/tests/fixtures/test_schema.json
@@ -1,98 +1,104 @@
 {
   "$schema": "../../../schema.schema.json",
+  "version": 2,
   "enums": {
     "status": ["raw", "backlog", "in-flight", "settled"],
     "priority": ["low", "medium", "high"]
   },
   "types": {
     "objective": {
-      "subtypes": {
-        "task": {
-          "output_dir": "Objectives/Tasks",
-          "frontmatter": {
-            "type": { "value": "objective" },
-            "objective-type": { "value": "task" },
-            "status": {
-              "prompt": "select",
-              "enum": "status",
-              "default": "raw"
-            },
-            "milestone": {
-              "prompt": "dynamic",
-              "source": "milestone",
-              "filter": { "status": { "not_in": ["settled"] } },
-              "format": "quoted-wikilink"
-            },
-            "creation-date": { "value": "$NOW" },
-            "deadline": { "prompt": "input", "label": "Deadline (YYYY-MM-DD)" }
-          },
-          "frontmatter_order": [
-            "type",
-            "objective-type",
-            "status",
-            "milestone",
-            "creation-date",
-            "deadline"
-          ],
-          "body_sections": [
-            {
-              "title": "Steps",
-              "level": 2,
-              "content_type": "checkboxes",
-              "prompt": "multi-input",
-              "prompt_label": "Steps (comma-separated)"
-            },
-            {
-              "title": "Notes",
-              "level": 2,
-              "content_type": "paragraphs"
-            }
-          ]
+      "output_dir": "Objectives",
+      "fields": {
+        "type": { "value": "objective" }
+      },
+      "field_order": ["type"]
+    },
+    "task": {
+      "extends": "objective",
+      "output_dir": "Objectives/Tasks",
+      "fields": {
+        "type": { "value": "task" },
+        "status": {
+          "prompt": "select",
+          "enum": "status",
+          "default": "raw"
         },
         "milestone": {
-          "output_dir": "Objectives/Milestones",
-          "frontmatter": {
-            "type": { "value": "objective" },
-            "objective-type": { "value": "milestone" },
-            "status": {
-              "prompt": "select",
-              "enum": "status",
-              "default": "raw"
-            }
-          },
-          "frontmatter_order": ["type", "objective-type", "status"],
-          "body_sections": [
-            {
-              "title": "Tasks",
-              "level": 2,
-              "content_type": "none"
-            }
-          ]
+          "prompt": "dynamic",
+          "source": "milestone",
+          "filter": { "status": { "not_in": ["settled"] } },
+          "format": "quoted-wikilink"
+        },
+        "creation-date": { "value": "$NOW" },
+        "deadline": { "prompt": "input", "label": "Deadline (YYYY-MM-DD)" }
+      },
+      "field_order": [
+        "type",
+        "status",
+        "milestone",
+        "creation-date",
+        "deadline"
+      ],
+      "body_sections": [
+        {
+          "title": "Steps",
+          "level": 2,
+          "content_type": "checkboxes",
+          "prompt": "multi-input",
+          "prompt_label": "Steps (comma-separated)"
+        },
+        {
+          "title": "Notes",
+          "level": 2,
+          "content_type": "paragraphs"
         }
-      }
+      ]
+    },
+    "milestone": {
+      "extends": "objective",
+      "output_dir": "Objectives/Milestones",
+      "fields": {
+        "type": { "value": "milestone" },
+        "status": {
+          "prompt": "select",
+          "enum": "status",
+          "default": "raw"
+        }
+      },
+      "field_order": ["type", "status"],
+      "body_sections": [
+        {
+          "title": "Tasks",
+          "level": 2,
+          "content_type": "none"
+        }
+      ]
     },
     "idea": {
       "output_dir": "Ideas",
-      "frontmatter": {
+      "fields": {
         "type": { "value": "idea" },
         "status": { "prompt": "select", "enum": "status", "default": "raw" },
         "priority": { "prompt": "select", "enum": "priority" }
       },
-      "frontmatter_order": ["type", "status", "priority"],
+      "field_order": ["type", "status", "priority"],
       "body_sections": []
     },
     "entity": {
-      "subtypes": {
-        "person": {
-          "output_dir": "Entities/People",
-          "frontmatter": {
-            "type": { "value": "entity" },
-            "entity-type": { "value": "person" }
-          },
-          "frontmatter_order": ["type", "entity-type"],
-          "body_sections": []
-        }
-      }
+      "output_dir": "Entities",
+      "fields": {
+        "type": { "value": "entity" }
+      },
+      "field_order": ["type"]
+    },
+    "person": {
+      "extends": "entity",
+      "output_dir": "Entities/People",
+      "fields": {
+        "type": { "value": "person" }
+      },
+      "field_order": ["type"],
+      "body_sections": []
     }
   }
 }

--- a/tests/fixtures/vault/.pika/schema.json
+++ b/tests/fixtures/vault/.pika/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../../schema.schema.json",
-  "version": 1,
+  "version": 2,
   "enums": {
     "status": ["raw", "backlog", "in-flight", "settled"],
     "priority": ["low", "medium", "high"]
@@ -8,94 +8,97 @@
   "types": {
     "objective": {
       "output_dir": "Objectives",
-      "subtypes": {
-        "task": {
-          "output_dir": "Objectives/Tasks",
-          "frontmatter": {
-            "type": { "value": "objective" },
-            "objective-type": { "value": "task" },
-            "status": {
-              "prompt": "select",
-              "enum": "status",
-              "default": "raw"
-            },
-            "milestone": {
-              "prompt": "dynamic",
-              "source": "milestone",
-              "filter": { "status": { "not_in": ["settled"] } },
-              "format": "quoted-wikilink"
-            },
-            "creation-date": { "value": "$NOW" },
-            "deadline": { "prompt": "input", "label": "Deadline (YYYY-MM-DD)" }
-          },
-          "frontmatter_order": [
-            "type",
-            "objective-type",
-            "status",
-            "milestone",
-            "creation-date",
-            "deadline"
-          ],
-          "body_sections": [
-            {
-              "title": "Steps",
-              "level": 2,
-              "content_type": "checkboxes",
-              "prompt": "multi-input",
-              "prompt_label": "Steps (comma-separated)"
-            },
-            {
-              "title": "Notes",
-              "level": 2,
-              "content_type": "paragraphs"
-            }
-          ]
+      "fields": {
+        "type": { "value": "objective" }
+      },
+      "field_order": ["type"]
+    },
+    "task": {
+      "extends": "objective",
+      "output_dir": "Objectives/Tasks",
+      "fields": {
+        "type": { "value": "task" },
+        "status": {
+          "prompt": "select",
+          "enum": "status",
+          "default": "raw"
         },
         "milestone": {
-          "output_dir": "Objectives/Milestones",
-          "frontmatter": {
-            "type": { "value": "objective" },
-            "objective-type": { "value": "milestone" },
-            "status": {
-              "prompt": "select",
-              "enum": "status",
-              "default": "raw"
-            }
-          },
-          "frontmatter_order": ["type", "objective-type", "status"],
-          "body_sections": [
-            {
-              "title": "Tasks",
-              "level": 2,
-              "content_type": "none"
-            }
-          ]
+          "prompt": "dynamic",
+          "source": "milestone",
+          "filter": { "status": { "not_in": ["settled"] } },
+          "format": "quoted-wikilink"
+        },
+        "creation-date": { "value": "$NOW" },
+        "deadline": { "prompt": "input", "label": "Deadline (YYYY-MM-DD)" }
+      },
+      "field_order": [
+        "type",
+        "status",
+        "milestone",
+        "creation-date",
+        "deadline"
+      ],
+      "body_sections": [
+        {
+          "title": "Steps",
+          "level": 2,
+          "content_type": "checkboxes",
+          "prompt": "multi-input",
+          "prompt_label": "Steps (comma-separated)"
+        },
+        {
+          "title": "Notes",
+          "level": 2,
+          "content_type": "paragraphs"
         }
-      }
+      ]
+    },
+    "milestone": {
+      "extends": "objective",
+      "output_dir": "Objectives/Milestones",
+      "fields": {
+        "type": { "value": "milestone" },
+        "status": {
+          "prompt": "select",
+          "enum": "status",
+          "default": "raw"
+        }
+      },
+      "field_order": ["type", "status"],
+      "body_sections": [
+        {
+          "title": "Tasks",
+          "level": 2,
+          "content_type": "none"
+        }
+      ]
     },
     "idea": {
       "output_dir": "Ideas",
-      "frontmatter": {
+      "fields": {
         "type": { "value": "idea" },
         "status": { "prompt": "select", "enum": "status", "default": "raw" },
         "priority": { "prompt": "select", "enum": "priority" }
       },
-      "frontmatter_order": ["type", "status", "priority"],
+      "field_order": ["type", "status", "priority"],
       "body_sections": []
     },
     "entity": {
       "output_dir": "Entities",
-      "subtypes": {
-        "person": {
-          "output_dir": "Entities/People",
-          "frontmatter": {
-            "type": { "value": "entity" },
-            "entity-type": { "value": "person" }
-          },
-          "frontmatter_order": ["type", "entity-type"],
-          "body_sections": []
-        }
-      }
+      "fields": {
+        "type": { "value": "entity" }
+      },
+      "field_order": ["type"]
+    },
+    "person": {
+      "extends": "entity",
+      "output_dir": "Entities/People",
+      "fields": {
+        "type": { "value": "person" }
+      },
+      "field_order": ["type"],
+      "body_sections": []
     }
   }
 }

--- a/tests/fixtures/vault/.pika/templates/task/bug-report.md
+++ b/tests/fixtures/vault/.pika/templates/task/bug-report.md
@@ -1,6 +1,6 @@
 ---
 type: template
-template-for: objective/task
+template-for: task
 description: Bug report with reproduction steps
 defaults:
   status: backlog

--- a/tests/fixtures/vault/.pika/templates/task/default.md
+++ b/tests/fixtures/vault/.pika/templates/task/default.md
@@ -1,6 +1,6 @@
 ---
 type: template
-template-for: objective/task
+template-for: task
 description: Default task template
 defaults:
   status: backlog

--- a/tests/fixtures/vault/.pika/templates/task/weekly-review.md
+++ b/tests/fixtures/vault/.pika/templates/task/weekly-review.md
@@ -1,6 +1,6 @@
 ---
 type: template
-template-for: objective/task
+template-for: task
 description: Weekly review task with auto-deadline
 defaults:
   status: backlog

--- a/tests/fixtures/vault/Objectives/Milestones/Active Milestone.md
+++ b/tests/fixtures/vault/Objectives/Milestones/Active Milestone.md
@@ -1,6 +1,5 @@
 ---
-type: objective
-objective-type: milestone
+type: milestone
 status: in-flight
 ---
 ## Tasks

--- a/tests/fixtures/vault/Objectives/Milestones/Settled Milestone.md
+++ b/tests/fixtures/vault/Objectives/Milestones/Settled Milestone.md
@@ -1,6 +1,5 @@
 ---
-type: objective
-objective-type: milestone
+type: milestone
 status: settled
 ---
 ## Tasks

--- a/tests/fixtures/vault/Objectives/Tasks/Sample Task.md
+++ b/tests/fixtures/vault/Objectives/Tasks/Sample Task.md
@@ -1,6 +1,5 @@
 ---
-type: objective
-objective-type: task
+type: task
 status: in-flight
 ---
 ## Steps

--- a/tests/ts/commands/audit-fix.pty.test.ts
+++ b/tests/ts/commands/audit-fix.pty.test.ts
@@ -22,34 +22,34 @@ const describePty = shouldSkipPtyTests()
 
 // Schema for audit tests
 const AUDIT_SCHEMA = {
-  version: 1,
+  version: 2,
   enums: {
     status: ['raw', 'backlog', 'in-flight', 'settled'],
-    type: ['idea', 'objective'],
-    'objective-type': ['task', 'milestone'],
   },
   types: {
     idea: {
       output_dir: 'Ideas',
-      frontmatter: {
+      fields: {
         type: { value: 'idea' },
         status: { prompt: 'select', enum: 'status', default: 'raw', required: true },
       },
-      frontmatter_order: ['type', 'status'],
+      field_order: ['type', 'status'],
     },
     objective: {
       output_dir: 'Objectives',
-      subtypes: {
-        task: {
-          output_dir: 'Tasks',
-          frontmatter: {
-            type: { value: 'objective' },
-            'objective-type': { value: 'task' },
-            status: { prompt: 'select', enum: 'status', default: 'raw', required: true },
-          },
-          frontmatter_order: ['type', 'objective-type', 'status'],
-        },
+      fields: {
+        type: { value: 'objective' },
       },
+      field_order: ['type'],
+    },
+    task: {
+      extends: 'objective',
+      output_dir: 'Tasks',
+      fields: {
+        type: { value: 'task' },
+        status: { prompt: 'select', enum: 'status', default: 'raw', required: true },
+      },
+      field_order: ['type', 'status'],
     },
   },
 };
@@ -186,11 +186,11 @@ Missing required status.
         types: {
           item: {
             output_dir: 'Items',
-            frontmatter: {
+            fields: {
               type: { value: 'item' },
               category: { prompt: 'select', enum: 'status', required: true }, // No default
             },
-            frontmatter_order: ['type', 'category'],
+            field_order: ['type', 'category'],
           },
         },
       };
@@ -418,11 +418,11 @@ some: value
         types: {
           item: {
             output_dir: 'Items',
-            frontmatter: {
+            fields: {
               type: { value: 'item' },
               link: { prompt: 'input', format: 'wikilink' },
             },
-            frontmatter_order: ['type', 'link'],
+            field_order: ['type', 'link'],
           },
         },
       };
@@ -511,11 +511,11 @@ Auto-fixable orphan.
         types: {
           item: {
             output_dir: 'Items',
-            frontmatter: {
+            fields: {
               type: { value: 'item' },
               category: { prompt: 'select', enum: 'status', required: true },
             },
-            frontmatter_order: ['type', 'category'],
+            field_order: ['type', 'category'],
           },
         },
       };

--- a/tests/ts/commands/bulk.test.ts
+++ b/tests/ts/commands/bulk.test.ts
@@ -568,7 +568,7 @@ tags:
 
   describe('subtype handling', () => {
     it('should work with subtypes', async () => {
-      const result = await runCLI(['bulk', 'objective/task', '--all', '--set', 'status=settled'], vaultDir);
+      const result = await runCLI(['bulk', 'task', '--all', '--set', 'status=settled'], vaultDir);
       
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Sample Task.md');

--- a/tests/ts/commands/edit.pty.test.ts
+++ b/tests/ts/commands/edit.pty.test.ts
@@ -23,7 +23,7 @@ const describePty = shouldSkipPtyTests()
 
 // Schema for edit tests
 const EDIT_SCHEMA = {
-  version: 1,
+  version: 2,
   enums: {
     status: ['raw', 'backlog', 'in-flight', 'settled'],
     priority: ['low', 'medium', 'high'],
@@ -31,13 +31,13 @@ const EDIT_SCHEMA = {
   types: {
     idea: {
       output_dir: 'Ideas',
-      frontmatter: {
+      fields: {
         type: { value: 'idea' },
         status: { prompt: 'select', enum: 'status', default: 'raw' },
         priority: { prompt: 'select', enum: 'priority' },
         description: { prompt: 'input', label: 'Description' },
       },
-      frontmatter_order: ['type', 'status', 'priority', 'description'],
+      field_order: ['type', 'status', 'priority', 'description'],
       body_sections: [
         { title: 'Notes', level: 2, content_type: 'paragraphs' },
       ],

--- a/tests/ts/commands/edit.test.ts
+++ b/tests/ts/commands/edit.test.ts
@@ -58,7 +58,7 @@ status: backlog
       // Verify the file was updated correctly
       const content = await readFile(testFilePath, 'utf-8');
       expect(content).toContain('status: settled');
-      expect(content).toContain('objective-type: task'); // Preserved
+      expect(content).toContain('type: task'); // Preserved
     });
 
     it('should detect milestone subtype', async () => {
@@ -73,7 +73,7 @@ status: backlog
 
       const content = await readFile(join(vaultDir, 'Objectives/Milestones/Active Milestone.md'), 'utf-8');
       expect(content).toContain('status: settled');
-      expect(content).toContain('objective-type: milestone'); // Preserved
+      expect(content).toContain('type: milestone'); // Preserved
     });
 
     it('should work with absolute file paths', async () => {

--- a/tests/ts/commands/json-io.test.ts
+++ b/tests/ts/commands/json-io.test.ts
@@ -127,7 +127,7 @@ describe('JSON I/O', () => {
     describe('with _body', () => {
       it('should create note with body sections from _body field', async () => {
         const result = await runCLI(
-          ['new', 'objective/task', '--json', JSON.stringify({
+          ['new', 'task', '--json', JSON.stringify({
             'name': 'Test Task',
             _body: {
               Steps: ['Step 1', 'Step 2', 'Step 3'],
@@ -150,7 +150,7 @@ describe('JSON I/O', () => {
 
       it('should handle string content for paragraphs section', async () => {
         const result = await runCLI(
-          ['new', 'objective/task', '--json', JSON.stringify({
+          ['new', 'task', '--json', JSON.stringify({
             'name': 'Notes Task',
             _body: {
               Notes: 'This is a paragraph of notes about the task.',
@@ -171,7 +171,7 @@ describe('JSON I/O', () => {
 
       it('should handle multiple body sections', async () => {
         const result = await runCLI(
-          ['new', 'objective/task', '--json', JSON.stringify({
+          ['new', 'task', '--json', JSON.stringify({
             'name': 'Multi Section Task',
             _body: {
               Steps: ['Step A', 'Step B'],
@@ -196,7 +196,7 @@ describe('JSON I/O', () => {
 
       it('should error on unknown body section', async () => {
         const result = await runCLI(
-          ['new', 'objective/task', '--json', JSON.stringify({
+          ['new', 'task', '--json', JSON.stringify({
             'name': 'Bad Section Task',
             _body: {
               UnknownSection: ['Item'],
@@ -214,7 +214,7 @@ describe('JSON I/O', () => {
 
       it('should error when _body is not an object', async () => {
         const result = await runCLI(
-          ['new', 'objective/task', '--json', JSON.stringify({
+          ['new', 'task', '--json', JSON.stringify({
             'name': 'Bad Body Task',
             _body: 'not an object',
           })],
@@ -229,7 +229,7 @@ describe('JSON I/O', () => {
 
       it('should error when _body is an array', async () => {
         const result = await runCLI(
-          ['new', 'objective/task', '--json', JSON.stringify({
+          ['new', 'task', '--json', JSON.stringify({
             'name': 'Array Body Task',
             _body: ['not', 'valid'],
           })],
@@ -244,7 +244,7 @@ describe('JSON I/O', () => {
 
       it('should handle empty _body object', async () => {
         const result = await runCLI(
-          ['new', 'objective/task', '--json', JSON.stringify({
+          ['new', 'task', '--json', JSON.stringify({
             'name': 'Empty Body Task',
             _body: {},
           })],
@@ -262,7 +262,7 @@ describe('JSON I/O', () => {
 
       it('should handle null _body', async () => {
         const result = await runCLI(
-          ['new', 'objective/task', '--json', JSON.stringify({
+          ['new', 'task', '--json', JSON.stringify({
             'name': 'Null Body Task',
             _body: null,
           })],
@@ -276,7 +276,7 @@ describe('JSON I/O', () => {
 
       it('should not include _body in frontmatter', async () => {
         const result = await runCLI(
-          ['new', 'objective/task', '--json', JSON.stringify({
+          ['new', 'task', '--json', JSON.stringify({
             'name': 'Body Not In FM',
             _body: {
               Steps: ['Step 1'],

--- a/tests/ts/commands/list.test.ts
+++ b/tests/ts/commands/list.test.ts
@@ -22,7 +22,7 @@ describe('list command', () => {
     });
 
     it('should list subtypes with slash notation', async () => {
-      const result = await runCLI(['list', 'objective/task'], vaultDir);
+      const result = await runCLI(['list', 'task'], vaultDir);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Sample Task');
@@ -38,7 +38,7 @@ describe('list command', () => {
     });
 
     it('should return empty for type with no files', async () => {
-      const result = await runCLI(['list', 'objective/milestone', '--status=raw'], vaultDir);
+      const result = await runCLI(['list', 'milestone', '--status=raw'], vaultDir);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toBe('');
@@ -65,7 +65,7 @@ describe('list command', () => {
     });
 
     it('should show nested paths for subtypes', async () => {
-      const result = await runCLI(['list', '--paths', 'objective/task'], vaultDir);
+      const result = await runCLI(['list', '--paths', 'task'], vaultDir);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Objectives/Tasks/Sample Task.md');
@@ -120,7 +120,7 @@ describe('list command', () => {
     });
 
     it('should filter by negation', async () => {
-      const result = await runCLI(['list', 'objective/milestone', '--status!=settled'], vaultDir);
+      const result = await runCLI(['list', 'milestone', '--status!=settled'], vaultDir);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Active Milestone');

--- a/tests/ts/commands/new.test.ts
+++ b/tests/ts/commands/new.test.ts
@@ -76,7 +76,7 @@ describe('new command', () => {
 
     it('should error when --default but no default.md exists', async () => {
       const result = await runCLI(
-        ['new', 'objective/milestone', '--json', '{"name": "Test"}', '--default'],
+        ['new', 'milestone', '--json', '{"name": "Test"}', '--default'],
         vaultDir
       );
 
@@ -89,7 +89,7 @@ describe('new command', () => {
     it('should create note with --template flag applying defaults', async () => {
       // bug-report template has defaults: status: backlog
       const result = await runCLI(
-        ['new', 'objective/task', '--json', '{"name": "Fix the bug"}', '--template', 'bug-report'],
+        ['new', 'task', '--json', '{"name": "Fix the bug"}', '--template', 'bug-report'],
         vaultDir
       );
 
@@ -177,7 +177,7 @@ describe('new command', () => {
     it('should evaluate date expressions in template defaults', async () => {
       // Use the weekly-review template which has deadline: "today() + '7d'"
       const result = await runCLI(
-        ['new', 'objective/task', '--json', '{"name": "Weekly Review Test"}', '--template', 'weekly-review'],
+        ['new', 'task', '--json', '{"name": "Weekly Review Test"}', '--template', 'weekly-review'],
         vaultDir
       );
 
@@ -202,7 +202,7 @@ describe('new command', () => {
     it('should allow JSON input to override date expression defaults', async () => {
       // Template has deadline: "today() + '7d'" but JSON input overrides it
       const result = await runCLI(
-        ['new', 'objective/task', '--json', '{"name": "Override Date", "deadline": "2030-01-15"}', '--template', 'weekly-review'],
+        ['new', 'task', '--json', '{"name": "Override Date", "deadline": "2030-01-15"}', '--template', 'weekly-review'],
         vaultDir
       );
 

--- a/tests/ts/commands/relative-paths.pty.test.ts
+++ b/tests/ts/commands/relative-paths.pty.test.ts
@@ -18,7 +18,7 @@ const describePty = shouldSkipPtyTests() ? describe.skip : describe;
 
 // Schema for testing
 const TEST_SCHEMA = {
-  version: 1,
+  version: 2,
   enums: {
     status: ['raw', 'backlog', 'in-flight', 'settled'],
     priority: ['low', 'medium', 'high'],
@@ -26,12 +26,12 @@ const TEST_SCHEMA = {
   types: {
     idea: {
       output_dir: 'Ideas',
-      frontmatter: {
+      fields: {
         type: { value: 'idea' },
         status: { prompt: 'select', enum: 'status', default: 'raw' },
         priority: { prompt: 'select', enum: 'priority' },
       },
-      frontmatter_order: ['type', 'status', 'priority'],
+      field_order: ['type', 'status', 'priority'],
     },
   },
 };

--- a/tests/ts/commands/relative-paths.test.ts
+++ b/tests/ts/commands/relative-paths.test.ts
@@ -43,7 +43,7 @@ describe('relative vault path handling', () => {
     });
 
     it('should work with subtypes using relative path', async () => {
-      const result = await runCLI(['--vault', relativeVaultPath, 'list', 'objective/task']);
+      const result = await runCLI(['--vault', relativeVaultPath, 'list', 'task']);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Sample Task');
@@ -158,7 +158,7 @@ describe('relative vault path handling', () => {
         '--vault',
         relativeVaultPath,
         'new',
-        'objective/task',
+        'task',
         '--json',
         json,
       ]);
@@ -237,16 +237,16 @@ describe('edge cases', () => {
       await writeFile(
         join(spacedVaultDir, '.pika', 'schema.json'),
         JSON.stringify({
-          version: 1,
+          version: 2,
           enums: { status: ['raw', 'done'] },
           types: {
             idea: {
               output_dir: 'Ideas',
-              frontmatter: {
+              fields: {
                 type: { value: 'idea' },
                 status: { prompt: 'select', enum: 'status' },
               },
-              frontmatter_order: ['type', 'status'],
+              field_order: ['type', 'status'],
             },
           },
         })

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -82,10 +82,10 @@ describe('schema command', () => {
     });
 
     it('should show subtype details with slash notation', async () => {
-      const result = await runCLI(['schema', 'show', 'objective/task'], vaultDir);
+      const result = await runCLI(['schema', 'show', 'task'], vaultDir);
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('Type: objective/task');
+      expect(result.stdout).toContain('Type: task');
       expect(result.stdout).toContain('Objectives/Tasks');
     });
 
@@ -99,7 +99,7 @@ describe('schema command', () => {
     });
 
     it('should show body sections if defined', async () => {
-      const result = await runCLI(['schema', 'show', 'objective/task'], vaultDir);
+      const result = await runCLI(['schema', 'show', 'task'], vaultDir);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Body Sections:');

--- a/tests/ts/commands/template.test.ts
+++ b/tests/ts/commands/template.test.ts
@@ -22,15 +22,15 @@ describe('template command', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Templates');
       expect(result.stdout).toContain('idea');
-      expect(result.stdout).toContain('objective/task');
+      expect(result.stdout).toContain('task');
       expect(result.stdout).toContain('default');
     });
 
     it('should filter by type', async () => {
-      const result = await runCLI(['template', 'list', 'objective/task'], vaultDir);
+      const result = await runCLI(['template', 'list', 'task'], vaultDir);
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('objective/task');
+      expect(result.stdout).toContain('task');
       expect(result.stdout).toContain('default');
       expect(result.stdout).toContain('bug-report');
       // Should not contain idea templates
@@ -192,10 +192,10 @@ Body
       // Create a template with valid date expression - use status which is a valid field
       // Date expressions are valid values even for non-date fields
       await writeFile(
-        join(vaultDir, '.pika/templates/objective/task', 'dated.md'),
+        join(vaultDir, '.pika/templates/task', 'dated.md'),
         `---
 type: template
-template-for: objective/task
+template-for: task
 defaults:
   status: backlog
   deadline: "today() + '7d'"
@@ -216,10 +216,10 @@ Body
     it('should reject invalid date expressions in defaults', async () => {
       // Create a template with invalid date expression syntax
       await writeFile(
-        join(vaultDir, '.pika/templates/objective/task', 'bad-date.md'),
+        join(vaultDir, '.pika/templates/task', 'bad-date.md'),
         `---
 type: template
-template-for: objective/task
+template-for: task
 defaults:
   status: backlog
   deadline: "today( + 7d"
@@ -465,12 +465,12 @@ Body
     });
 
     it('should delete nested subtype templates', async () => {
-      // Test with objective/task template (nested type)
-      const templatePath = join(vaultDir, '.pika/templates/objective/task', 'default.md');
+      // Test with task template (nested type)
+      const templatePath = join(vaultDir, '.pika/templates/task', 'default.md');
       expect(existsSync(templatePath)).toBe(true);
 
       const result = await runCLI([
-        'template', 'delete', 'objective/task', 'default', '--force',
+        'template', 'delete', 'task', 'default', '--force',
       ], vaultDir);
 
       expect(result.exitCode).toBe(0);

--- a/tests/ts/lib/discovery.test.ts
+++ b/tests/ts/lib/discovery.test.ts
@@ -168,10 +168,10 @@ describe('Discovery', () => {
 
   describe('collectFilesForType', () => {
     it('should collect files for a specific leaf type', async () => {
-      const files = await collectFilesForType(schema, vaultDir, 'objective/task');
+      const files = await collectFilesForType(schema, vaultDir, 'task');
       
       expect(files.length).toBeGreaterThan(0);
-      expect(files[0]!.expectedType).toBe('objective/task');
+      expect(files[0]!.expectedType).toBe('task');
     });
 
     it('should return empty for invalid type', async () => {

--- a/tests/ts/lib/frontmatter.test.ts
+++ b/tests/ts/lib/frontmatter.test.ts
@@ -39,7 +39,7 @@ describe('frontmatter', () => {
 
     it('should parse note with body content', async () => {
       const note = await parseNote(join(vaultDir, 'Objectives/Tasks', 'Sample Task.md'));
-      expect(note.frontmatter.type).toBe('objective');
+      expect(note.frontmatter.type).toBe('task');
       expect(note.body).toContain('## Steps');
       expect(note.body).toContain('## Notes');
     });

--- a/tests/ts/lib/numberedSelect.pty.test.ts
+++ b/tests/ts/lib/numberedSelect.pty.test.ts
@@ -41,7 +41,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
       // The confirmation line "✔ Select milestone: (skip)" is different - it doesn't
       // have the number prefix, so we can distinguish between render and confirmation.
 
-      const proc = spawnOvault(['new', 'objective/task'], {
+      const proc = spawnOvault(['new', 'task'], {
         cwd: TEST_VAULT_PATH,
       });
 
@@ -98,7 +98,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
     }, 30000);
 
     it('should show checkmark after number key selection', async () => {
-      const proc = spawnOvault(['new', 'objective/task'], {
+      const proc = spawnOvault(['new', 'task'], {
         cwd: TEST_VAULT_PATH,
       });
 
@@ -141,7 +141,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
 
   describe('Ctrl+C abort', () => {
     it('should abort cleanly on Ctrl+C during selection', async () => {
-      const proc = spawnOvault(['new', 'objective/task'], {
+      const proc = spawnOvault(['new', 'task'], {
         cwd: TEST_VAULT_PATH,
       });
 
@@ -184,13 +184,13 @@ describePty('NumberedSelectPrompt PTY tests', () => {
       // "on first render, it called clearPrompt() which erased lines
       //  printed BEFORE the prompt started"
 
-      const proc = spawnOvault(['new', 'objective/task'], {
+      const proc = spawnOvault(['new', 'task'], {
         cwd: TEST_VAULT_PATH,
       });
 
       try {
-        // Wait for initial output (the "=== New objective ===" header)
-        await proc.waitFor('New objective', 10000);
+        // Wait for initial output (the "=== New task ===" header)
+        await proc.waitFor('New task', 10000);
 
         // The header should remain visible throughout the interaction
         // Enter task name
@@ -201,7 +201,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
 
         // Check that the header is still visible
         const output = proc.getOutput();
-        expect(output).toContain('New objective');
+        expect(output).toContain('New task');
 
         // Also verify "Using template" is still visible
         expect(output).toContain('Using template');
@@ -219,7 +219,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
 
   describe('arrow key navigation', () => {
     it('should navigate with arrow keys without corrupting display', async () => {
-      const proc = spawnOvault(['new', 'objective/task'], {
+      const proc = spawnOvault(['new', 'task'], {
         cwd: TEST_VAULT_PATH,
       });
 
@@ -267,7 +267,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
       // Fixed behavior: Only update the lines that changed (cursor movement)
       // The hint line should only appear once (in the initial render).
 
-      const proc = spawnOvault(['new', 'objective/task'], {
+      const proc = spawnOvault(['new', 'task'], {
         cwd: TEST_VAULT_PATH,
       });
 
@@ -310,7 +310,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
   describe('pagination', () => {
     // Schema with a large enum to test pagination (>10 items)
     const PAGINATION_SCHEMA = {
-      version: 1,
+      version: 2,
       enums: {
         category: [
           'category-01', 'category-02', 'category-03', 'category-04', 'category-05',
@@ -321,11 +321,11 @@ describePty('NumberedSelectPrompt PTY tests', () => {
       types: {
         item: {
           output_dir: 'Items',
-          frontmatter: {
+          fields: {
             type: { value: 'item' },
             category: { prompt: 'select', enum: 'category', required: true },
           },
-          frontmatter_order: ['type', 'category'],
+          field_order: ['type', 'category'],
         },
       },
     };
@@ -545,17 +545,17 @@ describePty('NumberedSelectPrompt PTY tests', () => {
     it('should handle empty choices gracefully', async () => {
       // Schema with type-based source that returns no results (type doesn't exist)
       const emptySchema = {
-        version: 1,
+        version: 2,
         enums: {},
         types: {
           item: {
             output_dir: 'Items',
-            frontmatter: {
+            fields: {
               type: { value: 'item' },
               // Reference a type that doesn't exist - will return no results
               ref: { prompt: 'dynamic', source: 'nonexistent_type', format: 'wikilink' },
             },
-            frontmatter_order: ['type', 'ref'],
+            field_order: ['type', 'ref'],
           },
         },
       };
@@ -584,7 +584,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
 
   describe('escape key abort', () => {
     it('should abort on Escape key during selection', async () => {
-      const proc = spawnOvault(['new', 'objective/task'], {
+      const proc = spawnOvault(['new', 'task'], {
         cwd: TEST_VAULT_PATH,
       });
 

--- a/tests/ts/lib/prompt-confirm.pty.test.ts
+++ b/tests/ts/lib/prompt-confirm.pty.test.ts
@@ -24,18 +24,18 @@ const describePty = shouldSkipPtyTests()
 
 // Schema for testing confirmation prompts (used by edit command)
 const EDIT_TEST_SCHEMA = {
-  version: 1,
+  version: 2,
   enums: {
     status: ['raw', 'backlog', 'in-flight', 'settled'],
   },
   types: {
     idea: {
       output_dir: 'Ideas',
-      frontmatter: {
+      fields: {
         type: { value: 'idea' },
         status: { prompt: 'select', enum: 'status', default: 'raw' },
       },
-      frontmatter_order: ['type', 'status'],
+      field_order: ['type', 'status'],
       body_sections: [
         { title: 'Notes', level: 2, content_type: 'paragraphs' },
       ],

--- a/tests/ts/lib/prompt-input.pty.test.ts
+++ b/tests/ts/lib/prompt-input.pty.test.ts
@@ -123,11 +123,11 @@ describePty('Text Input Prompt PTY tests', () => {
         types: {
           task: {
             output_dir: 'Tasks',
-            frontmatter: {
+            fields: {
               type: { value: 'task' },
               deadline: { prompt: 'input', label: 'Deadline' },
             },
-            frontmatter_order: ['type', 'deadline'],
+            field_order: ['type', 'deadline'],
           },
         },
       };
@@ -164,11 +164,11 @@ describePty('Text Input Prompt PTY tests', () => {
         types: {
           note: {
             output_dir: 'Notes',
-            frontmatter: {
+            fields: {
               type: { value: 'note' },
               category: { prompt: 'input', label: 'Category', default: 'general' },
             },
-            frontmatter_order: ['type', 'category'],
+            field_order: ['type', 'category'],
           },
         },
       };

--- a/tests/ts/lib/prompt-multiinput.pty.test.ts
+++ b/tests/ts/lib/prompt-multiinput.pty.test.ts
@@ -23,18 +23,18 @@ const describePty = shouldSkipPtyTests()
 
 // Schema that includes a body section with multi-input prompt
 const TASK_SCHEMA = {
-  version: 1,
+  version: 2,
   enums: {
     status: ['raw', 'in-progress', 'done'],
   },
   types: {
     task: {
       output_dir: 'Tasks',
-      frontmatter: {
+      fields: {
         type: { value: 'task' },
         status: { prompt: 'select', enum: 'status', default: 'raw' },
       },
-      frontmatter_order: ['type', 'status'],
+      field_order: ['type', 'status'],
       body_sections: [
         {
           title: 'Steps',

--- a/tests/ts/lib/pty-helpers.test.ts
+++ b/tests/ts/lib/pty-helpers.test.ts
@@ -25,11 +25,11 @@ describe('copyFixtureTemplates', () => {
       const ideaDefault = await vaultFileExists(vaultPath, '.pika/templates/idea/default.md');
       expect(ideaDefault).toBe(true);
       
-      // Check that objective/task templates exist
-      const taskDefault = await vaultFileExists(vaultPath, '.pika/templates/objective/task/default.md');
+      // Check that task templates exist
+      const taskDefault = await vaultFileExists(vaultPath, '.pika/templates/task/default.md');
       expect(taskDefault).toBe(true);
       
-      const taskBugReport = await vaultFileExists(vaultPath, '.pika/templates/objective/task/bug-report.md');
+      const taskBugReport = await vaultFileExists(vaultPath, '.pika/templates/task/bug-report.md');
       expect(taskBugReport).toBe(true);
     } finally {
       await cleanupTempVault(vaultPath);
@@ -46,7 +46,7 @@ describe('copyFixtureTemplates', () => {
       expect(ideaDefault).toBe(true);
       
       // Objective templates should NOT exist
-      const taskDefault = await vaultFileExists(vaultPath, '.pika/templates/objective/task/default.md');
+      const taskDefault = await vaultFileExists(vaultPath, '.pika/templates/task/default.md');
       expect(taskDefault).toBe(false);
     } finally {
       await cleanupTempVault(vaultPath);
@@ -89,7 +89,7 @@ describe('createTempVault with includeTemplates', () => {
       const ideaDefault = await vaultFileExists(vaultPath, '.pika/templates/idea/default.md');
       expect(ideaDefault).toBe(true);
       
-      const taskDefault = await vaultFileExists(vaultPath, '.pika/templates/objective/task/default.md');
+      const taskDefault = await vaultFileExists(vaultPath, '.pika/templates/task/default.md');
       expect(taskDefault).toBe(true);
     } finally {
       await cleanupTempVault(vaultPath);
@@ -102,7 +102,7 @@ describe('createTempVault with includeTemplates', () => {
       const ideaDefault = await vaultFileExists(vaultPath, '.pika/templates/idea/default.md');
       expect(ideaDefault).toBe(true);
       
-      const taskDefault = await vaultFileExists(vaultPath, '.pika/templates/objective/task/default.md');
+      const taskDefault = await vaultFileExists(vaultPath, '.pika/templates/task/default.md');
       expect(taskDefault).toBe(false);
     } finally {
       await cleanupTempVault(vaultPath);

--- a/tests/ts/lib/pty-helpers.ts
+++ b/tests/ts/lib/pty-helpers.ts
@@ -330,7 +330,7 @@ export class PtyProcess {
  *
  * @example
  * ```ts
- * const proc = await spawnPika(['new', 'objective/task'], { cwd: testVaultPath });
+ * const proc = await spawnPika(['new', 'task'], { cwd: testVaultPath });
  * await proc.waitFor('Name');
  * proc.write('My Task\r');
  * ```
@@ -438,7 +438,7 @@ export const withOvault = withPika;
  */
 export const MINIMAL_SCHEMA = {
   $schema: '../../../schema.schema.json',
-  version: 1,
+  version: 2,
   enums: {
     status: ['raw', 'backlog', 'in-flight', 'settled'],
     priority: ['low', 'medium', 'high'],
@@ -446,12 +446,12 @@ export const MINIMAL_SCHEMA = {
   types: {
     idea: {
       output_dir: 'Ideas',
-      frontmatter: {
+      fields: {
         type: { value: 'idea' },
         status: { prompt: 'select', enum: 'status', default: 'raw' },
         priority: { prompt: 'select', enum: 'priority' },
       },
-      frontmatter_order: ['type', 'status', 'priority'],
+      field_order: ['type', 'status', 'priority'],
     },
   },
 };

--- a/tests/ts/lib/query.test.ts
+++ b/tests/ts/lib/query.test.ts
@@ -147,7 +147,7 @@ describe('query', () => {
     });
 
     it('should accept any value for non-enum fields', () => {
-      const result = validateFilterValues(schema, 'objective/task', 'deadline', ['anything']);
+      const result = validateFilterValues(schema, 'task', 'deadline', ['anything']);
       expect(result.valid).toBe(true);
     });
   });

--- a/tests/ts/lib/template.test.ts
+++ b/tests/ts/lib/template.test.ts
@@ -37,8 +37,8 @@ describe('template library', () => {
     });
 
     it('returns correct path for nested type', () => {
-      const result = getTemplateDir('/vault', 'objective/task');
-      expect(result).toBe('/vault/.pika/templates/objective/task');
+      const result = getTemplateDir('/vault', 'task');
+      expect(result).toBe('/vault/.pika/templates/task');
     });
 
     it('returns correct path for deeply nested type', () => {
@@ -160,25 +160,25 @@ Body.
 
   describe('findTemplates', () => {
     it('finds all templates for a type', async () => {
-      await mkdir(join(tempDir, '.pika/templates/objective/task'), { recursive: true });
+      await mkdir(join(tempDir, '.pika/templates/task'), { recursive: true });
       await writeFile(
-        join(tempDir, '.pika/templates/objective/task', 'default.md'),
+        join(tempDir, '.pika/templates/task', 'default.md'),
         `---
 type: template
-template-for: objective/task
+template-for: task
 ---
 `
       );
       await writeFile(
-        join(tempDir, '.pika/templates/objective/task', 'bug-report.md'),
+        join(tempDir, '.pika/templates/task', 'bug-report.md'),
         `---
 type: template
-template-for: objective/task
+template-for: task
 ---
 `
       );
 
-      const templates = await findTemplates(tempDir, 'objective/task');
+      const templates = await findTemplates(tempDir, 'task');
 
       expect(templates).toHaveLength(2);
       expect(templates.map(t => t.name)).toContain('default');
@@ -231,7 +231,7 @@ template-for: idea
         join(tempDir, '.pika/templates/idea', 'wrong.md'),
         `---
 type: template
-template-for: objective/task
+template-for: task
 ---
 `
       );
@@ -243,7 +243,7 @@ template-for: objective/task
     it('does not inherit templates from parent type (strict matching)', async () => {
       // Create template in parent directory
       await mkdir(join(tempDir, '.pika/templates/objective'), { recursive: true });
-      await mkdir(join(tempDir, '.pika/templates/objective/task'), { recursive: true });
+      await mkdir(join(tempDir, '.pika/templates/task'), { recursive: true });
       
       await writeFile(
         join(tempDir, '.pika/templates/objective', 'parent-template.md'),
@@ -255,7 +255,7 @@ template-for: objective
       );
 
       // Search for task templates - should NOT find parent template
-      const templates = await findTemplates(tempDir, 'objective/task');
+      const templates = await findTemplates(tempDir, 'task');
       expect(templates).toEqual([]);
     });
   });
@@ -301,7 +301,7 @@ template-for: idea
         join(tempDir, '.pika/templates/idea', 'default.md'),
         `---
 type: template
-template-for: objective/task
+template-for: task
 ---
 `
       );
@@ -313,18 +313,18 @@ template-for: objective/task
 
   describe('findTemplateByName', () => {
     it('finds template by name', async () => {
-      await mkdir(join(tempDir, '.pika/templates/objective/task'), { recursive: true });
+      await mkdir(join(tempDir, '.pika/templates/task'), { recursive: true });
       await writeFile(
-        join(tempDir, '.pika/templates/objective/task', 'bug-report.md'),
+        join(tempDir, '.pika/templates/task', 'bug-report.md'),
         `---
 type: template
-template-for: objective/task
+template-for: task
 description: Bug template
 ---
 `
       );
 
-      const template = await findTemplateByName(tempDir, 'objective/task', 'bug-report');
+      const template = await findTemplateByName(tempDir, 'task', 'bug-report');
 
       expect(template).not.toBeNull();
       expect(template?.name).toBe('bug-report');
@@ -358,7 +358,7 @@ template-for: idea
         join(tempDir, '.pika/templates/idea', 'wrong.md'),
         `---
 type: template
-template-for: objective/task
+template-for: task
 ---
 `
       );

--- a/tests/ts/lib/validation.test.ts
+++ b/tests/ts/lib/validation.test.ts
@@ -88,7 +88,7 @@ describe('validation', () => {
     it('should validate date format', () => {
       // Note: date validation only happens for fields with prompt: 'date'
       // The test schema's deadline field may use 'input' prompt instead
-      const result = validateFrontmatter(schema, 'objective/task', {
+      const result = validateFrontmatter(schema, 'task', {
         type: 'objective',
         'objective-type': 'task',
         status: 'raw',
@@ -106,7 +106,7 @@ describe('validation', () => {
     });
 
     it('should accept valid date format', () => {
-      const result = validateFrontmatter(schema, 'objective/task', {
+      const result = validateFrontmatter(schema, 'task', {
         type: 'objective',
         'objective-type': 'task',
         status: 'raw',
@@ -117,7 +117,7 @@ describe('validation', () => {
     });
 
     it('should accept datetime format', () => {
-      const result = validateFrontmatter(schema, 'objective/task', {
+      const result = validateFrontmatter(schema, 'task', {
         type: 'objective',
         'objective-type': 'task',
         status: 'raw',

--- a/tests/ts/lib/vault.test.ts
+++ b/tests/ts/lib/vault.test.ts
@@ -175,7 +175,7 @@ describe('vault', () => {
     });
 
     it('should return output_dir for nested type', () => {
-      const dir = getOutputDir(schema, 'objective/task');
+      const dir = getOutputDir(schema, 'task');
       expect(dir).toBe('Objectives/Tasks');
     });
 


### PR DESCRIPTION
## Summary

This PR removes support for v1 (legacy) schema format with nested subtypes and fully migrates to v2's flat type model with `extends` inheritance.

### Key Changes

**Source code (`src/`):**
- Removed `isLegacySchema()`, `convertLegacySchema()`, and `convertLegacyType()` from schema.ts
- Removed legacy type definitions (`LegacyPikaSchema`, `LegacyTypeSchema`, etc.) from types/schema.ts  
- Simplified `loadSchema()` to only parse v2 format
- Fixed subtype navigation in `new.ts` - use type names directly instead of path concatenation (e.g., `task` not `objective/task`)
- Fixed type tree display in `schema.ts` - lookup children by name, not path
- Fixed file collection in `list.ts` for parent types to properly recurse into children
- Added path format detection in `resolveSourceType()` with helpful migration messages
- Fixed field inheritance to allow `value` override for type identity fields

**Test fixtures:**
- Migrated `tests/fixtures/vault/.pika/schema.json` to v2 format
- Migrated `tests/fixtures/test_schema.json` to v2 format
- Moved templates from `.pika/templates/objective/task/` to `.pika/templates/task/`
- Updated vault markdown files to use single `type` field (e.g., `type: task` instead of `type: objective` + `objective-type: task`)
- Updated inline test schemas to use `fields` and `field_order` instead of `frontmatter` and `frontmatter_order`

### Breaking Change

V1 schemas with nested subtypes are no longer supported. Existing vaults using v1 format must migrate to v2 with `extends` inheritance.

### Testing

All 1035 tests pass.

Closes issue: pika-90ga