### PR TITLE
fix: standardize vault isolation for all tests

### DIFF
--- a/tests/ts/lib/vault.test.ts
+++ b/tests/ts/lib/vault.test.ts
@@ -38,6 +38,14 @@ describe('vault', () => {
       }
     });
 
+    it('should default to fixture vault in tests (regression test for vault isolation)', () => {
+      // This test verifies that tests/ts/setup.ts sets PIKA_VAULT to the fixture vault.
+      // Without this, tests could accidentally read a developer's real vault.
+      // See issue pika-smjf.
+      const result = resolveVaultDir({});
+      expect(result).toContain('tests/ts/fixtures/vault');
+    });
+
     it('should use --vault option first', () => {
       process.env['PIKA_VAULT'] = '/env/path';
       const result = resolveVaultDir({ vault: '/option/path' });


### PR DESCRIPTION
## Summary

- Set `PIKA_VAULT` to fixture vault in `tests/ts/setup.ts` as a safety net to prevent tests from accidentally reading a developer's real vault
- Add regression test to verify vault isolation is working

## Problem

Tests sometimes don't enforce `PIKA_VAULT`, which can cause accidental reads of a developer's real vault when their cwd differs from the project root. This undermines test reliability.

## Solution

Set `process.env.PIKA_VAULT` globally in the test setup file pointing to `tests/fixtures/vault`. This ensures any test that forgets the `--vault` flag still uses the fixture vault. Tests can still override via explicit `--vault` flag or by creating temp vaults.

Closes pika-smjf