### PR TITLE
fix(audit): detect wrong-directory in vault-wide audits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Vault-wide audit now detects wrong-directory issues** (#147)
+  - Previously, `bwrb audit` (without type) would not flag files in wrong directories
+  - Root cause: vault-wide discovery didn't set internal metadata needed by the check
+  - Fix: removed unnecessary condition since resolved type is available from frontmatter
+
 ### Added
 
 - **Hierarchy functions for `--where` expressions** (#121)

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -248,14 +248,18 @@ export async function auditFile(
 
   // Check wrong directory
   const expectedOutputDir = getOutputDir(schema, resolvedTypePath);
-  if (expectedOutputDir && file.expectedType) {
+  if (expectedOutputDir) {
     const expectedPath = expectedOutputDir;
     const actualDir = dirname(file.relativePath);
     // Normalize for comparison
     const normalizedExpected = expectedPath.replace(/\/$/, '');
     const normalizedActual = actualDir.replace(/\/$/, '');
     
-    if (!normalizedActual.startsWith(normalizedExpected)) {
+    // Segment-aware check: actualDir must be exactly expectedDir or a subdirectory
+    const isCorrectLocation =
+      normalizedActual === normalizedExpected ||
+      normalizedActual.startsWith(normalizedExpected + '/');
+    if (!isCorrectLocation) {
       issues.push({
         severity: 'error',
         code: 'wrong-directory',


### PR DESCRIPTION
## Summary

Fixes #147 - Vault-wide audit now correctly detects files in wrong directories.

**The Problem:**
- `bwrb audit` (vault-wide) was not detecting files in wrong directories
- `bwrb audit <type>` (type-specific) worked correctly
- Root cause: vault-wide discovery didn't set `file.expectedType`, which was required by the wrong-directory check

**The Fix:**
- Remove unnecessary `file.expectedType` condition from wrong-directory check
- The resolved type from frontmatter (`resolvedTypePath`) is sufficient
- Also improved path matching to be segment-aware (prevents `Ideas2` matching `Ideas`)

## Changes

- `src/lib/audit/detection.ts`: 1-line condition fix + segment-aware path check
- `tests/ts/commands/audit.test.ts`: 5 new tests for wrong-directory detection
- `CHANGELOG.md`: Added entry under [Unreleased] > Fixed

## Testing

```bash
cd ../worktree-fix-vault-wide-audit
pnpm test -- --run tests/ts/commands/audit.test.ts -t "wrong-directory"
```

All 5 wrong-directory tests pass. Look for output showing tests for:
- Vault-wide audit detects wrong-directory
- Type-specific audit detects wrong-directory (regression)
- Directory name prefix collision (Ideas vs Ideas2)
- No false positives for correctly placed files
- Computed default directory detection

## Product Note

The product and devex agents raised a valid concern: **owned notes** (notes living in subdirectories of their owner) will now be flagged as wrong-directory. This is expected behavior - the fix correctly identifies the location mismatch. Exempting owned notes from this check would be a separate product decision and enhancement (not in scope for this bug fix).