### PR TITLE
feat: add shell completion for --type and --path options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Pika are documented in this file.
 
 ### Added
 
+- **Shell completion for bash, zsh, and fish** (pika-nn8b)
+  - `pika completion bash|zsh|fish` outputs shell scripts for tab completion
+  - Completes commands, options, `--type` values (from schema), and `--path` values (vault directories)
+  - Dynamic completions that always match the installed version
+  - See README for installation instructions
+
 - **Unified CLI targeting model** (pika-s8kt)
   - All set-operating commands now support four composable selectors: `--type`, `--path`, `--where`, `--text`
   - Selectors compose via AND: `pika list --type task --where "status=active" --path "Projects/*"`

--- a/README.md
+++ b/README.md
@@ -492,6 +492,41 @@ pika search "My Note" --wikilink | pbcopy
 local link = vim.fn.system("pika search 'My Note' --picker none")
 ```
 
+## Shell Completion
+
+Enable tab completion for commands, types, and paths.
+
+### Bash
+
+Add to `~/.bashrc`:
+
+```bash
+eval "$(pika completion bash)"
+```
+
+### Zsh
+
+Add to `~/.zshrc`:
+
+```zsh
+eval "$(pika completion zsh)"
+```
+
+### Fish
+
+Run once to install:
+
+```fish
+pika completion fish > ~/.config/fish/completions/pika.fish
+```
+
+### What Gets Completed
+
+- **Commands**: `pika <TAB>` shows `new`, `edit`, `list`, `open`, etc.
+- **Options**: `pika list -<TAB>` shows `--type`, `--path`, `--where`, etc.
+- **Types**: `pika list --type <TAB>` shows types from your schema (task, idea, etc.)
+- **Paths**: `pika list --path <TAB>` shows vault directories (Ideas/, Objectives/, etc.)
+
 ## Running Tests
 
 ```sh

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -1,0 +1,55 @@
+/**
+ * Completion command - outputs shell completion scripts.
+ * 
+ * Usage:
+ *   pika completion bash   # Output bash completion script
+ *   pika completion zsh    # Output zsh completion script
+ *   pika completion fish   # Output fish completion script
+ * 
+ * Installation:
+ *   # Bash (add to ~/.bashrc)
+ *   eval "$(pika completion bash)"
+ *   
+ *   # Zsh (add to ~/.zshrc)
+ *   eval "$(pika completion zsh)"
+ *   
+ *   # Fish (run once)
+ *   pika completion fish > ~/.config/fish/completions/pika.fish
+ */
+
+import { Command } from 'commander';
+import { getCompletionScript } from '../lib/completion.js';
+
+const SUPPORTED_SHELLS = ['bash', 'zsh', 'fish'];
+
+export const completionCommand = new Command('completion')
+  .description('Generate shell completion scripts')
+  .argument('<shell>', `Shell type (${SUPPORTED_SHELLS.join(', ')})`)
+  .addHelpText('after', `
+Examples:
+  # Bash (add to ~/.bashrc)
+  eval "$(pika completion bash)"
+
+  # Zsh (add to ~/.zshrc)  
+  eval "$(pika completion zsh)"
+
+  # Fish (run once)
+  pika completion fish > ~/.config/fish/completions/pika.fish
+`)
+  .action((shell: string) => {
+    const normalizedShell = shell.toLowerCase();
+    
+    if (!SUPPORTED_SHELLS.includes(normalizedShell)) {
+      console.error(`Error: Unsupported shell "${shell}".`);
+      console.error(`Supported shells: ${SUPPORTED_SHELLS.join(', ')}`);
+      process.exit(1);
+    }
+    
+    const script = getCompletionScript(normalizedShell);
+    if (script) {
+      console.log(script);
+    } else {
+      console.error(`Error: Failed to generate completion script for ${shell}.`);
+      process.exit(1);
+    }
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,24 +11,51 @@ import { schemaCommand } from './commands/schema.js';
 import { auditCommand } from './commands/audit.js';
 import { bulkCommand } from './commands/bulk.js';
 import { templateCommand } from './commands/template.js';
+import { completionCommand } from './commands/completion.js';
+import { handleCompletionRequest } from './lib/completion.js';
 
 const program = new Command();
 
-program
-  .name('pika')
-  .description('Schema-driven note management for markdown vaults')
-  .version('0.2.0')
-  .option('-v, --vault <path>', 'Path to the vault directory');
+// Handle --completions before normal parsing (hidden flag for shell completion)
+const completionsIndex = process.argv.indexOf('--completions');
+if (completionsIndex !== -1) {
+  // Extract everything after --completions as the words to complete
+  const completionArgs = process.argv.slice(completionsIndex + 1);
+  
+  // Extract --vault if present in the completion args
+  const vaultIndex = completionArgs.indexOf('--vault');
+  const vault = vaultIndex !== -1 ? completionArgs[vaultIndex + 1] : undefined;
+  
+  handleCompletionRequest(completionArgs, vault ? { vault } : {})
+    .then(completions => {
+      // Output one completion per line
+      for (const c of completions) {
+        console.log(c);
+      }
+      process.exit(0);
+    })
+    .catch(() => {
+      // Fail silently for completions
+      process.exit(0);
+    });
+} else {
+  program
+    .name('pika')
+    .description('Schema-driven note management for markdown vaults')
+    .version('0.2.0')
+    .option('-v, --vault <path>', 'Path to the vault directory');
 
-program.addCommand(newCommand);
-program.addCommand(editCommand);
-program.addCommand(deleteCommand);
-program.addCommand(listCommand);
-program.addCommand(openCommand);
-program.addCommand(searchCommand);
-program.addCommand(schemaCommand);
-program.addCommand(auditCommand);
-program.addCommand(bulkCommand);
-program.addCommand(templateCommand);
+  program.addCommand(newCommand);
+  program.addCommand(editCommand);
+  program.addCommand(deleteCommand);
+  program.addCommand(listCommand);
+  program.addCommand(openCommand);
+  program.addCommand(searchCommand);
+  program.addCommand(schemaCommand);
+  program.addCommand(auditCommand);
+  program.addCommand(bulkCommand);
+  program.addCommand(templateCommand);
+  program.addCommand(completionCommand);
 
-program.parse();
+  program.parse();
+}

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -1,0 +1,412 @@
+/**
+ * Shell completion support for pika CLI.
+ * 
+ * This module provides:
+ * - Type name completion (--type/-t)
+ * - Path completion (--path/-p)
+ * - Command and option completion
+ * 
+ * The completion system works via a runtime callback model:
+ * 1. `pika completion <shell>` outputs a shell script
+ * 2. The script calls `pika --completions ...` at tab-completion time
+ * 3. This module returns candidates based on current context
+ */
+
+import { readdir } from 'fs/promises';
+import { join } from 'path';
+import { existsSync } from 'fs';
+import type { LoadedSchema } from '../types/schema.js';
+import { loadSchema, getConcreteTypeNames } from './schema.js';
+import { resolveVaultDir } from './vault.js';
+
+// ============================================================================
+// Completion Context
+// ============================================================================
+
+/**
+ * Context for a completion request, parsed from shell arguments.
+ */
+export interface CompletionContext {
+  /** All words in the command line */
+  words: string[];
+  /** Index of the word being completed (0-based) */
+  currentIndex: number;
+  /** The word being completed (may be partial) */
+  current: string;
+  /** The previous word (for option value completion) */
+  previous: string;
+  /** The subcommand being used (if any) */
+  command: string | undefined;
+}
+
+/**
+ * Parse completion request from argv.
+ * 
+ * The shell scripts pass the command line words after --completions.
+ * Format: pika --completions pika <subcommand> [options...] <current>
+ * 
+ * The first word is 'pika' (the command name), which we skip.
+ * The last word is always the one being completed (may be empty string).
+ */
+export function parseCompletionRequest(argv: string[]): CompletionContext {
+  // argv is everything after --completions
+  // First word is 'pika', skip it
+  // Last element is the word being completed
+  let words = argv.length > 0 ? argv : [''];
+  
+  // Skip 'pika' if it's the first word
+  if (words[0] === 'pika') {
+    words = words.slice(1);
+  }
+  
+  // Ensure we have at least an empty string to complete
+  if (words.length === 0) {
+    words = [''];
+  }
+  
+  const currentIndex = words.length - 1;
+  const current = words[currentIndex] ?? '';
+  const previous = currentIndex > 0 ? (words[currentIndex - 1] ?? '') : '';
+  
+  // Find the subcommand (first word that doesn't start with -)
+  // Only look at words before the current one
+  let command: string | undefined;
+  for (let i = 0; i < words.length - 1; i++) {
+    const word = words[i];
+    if (word && !word.startsWith('-')) {
+      command = word;
+      break;
+    }
+  }
+  
+  return { words, currentIndex, current, previous, command };
+}
+
+// ============================================================================
+// Type Completion
+// ============================================================================
+
+/**
+ * Get type name completions from the schema.
+ * Returns all concrete type names (excludes 'meta').
+ */
+export function getTypeCompletions(schema: LoadedSchema): string[] {
+  return getConcreteTypeNames(schema).sort();
+}
+
+/**
+ * Filter completions by a prefix.
+ */
+export function filterByPrefix(items: string[], prefix: string): string[] {
+  if (!prefix) return items;
+  const lower = prefix.toLowerCase();
+  return items.filter(item => item.toLowerCase().startsWith(lower));
+}
+
+// ============================================================================
+// Path Completion
+// ============================================================================
+
+/**
+ * Get path completions for vault directories.
+ * 
+ * @param vaultDir - The vault root directory
+ * @param partial - The partial path typed so far
+ * @returns Array of directory paths (relative to vault root)
+ */
+export async function getPathCompletions(
+  vaultDir: string,
+  partial: string
+): Promise<string[]> {
+  // Determine the directory to list and the prefix to filter by
+  const lastSlash = partial.lastIndexOf('/');
+  const baseDir = lastSlash >= 0 ? partial.slice(0, lastSlash) : '';
+  const prefix = lastSlash >= 0 ? partial.slice(lastSlash + 1) : partial;
+  
+  const targetDir = baseDir ? join(vaultDir, baseDir) : vaultDir;
+  
+  if (!existsSync(targetDir)) {
+    return [];
+  }
+  
+  try {
+    const entries = await readdir(targetDir, { withFileTypes: true });
+    const dirs: string[] = [];
+    
+    for (const entry of entries) {
+      // Skip hidden directories and .pika
+      if (entry.name.startsWith('.')) continue;
+      if (entry.name === '.pika') continue;
+      
+      if (entry.isDirectory()) {
+        // Build the full path relative to vault
+        const relativePath = baseDir 
+          ? `${baseDir}/${entry.name}`
+          : entry.name;
+        
+        // Add trailing slash to indicate it's a directory
+        dirs.push(`${relativePath}/`);
+      }
+    }
+    
+    // Filter by prefix and sort
+    const filtered = prefix 
+      ? dirs.filter(d => {
+          const name = d.slice(baseDir ? baseDir.length + 1 : 0);
+          return name.toLowerCase().startsWith(prefix.toLowerCase());
+        })
+      : dirs;
+    
+    return filtered.sort();
+  } catch {
+    return [];
+  }
+}
+
+// ============================================================================
+// Command and Option Completion
+// ============================================================================
+
+/**
+ * Commands that support targeting options (--type, --path, --where, --text).
+ */
+const TARGETING_COMMANDS = new Set([
+  'list', 'bulk', 'audit', 'search', 'open', 'delete'
+]);
+
+/**
+ * All available pika commands.
+ */
+const COMMANDS = [
+  'new',
+  'edit', 
+  'list',
+  'open',
+  'search',
+  'audit',
+  'bulk',
+  'schema',
+  'template',
+  'delete',
+  'completion',
+];
+
+/**
+ * Options available for each command.
+ * Only includes options that make sense to complete.
+ */
+const COMMAND_OPTIONS: Record<string, string[]> = {
+  new: ['--type', '-t', '--vault', '--template', '--json', '--help'],
+  edit: ['--vault', '--json', '--help'],
+  list: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--output', '-o', '--vault', '--json', '--help'],
+  open: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--app', '--vault', '--help'],
+  search: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--wikilink', '--vault', '--help'],
+  audit: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--fix', '--vault', '--help'],
+  bulk: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--set', '--vault', '--dry-run', '--yes', '-y', '--help'],
+  schema: ['--vault', '--help'],
+  template: ['--vault', '--help'],
+  delete: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--vault', '--yes', '-y', '--help'],
+  completion: ['--help'],
+};
+
+/**
+ * Get command completions.
+ */
+export function getCommandCompletions(): string[] {
+  return COMMANDS;
+}
+
+/**
+ * Get option completions for a command.
+ */
+export function getOptionCompletions(command: string): string[] {
+  return COMMAND_OPTIONS[command] ?? [];
+}
+
+/**
+ * Check if an option expects a type value.
+ */
+export function isTypeOption(option: string): boolean {
+  return option === '--type' || option === '-t';
+}
+
+/**
+ * Check if an option expects a path value.
+ */
+export function isPathOption(option: string): boolean {
+  return option === '--path' || option === '-p';
+}
+
+/**
+ * Check if a command supports targeting options.
+ */
+export function supportsTargeting(command: string): boolean {
+  return TARGETING_COMMANDS.has(command);
+}
+
+// ============================================================================
+// Main Completion Handler
+// ============================================================================
+
+/**
+ * Handle a completion request and return candidates.
+ * 
+ * @param argv - Arguments after --completions
+ * @param options - Optional vault override
+ * @returns Array of completion candidates (one per line when joined)
+ */
+export async function handleCompletionRequest(
+  argv: string[],
+  options: { vault?: string } = {}
+): Promise<string[]> {
+  const ctx = parseCompletionRequest(argv);
+  
+  // If completing the first word (after 'pika'), return commands
+  if (ctx.currentIndex === 0 || (!ctx.command && !ctx.current.startsWith('-'))) {
+    return filterByPrefix(getCommandCompletions(), ctx.current);
+  }
+  
+  // If previous word is --type or -t, complete with type names
+  if (isTypeOption(ctx.previous)) {
+    try {
+      const vaultDir = resolveVaultDir(options);
+      const schema = await loadSchema(vaultDir);
+      return filterByPrefix(getTypeCompletions(schema), ctx.current);
+    } catch {
+      // Can't load schema, return empty
+      return [];
+    }
+  }
+  
+  // If previous word is --path or -p, complete with paths
+  if (isPathOption(ctx.previous)) {
+    try {
+      const vaultDir = resolveVaultDir(options);
+      return await getPathCompletions(vaultDir, ctx.current);
+    } catch {
+      return [];
+    }
+  }
+  
+  // If current word starts with -, complete options
+  if (ctx.current.startsWith('-')) {
+    const options = ctx.command 
+      ? getOptionCompletions(ctx.command)
+      : ['--vault', '--help', '--version'];
+    return filterByPrefix(options, ctx.current);
+  }
+  
+  // If we have a command and it's schema or template, complete subcommands
+  if (ctx.command === 'schema') {
+    return filterByPrefix(['show', 'types', 'enums'], ctx.current);
+  }
+  if (ctx.command === 'template') {
+    return filterByPrefix(['list', 'show', 'new', 'edit', 'validate'], ctx.current);
+  }
+  if (ctx.command === 'completion') {
+    return filterByPrefix(['bash', 'zsh', 'fish'], ctx.current);
+  }
+  
+  // Default: no completions
+  return [];
+}
+
+// ============================================================================
+// Shell Script Generation
+// ============================================================================
+
+/**
+ * Generate bash completion script.
+ */
+export function generateBashScript(): string {
+  return `# pika bash completion
+# Add to ~/.bashrc: eval "$(pika completion bash)"
+
+_pika_completions() {
+  local cur prev words cword
+  _init_completion || return
+
+  # Build the completion request
+  # Pass all words to pika --completions
+  local completions
+  completions=$(pika --completions "\${COMP_WORDS[@]:1}" 2>/dev/null)
+  
+  # Handle path completion specially (preserve trailing slashes)
+  if [[ "\${prev}" == "--path" ]] || [[ "\${prev}" == "-p" ]]; then
+    compopt -o nospace
+  fi
+  
+  COMPREPLY=($(compgen -W "\${completions}" -- "\${cur}"))
+}
+
+complete -F _pika_completions pika
+`;
+}
+
+/**
+ * Generate zsh completion script.
+ */
+export function generateZshScript(): string {
+  return `#compdef pika
+# pika zsh completion
+# Add to ~/.zshrc: eval "$(pika completion zsh)"
+
+_pika() {
+  local completions
+  
+  # Build completion request from words array
+  # \${words[@]:1} skips the command name 'pika'
+  completions=("\${(@f)$(pika --completions "\${words[@]:1}" 2>/dev/null)}")
+  
+  if [[ \${#completions[@]} -gt 0 ]]; then
+    # Check if completing paths (preserve trailing slashes)
+    if [[ "\${words[-2]}" == "--path" ]] || [[ "\${words[-2]}" == "-p" ]]; then
+      compadd -S '' -- "\${completions[@]}"
+    else
+      compadd -- "\${completions[@]}"
+    fi
+  fi
+}
+
+compdef _pika pika
+`;
+}
+
+/**
+ * Generate fish completion script.
+ */
+export function generateFishScript(): string {
+  return `# pika fish completion
+# Save to ~/.config/fish/completions/pika.fish
+
+function __pika_completions
+  set -l tokens (commandline -opc)
+  # Remove 'pika' from the start
+  set -e tokens[1]
+  # Add the current token being completed
+  set -l current (commandline -ct)
+  set tokens $tokens $current
+  
+  pika --completions $tokens 2>/dev/null
+end
+
+# Disable file completion, use our custom completions
+complete -c pika -f -a "(__pika_completions)"
+`;
+}
+
+/**
+ * Get completion script for a shell.
+ */
+export function getCompletionScript(shell: string): string | null {
+  switch (shell) {
+    case 'bash':
+      return generateBashScript();
+    case 'zsh':
+      return generateZshScript();
+    case 'fish':
+      return generateFishScript();
+    default:
+      return null;
+  }
+}

--- a/tests/ts/commands/completion.test.ts
+++ b/tests/ts/commands/completion.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { execSync } from "child_process";
+import path from "path";
+
+const VAULT_DIR = path.join(__dirname, "../../fixtures/vault");
+const CLI_PATH = path.join(__dirname, "../../../dist/index.js");
+
+function runCli(args: string, cwd: string = VAULT_DIR): string {
+  try {
+    return execSync(`node ${CLI_PATH} ${args}`, {
+      cwd,
+      encoding: "utf-8",
+      env: { ...process.env, NO_COLOR: "1", PIKA_VAULT: cwd },
+    }).trim();
+  } catch (error: unknown) {
+    const execError = error as { stdout?: string; stderr?: string };
+    // Return stdout even on error (some commands exit non-zero but produce output)
+    if (execError.stdout) return execError.stdout.toString().trim();
+    throw error;
+  }
+}
+
+describe("pika completion command", () => {
+  beforeAll(() => {
+    // Ensure the CLI is built
+    execSync("pnpm build", {
+      cwd: path.join(__dirname, "../../.."),
+      stdio: "ignore",
+    });
+  });
+
+  describe("completion bash", () => {
+    it("should output a valid bash completion script", () => {
+      const output = runCli("completion bash");
+
+      // Should contain bash-specific completion setup
+      expect(output).toContain("_pika_completions()");
+      expect(output).toContain("complete -F _pika_completions pika");
+      expect(output).toContain("COMPREPLY");
+      expect(output).toContain("--completions");
+    });
+
+    it("should be valid bash syntax", () => {
+      const script = runCli("completion bash");
+      // Use bash -n to check syntax without executing
+      expect(() => {
+        execSync(`bash -n`, { input: script, encoding: "utf-8" });
+      }).not.toThrow();
+    });
+  });
+
+  describe("completion zsh", () => {
+    it("should output a valid zsh completion script", () => {
+      const output = runCli("completion zsh");
+
+      // Should contain zsh-specific completion setup
+      expect(output).toContain("#compdef pika");
+      expect(output).toContain("_pika()");
+      expect(output).toContain("compdef _pika pika");
+      expect(output).toContain("--completions");
+    });
+  });
+
+  describe("completion fish", () => {
+    it("should output a valid fish completion script", () => {
+      const output = runCli("completion fish");
+
+      // Should contain fish-specific completion setup
+      expect(output).toContain("complete -c pika");
+      expect(output).toContain("--completions");
+    });
+  });
+
+  describe("--completions flag", () => {
+    it("should return type completions after --type", () => {
+      const output = runCli("--completions pika list --type ''");
+      const completions = output.split("\n").filter((l) => l.trim());
+
+      // Should include types from the test vault schema
+      expect(completions).toContain("task");
+      expect(completions).toContain("idea");
+    });
+
+    it("should filter type completions by prefix", () => {
+      const output = runCli("--completions pika list --type ta");
+      const completions = output.split("\n").filter((l) => l.trim());
+
+      expect(completions).toContain("task");
+      expect(completions).not.toContain("idea");
+    });
+
+    it("should return path completions after --path", () => {
+      const output = runCli("--completions pika list --path ''");
+      const completions = output.split("\n").filter((l) => l.trim());
+
+      // Should include directories from the test vault
+      expect(completions.some((c) => c.includes("Ideas"))).toBe(true);
+      expect(completions.some((c) => c.includes("Objectives"))).toBe(true);
+    });
+
+    it("should return command completions for bare pika", () => {
+      const output = runCli("--completions pika ''");
+      const completions = output.split("\n").filter((l) => l.trim());
+
+      // Should include available commands
+      expect(completions).toContain("list");
+      expect(completions).toContain("new");
+      expect(completions).toContain("edit");
+      expect(completions).toContain("completion");
+    });
+
+    it("should return option completions when current word starts with -", () => {
+      const output = runCli("--completions pika list --");
+      const completions = output.split("\n").filter((l) => l.trim());
+
+      // Should include targeting options for list command
+      expect(completions).toContain("--type");
+      expect(completions).toContain("--path");
+      expect(completions).toContain("--where");
+    });
+
+    it("should fail silently outside a vault", () => {
+      // Run from a non-vault directory
+      const output = runCli("--completions pika list --type ''", "/tmp");
+
+      // Should return empty or just not crash
+      expect(output).toBeDefined();
+    });
+  });
+});

--- a/tests/ts/lib/completion.test.ts
+++ b/tests/ts/lib/completion.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  parseCompletionRequest,
+  getTypeCompletions,
+  getPathCompletions,
+  getCommandCompletions,
+  getOptionCompletions,
+  handleCompletionRequest,
+  filterByPrefix,
+} from "../../../src/lib/completion.js";
+import { loadSchema } from "../../../src/lib/schema.js";
+import { createTestVault, cleanupTestVault } from "../fixtures/setup.js";
+
+describe("completion", () => {
+  describe("parseCompletionRequest", () => {
+    it("parses simple command being completed", () => {
+      // When completing "list", command is undefined because we're still typing it
+      const ctx = parseCompletionRequest(["list"]);
+      expect(ctx.words).toEqual(["list"]);
+      expect(ctx.current).toBe("list");
+      expect(ctx.command).toBeUndefined(); // Still typing the command
+    });
+
+    it("parses completed command with option value", () => {
+      const ctx = parseCompletionRequest(["list", "--type", "task"]);
+      expect(ctx.command).toBe("list");
+      expect(ctx.current).toBe("task");
+      expect(ctx.previous).toBe("--type");
+    });
+
+    it("parses empty current word after option", () => {
+      const ctx = parseCompletionRequest(["list", "--type", ""]);
+      expect(ctx.command).toBe("list");
+      expect(ctx.current).toBe("");
+      expect(ctx.previous).toBe("--type");
+    });
+
+    it("handles empty array", () => {
+      const ctx = parseCompletionRequest([]);
+      expect(ctx.command).toBeUndefined();
+      expect(ctx.current).toBe("");
+    });
+
+    it("handles partial command being typed", () => {
+      // When completing a partial command, command is undefined
+      const ctx = parseCompletionRequest(["li"]);
+      expect(ctx.command).toBeUndefined(); // Still typing the command
+      expect(ctx.current).toBe("li");
+    });
+
+    it("identifies command when completing next word", () => {
+      // When we've typed "list " and are completing the next word
+      const ctx = parseCompletionRequest(["list", ""]);
+      expect(ctx.command).toBe("list");
+      expect(ctx.current).toBe("");
+      expect(ctx.previous).toBe("list");
+    });
+  });
+
+  describe("getTypeCompletions", () => {
+    let vaultDir: string;
+
+    beforeEach(async () => {
+      vaultDir = await createTestVault();
+    });
+
+    afterEach(async () => {
+      await cleanupTestVault(vaultDir);
+    });
+
+    it("returns all type names from schema", async () => {
+      const schema = await loadSchema(vaultDir);
+      const types = getTypeCompletions(schema);
+
+      expect(types).toContain("task");
+      expect(types).toContain("idea");
+      expect(types).toContain("milestone");
+      expect(types).toContain("objective");
+    });
+
+    it("can be filtered by prefix", async () => {
+      const schema = await loadSchema(vaultDir);
+      const types = filterByPrefix(getTypeCompletions(schema), "ta");
+
+      expect(types).toContain("task");
+      expect(types).not.toContain("idea");
+    });
+  });
+
+  describe("getPathCompletions", () => {
+    let vaultDir: string;
+
+    beforeEach(async () => {
+      vaultDir = await createTestVault();
+    });
+
+    afterEach(async () => {
+      await cleanupTestVault(vaultDir);
+    });
+
+    it("returns directories in vault", async () => {
+      const paths = await getPathCompletions(vaultDir, "");
+
+      expect(paths).toContain("Ideas/");
+      expect(paths).toContain("Objectives/");
+    });
+
+    it("excludes .pika directory", async () => {
+      const paths = await getPathCompletions(vaultDir, "");
+
+      expect(paths).not.toContain(".pika/");
+    });
+
+    it("filters by prefix", async () => {
+      const paths = await getPathCompletions(vaultDir, "Id");
+
+      expect(paths).toContain("Ideas/");
+      expect(paths).not.toContain("Objectives/");
+    });
+
+    it("handles nested paths", async () => {
+      const paths = await getPathCompletions(vaultDir, "Objectives/");
+
+      expect(paths).toContain("Objectives/Milestones/");
+      expect(paths).toContain("Objectives/Tasks/");
+    });
+  });
+
+  describe("getCommandCompletions", () => {
+    it("returns all commands", () => {
+      const commands = getCommandCompletions();
+
+      expect(commands).toContain("new");
+      expect(commands).toContain("edit");
+      expect(commands).toContain("list");
+      expect(commands).toContain("open");
+      expect(commands).toContain("search");
+      expect(commands).toContain("audit");
+      expect(commands).toContain("bulk");
+      expect(commands).toContain("schema");
+      expect(commands).toContain("template");
+      expect(commands).toContain("delete");
+      expect(commands).toContain("completion");
+    });
+
+    it("can be filtered by prefix", () => {
+      const commands = filterByPrefix(getCommandCompletions(), "li");
+
+      expect(commands).toContain("list");
+      expect(commands).not.toContain("new");
+    });
+  });
+
+  describe("getOptionCompletions", () => {
+    it("returns options for list command", () => {
+      const options = getOptionCompletions("list");
+
+      expect(options).toContain("--type");
+      expect(options).toContain("-t");
+      expect(options).toContain("--path");
+      expect(options).toContain("-p");
+      expect(options).toContain("--where");
+      expect(options).toContain("-w");
+    });
+
+    it("returns options for new command", () => {
+      const options = getOptionCompletions("new");
+
+      expect(options).toContain("--type");
+      expect(options).toContain("-t");
+    });
+
+    it("can be filtered by prefix", () => {
+      const options = filterByPrefix(getOptionCompletions("list"), "--t");
+
+      expect(options).toContain("--type");
+      expect(options).toContain("--text");
+      expect(options).not.toContain("--path");
+    });
+
+    it("returns empty for unknown command", () => {
+      const options = getOptionCompletions("unknown");
+
+      expect(options).toEqual([]);
+    });
+  });
+
+  describe("handleCompletionRequest", () => {
+    let vaultDir: string;
+
+    beforeEach(async () => {
+      vaultDir = await createTestVault();
+    });
+
+    afterEach(async () => {
+      await cleanupTestVault(vaultDir);
+    });
+
+    it("completes commands when no command given", async () => {
+      const completions = await handleCompletionRequest([""], { vault: vaultDir });
+
+      expect(completions).toContain("list");
+      expect(completions).toContain("new");
+    });
+
+    it("completes partial commands", async () => {
+      const completions = await handleCompletionRequest(["li"], { vault: vaultDir });
+
+      expect(completions).toContain("list");
+      expect(completions).not.toContain("new");
+    });
+
+    it("completes --type values", async () => {
+      const completions = await handleCompletionRequest(
+        ["list", "--type", ""],
+        { vault: vaultDir }
+      );
+
+      expect(completions).toContain("task");
+      expect(completions).toContain("idea");
+    });
+
+    it("completes -t values (short form)", async () => {
+      const completions = await handleCompletionRequest(
+        ["list", "-t", ""],
+        { vault: vaultDir }
+      );
+
+      expect(completions).toContain("task");
+    });
+
+    it("completes --path values", async () => {
+      const completions = await handleCompletionRequest(
+        ["list", "--path", ""],
+        { vault: vaultDir }
+      );
+
+      expect(completions).toContain("Ideas/");
+      expect(completions).toContain("Objectives/");
+    });
+
+    it("completes nested --path values", async () => {
+      const completions = await handleCompletionRequest(
+        ["list", "--path", "Objectives/"],
+        { vault: vaultDir }
+      );
+
+      expect(completions).toContain("Objectives/Milestones/");
+      expect(completions).toContain("Objectives/Tasks/");
+    });
+
+    it("completes options when current word starts with dash", async () => {
+      const completions = await handleCompletionRequest(
+        ["list", "--"],
+        { vault: vaultDir }
+      );
+
+      expect(completions).toContain("--type");
+      expect(completions).toContain("--path");
+    });
+
+    it("returns empty array when vault not found", async () => {
+      const completions = await handleCompletionRequest(
+        ["list", "--type", ""],
+        { vault: "/nonexistent/path" }
+      );
+
+      expect(completions).toEqual([]);
+    });
+
+    it("completes completion subcommands", async () => {
+      const completions = await handleCompletionRequest(
+        ["completion", ""],
+        { vault: vaultDir }
+      );
+
+      expect(completions).toContain("bash");
+      expect(completions).toContain("zsh");
+      expect(completions).toContain("fish");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements `pika completion <bash|zsh|fish>` command for tab completion support, addressing issue pika-nn8b.

- **Type completion**: Suggests schema type names (`task`, `idea`, `objective/milestone`, etc.)
- **Path completion**: Suggests vault directories with nested path support
- **Command completion**: Suggests available pika commands
- **Option completion**: Suggests valid options for targeting commands

## Implementation

Uses a runtime callback model (similar to `gh`, `pnpm`) where the shell script calls back to the CLI at completion time. This ensures completions always match the installed version without regenerating static scripts.

### New files
- `src/lib/completion.ts` - Core completion logic
- `src/commands/completion.ts` - Completion command implementation
- `tests/ts/lib/completion.test.ts` - Unit tests (27 tests)
- `tests/ts/commands/completion.test.ts` - Integration tests (10 tests)

## Usage

```bash
# Bash (add to ~/.bashrc)
eval "$(pika completion bash)"

# Zsh (add to ~/.zshrc)  
eval "$(pika completion zsh)"

# Fish (run once)
pika completion fish > ~/.config/fish/completions/pika.fish
```

## Testing

All 37 new tests pass. Run `pnpm test` to verify.

Closes pika-nn8b