### PR TITLE
docs: update product docs for field primitives refactor

### DIFF
--- a/docs/product/migrations.md
+++ b/docs/product/migrations.md
@@ -17,8 +17,7 @@ Schemas include a `schemaVersion` field for tracking content versions:
 {
   "version": 2,
   "schemaVersion": "1.0.0",
-  "types": { ... },
-  "enums": { ... }
+  "types": { ... }
 }
 ```
 
@@ -81,14 +80,9 @@ bwrb schema history --json
 | Add field | Deterministic | No action needed (field absent in old notes is valid) |
 | Remove field | Non-deterministic | Removes field from affected notes |
 | Rename field | Non-deterministic | Renames field in affected notes |
-
-### Enum Operations
-
-| Change | Classification | Migration Action |
-|--------|---------------|------------------|
-| Add enum value | Deterministic | No action needed |
-| Remove enum value | Non-deterministic | Prompts for value mapping |
-| Rename enum value | Non-deterministic | Updates references in notes |
+| Add select option | Deterministic | No action needed |
+| Remove select option | Non-deterministic | Prompts for value mapping |
+| Rename select option | Non-deterministic | Updates references in notes |
 
 ### Type Operations
 

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -42,7 +42,7 @@ After inheritance model is in place:
 | P1 | `bwrb-tsh` | Schema Management CLI |
 | P2 | `bwrb-w2a` | `bwrb schema add-type` command |
 | P2 | `bwrb-tev` | `bwrb schema add-field` command |
-| P2 | `bwrb-1kr` | `bwrb schema enum` management |
+| P1 | — | Field primitives (text, number, boolean, relation) |
 
 #### Phase 4: Polish
 | Priority | Issue | Title |
@@ -58,7 +58,8 @@ After inheritance model is in place:
 - [ ] Inheritance model fully implemented
 - [ ] Ownership/colocation working
 - [ ] Context field validation in audit
-- [ ] Schema management CLI (add-type, add-field, enums)
+- [ ] Schema management CLI (add-type, add-field)
+- [ ] Field primitives: text, number, boolean, date, select, relation, list
 - [ ] All tests passing with new schema format
 - [ ] Documentation updated
 

--- a/docs/product/type-system.md
+++ b/docs/product/type-system.md
@@ -149,6 +149,83 @@ When creating a type, the user decides:
 
 ---
 
+---
+
+## Field Value Types
+
+Fields have a **prompt type** that determines how values are collected and what data type is stored.
+
+### Prompt Types
+
+| Prompt | UX | Stored As | Use Cases |
+|--------|-----|-----------|-----------|
+| `text` | Single-line input | `string` | Names, descriptions, short answers |
+| `number` | Numeric input | `number` | Priority, word count, ratings |
+| `boolean` | Y/n confirm | `true`/`false` | Completed, archived, pinned |
+| `date` | Date input | `string` (YYYY-MM-DD) | Due dates, created dates |
+| `select` | Numbered picker | `string` or `string[]` | Status, category, tags |
+| `relation` | Picker from vault | `string` (wikilink) | Parent task, milestone, project |
+| `list` | Comma-separated input | `string[]` | Aliases, keywords |
+
+### Select Fields
+
+Select fields define their options inline:
+
+```json
+{
+  "status": {
+    "prompt": "select",
+    "options": ["active", "settled", "dropped"],
+    "required": true
+  }
+}
+```
+
+For multi-select (multiple values allowed):
+
+```json
+{
+  "tags": {
+    "prompt": "select",
+    "options": ["urgent", "blocked", "waiting", "review"],
+    "multiple": true
+  }
+}
+```
+
+### Relation Fields
+
+Relation fields link to notes of a specific type (and its descendants):
+
+```json
+{
+  "milestone": {
+    "prompt": "relation",
+    "source": "milestone",
+    "format": "wikilink"
+  }
+}
+```
+
+The picker shows only notes matching the `source` type constraint.
+
+### Field Inheritance
+
+Fields are inherited from parent types. Define shared fields on a common ancestor:
+
+```
+meta (status, created)        <- all types get these
+├── objective (deadline)      <- objectives and children get deadline
+│   ├── task
+│   └── milestone
+└── draft (draft-status)
+    └── chapter
+```
+
+This eliminates duplication. Change a field on `meta`, all types reflect it.
+
+---
+
 ## Out of Scope
 
 The type system does NOT handle:


### PR DESCRIPTION
## Summary

Updates product documentation to reflect the field primitives refactor decisions made in #159.

## Changes

- **type-system.md**: Added "Field Value Types" section defining all prompt types
- **roadmap.md**: Updated v1 exit criteria to include field primitives
- **migrations.md**: Replaced enum operations with select option operations

## Key decisions documented

- Prompt types: `text`, `number`, `boolean`, `date`, `select`, `relation`, `list`
- Select fields use inline `options` array (no global enums)
- Multi-select via `multiple: true` on select fields
- Inheritance handles field sharing across types

Relates to #159