### PR TITLE
feat(edit): add flexible file targeting with picker support

### DIFF
--- a/docs/product/cli-targeting.md
+++ b/docs/product/cli-targeting.md
@@ -130,16 +130,19 @@ Use the explicit flag to clarify.
 
 All commands that operate on note sets support the same selectors:
 
-| Command | `--type` | `--path` | `--where` | `--text` |
-|---------|----------|----------|-----------|----------|
-| list    | Y | Y | Y | Y |
-| bulk    | Y | Y | Y | Y |
-| audit   | Y | Y | Y | Y |
-| search  | Y | Y | Y | Y (primary) |
-| open    | Y | Y | Y | Y |
-| delete  | Y | Y | Y | Y |
+| Command | `--type` | `--path` | `--where` | `--text` | Picker |
+|---------|----------|----------|-----------|----------|--------|
+| list    | Y | Y | Y | Y | - |
+| bulk    | Y | Y | Y | Y | - |
+| audit   | Y | Y | Y | Y | - |
+| search  | Y | Y | Y | Y (primary) | Y |
+| open    | Y | Y | Y | Y | Y |
+| edit    | Y | - | - | - | Y |
+| delete  | Y | Y | Y | Y | - |
 
-**Note:** `open` is an alias for `search --open`.
+**Notes:**
+- `open` is an alias for `search --open`.
+- `edit` supports `--type` for filtering and `--picker` for picker mode selection.
 
 ---
 
@@ -156,7 +159,7 @@ pika list           # Lists all notes
 pika audit          # Audits all notes
 ```
 
-### Interactive commands (`open`)
+### Interactive commands (`open`, `edit`)
 
 No selectors = prompt with picker.
 

--- a/tests/ts/commands/edit.pty.test.ts
+++ b/tests/ts/commands/edit.pty.test.ts
@@ -390,8 +390,8 @@ status: raw
       await withTempVault(
         ['edit', 'Ideas/NonExistent.md'],
         async (proc) => {
-          // Should show file not found error
-          await proc.waitFor('not found', 5000);
+          // Should show no matching notes found error
+          await proc.waitFor('No matching notes found', 5000);
 
           // Wait for exit
           await proc.waitForExit(5000);
@@ -431,5 +431,40 @@ Content.
         { files: [unknownTypeFile], schema: EDIT_SCHEMA }
       );
     }, 30000);
+  });
+
+  describe('flexible targeting with picker', () => {
+    it('should resolve partial name and edit directly', async () => {
+      const existingFile: TempVaultFile = {
+        path: 'Ideas/Unique Name.md',
+        content: `---
+type: idea
+status: raw
+priority: low
+description: Original description
+---
+
+Content here.
+`,
+      };
+
+      await withTempVault(
+        ['edit', 'Unique Name'],
+        async (proc) => {
+          // Should resolve directly and show editing header
+          await proc.waitFor('Editing:', 5000);
+          // Should show status field (first editable field)
+          await proc.waitFor('status', 5000);
+
+          // Cancel the edit
+          await proc.write(Keys.CTRL_C);
+          await proc.waitForExit(5000);
+        },
+        { files: [existingFile], schema: EDIT_SCHEMA }
+      );
+    }, 30000);
+
+    // Note: Ambiguous query picker behavior is tested in edit.test.ts unit tests
+    // PTY tests for picker are flaky due to timing issues with note index building
   });
 });

--- a/tests/ts/commands/json-io.test.ts
+++ b/tests/ts/commands/json-io.test.ts
@@ -358,14 +358,14 @@ describe('JSON I/O', () => {
 
     it('should error on file not found', async () => {
       const result = await runCLI(
-        ['edit', 'Ideas/Nonexistent.md', '--json', '{"status": "raw"}'],
+        ['edit', 'CompletelyUniqueNonexistentFile12345.md', '--json', '{"status": "raw"}'],
         vaultDir
       );
 
-      expect(result.exitCode).toBe(2);
+      expect(result.exitCode).toBe(1);
       const json = JSON.parse(result.stdout);
       expect(json.success).toBe(false);
-      expect(json.error).toContain('not found');
+      expect(json.error).toMatch(/no match/i);
     });
   });
 


### PR DESCRIPTION
## Summary

- Make `pika edit` file argument optional - shows picker when no query provided
- Add `--picker` option (auto/fzf/numbered/none) for picker mode control  
- Add `--type` option to filter notes by schema type
- Aligns `edit` with the unified targeting model used by `search` and `open`

## Changes

- **src/commands/edit.ts**: Refactored to use `resolveAndPick` pattern, added `--picker` and `--type` options
- **docs/product/cli-targeting.md**: Added `edit` to command support matrix
- **tests/**: Updated existing tests and added new tests for flexible targeting behavior

## Testing

```bash
cd ../pika-edit-flexible-targeting
pnpm test -- --run tests/ts/commands/edit.test.ts tests/ts/commands/edit.pty.test.ts
```

Manual testing:
```bash
# No-arg picker (shows all notes)
pika edit

# Partial name resolution
pika edit "Sample"

# Type filtering
pika edit --type idea

# Picker mode control
pika edit --picker numbered
```

Closes pika-rvkf