### PR TITLE
feat(list): add hierarchy functions to --where expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,27 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Added
 
+- **Hierarchy functions for `--where` expressions** (#121)
+  - `isRoot()` - Match notes with no parent
+  - `isChildOf('[[Note]]')` - Match direct children of specified note
+  - `isDescendantOf('[[Note]]')` - Match all descendants of specified note
+  - Example: `bwrb list --type task --where "isDescendantOf('[[Epic]]') && status != 'done'"`
+  - Functions work with recursive types and respect `--depth`/`-L` flag
+
+- **`-L` alias for `--depth` flag** (#121)
+  - Shorthand for depth limiting: `bwrb list --type task -L 2`
+
 - **`--type`/`-t` flag for `new` command** (#120)
   - Explicit type selection: `bwrb new --type task` or `bwrb new -t task`
   - Positional argument still works: `bwrb new task`
   - Flag takes precedence if both provided
 
 ### Removed
+
+- **Hierarchy flags on `list` command** (#121)
+  - `--roots`, `--children-of`, `--descendants-of` now emit deprecation warnings
+  - Use `--where "isRoot()"`, `--where "isChildOf('[[Note]]')"`, `--where "isDescendantOf('[[Note]]')"` instead
+  - Old flags continue to work but will be removed in a future release
 
 - **Deprecated flags from `new` command** (#120)
   - `--default` flag removed - use `--template default` instead

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -133,12 +133,12 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
   // Open options
   .option('--open', 'Open the first result (or pick from results interactively)')
   .option('--app <mode>', 'How to open: obsidian (default), editor, system, print')
-  // Hierarchy options for recursive types
-  .option('--roots', 'Only show notes with no parent (root nodes)')
-  .option('--children-of <note>', 'Only show direct children of the specified note (wikilink format)')
-  .option('--descendants-of <note>', 'Only show all descendants of the specified note')
+  // Hierarchy options for recursive types (deprecated in favor of --where functions)
+  .option('--roots', 'Only show root notes (deprecated: use --where "isRoot()")')
+  .option('--children-of <note>', 'Only show direct children (deprecated: use --where "isChildOf(\'[[Note]]\')")')
+  .option('--descendants-of <note>', 'Only show descendants (deprecated: use --where "isDescendantOf(\'[[Note]]\')")')
   .option('--tree', 'Display as tree (deprecated: use --output tree)')
-  .option('--depth <n>', 'Limit tree/descendants depth (use with --tree or --descendants-of)')
+  .option('-L, --depth <n>', 'Limit tree/descendants depth')
   .allowUnknownOption(true)
   .action(async (positional: string | undefined, options: ListCommandOptions, cmd: Command) => {
     // Resolve output format from --output flag and deprecated flags
@@ -238,6 +238,19 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
 
       const fields = options.fields?.split(',').map(f => f.trim());
       const depth = options.depth ? parseInt(options.depth, 10) : undefined;
+
+      // Emit deprecation warnings for hierarchy flags (unless in JSON mode)
+      if (!jsonMode) {
+        if (options.roots) {
+          warnDeprecated('--roots', '--where "isRoot()"');
+        }
+        if (options.childrenOf) {
+          warnDeprecated('--children-of', `--where "isChildOf('[[${extractNoteName(options.childrenOf) ?? options.childrenOf}]]')"`);
+        }
+        if (options.descendantsOf) {
+          warnDeprecated('--descendants-of', `--where "isDescendantOf('[[${extractNoteName(options.descendantsOf) ?? options.descendantsOf}]]')"`);
+        }
+      }
       
       await listObjects(schema, vaultDir, targeting.type, targetResult.files, {
         outputFormat,


### PR DESCRIPTION
## Summary

- Add `isRoot()`, `isChildOf('[[Note]]')`, `isDescendantOf('[[Note]]')` functions to the `--where` expression language for filtering notes by hierarchy relationships
- Add `-L` as alias for `--depth` flag
- Deprecate `--roots`, `--children-of`, `--descendants-of` flags (still work, emit warnings)

## Examples

```bash
# Find all root tasks (no parent)
bwrb list --type task --where "isRoot()"

# Find direct children of a specific note
bwrb list --type task --where "isChildOf('[[Epic]]')"

# Find all descendants, composable with other filters
bwrb list --type task --where "isDescendantOf('[[Q1 Goals]]') && status != 'done'"

# Use -L alias for depth limiting
bwrb list --type task --where "isDescendantOf('[[Epic]]')" -L 2
```

## Technical Notes

- Hierarchy data is built lazily only when expressions use hierarchy functions
- Cycle-safe descendant traversal (uses visited set to prevent infinite loops)
- Functions accept both `[[Note]]` and plain `Note` syntax
- Deprecation warnings go to stderr (won't break JSON output)

## Tests

- 49 unit tests for expression language (including hierarchy functions)
- 12 integration tests for list command hierarchy filtering
- Cycle safety test to prevent infinite loops

Fixes #121