### PR TITLE
feat!: rename 'input' prompt type to 'text'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Changed (Breaking)
+
+- **Renamed `input` prompt type to `text`** (#160)
+  - The prompt type `input` has been renamed to `text` to describe the value type, not the UX
+  - Update your schemas: `{ "prompt": "input" }` → `{ "prompt": "text" }`
+  - CLI flag updated: `--type input` → `--type text`
+
 ### Fixed
 
 - **Audit similar files suggestions no longer match unrelated files**

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Special values: `$NOW` (datetime), `$TODAY` (date)
 ```json
 {
   "deadline": {
-    "prompt": "input",
+    "prompt": "text",
     "label": "Deadline (YYYY-MM-DD)",
     "required": false
   }

--- a/docs/product/migrations.md
+++ b/docs/product/migrations.md
@@ -97,7 +97,7 @@ bwrb schema history --json
 
 ```bash
 # 1. Make schema changes
-bwrb schema add-field task --name assignee --prompt input
+bwrb schema add-field task --name assignee --prompt text
 
 # 2. Check what changed
 bwrb schema diff

--- a/docs/technical/inheritance.md
+++ b/docs/technical/inheritance.md
@@ -65,7 +65,7 @@ Child types inherit all fields from ancestors:
   "objective": {
     "extends": "meta",
     "fields": {
-      "deadline": { "prompt": "input", "required": false }
+      "deadline": { "prompt": "text", "required": false }
     }
   },
   "task": {
@@ -496,7 +496,7 @@ goal       Ship v1.0            raw
     
     "objective": {
       "fields": {
-        "deadline": { "prompt": "input", "required": false }
+        "deadline": { "prompt": "text", "required": false }
       }
     },
     
@@ -610,21 +610,21 @@ goal       Ship v1.0            raw
     "person": {
       "extends": "entity",
       "fields": {
-        "email": { "prompt": "input" }
+        "email": { "prompt": "text" }
       }
     },
     
     "place": {
       "extends": "entity",
       "fields": {
-        "location": { "prompt": "input" }
+        "location": { "prompt": "text" }
       }
     },
     
     "software": {
       "extends": "entity",
       "fields": {
-        "url": { "prompt": "input" }
+        "url": { "prompt": "text" }
       }
     }
   }

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -122,8 +122,8 @@
         },
         "prompt": {
           "type": "string",
-          "enum": ["input", "select", "dynamic", "multi-input"],
-          "description": "Type of prompt: input (free text), select (from enum), dynamic (from vault query), multi-input (comma-separated list)"
+          "enum": ["text", "select", "dynamic", "multi-input"],
+          "description": "Type of prompt: text (free text), select (from enum), dynamic (from vault query), multi-input (comma-separated list)"
         },
         "label": {
           "type": "string",

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1026,7 +1026,7 @@ async function promptField(
       return formatValue(selected, field.format);
     }
 
-    case 'input': {
+    case 'text': {
       const label = field.label ?? fieldName;
       if (field.required) {
         const value = await promptRequired(label);

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -245,7 +245,7 @@ async function promptFieldDefinition(
   
   // Get prompt type
   const promptTypes = [
-    'input (text)',
+    'text',
     'select (enum)',
     'date',
     'multi-input (list)',
@@ -257,7 +257,7 @@ async function promptFieldDefinition(
   
   const promptTypeIndex = promptTypes.indexOf(promptTypeResult);
   const promptTypeMap: Record<number, Field['prompt'] | 'value'> = {
-    0: 'input',
+    0: 'text',
     1: 'select',
     2: 'date',
     3: 'multi-input',
@@ -537,9 +537,9 @@ function buildFieldFromOptions(
     field.value = options.value;
   } else if (promptType) {
     // Validate prompt type
-    const validPromptTypes = ['input', 'select', 'date', 'multi-input', 'dynamic'];
+    const validPromptTypes = ['text', 'select', 'date', 'multi-input', 'dynamic'];
     if (!validPromptTypes.includes(promptType)) {
-      throw new Error(`Invalid prompt type "${promptType}". Valid types: input, select, date, multi-input, dynamic, fixed`);
+      throw new Error(`Invalid prompt type "${promptType}". Valid types: text, select, date, multi-input, dynamic, fixed`);
     }
     
     field.prompt = promptType as Field['prompt'];
@@ -622,7 +622,7 @@ async function promptSingleFieldDefinition(
   
   // Get prompt type
   const promptTypes = [
-    'input (text)',
+    'text',
     'select (enum)',
     'date',
     'multi-input (list)',
@@ -634,7 +634,7 @@ async function promptSingleFieldDefinition(
   
   const promptTypeIndex = promptTypes.indexOf(promptTypeResult);
   const promptTypeMap: Record<number, Field['prompt'] | 'value'> = {
-    0: 'input',
+    0: 'text',
     1: 'select',
     2: 'date',
     3: 'multi-input',
@@ -1968,8 +1968,8 @@ function getFieldType(field: Field): string {
       return field.enum ? chalk.blue(`enum:${field.enum}`) : chalk.blue('select');
     case 'multi-input':
       return chalk.blue('multi-input');
-    case 'input':
-      return chalk.blue('input');
+    case 'text':
+      return chalk.blue('text');
     case 'date':
       return chalk.blue('date');
     case 'dynamic':
@@ -2412,7 +2412,7 @@ newCommand
             throw new Error(`Invalid field definition: "${fieldDef}". Use "name:type" format.`);
           }
           // Map simple type strings to field definitions
-          const promptType = fieldType as 'input' | 'select' | 'date' | 'dynamic';
+          const promptType = fieldType as 'text' | 'select' | 'date' | 'dynamic';
           fields[fieldName] = { prompt: promptType };
         }
       } else if (!jsonMode) {
@@ -2897,7 +2897,7 @@ editCommand
         }
 
         if (choice === 'Change prompt type') {
-          const promptOptions = ['input', 'select', 'multi-input', 'date', 'dynamic'];
+          const promptOptions = ['text', 'select', 'multi-input', 'date', 'dynamic'];
           const newPrompt = await promptSelection('Prompt type', promptOptions);
           const fieldEntry = rawTypeEntry.fields?.[fieldName];
           if (newPrompt !== null && fieldEntry) {

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -755,7 +755,7 @@ async function promptFieldDefault(
       return values;
     }
 
-    case 'input':
+    case 'text':
     case 'date':
     default: {
       const input = await promptInput(`Default ${label} (or Enter to skip)`);
@@ -1213,7 +1213,7 @@ async function promptFieldDefaultEdit(
       return input.split(',').map(s => s.trim()).filter(Boolean);
     }
 
-    case 'input':
+    case 'text':
     case 'date':
     default: {
       const input = await promptInput(`New ${label} (Enter to keep, "clear" to remove)`);

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -379,7 +379,7 @@ async function promptFieldEdit(
       return formatValue(selected, field.format);
     }
 
-    case 'input': {
+    case 'text': {
       const label = field.label ?? fieldName;
       const currentDefault = typeof currentValue === 'string' ? currentValue : '';
       const newValue = await promptInput(`New ${label} (or Enter to keep)`, currentDefault);

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -18,7 +18,7 @@ export const FilterConditionSchema = z.object({
  */
 export const FieldSchema = z.object({
   // Prompt type (how the field is collected)
-  prompt: z.enum(['input', 'select', 'multi-input', 'date', 'dynamic']).optional(),
+  prompt: z.enum(['text', 'select', 'multi-input', 'date', 'dynamic']).optional(),
   // Static value (no prompting)
   value: z.string().optional(),
   // Enum reference for select prompts

--- a/tests/fixtures/test_schema.json
+++ b/tests/fixtures/test_schema.json
@@ -30,7 +30,7 @@
           "format": "quoted-wikilink"
         },
         "creation-date": { "value": "$NOW" },
-        "deadline": { "prompt": "input", "label": "Deadline (YYYY-MM-DD)" }
+        "deadline": { "prompt": "text", "label": "Deadline (YYYY-MM-DD)" }
       },
       "field_order": [
         "type",

--- a/tests/fixtures/vault/.bwrb/schema.json
+++ b/tests/fixtures/vault/.bwrb/schema.json
@@ -30,7 +30,7 @@
           "format": "quoted-wikilink"
         },
         "creation-date": { "value": "$NOW" },
-        "deadline": { "prompt": "input", "label": "Deadline (YYYY-MM-DD)" }
+        "deadline": { "prompt": "text", "label": "Deadline (YYYY-MM-DD)" }
       },
       "field_order": [
         "type",

--- a/tests/ts/commands/audit-fix.pty.test.ts
+++ b/tests/ts/commands/audit-fix.pty.test.ts
@@ -420,7 +420,7 @@ some: value
             output_dir: 'Items',
             fields: {
               type: { value: 'item' },
-              link: { prompt: 'input', format: 'wikilink' },
+              link: { prompt: 'text', format: 'wikilink' },
             },
             field_order: ['type', 'link'],
           },

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -57,7 +57,7 @@ describe('audit command', () => {
             ...TEST_SCHEMA.types.idea,
             fields: {
               ...TEST_SCHEMA.types.idea.fields,
-              requiredNoDefault: { prompt: 'input', required: true },
+              requiredNoDefault: { prompt: 'text', required: true },
             },
           },
         },

--- a/tests/ts/commands/edit.pty.test.ts
+++ b/tests/ts/commands/edit.pty.test.ts
@@ -35,7 +35,7 @@ const EDIT_SCHEMA = {
         type: { value: 'idea' },
         status: { prompt: 'select', enum: 'status', default: 'raw' },
         priority: { prompt: 'select', enum: 'priority' },
-        description: { prompt: 'input', label: 'Description' },
+        description: { prompt: 'text', label: 'Description' },
       },
       field_order: ['type', 'status', 'priority', 'description'],
       body_sections: [

--- a/tests/ts/commands/schema-add-field.pty.test.ts
+++ b/tests/ts/commands/schema-add-field.pty.test.ts
@@ -102,7 +102,7 @@ describePty('bwrb schema add-field PTY tests', () => {
           const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
           const schema = JSON.parse(schemaContent);
           expect(schema.types.project.fields.description).toEqual({
-            prompt: 'input',
+            prompt: 'text',
             required: false,
           });
         },
@@ -289,7 +289,7 @@ describePty('bwrb schema add-field PTY tests', () => {
           const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
           const schema = JSON.parse(schemaContent);
           expect(schema.types.project.fields.name).toEqual({
-            prompt: 'input',
+            prompt: 'text',
             required: true,
           });
         },

--- a/tests/ts/commands/schema-add-field.test.ts
+++ b/tests/ts/commands/schema-add-field.test.ts
@@ -50,7 +50,7 @@ describe('schema add-field command', () => {
   describe('basic field creation (JSON mode)', () => {
     it('should add an input field to a type', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'description', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'description', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -59,11 +59,11 @@ describe('schema add-field command', () => {
       expect(json.success).toBe(true);
       expect(json.data.type).toBe('project');
       expect(json.data.field).toBe('description');
-      expect(json.data.definition.prompt).toBe('input');
+      expect(json.data.definition.prompt).toBe('text');
 
       // Verify schema was updated
       const schema = JSON.parse(await readFile(join(tempVaultDir, '.bwrb', 'schema.json'), 'utf-8'));
-      expect(schema.types.project.fields.description).toEqual({ prompt: 'input' });
+      expect(schema.types.project.fields.description).toEqual({ prompt: 'text' });
     });
 
     it('should add a select field with enum', async () => {
@@ -149,7 +149,7 @@ describe('schema add-field command', () => {
 
     it('should add a required field', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'name', '--type', 'input', '--required', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'name', '--type', 'text', '--required', '--output', 'json'],
         tempVaultDir
       );
 
@@ -159,7 +159,7 @@ describe('schema add-field command', () => {
 
       const schema = JSON.parse(await readFile(join(tempVaultDir, '.bwrb', 'schema.json'), 'utf-8'));
       expect(schema.types.project.fields.name).toEqual({
-        prompt: 'input',
+        prompt: 'text',
         required: true,
       });
     });
@@ -186,7 +186,7 @@ describe('schema add-field command', () => {
   describe('validation', () => {
     it('should reject non-existent type', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'nonexistent', 'field', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'nonexistent', 'field', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -198,7 +198,7 @@ describe('schema add-field command', () => {
 
     it('should reject duplicate field name on same type', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'note', 'status', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'note', 'status', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -211,7 +211,7 @@ describe('schema add-field command', () => {
     it('should reject overriding inherited field', async () => {
       // task inherits from note, which has status field
       const result = await runCLI(
-        ['schema', 'add-field', 'task', 'status', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'task', 'status', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -223,7 +223,7 @@ describe('schema add-field command', () => {
 
     it('should reject invalid field name starting with number', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', '123field', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'project', '123field', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -235,7 +235,7 @@ describe('schema add-field command', () => {
 
     it('should reject field name with uppercase letters', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'MyField', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'MyField', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -247,7 +247,7 @@ describe('schema add-field command', () => {
 
     it('should reject field name with underscores', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'my_field', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'my_field', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -343,7 +343,7 @@ describe('schema add-field command', () => {
 
     it('should require field name in JSON mode', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'project', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -385,12 +385,12 @@ describe('schema add-field command', () => {
       // First, add field_order to the schema
       const schemaPath = join(tempVaultDir, '.bwrb', 'schema.json');
       const schema = JSON.parse(await readFile(schemaPath, 'utf-8'));
-      schema.types.project.fields = { existing: { prompt: 'input' } };
+      schema.types.project.fields = { existing: { prompt: 'text' } };
       schema.types.project.field_order = ['existing'];
       await writeFile(schemaPath, JSON.stringify(schema));
 
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'new-field', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'new-field', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -403,13 +403,13 @@ describe('schema add-field command', () => {
     it('should create field_order when adding second field', async () => {
       // Add first field
       await runCLI(
-        ['schema', 'add-field', 'project', 'first', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'first', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
       // Add second field
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'second', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'second', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -422,7 +422,7 @@ describe('schema add-field command', () => {
 
     it('should not create field_order for first field only', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'only-field', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'only-field', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -437,7 +437,7 @@ describe('schema add-field command', () => {
   describe('schema validation after add', () => {
     it('should maintain valid schema after adding field', async () => {
       await runCLI(
-        ['schema', 'add-field', 'project', 'description', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'description', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -453,7 +453,7 @@ describe('schema add-field command', () => {
 
     it('should show new field in schema show', async () => {
       await runCLI(
-        ['schema', 'add-field', 'project', 'description', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'description', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -465,14 +465,14 @@ describe('schema add-field command', () => {
       expect(result.exitCode).toBe(0);
       const json = JSON.parse(result.stdout);
       expect(json.fields.description).toBeDefined();
-      expect(json.fields.description.type).toBe('input');
+      expect(json.fields.description.type).toBe('text');
     });
   });
 
   describe('inheritance indication', () => {
     it('should indicate when field affects child types', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'note', 'new-field', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'note', 'new-field', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -483,7 +483,7 @@ describe('schema add-field command', () => {
 
     it('should indicate when field does not affect child types', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'new-field', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'new-field', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 
@@ -496,7 +496,7 @@ describe('schema add-field command', () => {
   describe('text mode output', () => {
     it('should show error message in text mode', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'nonexistent', 'field', '--type', 'input'],
+        ['schema', 'add-field', 'nonexistent', 'field', '--type', 'text'],
         tempVaultDir
       );
 
@@ -506,7 +506,7 @@ describe('schema add-field command', () => {
 
     it('should show validation error in text mode', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', '123invalid', '--type', 'input'],
+        ['schema', 'add-field', 'project', '123invalid', '--type', 'text'],
         tempVaultDir
       );
 
@@ -655,7 +655,7 @@ describe('schema add-field command', () => {
       await writeFile(schemaPath, JSON.stringify(schema));
 
       const result = await runCLI(
-        ['schema', 'add-field', 'meta', 'created', '--type', 'input', '--output', 'json'],
+        ['schema', 'add-field', 'meta', 'created', '--type', 'text', '--output', 'json'],
         tempVaultDir
       );
 

--- a/tests/ts/commands/schema-add-type.pty.test.ts
+++ b/tests/ts/commands/schema-add-type.pty.test.ts
@@ -211,7 +211,7 @@ describePty('bwrb schema add-type PTY tests', () => {
           const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
           const schema = JSON.parse(schemaContent);
           expect(schema.types.task.fields.description).toEqual({
-            prompt: 'input',
+            prompt: 'text',
             required: true,
           });
           expect(schema.types.task.fields.priority).toEqual({
@@ -264,7 +264,7 @@ describePty('bwrb schema add-type PTY tests', () => {
           const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
           const schema = JSON.parse(schemaContent);
           expect(schema.types.task.fields.description).toEqual({
-            prompt: 'input',
+            prompt: 'text',
             required: true,
           });
         },

--- a/tests/ts/commands/schema-edit-field.pty.test.ts
+++ b/tests/ts/commands/schema-edit-field.pty.test.ts
@@ -23,16 +23,16 @@ const TEST_SCHEMA = {
     task: {
       output_dir: 'Tasks',
       fields: {
-        title: { prompt: 'input', required: true },
+        title: { prompt: 'text', required: true },
         status: { enum: 'status' },
         priority: { enum: 'priority', default: 'medium' },
-        notes: { prompt: 'input', label: 'Additional Notes' },
+        notes: { prompt: 'text', label: 'Additional Notes' },
       },
     },
     project: {
       output_dir: 'Projects',
       fields: {
-        name: { prompt: 'input', required: true },
+        name: { prompt: 'text', required: true },
         deadline: { prompt: 'date' },
       },
     },

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -204,7 +204,7 @@ describe('schema command', () => {
             task: {
               extends: 'objective',
               fields: {
-                deadline: { prompt: 'input' }
+                deadline: { prompt: 'text' }
               }
             }
           }
@@ -401,7 +401,7 @@ describe('schema command', () => {
             task: {
               extends: 'meta',
               output_dir: 'Tasks',
-              fields: { status: { prompt: 'input' } }
+              fields: { status: { prompt: 'text' } }
             }
           }
         })
@@ -437,7 +437,7 @@ describe('schema command', () => {
           version: 2,
           types: {
             meta: { fields: { created: { prompt: 'date' } } },
-            objective: { extends: 'meta', fields: { status: { prompt: 'input' } } },
+            objective: { extends: 'meta', fields: { status: { prompt: 'text' } } },
             task: { extends: 'meta', output_dir: 'Tasks' }
           }
         })
@@ -712,7 +712,7 @@ describe('schema command', () => {
             meta: {},
             task: {
               extends: 'meta',
-              fields: { status: { prompt: 'input' } }
+              fields: { status: { prompt: 'text' } }
             }
           }
         })
@@ -749,7 +749,7 @@ describe('schema command', () => {
             meta: {},
             task: {
               extends: 'meta',
-              fields: { status: { prompt: 'input', required: true } }
+              fields: { status: { prompt: 'text', required: true } }
             }
           }
         })
@@ -786,7 +786,7 @@ describe('schema command', () => {
             meta: {},
             task: {
               extends: 'meta',
-              fields: { priority: { prompt: 'input' } }
+              fields: { priority: { prompt: 'text' } }
             }
           }
         })
@@ -822,7 +822,7 @@ describe('schema command', () => {
             meta: {},
             task: {
               extends: 'meta',
-              fields: { priority: { prompt: 'input', default: 'low' } }
+              fields: { priority: { prompt: 'text', default: 'low' } }
             }
           }
         })
@@ -858,7 +858,7 @@ describe('schema command', () => {
             meta: {},
             task: {
               extends: 'meta',
-              fields: { deadline: { prompt: 'input' } }
+              fields: { deadline: { prompt: 'text' } }
             }
           }
         })
@@ -919,7 +919,7 @@ describe('schema command', () => {
           version: 2,
           types: {
             meta: {},
-            task: { extends: 'meta', fields: { status: { prompt: 'input' } } }
+            task: { extends: 'meta', fields: { status: { prompt: 'text' } } }
           }
         })
       );
@@ -948,7 +948,7 @@ describe('schema command', () => {
             meta: {},
             task: {
               extends: 'meta',
-              fields: { status: { prompt: 'input' } }
+              fields: { status: { prompt: 'text' } }
             }
           }
         })
@@ -983,7 +983,7 @@ describe('schema command', () => {
             task: {
               extends: 'meta',
               output_dir: 'Tasks',
-              fields: { status: { prompt: 'input' }, deadline: { prompt: 'input' } }
+              fields: { status: { prompt: 'text' }, deadline: { prompt: 'text' } }
             }
           }
         })
@@ -1027,7 +1027,7 @@ describe('schema command', () => {
             meta: {},
             task: {
               extends: 'meta',
-              fields: { status: { prompt: 'input' }, deadline: { prompt: 'input' } }
+              fields: { status: { prompt: 'text' }, deadline: { prompt: 'text' } }
             }
           }
         })
@@ -1063,7 +1063,7 @@ describe('schema command', () => {
           version: 2,
           types: {
             meta: { fields: { created: { prompt: 'date' } } },
-            task: { extends: 'meta', fields: { status: { prompt: 'input' } } }
+            task: { extends: 'meta', fields: { status: { prompt: 'text' } } }
           }
         })
       );
@@ -1090,7 +1090,7 @@ describe('schema command', () => {
           version: 2,
           types: {
             meta: {},
-            task: { extends: 'meta', fields: { status: { prompt: 'input' } } }
+            task: { extends: 'meta', fields: { status: { prompt: 'text' } } }
           }
         })
       );
@@ -1121,7 +1121,7 @@ describe('schema command', () => {
             meta: {},
             objective: {
               extends: 'meta',
-              fields: { status: { prompt: 'input' } }
+              fields: { status: { prompt: 'text' } }
             },
             task: { extends: 'objective', output_dir: 'Tasks' },
             milestone: { extends: 'objective', output_dir: 'Milestones' }
@@ -1370,7 +1370,7 @@ describe('schema command', () => {
             meta: {},
             task: {
               extends: 'meta',
-              fields: { status: { prompt: 'input' }, deadline: { prompt: 'date' } }
+              fields: { status: { prompt: 'text' }, deadline: { prompt: 'date' } }
             }
           }
         })

--- a/tests/ts/fixtures/setup.ts
+++ b/tests/ts/fixtures/setup.ts
@@ -52,7 +52,7 @@ export const TEST_SCHEMA = {
           format: 'quoted-wikilink',
         },
         'creation-date': { value: '$NOW' },
-        deadline: { prompt: 'input', label: 'Deadline (YYYY-MM-DD)' },
+        deadline: { prompt: 'text', label: 'Deadline (YYYY-MM-DD)' },
         tags: {
           prompt: 'multi-input',
           list_format: 'yaml-array',

--- a/tests/ts/lib/hierarchy.test.ts
+++ b/tests/ts/lib/hierarchy.test.ts
@@ -124,7 +124,7 @@ describe('hierarchy', () => {
               recursive: true,
               output_dir: 'Tasks',
               fields: {
-                title: { prompt: 'input' },
+                title: { prompt: 'text' },
               },
             },
           },
@@ -194,7 +194,7 @@ parent: "[[Child Task]]"
           types: {
             task: {
               output_dir: 'Tasks',
-              fields: { title: { prompt: 'input' } },
+              fields: { title: { prompt: 'text' } },
             },
           },
         })
@@ -239,7 +239,7 @@ title: My Task
               recursive: true,
               output_dir: 'Tasks',
               fields: {
-                title: { prompt: 'input' },
+                title: { prompt: 'text' },
               },
             },
           },

--- a/tests/ts/lib/migration/diff.test.ts
+++ b/tests/ts/lib/migration/diff.test.ts
@@ -47,7 +47,7 @@ describe("diffSchemas", () => {
             ...baseSchema.types.task,
             fields: {
               ...baseSchema.types.task.fields,
-              assignee: { prompt: "input" },
+              assignee: { prompt: "text" },
             },
           },
         },
@@ -143,7 +143,7 @@ describe("diffSchemas", () => {
           project: {
             output_dir: "Projects",
             fields: {
-              name: { prompt: "input", required: true },
+              name: { prompt: "text", required: true },
             },
           },
         },

--- a/tests/ts/lib/prompt-input.pty.test.ts
+++ b/tests/ts/lib/prompt-input.pty.test.ts
@@ -125,7 +125,7 @@ describePty('Text Input Prompt PTY tests', () => {
             output_dir: 'Tasks',
             fields: {
               type: { value: 'task' },
-              deadline: { prompt: 'input', label: 'Deadline' },
+              deadline: { prompt: 'text', label: 'Deadline' },
             },
             field_order: ['type', 'deadline'],
           },
@@ -166,7 +166,7 @@ describePty('Text Input Prompt PTY tests', () => {
             output_dir: 'Notes',
             fields: {
               type: { value: 'note' },
-              category: { prompt: 'input', label: 'Category', default: 'general' },
+              category: { prompt: 'text', label: 'Category', default: 'general' },
             },
             field_order: ['type', 'category'],
           },

--- a/tests/ts/lib/schema.test.ts
+++ b/tests/ts/lib/schema.test.ts
@@ -347,7 +347,7 @@ describe('schema', () => {
               task: {
                 recursive: true,
                 fields: {
-                  title: { prompt: 'input' }
+                  title: { prompt: 'text' }
                 }
               }
             }
@@ -385,7 +385,7 @@ describe('schema', () => {
               task: {
                 recursive: true,
                 fields: {
-                  title: { prompt: 'input' },
+                  title: { prompt: 'text' },
                   parent: {
                     prompt: 'dynamic',
                     source: 'task',
@@ -438,14 +438,14 @@ describe('schema', () => {
             types: {
               chapter: {
                 fields: {
-                  title: { prompt: 'input' }
+                  title: { prompt: 'text' }
                 }
               },
               scene: {
                 extends: 'chapter',
                 recursive: true,
                 fields: {
-                  content: { prompt: 'input' }
+                  content: { prompt: 'text' }
                 }
               }
             }
@@ -490,7 +490,7 @@ describe('schema', () => {
               task: {
                 recursive: true,
                 fields: {
-                  title: { prompt: 'input' }
+                  title: { prompt: 'text' }
                 }
               }
             }
@@ -615,7 +615,7 @@ describe('schema', () => {
               task: {
                 extends: 'meta',
                 fields: {
-                  status: { prompt: 'input' }
+                  status: { prompt: 'text' }
                 }
               }
             }
@@ -687,13 +687,13 @@ describe('schema', () => {
               objective: {
                 extends: 'meta',
                 fields: {
-                  status: { prompt: 'input' }
+                  status: { prompt: 'text' }
                 }
               },
               task: {
                 extends: 'objective',
                 fields: {
-                  deadline: { prompt: 'input' }
+                  deadline: { prompt: 'text' }
                 }
               }
             }
@@ -741,9 +741,9 @@ describe('schema', () => {
             types: {
               meta: {
                 fields: {
-                  alpha: { prompt: 'input' },
-                  beta: { prompt: 'input' },
-                  gamma: { prompt: 'input' }
+                  alpha: { prompt: 'text' },
+                  beta: { prompt: 'text' },
+                  gamma: { prompt: 'text' }
                 },
                 field_order: ['gamma', 'alpha', 'beta']
               }

--- a/tests/ts/lib/template.test.ts
+++ b/tests/ts/lib/template.test.ts
@@ -852,26 +852,26 @@ describe('createScaffoldedInstances', () => {
       draft: {
         output_dir: 'Drafts',
         fields: {
-          Name: { prompt: 'input', required: true },
+          Name: { prompt: 'text', required: true },
           status: { prompt: 'select', enum: 'status', default: 'draft' },
         },
       },
       version: {
         extends: 'draft',
         fields: {
-          version: { prompt: 'input', default: '1' },
+          version: { prompt: 'text', default: '1' },
         },
       },
       research: {
         extends: 'draft',
         fields: {
-          topic: { prompt: 'input' },
+          topic: { prompt: 'text' },
         },
       },
       notes: {
         extends: 'draft',
         fields: {
-          source: { prompt: 'input' },
+          source: { prompt: 'text' },
         },
       },
     },


### PR DESCRIPTION
## Summary

Renames the `input` prompt type to `text` as part of the Field Primitives Refactor (#159).

**BREAKING CHANGE**: The prompt type `input` has been renamed to `text`.

## Changes

- Updated `FieldSchema` prompt enum from `input` to `text`
- Updated `schema.schema.json` validation
- Updated all command handlers (new, edit, template, schema)
- Updated all documentation examples
- Updated test fixtures and assertions
- All 1313 tests pass

## Migration

Update your schemas:
```json
// Before
{ "prompt": "input" }

// After
{ "prompt": "text" }
```

## Rationale

The name `text` describes the **value type** (a string), not the UX (an input field). This aligns with industry standards and makes the schema more intuitive.

Closes #160
Part of #159