### PR TITLE
fix: clean up PTY processes on interrupt (Ctrl+C)

### DIFF
--- a/tests/ts/setup.ts
+++ b/tests/ts/setup.ts
@@ -1,9 +1,14 @@
 /**
  * Vitest setup file for PTY test cleanup.
- * 
- * Ensures orphaned PTY processes are killed after each test,
- * even if the test times out (when vitest aborts the test
- * without running the finally block).
+ *
+ * Ensures orphaned PTY processes are killed:
+ * 1. After each test (via afterEach hook)
+ * 2. On process interrupt (Ctrl+C) via SIGINT/SIGTERM handlers
+ * 3. On uncaught exceptions
+ *
+ * The afterEach hook handles normal test completion and timeouts,
+ * but signal handlers are needed for user interrupts (Ctrl+C)
+ * which bypass vitest's lifecycle hooks entirely.
  */
 
 import { afterEach } from 'vitest';
@@ -12,4 +17,22 @@ import { killAllPtyProcesses } from './lib/pty-helpers.js';
 // Kill any orphaned PTY processes after each test
 afterEach(() => {
   killAllPtyProcesses();
+});
+
+// Handle process interrupts (Ctrl+C) - vitest lifecycle doesn't run on SIGINT
+process.once('SIGINT', () => {
+  killAllPtyProcesses();
+  process.exit(130); // Standard exit code for SIGINT
+});
+
+process.once('SIGTERM', () => {
+  killAllPtyProcesses();
+  process.exit(143); // Standard exit code for SIGTERM
+});
+
+// Clean up on uncaught exceptions before crashing
+process.once('uncaughtException', (err) => {
+  console.error('Uncaught exception in tests:', err);
+  killAllPtyProcesses();
+  process.exit(1);
 });

--- a/tests/ts/teardown.ts
+++ b/tests/ts/teardown.ts
@@ -1,0 +1,13 @@
+/**
+ * Vitest global teardown for PTY process cleanup.
+ *
+ * Runs after all tests complete to ensure no orphaned PTY processes remain.
+ * This is a safety net - individual tests should clean up via afterEach,
+ * but this catches any processes that slip through.
+ */
+
+import { killAllPtyProcesses } from './lib/pty-helpers.js';
+
+export default async function teardown(): Promise<void> {
+  killAllPtyProcesses();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     include: ['tests/ts/**/*.test.ts'],
     setupFiles: ['tests/ts/setup.ts'],
+    globalTeardown: 'tests/ts/teardown.ts',
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

- Add SIGINT/SIGTERM signal handlers to kill orphaned PTY processes when tests are interrupted with Ctrl+C
- Add globalTeardown hook for cleanup after suite completion
- Handle uncaughtException to ensure cleanup on crashes

## Problem

When PTY tests were interrupted (Ctrl+C), vitest's `afterEach` hooks never ran, leaving orphaned node processes running on the developer's machine.

## Solution

Signal handlers bypass vitest's lifecycle entirely, so we register them directly on the process object in `setup.ts`. The existing `killAllPtyProcesses()` mechanism works correctly - it just needed to be invoked on interrupt.

## Testing

- All 1120 tests pass
- Manual verification: interrupt PTY tests with Ctrl+C and confirm no orphaned processes remain

Closes pika-jcrr