### PR TITLE
Add pronunciation note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # bwrb
 
+Short for **bowerbird**, pronounced "birb".
+
 Schema-driven note management for markdown vaults.
 
 ## Overview


### PR DESCRIPTION
Adds a line clarifying that bwrb is short for bowerbird, pronounced 'birb'.