### PR TITLE
fix: search/edit/open now find notes in gitignored type directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Fixed
 
+- **search/edit/open now find notes in gitignored type directories** (#149)
+  - Previously, notes in type directories that were also in `.gitignore` or `schema.audit.ignored_directories` were invisible to `search`, `edit`, and `open` commands, while `list --type` could find them
+  - Fix: navigation/search now uses hybrid discovery - type files ignore exclusion rules (matching `list --type` behavior), while unmanaged files still respect exclusions
+  - This ensures consistency with the product principle "unified verbs"
+
 - **Vault-wide audit now detects wrong-directory issues** (#147)
   - Previously, `bwrb audit` (without type) would not flag files in wrong directories
   - Root cause: vault-wide discovery didn't set internal metadata needed by the check


### PR DESCRIPTION
## Summary

- Fixes inconsistency where `list --type` found notes that `search/edit/open` couldn't find
- Type files are now always discoverable regardless of `.gitignore` or `schema.audit.ignored_directories`
- Unmanaged files still respect exclusion rules (supports migration workflows)

Fixes #149

## Implementation

Uses hybrid discovery in `buildNoteIndex()`:
1. **Type files**: Collected from all type output directories (ignores exclusion rules)
2. **Unmanaged files**: Vault-wide scan minus type directories (respects exclusion rules)

New functions in `src/lib/discovery.ts`:
- `getTypeOutputDirs()` - Returns Set of all type output directories
- `isInTypeOutputDir()` - Checks if a path is in any type directory
- `discoverAllTypeFiles()` - Collects from all types
- `discoverUnmanagedFiles()` - Finds non-type files
- `discoverFilesForNavigation()` - Combines both

## Testing

- Unit tests for all new discovery functions
- Integration tests for search command with gitignored type directories
- All 1302 tests pass (1 pre-existing flaky PTY test excluded)

## Product alignment

Per product docs:
- "Nothing feels lost — Every note is discoverable"
- "Consistency Above All — The CLI should be predictable"
- `open` and `edit` are aliases for `search`, so they should find the same notes as `list --type`