### PR TITLE
feat: Schema Management CLI - edit-type, remove-type, edit-field, remove-field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Pika are documented in this file.
 
 ### Added
 
+- **Schema management CLI** (pika-tsh)
+  - `pika schema edit-type <name>` - Modify type settings (output directory, extends, filename pattern)
+  - `pika schema remove-type <name>` - Remove a type from schema (dry-run by default, `--execute` to apply)
+  - `pika schema edit-field <type> <field>` - Modify field properties (required, default, label)
+  - `pika schema remove-field <type> <field>` - Remove a field from a type (dry-run by default)
+  - All destructive operations show impact analysis (affected files, child types) before confirmation
+  - Interactive mode for edit-field when no flags provided
+  - Full JSON output support with `--output json`
+
 - **Schema migration system** (pika-3nd)
   - `pika schema diff` - Shows pending changes between current schema and last-applied snapshot
   - `pika schema migrate` - Applies schema changes to existing notes (dry-run by default)

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -838,6 +838,696 @@ Examples:
     }
   });
 
+// schema edit-type
+schemaCommand
+  .command('edit-type <type>')
+  .description('Edit type settings (output directory, extends, filename pattern)')
+  .option('--output-dir <dir>', 'Set output directory for notes of this type')
+  .option('--extends <parent>', 'Change parent type')
+  .option('--filename <pattern>', 'Set filename pattern')
+  .option('-o, --output <format>', 'Output format: text (default) or json')
+  .action(async (typeName: string, options: {
+    outputDir?: string;
+    extends?: string;
+    filename?: string;
+    output?: string;
+  }, cmd: Command) => {
+    const jsonMode = options.output === 'json';
+
+    try {
+      const parentOpts = cmd.parent?.parent?.opts() as { vault?: string } | undefined;
+      const vaultDir = resolveVaultDir(parentOpts ?? {});
+      const schema = await loadSchema(vaultDir);
+      const rawSchema = await loadRawSchemaJson(vaultDir);
+
+      // Validate type exists
+      const typeDef = getTypeDefByPath(schema, typeName);
+      if (!typeDef) {
+        const msg = `Unknown type: ${typeName}`;
+        if (jsonMode) {
+          printJson(jsonError(msg));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(msg);
+        process.exit(1);
+      }
+
+      // Don't allow editing meta
+      if (typeName === 'meta') {
+        const msg = 'Cannot edit the meta type directly';
+        if (jsonMode) {
+          printJson(jsonError(msg));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(msg);
+        process.exit(1);
+      }
+
+      // Get or create the type entry in raw schema
+      const typeEntry = rawSchema.types[typeName];
+      if (!typeEntry) {
+        const msg = `Type not found in schema: ${typeName}`;
+        if (jsonMode) {
+          printJson(jsonError(msg));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(msg);
+        process.exit(1);
+      }
+
+      const changes: string[] = [];
+
+      // Interactive mode if no flags provided
+      if (!options.outputDir && !options.extends && !options.filename) {
+        console.log(chalk.bold(`Editing type: ${typeName}`));
+        console.log('');
+
+        // Prompt for output_dir
+        const currentOutputDir = typeEntry.output_dir ?? computeDefaultOutputDir(schema, typeName);
+        const newOutputDirResult = await promptInput(
+          `Output directory`,
+          currentOutputDir
+        );
+        if (newOutputDirResult === null) {
+          process.exit(0); // User cancelled
+        }
+        const newOutputDir = newOutputDirResult.trim() || currentOutputDir;
+        if (newOutputDir !== currentOutputDir) {
+          typeEntry.output_dir = newOutputDir;
+          changes.push(`output_dir: ${currentOutputDir} → ${newOutputDir}`);
+        }
+
+        // Prompt for extends
+        const currentExtends = typeEntry.extends ?? 'meta';
+        const allTypes = getTypeNames(schema).filter(t => t !== typeName && t !== 'meta');
+        const extendsOptions = ['meta', ...allTypes];
+        console.log('');
+        console.log(chalk.gray(`Current extends: ${currentExtends}`));
+        const newExtendsResult = await promptSelection('Extends:', extendsOptions);
+        if (newExtendsResult === null) {
+          process.exit(0); // User cancelled
+        }
+        if (newExtendsResult !== currentExtends) {
+          typeEntry.extends = newExtendsResult;
+          changes.push(`extends: ${currentExtends} → ${newExtendsResult}`);
+        }
+
+        // Prompt for filename pattern
+        const currentFilename = typeEntry.filename ?? '';
+        const newFilenameResult = await promptInput(
+          `Filename pattern (blank for default)`,
+          currentFilename
+        );
+        if (newFilenameResult === null) {
+          process.exit(0); // User cancelled
+        }
+        if (newFilenameResult !== currentFilename) {
+          if (newFilenameResult) {
+            typeEntry.filename = newFilenameResult;
+          } else {
+            delete typeEntry.filename;
+          }
+          changes.push(`filename: ${currentFilename || '(default)'} → ${newFilenameResult || '(default)'}`);
+        }
+      } else {
+        // Flag-based mode
+        if (options.outputDir) {
+          const currentOutputDir = typeEntry.output_dir ?? computeDefaultOutputDir(schema, typeName);
+          typeEntry.output_dir = options.outputDir;
+          changes.push(`output_dir: ${currentOutputDir} → ${options.outputDir}`);
+        }
+
+        if (options.extends) {
+          // Validate parent type exists
+          if (options.extends !== 'meta' && !getTypeDefByPath(schema, options.extends)) {
+            const msg = `Unknown parent type: ${options.extends}`;
+            if (jsonMode) {
+              printJson(jsonError(msg));
+              process.exit(ExitCodes.VALIDATION_ERROR);
+            }
+            printError(msg);
+            process.exit(1);
+          }
+          // Prevent circular inheritance
+          if (options.extends === typeName) {
+            const msg = 'A type cannot extend itself';
+            if (jsonMode) {
+              printJson(jsonError(msg));
+              process.exit(ExitCodes.VALIDATION_ERROR);
+            }
+            printError(msg);
+            process.exit(1);
+          }
+          const currentExtends = typeEntry.extends ?? 'meta';
+          typeEntry.extends = options.extends;
+          changes.push(`extends: ${currentExtends} → ${options.extends}`);
+        }
+
+        if (options.filename !== undefined) {
+          const currentFilename = typeEntry.filename ?? '';
+          if (options.filename) {
+            typeEntry.filename = options.filename;
+          } else {
+            delete typeEntry.filename;
+          }
+          changes.push(`filename: ${currentFilename || '(default)'} → ${options.filename || '(default)'}`);
+        }
+      }
+
+      if (changes.length === 0) {
+        if (jsonMode) {
+          printJson(jsonSuccess({ message: 'No changes made' }));
+        } else {
+          console.log(chalk.gray('No changes made.'));
+        }
+        return;
+      }
+
+      // Write updated schema
+      await writeSchema(vaultDir, rawSchema);
+
+      if (jsonMode) {
+        printJson(jsonSuccess({ message: `Updated type '${typeName}'` }));
+      } else {
+        printSuccess(`Updated type '${typeName}'`);
+        for (const change of changes) {
+          console.log(`  ${chalk.gray('•')} ${change}`);
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (jsonMode) {
+        printJson(jsonError(message));
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+      printError(message);
+      process.exit(1);
+    }
+  });
+
+// schema remove-type
+schemaCommand
+  .command('remove-type <type>')
+  .description('Remove a type from the schema (dry-run by default)')
+  .option('--execute', 'Actually apply the removal (default is dry-run)')
+  .option('-o, --output <format>', 'Output format: text (default) or json')
+  .action(async (typeName: string, options: { execute?: boolean; output?: string }, cmd: Command) => {
+    const jsonMode = options.output === 'json';
+
+    try {
+      const parentOpts = cmd.parent?.parent?.opts() as { vault?: string } | undefined;
+      const vaultDir = resolveVaultDir(parentOpts ?? {});
+      const schema = await loadSchema(vaultDir);
+      const rawSchema = await loadRawSchemaJson(vaultDir);
+
+      // Validate type exists
+      const typeDef = getTypeDefByPath(schema, typeName);
+      if (!typeDef) {
+        const msg = `Unknown type: ${typeName}`;
+        if (jsonMode) {
+          printJson(jsonError(msg));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(msg);
+        process.exit(1);
+      }
+
+      // Don't allow removing meta
+      if (typeName === 'meta') {
+        const msg = 'Cannot remove the meta type';
+        if (jsonMode) {
+          printJson(jsonError(msg));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(msg);
+        process.exit(1);
+      }
+
+      // Check if type has children
+      const children = getTypeNames(schema).filter(t => {
+        const def = rawSchema.types[t];
+        return def?.extends === typeName;
+      });
+
+      if (children.length > 0) {
+        const msg = `Cannot remove type '${typeName}': it has child types (${children.join(', ')}). Remove or reparent them first.`;
+        if (jsonMode) {
+          printJson(jsonError(msg));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(msg);
+        process.exit(1);
+      }
+
+      // Count affected files using discovery
+      const { discoverManagedFiles } = await import('../lib/discovery.js');
+      const managedFiles = await discoverManagedFiles(schema, vaultDir, typeName);
+      const affectedCount = managedFiles.length;
+
+      // Show what would happen
+      if (!options.execute) {
+        if (jsonMode) {
+          console.log(JSON.stringify({
+            success: true,
+            dryRun: true,
+            type: typeName,
+            affectedFiles: affectedCount,
+            message: affectedCount > 0
+              ? `Would remove type '${typeName}' affecting ${affectedCount} file(s)`
+              : `Would remove type '${typeName}' (no files affected)`,
+          }, null, 2));
+        } else {
+          console.log(chalk.bold('Dry run - no changes made'));
+          console.log('');
+          console.log(`Type to remove: ${chalk.cyan(typeName)}`);
+          console.log(`Files affected: ${affectedCount > 0 ? chalk.yellow(String(affectedCount)) : chalk.green('0')}`);
+          
+          if (affectedCount > 0) {
+            console.log('');
+            console.log(chalk.yellow(`Warning: ${affectedCount} file(s) currently use this type.`));
+            console.log(chalk.yellow('These files will become untyped after removal.'));
+          }
+          
+          console.log('');
+          
+          // Prompt for confirmation
+          const confirmed = await promptConfirm('Apply this change?');
+          if (confirmed === null) {
+            process.exit(0); // User cancelled
+          }
+          if (confirmed) {
+            // Apply the removal
+            delete rawSchema.types[typeName];
+            await writeSchema(vaultDir, rawSchema);
+            printSuccess(`Removed type '${typeName}'`);
+            if (affectedCount > 0) {
+              console.log(chalk.gray(`Run 'pika audit' to review affected files.`));
+            }
+          } else {
+            console.log(chalk.gray('No changes made.'));
+          }
+        }
+        return;
+      }
+
+      // Execute mode - apply the removal
+      delete rawSchema.types[typeName];
+      await writeSchema(vaultDir, rawSchema);
+
+      if (jsonMode) {
+        printJson(jsonSuccess({ message: `Removed type '${typeName}'` }));
+      } else {
+        printSuccess(`Removed type '${typeName}'`);
+        if (affectedCount > 0) {
+          console.log(chalk.gray(`Run 'pika audit' to review ${affectedCount} affected file(s).`));
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (jsonMode) {
+        printJson(jsonError(message));
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+      printError(message);
+      process.exit(1);
+    }
+  });
+
+// schema edit-field
+schemaCommand
+  .command('edit-field <type> <field>')
+  .description('Edit field properties')
+  .option('--required', 'Mark field as required')
+  .option('--not-required', 'Mark field as not required')
+  .option('--default <value>', 'Set default value')
+  .option('--clear-default', 'Remove default value')
+  .option('--label <text>', 'Set prompt label')
+  .option('-o, --output <format>', 'Output format: text (default) or json')
+  .action(async (typeName: string, fieldName: string, options: {
+    required?: boolean;
+    notRequired?: boolean;
+    default?: string;
+    clearDefault?: boolean;
+    label?: string;
+    output?: string;
+  }, cmd: Command) => {
+    const jsonMode = options.output === 'json';
+
+    try {
+      const parentOpts = cmd.parent?.parent?.opts() as { vault?: string } | undefined;
+      const vaultDir = resolveVaultDir(parentOpts ?? {});
+      const schema = await loadSchema(vaultDir);
+
+      // Validate type exists
+      const typeDef = getTypeDefByPath(schema, typeName);
+      if (!typeDef) {
+        const msg = `Unknown type: ${typeName}`;
+        if (jsonMode) {
+          printJson(jsonError(msg));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(msg);
+        process.exit(1);
+      }
+
+      // Get type entry from raw schema
+      const typeEntry = schema.raw.types[typeName];
+      if (!typeEntry) {
+        const msg = `Type not found in schema: ${typeName}`;
+        if (jsonMode) {
+          printJson(jsonError(msg));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(msg);
+        process.exit(1);
+      }
+
+      // Check if field exists on this type (not inherited)
+      const ownFields = typeEntry.fields ?? {};
+      if (!(fieldName in ownFields)) {
+        // Check if it's inherited
+        const allFields = getFieldsForType(schema, typeName);
+        if (fieldName in allFields) {
+          const msg = `Field '${fieldName}' is inherited and cannot be edited on '${typeName}'. Edit it on the parent type instead.`;
+          if (jsonMode) {
+            printJson(jsonError(msg));
+            process.exit(ExitCodes.VALIDATION_ERROR);
+          }
+          printError(msg);
+          process.exit(1);
+        }
+        const msg = `Field '${fieldName}' not found on type '${typeName}'`;
+        if (jsonMode) {
+          printJson(jsonError(msg));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(msg);
+        process.exit(1);
+      }
+
+      const fieldDef = ownFields[fieldName]!;
+      const changes: string[] = [];
+
+      // Interactive mode if no flags provided
+      if (options.required === undefined && !options.notRequired && options.default === undefined && 
+          !options.clearDefault && options.label === undefined) {
+        console.log(chalk.bold(`Editing field: ${typeName}.${fieldName}`));
+        console.log('');
+
+        // Show current field info
+        const fieldInfo: string[] = [];
+        if (fieldDef.prompt) fieldInfo.push(`prompt: ${fieldDef.prompt}`);
+        if (fieldDef.enum) fieldInfo.push(`enum: ${fieldDef.enum}`);
+        if (fieldDef.source) fieldInfo.push(`source: ${fieldDef.source}`);
+        if (fieldInfo.length > 0) {
+          console.log(chalk.gray(fieldInfo.join(', ')));
+          console.log('');
+        }
+
+        // Prompt for required
+        const currentRequired = fieldDef.required ?? false;
+        console.log(chalk.gray(`Currently required: ${currentRequired}`));
+        const requiredResult = await promptSelection('Required?', ['true', 'false']);
+        if (requiredResult === null) {
+          process.exit(0); // User cancelled
+        }
+        const newRequired = requiredResult === 'true';
+        if (newRequired !== currentRequired) {
+          fieldDef.required = newRequired;
+          changes.push(`required: ${currentRequired} → ${newRequired}`);
+        }
+
+        // Prompt for default value
+        const currentDefault = fieldDef.default !== undefined 
+          ? (Array.isArray(fieldDef.default) ? fieldDef.default.join(', ') : String(fieldDef.default))
+          : '';
+        const newDefaultResult = await promptInput(
+          `Default value (blank to clear)`,
+          currentDefault
+        );
+        if (newDefaultResult === null) {
+          process.exit(0); // User cancelled
+        }
+        if (newDefaultResult !== currentDefault) {
+          if (newDefaultResult) {
+            fieldDef.default = newDefaultResult;
+            changes.push(`default: ${currentDefault || '(none)'} → ${newDefaultResult}`);
+          } else if (currentDefault) {
+            delete fieldDef.default;
+            changes.push(`default: ${currentDefault} → (none)`);
+          }
+        }
+
+        // Prompt for label
+        const currentLabel = fieldDef.label ?? '';
+        const newLabelResult = await promptInput(
+          `Prompt label (blank to clear)`,
+          currentLabel
+        );
+        if (newLabelResult === null) {
+          process.exit(0); // User cancelled
+        }
+        if (newLabelResult !== currentLabel) {
+          if (newLabelResult) {
+            fieldDef.label = newLabelResult;
+          } else {
+            delete fieldDef.label;
+          }
+          changes.push(`label: ${currentLabel || '(none)'} → ${newLabelResult || '(none)'}`);
+        }
+      } else {
+        // Flag-based mode
+        if (options.required) {
+          const currentRequired = fieldDef.required ?? false;
+          if (!currentRequired) {
+            fieldDef.required = true;
+            changes.push(`required: false → true`);
+          }
+        } else if (options.notRequired) {
+          const currentRequired = fieldDef.required ?? false;
+          if (currentRequired) {
+            delete fieldDef.required;
+            changes.push(`required: true → false`);
+          }
+        }
+
+        if (options.clearDefault) {
+          if (fieldDef.default !== undefined) {
+            const oldDefault = fieldDef.default;
+            delete fieldDef.default;
+            changes.push(`default: ${oldDefault} → (none)`);
+          }
+        } else if (options.default !== undefined) {
+          const oldDefault = fieldDef.default;
+          fieldDef.default = options.default;
+          changes.push(`default: ${oldDefault ?? '(none)'} → ${options.default}`);
+        }
+
+        if (options.label !== undefined) {
+          const oldLabel = fieldDef.label;
+          if (options.label) {
+            fieldDef.label = options.label;
+          } else {
+            delete fieldDef.label;
+          }
+          changes.push(`label: ${oldLabel ?? '(none)'} → ${options.label || '(none)'}`);
+        }
+      }
+
+      if (changes.length === 0) {
+        if (jsonMode) {
+          printJson(jsonSuccess({ message: 'No changes made' }));
+        } else {
+          console.log(chalk.gray('No changes made.'));
+        }
+        return;
+      }
+
+      // Update the field in the type
+      typeEntry.fields = { ...typeEntry.fields, [fieldName]: fieldDef };
+
+      // Write updated schema
+      await writeSchema(vaultDir, schema.raw);
+
+      if (jsonMode) {
+        printJson(jsonSuccess({ message: `Updated field '${fieldName}' on type '${typeName}'` }));
+      } else {
+        printSuccess(`Updated field '${fieldName}' on type '${typeName}'`);
+        for (const change of changes) {
+          console.log(`  ${chalk.gray('•')} ${change}`);
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (jsonMode) {
+        printJson(jsonError(message));
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+      printError(message);
+      process.exit(1);
+    }
+  });
+
+// schema remove-field
+schemaCommand
+  .command('remove-field <type> <field>')
+  .description('Remove a field from a type (dry-run by default)')
+  .option('--execute', 'Actually apply the removal (default is dry-run)')
+  .option('-o, --output <format>', 'Output format: text (default) or json')
+  .action(async (typeName: string, fieldName: string, options: { execute?: boolean; output?: string }, cmd: Command) => {
+    const jsonMode = options.output === 'json';
+
+    try {
+      const parentOpts = cmd.parent?.parent?.opts() as { vault?: string } | undefined;
+      const vaultDir = resolveVaultDir(parentOpts ?? {});
+      const schema = await loadSchema(vaultDir);
+
+      // Validate type exists
+      const typeDef = getTypeDefByPath(schema, typeName);
+      if (!typeDef) {
+        const msg = `Unknown type: ${typeName}`;
+        if (jsonMode) {
+          printJson(jsonError(msg));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(msg);
+        process.exit(1);
+      }
+
+      // Get type entry from raw schema
+      const typeEntry = schema.raw.types[typeName];
+      if (!typeEntry) {
+        const msg = `Type not found in schema: ${typeName}`;
+        if (jsonMode) {
+          printJson(jsonError(msg));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(msg);
+        process.exit(1);
+      }
+
+      // Check if field exists on this type (not inherited)
+      const ownFields = typeEntry.fields ?? {};
+      if (!(fieldName in ownFields)) {
+        // Check if it's inherited
+        const allFields = getFieldsForType(schema, typeName);
+        if (fieldName in allFields) {
+          const msg = `Field '${fieldName}' is inherited and cannot be removed from '${typeName}'. Remove it from the parent type instead.`;
+          if (jsonMode) {
+            printJson(jsonError(msg));
+            process.exit(ExitCodes.VALIDATION_ERROR);
+          }
+          printError(msg);
+          process.exit(1);
+        }
+        const msg = `Field '${fieldName}' not found on type '${typeName}'`;
+        if (jsonMode) {
+          printJson(jsonError(msg));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(msg);
+        process.exit(1);
+      }
+
+      // Count affected files - files of this type and all descendant types
+      const { discoverManagedFiles } = await import('../lib/discovery.js');
+      const managedFiles = await discoverManagedFiles(schema, vaultDir, typeName);
+      const affectedCount = managedFiles.length;
+
+      // Check if field is inherited by children
+      const childTypes = getTypeNames(schema).filter(t => {
+        const def = schema.raw.types[t];
+        return def?.extends === typeName;
+      });
+      const descendantCount = childTypes.length;
+
+      // Show what would happen
+      if (!options.execute) {
+        if (jsonMode) {
+          console.log(JSON.stringify({
+            success: true,
+            dryRun: true,
+            type: typeName,
+            field: fieldName,
+            affectedFiles: affectedCount,
+            childTypes: childTypes.length > 0 ? childTypes : undefined,
+            message: `Would remove field '${fieldName}' from type '${typeName}'`,
+          }, null, 2));
+        } else {
+          console.log(chalk.bold('Dry run - no changes made'));
+          console.log('');
+          console.log(`Field to remove: ${chalk.cyan(`${typeName}.${fieldName}`)}`);
+          console.log(`Files of this type: ${affectedCount > 0 ? chalk.yellow(String(affectedCount)) : chalk.green('0')}`);
+          
+          if (descendantCount > 0) {
+            console.log(`Child types affected: ${chalk.yellow(String(descendantCount))} (${childTypes.join(', ')})`);
+          }
+          
+          if (affectedCount > 0) {
+            console.log('');
+            console.log(chalk.yellow(`Warning: ${affectedCount} file(s) may have this field in their frontmatter.`));
+            console.log(chalk.yellow('The field data will remain in files but become unrecognized.'));
+          }
+          
+          console.log('');
+          
+          // Prompt for confirmation
+          const confirmed = await promptConfirm('Apply this change?');
+          if (confirmed === null) {
+            process.exit(0); // User cancelled
+          }
+          if (confirmed) {
+            // Apply the removal
+            delete ownFields[fieldName];
+            typeEntry.fields = ownFields;
+            
+            // Also remove from field_order if present
+            if (typeEntry.field_order) {
+              typeEntry.field_order = typeEntry.field_order.filter(f => f !== fieldName);
+            }
+            
+            await writeSchema(vaultDir, schema.raw);
+            printSuccess(`Removed field '${fieldName}' from type '${typeName}'`);
+            if (affectedCount > 0) {
+              console.log(chalk.gray(`Run 'pika audit' to review affected files.`));
+            }
+          } else {
+            console.log(chalk.gray('No changes made.'));
+          }
+        }
+        return;
+      }
+
+      // Execute mode - apply the removal
+      delete ownFields[fieldName];
+      typeEntry.fields = ownFields;
+      
+      // Also remove from field_order if present
+      if (typeEntry.field_order) {
+        typeEntry.field_order = typeEntry.field_order.filter(f => f !== fieldName);
+      }
+      
+      await writeSchema(vaultDir, schema.raw);
+
+      if (jsonMode) {
+        printJson(jsonSuccess({ message: `Removed field '${fieldName}' from type '${typeName}'` }));
+      } else {
+        printSuccess(`Removed field '${fieldName}' from type '${typeName}'`);
+        if (affectedCount > 0) {
+          console.log(chalk.gray(`Run 'pika audit' to review ${affectedCount} affected file(s).`));
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (jsonMode) {
+        printJson(jsonError(message));
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+      printError(message);
+      process.exit(1);
+    }
+  });
+
 /**
  * Output schema as JSON for AI/scripting usage.
  */

--- a/tests/ts/commands/schema-edit-field.pty.test.ts
+++ b/tests/ts/commands/schema-edit-field.pty.test.ts
@@ -1,0 +1,261 @@
+/**
+ * PTY tests for schema edit-field command
+ * Tests interactive mode behavior
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  withTempVault,
+  readVaultFile,
+  shouldSkipPtyTests,
+  killAllPtyProcesses,
+} from '../lib/pty-helpers.js';
+
+// Skip PTY tests if running in CI without TTY support or node-pty is incompatible
+const skipPty = shouldSkipPtyTests();
+
+afterEach(() => {
+  killAllPtyProcesses();
+});
+
+// Test schema with fields that can be edited
+const TEST_SCHEMA = {
+  types: {
+    task: {
+      output_dir: 'Tasks',
+      fields: {
+        title: { prompt: 'input', required: true },
+        status: { enum: 'status' },
+        priority: { enum: 'priority', default: 'medium' },
+        notes: { prompt: 'input', label: 'Additional Notes' },
+      },
+    },
+    project: {
+      output_dir: 'Projects',
+      fields: {
+        name: { prompt: 'input', required: true },
+        deadline: { prompt: 'date' },
+      },
+    },
+  },
+  enums: {
+    status: ['todo', 'in-progress', 'done'],
+    priority: ['low', 'medium', 'high'],
+  },
+};
+
+describe.skipIf(skipPty)('schema edit-field PTY', () => {
+  // ==========================================================================
+  // CLI Flag Mode (non-interactive)
+  // ==========================================================================
+  describe('CLI flag mode', () => {
+    it('should set field to required with --required flag', async () => {
+      await withTempVault(
+        ['schema', 'edit-field', 'task', 'notes', '--required'],
+        async (proc, vaultPath) => {
+          await proc.waitForExit(10000);
+
+          // Verify the field was updated
+          const schema = JSON.parse(
+            await readVaultFile(vaultPath, '.pika/schema.json')
+          );
+          expect(schema.types.task.fields.notes.required).toBe(true);
+        },
+        { schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should set field to not required with --not-required flag', async () => {
+      // Start with a required field
+      const schemaWithRequired = {
+        ...TEST_SCHEMA,
+        types: {
+          ...TEST_SCHEMA.types,
+          task: {
+            ...TEST_SCHEMA.types.task,
+            fields: {
+              ...TEST_SCHEMA.types.task.fields,
+              notes: { ...TEST_SCHEMA.types.task.fields.notes, required: true },
+            },
+          },
+        },
+      };
+
+      await withTempVault(
+        ['schema', 'edit-field', 'task', 'notes', '--not-required'],
+        async (proc, vaultPath) => {
+          await proc.waitForExit(10000);
+
+          // Verify the field was updated
+          const schema = JSON.parse(
+            await readVaultFile(vaultPath, '.pika/schema.json')
+          );
+          expect(schema.types.task.fields.notes.required).toBeUndefined();
+        },
+        { schema: schemaWithRequired }
+      );
+    }, 30000);
+
+    it('should set default value with --default flag', async () => {
+      await withTempVault(
+        ['schema', 'edit-field', 'task', 'notes', '--default', 'N/A'],
+        async (proc, vaultPath) => {
+          await proc.waitForExit(10000);
+
+          const schema = JSON.parse(
+            await readVaultFile(vaultPath, '.pika/schema.json')
+          );
+          expect(schema.types.task.fields.notes.default).toBe('N/A');
+        },
+        { schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should clear default with --clear-default flag', async () => {
+      await withTempVault(
+        ['schema', 'edit-field', 'task', 'priority', '--clear-default'],
+        async (proc, vaultPath) => {
+          await proc.waitForExit(10000);
+
+          const schema = JSON.parse(
+            await readVaultFile(vaultPath, '.pika/schema.json')
+          );
+          expect(schema.types.task.fields.priority.default).toBeUndefined();
+        },
+        { schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should set label with --label flag', async () => {
+      await withTempVault(
+        ['schema', 'edit-field', 'task', 'notes', '--label', 'Extra Notes'],
+        async (proc, vaultPath) => {
+          await proc.waitForExit(10000);
+
+          const schema = JSON.parse(
+            await readVaultFile(vaultPath, '.pika/schema.json')
+          );
+          expect(schema.types.task.fields.notes.label).toBe('Extra Notes');
+        },
+        { schema: TEST_SCHEMA }
+      );
+    }, 30000);
+  });
+
+  // ==========================================================================
+  // Full Interactive Flow
+  // ==========================================================================
+  describe('full interactive flow', () => {
+    it('should edit field required status interactively', async () => {
+      await withTempVault(
+        ['schema', 'edit-field', 'task', 'notes'],
+        async (proc, vaultPath) => {
+          // Wait for "Required?" selection prompt
+          await proc.waitFor('Required?');
+          // Select 'true' (arrow down to select, or just press enter since it's a selection)
+          await proc.typeAndEnter('true');
+
+          // Wait for "Default value" input prompt
+          await proc.waitFor('Default value');
+          // Press enter to keep empty/current value
+          await proc.typeAndEnter('');
+
+          // Wait for "Prompt label" input prompt
+          await proc.waitFor('Prompt label');
+          // Press enter to keep current value
+          await proc.typeAndEnter('');
+
+          // Wait for completion
+          await proc.waitForExit(10000);
+
+          // Verify the field was updated
+          const schema = JSON.parse(
+            await readVaultFile(vaultPath, '.pika/schema.json')
+          );
+          expect(schema.types.task.fields.notes.required).toBe(true);
+        },
+        { schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should edit field default value interactively', async () => {
+      await withTempVault(
+        ['schema', 'edit-field', 'task', 'notes'],
+        async (proc, vaultPath) => {
+          // Wait for "Required?" selection prompt
+          await proc.waitFor('Required?');
+          await proc.typeAndEnter('false');
+
+          // Wait for "Default value" input prompt
+          await proc.waitFor('Default value');
+          await proc.typeAndEnter('No notes provided');
+
+          // Wait for "Prompt label" input prompt
+          await proc.waitFor('Prompt label');
+          await proc.typeAndEnter('');
+
+          await proc.waitForExit(10000);
+
+          const schema = JSON.parse(
+            await readVaultFile(vaultPath, '.pika/schema.json')
+          );
+          expect(schema.types.task.fields.notes.default).toBe('No notes provided');
+        },
+        { schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should edit field label interactively', async () => {
+      await withTempVault(
+        ['schema', 'edit-field', 'task', 'notes'],
+        async (proc, vaultPath) => {
+          // Wait for "Required?" selection prompt
+          await proc.waitFor('Required?');
+          await proc.typeAndEnter('false');
+
+          // Wait for "Default value" input prompt
+          await proc.waitFor('Default value');
+          await proc.typeAndEnter('');
+
+          // Wait for "Prompt label" input prompt
+          await proc.waitFor('Prompt label');
+          await proc.typeAndEnter('Extra Notes');
+
+          await proc.waitForExit(10000);
+
+          const schema = JSON.parse(
+            await readVaultFile(vaultPath, '.pika/schema.json')
+          );
+          expect(schema.types.task.fields.notes.label).toBe('Extra Notes');
+        },
+        { schema: TEST_SCHEMA }
+      );
+    }, 30000);
+  });
+
+  // ==========================================================================
+  // Error Cases
+  // ==========================================================================
+  describe('error cases', () => {
+    it('should error on unknown type', async () => {
+      await withTempVault(
+        ['schema', 'edit-field', 'nonexistent', 'field', '--required'],
+        async (proc) => {
+          await proc.waitFor('Unknown type');
+          await proc.waitForExit(10000);
+        },
+        { schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should error on unknown field', async () => {
+      await withTempVault(
+        ['schema', 'edit-field', 'task', 'nonexistent', '--required'],
+        async (proc) => {
+          await proc.waitFor('not found');
+          await proc.waitForExit(10000);
+        },
+        { schema: TEST_SCHEMA }
+      );
+    }, 30000);
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 4 Schema Management CLI (pika-tsh) with four new commands:

- **`schema edit-type <name>`** - Modify type settings (output directory, extends, filename pattern)
- **`schema remove-type <name>`** - Remove type definitions with dry-run safety
- **`schema edit-field <type> <field>`** - Modify field properties (required, default, label)
- **`schema remove-field <type> <field>`** - Remove fields with dry-run safety

## Key Design Decisions

1. **Dry-run by default**: All destructive operations show what would change and prompt for confirmation
2. **`--execute` flag**: Skip confirmation prompt for scripting/automation
3. **No separate subtype commands**: Use `add-type --extends <parent>` instead (aligns with inheritance model)
4. **No shared field commands**: Deprecated in favor of inheritance (put shared fields on parent types)

## Test Coverage

- 47 new integration tests for all commands
- 8 new PTY tests for interactive edit-field flows
- All 1176 tests passing

## Files Changed

- `src/commands/schema.ts` - New command implementations
- `tests/ts/commands/schema.test.ts` - Integration tests
- `tests/ts/commands/schema-edit-field.pty.test.ts` - PTY tests (new file)
- `plans/features/schema-management.md` - Updated plan reflecting revised scope
- `CHANGELOG.md` - Added v0.22.0 entry

Closes pika-tsh