### PR TITLE
fix: remove incorrect positional type deprecation warnings from audit and bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,11 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Fixed
 
+- **Removed incorrect positional type deprecation warnings from audit and bulk commands** (#127)
+  - `bwrb audit task` and `bwrb bulk task --set x=y` no longer show deprecation warnings
+  - Positional type is a permanent CLI shortcut as documented in `cli-targeting.md`
+  - Removed unused `getTypePositionalDeprecationWarning` function from targeting module
+
 - **`bwrb schema add-field meta` now works correctly** (bwrb-tsbb)
   - Previously failed with `Type "meta" not found in raw schema` when meta was implicit
   - Now creates the meta type definition in schema.json when adding a field to implicit meta

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -11,7 +11,7 @@ import {
   getTypeDefByPath,
 } from '../lib/schema.js';
 import { resolveVaultDir } from '../lib/vault.js';
-import { printError, printWarning } from '../lib/prompt.js';
+import { printError } from '../lib/prompt.js';
 import {
   printJson,
   jsonError,
@@ -19,7 +19,6 @@ import {
 } from '../lib/output.js';
 import {
   parsePositionalArg,
-  getTypePositionalDeprecationWarning,
 } from '../lib/targeting.js';
 
 // Import from audit modules
@@ -141,14 +140,6 @@ Examples:
 
       // Handle positional argument with smart detection
       if (target) {
-        if (typePath || pathGlob || whereExprs) {
-          // Positional provided along with explicit flags - emit deprecation warning
-          const deprecation = getTypePositionalDeprecationWarning('audit');
-          if (deprecation) {
-            printWarning(deprecation);
-          }
-        }
-        
         const existingOpts: Record<string, string | string[] | undefined> = {};
         if (typePath) existingOpts.type = typePath;
         if (pathGlob) existingOpts.path = pathGlob;
@@ -166,11 +157,6 @@ Examples:
         // Apply parsed positional to appropriate option
         if (parsed.options.type && !typePath) {
           typePath = parsed.options.type;
-          // Emit deprecation warning for positional type
-          const deprecation = getTypePositionalDeprecationWarning('audit');
-          if (deprecation) {
-            printWarning(deprecation);
-          }
         }
         if (parsed.options.path && !pathGlob) {
           pathGlob = parsed.options.path;

--- a/src/commands/bulk.ts
+++ b/src/commands/bulk.ts
@@ -31,7 +31,6 @@ import { buildOperation, formatChange } from '../lib/bulk/operations.js';
 import { executeBulk } from '../lib/bulk/execute.js';
 import {
   parsePositionalArg,
-  getTypePositionalDeprecationWarning,
   hasAnyTargeting,
   checkDeprecatedFilters,
 } from '../lib/targeting.js';
@@ -137,7 +136,7 @@ Examples:
 
   # Move files to archive (updates wikilinks automatically)
   bwrb bulk --type idea --where "status == 'settled'" --move Archive/Ideas --execute`)
-  .argument('[target]', 'Type, path, or where expression (auto-detected) [DEPRECATED: use --type, --path, or --where]')
+  .argument('[target]', 'Type, path, or where expression (auto-detected)')
   .option('-t, --type <type>', 'Filter by type (e.g., task, objective/milestone)')
   .option('-p, --path <glob>', 'Filter by file path (supports globs)')
   .option('-b, --body <query>', 'Filter by body content')
@@ -176,7 +175,7 @@ Examples:
       let whereExpressions = options.where ?? [];
       const bodyQuery = options.body ?? options.text;
 
-      // Handle positional argument (deprecated)
+      // Handle positional argument
       if (target) {
         const parsed = parsePositionalArg(target, schema, {});
         if (parsed.error) {
@@ -186,11 +185,6 @@ Examples:
           }
           printError(parsed.error);
           process.exit(1);
-        }
-
-        // Emit deprecation warning
-        if (parsed.detectedAs === 'type' && parsed.options.type) {
-          console.error(getTypePositionalDeprecationWarning(parsed.options.type));
         }
 
         // Apply the detected value

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -219,15 +219,6 @@ export function checkDeprecatedFilters(
   return { filters, warnings };
 }
 
-/**
- * Generate deprecation warning for type positional argument.
- */
-export function getTypePositionalDeprecationWarning(typeName: string): string {
-  return `Deprecation warning: Positional type argument is deprecated.\n` +
-    `Use --type flag instead:\n` +
-    `  --type ${typeName}`;
-}
-
 // ============================================================================
 // Path Filtering
 // ============================================================================

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -1730,6 +1730,26 @@ milestone: "[[Some Idea]]"
     });
   });
 
+  describe('positional type argument', () => {
+    it('should not show deprecation warning when using positional type', async () => {
+      const result = await runCLI(['audit', 'idea'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      // Positional type is a permanent shortcut, not deprecated
+      expect(result.stderr).not.toContain('deprecated');
+      expect(result.stderr).not.toContain('Deprecated');
+      expect(result.stdout).not.toContain('deprecated');
+    });
+
+    it('should not show deprecation warning for child type positional', async () => {
+      const result = await runCLI(['audit', 'task'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).not.toContain('deprecated');
+      expect(result.stderr).not.toContain('Deprecated');
+    });
+  });
+
   describe('parent cycle detection', () => {
     let tempVaultDir: string;
 

--- a/tests/ts/commands/bulk.test.ts
+++ b/tests/ts/commands/bulk.test.ts
@@ -750,6 +750,36 @@ This task relates to [[Sample Idea]].
   });
 });
 
+describe('bulk positional type argument', () => {
+  let vaultDir: string;
+
+  beforeAll(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterAll(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  it('should not show deprecation warning when using positional type', async () => {
+    const result = await runCLI(['bulk', 'idea', '--all', '--set', 'status=settled'], vaultDir);
+
+    expect(result.exitCode).toBe(0);
+    // Positional type is a permanent shortcut, not deprecated
+    expect(result.stderr).not.toContain('deprecated');
+    expect(result.stderr).not.toContain('Deprecated');
+    expect(result.stdout).not.toContain('deprecated');
+  });
+
+  it('should not show deprecation warning for child type positional', async () => {
+    const result = await runCLI(['bulk', 'task', '--all', '--set', 'status=settled'], vaultDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain('deprecated');
+    expect(result.stderr).not.toContain('Deprecated');
+  });
+});
+
 describe('bulk operations unit tests', () => {
   describe('applyOperations', () => {
     // Import dynamically in tests

--- a/tests/ts/lib/targeting.test.ts
+++ b/tests/ts/lib/targeting.test.ts
@@ -4,7 +4,6 @@ import {
   detectPositionalType,
   parsePositionalArg,
   checkDeprecatedFilters,
-  getTypePositionalDeprecationWarning,
   filterByPath,
   resolveTargets,
   validateDestructiveTargeting,
@@ -121,14 +120,6 @@ describe('targeting', () => {
       const result = checkDeprecatedFilters(['--type', 'task', '--path', 'Projects/**']);
       expect(result.filters).toHaveLength(0);
       expect(result.warnings).toHaveLength(0);
-    });
-  });
-
-  describe('getTypePositionalDeprecationWarning', () => {
-    it('generates correct warning message', () => {
-      const warning = getTypePositionalDeprecationWarning('task');
-      expect(warning).toContain('Deprecation warning');
-      expect(warning).toContain('--type task');
     });
   });
 


### PR DESCRIPTION
## Summary

- Remove incorrect deprecation warnings shown when using positional type arguments (e.g., `bwrb audit task`, `bwrb bulk task`)
- Per `cli-targeting.md`, positional type is a **permanent shortcut**, not deprecated
- Remove the now-unused `getTypePositionalDeprecationWarning` function from targeting.ts
- Remove deprecated text from bulk command help
- Add regression tests to verify no deprecation warnings are shown

## Changes

- `src/commands/audit.ts`: Remove import and 2 call sites for deprecation warning
- `src/commands/bulk.ts`: Remove import, call site, and deprecated help text
- `src/lib/targeting.ts`: Remove unused `getTypePositionalDeprecationWarning` function
- `tests/ts/lib/targeting.test.ts`: Remove tests for removed function
- `tests/ts/commands/audit.test.ts`: Add regression test for no deprecation warning
- `tests/ts/commands/bulk.test.ts`: Add regression test for no deprecation warning
- `CHANGELOG.md`: Document the fix

Fixes #127