### PR TITLE
feat(template): redesign commands with unified verbs and pickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Changed
 
+- **Template command unified verbs redesign** (#123)
+  - `template list [type] [name]` - Shows template details when both args provided
+  - `template new [type]` - Prompts for type if omitted
+  - `template edit [type] [name]` - Shows template picker if args omitted
+  - `template delete [type] [name]` - Shows template picker if args omitted
+  - Removed `template show` command (absorbed into `template list`)
+  - Consistent with schema command patterns
+
 - **Unified search/open/edit commands** (#119)
   - `search` is now the single note-resolution core with `--open` and `--edit` modes
   - `bwrb search "note" --edit` - Edit frontmatter of matching note

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -228,11 +228,11 @@ bwrb schema edit [type|field|enum]   # Edit with picker
 bwrb schema delete [type|field|enum] # Delete (dry-run default)
 bwrb schema list [types|fields|enums] # List/show
 
-# Template management
-bwrb template new [type]      # Create template
-bwrb template edit [type/name] # Edit with picker
-bwrb template delete [type/name]
-bwrb template list [type]
+# Template management (uses two separate args like schema commands)
+bwrb template new [type]           # Create template (prompts for type if omitted)
+bwrb template edit [type] [name]   # Edit with picker
+bwrb template delete [type] [name] # Delete with picker
+bwrb template list [type] [name]   # List all, or show details if both provided
 ```
 
 **Decisions made:**

--- a/tests/ts/commands/relative-paths.test.ts
+++ b/tests/ts/commands/relative-paths.test.ts
@@ -190,10 +190,10 @@ describe('relative vault path handling', () => {
       expect(result.stdout).toContain('idea');
     });
 
-    it('should show template with relative vault path', async () => {
-      // template show requires both type and template name
+    it('should show template details with relative vault path', async () => {
+      // template list with type and name shows template details
       const result = await runCLI([
-        '--vault', relativeVaultPath, 'template', 'show', 'idea', 'default',
+        '--vault', relativeVaultPath, 'template', 'list', 'idea', 'default',
       ]);
 
       expect(result.exitCode).toBe(0);

--- a/tests/ts/commands/template.test.ts
+++ b/tests/ts/commands/template.test.ts
@@ -67,9 +67,9 @@ describe('template command', () => {
     });
   });
 
-  describe('template show', () => {
-    it('should show template details', async () => {
-      const result = await runCLI(['template', 'show', 'idea', 'default'], vaultDir);
+  describe('template list [type] [name] (show details)', () => {
+    it('should show template details when both type and name provided', async () => {
+      const result = await runCLI(['template', 'list', 'idea', 'default'], vaultDir);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Template: default');
@@ -80,8 +80,8 @@ describe('template command', () => {
       expect(result.stdout).toContain('Defaults:');
     });
 
-    it('should show JSON format', async () => {
-      const result = await runCLI(['template', 'show', 'idea', 'default', '--output', 'json'], vaultDir);
+    it('should show JSON format for specific template', async () => {
+      const result = await runCLI(['template', 'list', 'idea', 'default', '--output', 'json'], vaultDir);
 
       expect(result.exitCode).toBe(0);
       const json = JSON.parse(result.stdout);
@@ -93,14 +93,14 @@ describe('template command', () => {
     });
 
     it('should error on unknown template', async () => {
-      const result = await runCLI(['template', 'show', 'idea', 'nonexistent'], vaultDir);
+      const result = await runCLI(['template', 'list', 'idea', 'nonexistent'], vaultDir);
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('Template not found');
     });
 
     it('should error on unknown type', async () => {
-      const result = await runCLI(['template', 'show', 'nonexistent', 'default'], vaultDir);
+      const result = await runCLI(['template', 'list', 'nonexistent', 'default'], vaultDir);
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('Unknown type');


### PR DESCRIPTION
## Summary

Redesigns the template command to follow the unified verb pattern established by schema commands:

- **Absorb `template show` into `template list`** - `template list [type] [name]` now shows details when both args provided
- **Make args optional with pickers** - `new`, `edit`, `delete` prompt interactively when args are omitted
- **Consistent with schema commands** - Uses two separate arguments (`<type> <name>`) not slash format

## Changes

- `template list [type] [name]` - Shows details when both provided (replaces `show`)
- `template new [type]` - Prompts for type if omitted
- `template edit [type] [name]` - Shows template picker if args omitted  
- `template delete [type] [name]` - Shows template picker if args omitted
- Removed `template show` entirely
- Added `promptTypePicker()` and `promptTemplatePicker()` helpers
- Types sorted alphabetically in picker for stable UX
- Updated product docs to reflect two-arg format

## Testing

- Updated unit tests for new `template list` behavior
- Added PTY tests for interactive picker flows
- Fixed `relative-paths.test.ts` to use `template list` instead of deleted `show`
- All 1276 tests pass

Fixes #123