### PR TITLE
feat(new): add --type flag, remove deprecated flags and dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`--type`/`-t` flag for `new` command** (#120)
+  - Explicit type selection: `bwrb new --type task` or `bwrb new -t task`
+  - Positional argument still works: `bwrb new task`
+  - Flag takes precedence if both provided
+
+### Removed
+
+- **Deprecated flags from `new` command** (#120)
+  - `--default` flag removed - use `--template default` instead
+  - `--instance` flag removed (instance-grouped mode was never enabled)
+
+- **Instance-grouped dead code cleanup** (#120)
+  - Removed ~500 lines of unused instance-grouped note creation code
+  - Removed `getDirMode`, `isInstanceGroupedSubtype`, and related vault functions
+  - Removed `collectInstanceGroupedFiles` from discovery module
+
 ### Changed
 
 - **Unified search/open/edit commands** (#119)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ bwrb new idea         # Creates idea directly (no subtypes)
 
 # Templates
 bwrb new task --template bug-report  # Use specific template
-bwrb new task --default              # Use default.md template  
+bwrb new task --template default     # Use default.md template explicitly
 bwrb new task --no-template          # Skip templates, use schema only
 
 # Edit existing file
@@ -315,7 +315,7 @@ bwrb new task
 bwrb new task --template bug-report
 
 # Require default template (error if not found)
-bwrb new task --default
+bwrb new task --template default
 
 # Skip template system
 bwrb new task --no-template

--- a/plans/archive/roadmap.md
+++ b/plans/archive/roadmap.md
@@ -147,7 +147,7 @@ Markdown-based templates with defaults and body structure:
 ```bash
 bwrb new task                           # Prompts for template if multiple
 bwrb new task --template bug-report     # Use specific template
-bwrb new task --default                 # Use default template
+bwrb new task --template default        # Use default template
 ```
 
 Templates live in `Templates/{type}/{subtype}/{name}.md`.

--- a/plans/features/template-system.md
+++ b/plans/features/template-system.md
@@ -263,7 +263,7 @@ Empty sections indicate expected content type:
 
 ```bash
 # Use default template
-bwrb new task --default
+bwrb new task --template default
 # → Uses Templates/objective/task/default.md
 
 # Specify template

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -39,7 +39,6 @@ import {
 } from '../lib/audit/detection.js';
 import {
   collectPooledFiles,
-  collectInstanceGroupedFiles,
 } from '../lib/discovery.js';
 import {
   runAutoFix,
@@ -258,7 +257,6 @@ export {
   discoverManagedFiles,
   auditFile,
   collectPooledFiles,
-  collectInstanceGroupedFiles,
   
   // Fix functions
   runAutoFix,

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -228,42 +228,8 @@ export function getOutputDir(
 }
 
 // ============================================================================
-// Directory Mode Support
+// Ownership Support
 // ============================================================================
-
-/**
- * Get directory mode for a type.
- * 
- * In the ownership model, notes are either:
- * - "pooled": Live in the type's output_dir (default)
- * - "owned": Live in their owner's folder (determined by `owned: true` on parent's field)
- * 
- * This function returns 'pooled' because the ownership model handles colocation
- * through the ownership system rather than a separate dir_mode property.
- * See docs/technical/inheritance.md for ownership semantics.
- * 
- * @deprecated Consider using canTypeBeOwned() or getOwnerTypes() for ownership checks
- */
-export function getDirMode(
-  _schema: LoadedSchema,
-  _typeName: string
-): 'pooled' | 'instance-grouped' {
-  // Ownership model supersedes dir_mode - owned notes colocate with owner,
-  // all other notes are pooled in their type's output_dir
-  return 'pooled';
-}
-
-/**
- * Check if a type is a subtype of an instance-grouped type.
- * @deprecated Use ownership model instead
- */
-export function isInstanceGroupedSubtype(
-  _schema: LoadedSchema,
-  _typeName: string
-): boolean {
-  // In new model, this is determined by ownership
-  return false;
-}
 
 /**
  * Get the parent type name for an owned type.
@@ -274,58 +240,6 @@ export function getParentTypeName(
 ): string | undefined {
   const type = getType(schema, typeName);
   return type?.parent;
-}
-
-/**
- * List all instance folders for an instance-grouped type.
- */
-export async function listInstanceFolders(
-  vaultDir: string,
-  outputDir: string
-): Promise<string[]> {
-  const fullDir = join(vaultDir, outputDir);
-  if (!existsSync(fullDir)) return [];
-
-  const entries = await readdir(fullDir, { withFileTypes: true });
-  return entries
-    .filter(entry => entry.isDirectory())
-    .map(entry => entry.name);
-}
-
-/**
- * Get the path to an instance folder.
- */
-export function getInstanceFolderPath(
-  vaultDir: string,
-  outputDir: string,
-  instanceName: string
-): string {
-  return join(vaultDir, outputDir, instanceName);
-}
-
-/**
- * Get the path to the parent note (index file) for an instance.
- * The parent note has the same name as the folder.
- */
-export function getParentNotePath(
-  vaultDir: string,
-  outputDir: string,
-  instanceName: string
-): string {
-  return join(vaultDir, outputDir, instanceName, `${instanceName}.md`);
-}
-
-/**
- * Create an instance folder and its parent note.
- */
-export async function createInstanceFolder(
-  vaultDir: string,
-  outputDir: string,
-  instanceName: string
-): Promise<string> {
-  const folderPath = getInstanceFolderPath(vaultDir, outputDir, instanceName);
-  await mkdir(folderPath, { recursive: true });
-  return folderPath;
 }
 
 /**

--- a/tests/ts/commands/new.test.ts
+++ b/tests/ts/commands/new.test.ts
@@ -27,6 +27,20 @@ describe('new command', () => {
       expect(result.stderr).toContain('Unknown type');
     });
 
+    it('should accept --type flag as alternative to positional argument', async () => {
+      const result = await runCLI(['new', '--type', 'nonexistent'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown type');
+    });
+
+    it('should accept -t shorthand for --type flag', async () => {
+      const result = await runCLI(['new', '-t', 'nonexistent'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown type');
+    });
+
     it('should error on unknown subtype', async () => {
       const result = await runCLI(['new', 'objective/nonexistent'], vaultDir);
 
@@ -56,7 +70,7 @@ describe('new command', () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('--template');
-      expect(result.stdout).toContain('--default');
+      expect(result.stdout).toContain('--type');
       expect(result.stdout).toContain('--no-template');
     });
   });
@@ -74,16 +88,16 @@ describe('new command', () => {
       expect(output.error).toContain('Template not found');
     });
 
-    it('should error when --default but no default.md exists', async () => {
+    it('should error when --template default but no default.md exists', async () => {
       const result = await runCLI(
-        ['new', 'milestone', '--json', '{"name": "Test"}', '--default'],
+        ['new', 'milestone', '--json', '{"name": "Test"}', '--template', 'default'],
         vaultDir
       );
 
       expect(result.exitCode).not.toBe(0);
       const output = JSON.parse(result.stdout);
       expect(output.success).toBe(false);
-      expect(output.error).toContain('No default template');
+      expect(output.error).toContain('Template not found');
     });
 
     it('should create note with --template flag applying defaults', async () => {
@@ -105,10 +119,10 @@ describe('new command', () => {
       expect(content).toContain('Expected Behavior');
     });
 
-    it('should create note with --default flag', async () => {
+    it('should create note with --template default', async () => {
       // default.md for idea has defaults: status: raw, priority: medium
       const result = await runCLI(
-        ['new', 'idea', '--json', '{"name": "My Great Idea"}', '--default'],
+        ['new', 'idea', '--json', '{"name": "My Great Idea"}', '--template', 'default'],
         vaultDir
       );
 
@@ -127,7 +141,7 @@ describe('new command', () => {
       // Template defaults status: raw, priority: medium
       // JSON input overrides priority to high
       const result = await runCLI(
-        ['new', 'idea', '--json', '{"name": "Override Test", "priority": "high"}', '--default'],
+        ['new', 'idea', '--json', '{"name": "Override Test", "priority": "high"}', '--template', 'default'],
         vaultDir
       );
 
@@ -159,7 +173,7 @@ describe('new command', () => {
 
     it('should substitute {title} in template body', async () => {
       const result = await runCLI(
-        ['new', 'idea', '--json', '{"name": "Substitution Test"}', '--default'],
+        ['new', 'idea', '--json', '{"name": "Substitution Test"}', '--template', 'default'],
         vaultDir
       );
 

--- a/tests/ts/lib/discovery.test.ts
+++ b/tests/ts/lib/discovery.test.ts
@@ -8,7 +8,6 @@ import {
   discoverManagedFiles,
   collectFilesForType,
   collectPooledFiles,
-  collectInstanceGroupedFiles,
   findSimilarFiles,
   levenshteinDistance,
   type ManagedFile,
@@ -197,33 +196,6 @@ describe('Discovery', () => {
     it('should return empty for non-existent directory', async () => {
       const files = await collectPooledFiles(vaultDir, 'Nonexistent', 'test');
       expect(files).toEqual([]);
-    });
-  });
-
-  describe('collectInstanceGroupedFiles', () => {
-    it('should collect files from instance-grouped directories', async () => {
-      // Create an instance-grouped structure
-      await mkdir(join(vaultDir, 'Projects/ProjectA'), { recursive: true });
-      await mkdir(join(vaultDir, 'Projects/ProjectB'), { recursive: true });
-      await writeFile(join(vaultDir, 'Projects/ProjectA', 'Note1.md'), '---\ntype: note\n---\n');
-      await writeFile(join(vaultDir, 'Projects/ProjectB', 'Note2.md'), '---\ntype: note\n---\n');
-      
-      const files = await collectInstanceGroupedFiles(vaultDir, 'Projects', 'project');
-      
-      expect(files.length).toBe(2);
-      expect(files.some(f => f.instance === 'ProjectA')).toBe(true);
-      expect(files.some(f => f.instance === 'ProjectB')).toBe(true);
-    });
-
-    it('should set instance field correctly', async () => {
-      await mkdir(join(vaultDir, 'Projects/MyProject'), { recursive: true });
-      await writeFile(join(vaultDir, 'Projects/MyProject', 'Test.md'), '---\ntype: note\n---\n');
-      
-      const files = await collectInstanceGroupedFiles(vaultDir, 'Projects', 'project');
-      
-      const file = files.find(f => f.relativePath.includes('MyProject'));
-      expect(file).toBeDefined();
-      expect(file!.instance).toBe('MyProject');
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `--type/-t` flag for explicit type selection (e.g., `bwrb new --type task`)
- Remove `--default` flag (use `--template default` instead)
- Remove `--instance` flag (instance-grouped mode was never enabled)
- Remove ~500 lines of unused instance-grouped code from new.ts, vault.ts, discovery.ts
- Update docs and tests to reflect the new CLI surface

## Changes

| File | Changes |
|------|---------|
| `src/commands/new.ts` | Add `--type/-t`, remove `--default`/`--instance`, remove dead functions |
| `src/lib/vault.ts` | Remove `getDirMode`, `isInstanceGroupedSubtype`, instance folder helpers |
| `src/lib/discovery.ts` | Remove `collectInstanceGroupedFiles` and dead branch |
| `src/commands/audit.ts` | Remove unused import/export |
| `tests/ts/commands/new.test.ts` | Update tests for `--template default`, add `--type` tests |
| `tests/ts/lib/discovery.test.ts` | Remove tests for removed function |
| `README.md`, `CHANGELOG.md`, `plans/` | Update docs |

## Testing

- `pnpm typecheck` passes
- `pnpm build` passes  
- All related tests pass (pre-existing PTY test flakiness in open.test.ts is unrelated)

Fixes #120