### PR TITLE
Remove stale useDefault option from template lib

### DIFF
--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -355,7 +355,6 @@ export interface TemplateResolutionResult {
  * Logic:
  * - --no-template: Return null template, no prompt
  * - --template <name>: Find and return that template (error if not found)
- * - --default: Find and return default.md (error if not found)
  * - No flags:
  *   - If default.md exists: Use it automatically
  *   - If multiple templates: Prompt user to select
@@ -367,7 +366,6 @@ export async function resolveTemplate(
   options: {
     noTemplate?: boolean;
     templateName?: string;
-    useDefault?: boolean;
   }
 ): Promise<TemplateResolutionResult> {
   // --no-template: Skip template system entirely
@@ -378,13 +376,6 @@ export async function resolveTemplate(
   // --template <name>: Find specific template
   if (options.templateName) {
     const template = await findTemplateByName(vaultDir, typePath, options.templateName);
-    // Note: Caller should handle null case as an error
-    return { template, shouldPrompt: false, availableTemplates: [] };
-  }
-  
-  // --default: Find default.md
-  if (options.useDefault) {
-    const template = await findDefaultTemplate(vaultDir, typePath);
     // Note: Caller should handle null case as an error
     return { template, shouldPrompt: false, availableTemplates: [] };
   }

--- a/tests/ts/lib/template.test.ts
+++ b/tests/ts/lib/template.test.ts
@@ -459,24 +459,6 @@ template-for: idea
       expect(result.shouldPrompt).toBe(false);
     });
 
-    it('finds default template when useDefault is true', async () => {
-      await mkdir(join(tempDir, '.bwrb/templates/idea'), { recursive: true });
-      await writeFile(
-        join(tempDir, '.bwrb/templates/idea', 'default.md'),
-        `---
-type: template
-template-for: idea
----
-`
-      );
-
-      const result = await resolveTemplate(tempDir, 'idea', { useDefault: true });
-
-      expect(result.template).not.toBeNull();
-      expect(result.template?.name).toBe('default');
-      expect(result.shouldPrompt).toBe(false);
-    });
-
     it('auto-selects default.md when no flags provided', async () => {
       await mkdir(join(tempDir, '.bwrb/templates/idea'), { recursive: true });
       await writeFile(


### PR DESCRIPTION
## Summary

- Remove dead `useDefault` option from `resolveTemplate()` in `src/lib/template.ts`
- Update docblock to reflect current behavior (no `--default` flag)
- Remove corresponding test case

## Context

The `--default` flag was removed from `bwrb new` in #120 (replaced by `--template default`), but the `useDefault` option remained in the template lib as dead code. This creates an "API smells unused" situation for future readers.

Fixes #137