### PR TITLE
feat!: rename 'dynamic' prompt type to 'relation'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to Bowerbird are documented in this file.
   - Update your schemas: `{ "prompt": "input" }` → `{ "prompt": "text" }`
   - CLI flag updated: `--type input` → `--type text`
 
+- **Renamed `dynamic` prompt type to `relation`** (#161)
+  - The prompt type `dynamic` has been renamed to `relation` (industry standard term)
+  - Update your schemas: `{ "prompt": "dynamic" }` → `{ "prompt": "relation" }`
+  - CLI flag updated: `--type dynamic` → `--type relation`
+
 ### Fixed
 
 - **Audit similar files suggestions no longer match unrelated files**

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Query notes of a specific type to populate field options:
 ```json
 {
   "milestone": {
-    "prompt": "dynamic",
+    "prompt": "relation",
     "source": "objective/milestone",
     "filter": "status != 'settled' && status != 'ghosted'",
     "format": "quoted-wikilink"

--- a/docs/technical/inheritance.md
+++ b/docs/technical/inheritance.md
@@ -72,7 +72,7 @@ Child types inherit all fields from ancestors:
     "extends": "objective",
     "fields": {
       "status": { "default": "inbox" },  // Override default only
-      "assignee": { "prompt": "dynamic", "source": "person" }
+      "assignee": { "prompt": "relation", "source": "person" }
     }
   }
 }
@@ -154,7 +154,7 @@ Any wikilink field can be a context relationship:
     "extends": "objective",
     "fields": {
       "milestone": {
-        "prompt": "dynamic",
+        "prompt": "relation",
         "source": "milestone",
         "format": "wikilink",
         "required": false
@@ -215,14 +215,14 @@ The **parent** declares ownership of its children using `owned: true` on a conte
     "extends": "meta",
     "fields": {
       "research": {
-        "prompt": "dynamic",
+        "prompt": "relation",
         "source": "research",
         "format": "wikilink",
         "multiple": true,
         "owned": true
       },
       "related-research": {
-        "prompt": "dynamic",
+        "prompt": "relation",
         "source": "research", 
         "format": "wikilink",
         "multiple": true,
@@ -349,7 +349,7 @@ The parent field for recursive types. Note that for recursion, the **child** dec
     "recursive": true,
     "fields": {
       "parent": {
-        "prompt": "dynamic",
+        "prompt": "relation",
         "source": "task",      // Same type
         "format": "wikilink",
         "required": false
@@ -508,7 +508,7 @@ goal       Ship v1.0            raw
       "extends": "objective",
       "fields": {
         "goal": {
-          "prompt": "dynamic",
+          "prompt": "relation",
           "source": "goal",
           "format": "wikilink"
         }
@@ -519,7 +519,7 @@ goal       Ship v1.0            raw
       "extends": "objective",
       "fields": {
         "project": {
-          "prompt": "dynamic",
+          "prompt": "relation",
           "source": "project",
           "format": "wikilink"
         }
@@ -532,12 +532,12 @@ goal       Ship v1.0            raw
       "fields": {
         "status": { "default": "inbox" },
         "milestone": {
-          "prompt": "dynamic",
+          "prompt": "relation",
           "source": "milestone",
           "format": "wikilink"
         },
         "subtasks": {
-          "prompt": "dynamic",
+          "prompt": "relation",
           "source": "task",
           "format": "wikilink",
           "multiple": true,
@@ -550,14 +550,14 @@ goal       Ship v1.0            raw
       "fields": {
         "draft-status": { "prompt": "select", "enum": "draft-status", "default": "idea" },
         "chapters": {
-          "prompt": "dynamic",
+          "prompt": "relation",
           "source": "chapter",
           "format": "wikilink",
           "multiple": true,
           "owned": true
         },
         "research": {
-          "prompt": "dynamic",
+          "prompt": "relation",
           "source": "research",
           "format": "wikilink",
           "multiple": true,
@@ -571,14 +571,14 @@ goal       Ship v1.0            raw
       "recursive": true,
       "fields": {
         "scenes": {
-          "prompt": "dynamic",
+          "prompt": "relation",
           "source": "scene",
           "format": "wikilink",
           "multiple": true,
           "owned": true
         },
         "subchapters": {
-          "prompt": "dynamic",
+          "prompt": "relation",
           "source": "chapter",
           "format": "wikilink",
           "multiple": true,
@@ -592,7 +592,7 @@ goal       Ship v1.0            raw
       "recursive": true,
       "fields": {
         "subscenes": {
-          "prompt": "dynamic",
+          "prompt": "relation",
           "source": "scene",
           "format": "wikilink",
           "multiple": true,

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -122,8 +122,8 @@
         },
         "prompt": {
           "type": "string",
-          "enum": ["text", "select", "dynamic", "multi-input"],
-          "description": "Type of prompt: text (free text), select (from enum), dynamic (from vault query), multi-input (comma-separated list)"
+          "enum": ["text", "select", "relation", "multi-input"],
+          "description": "Type of prompt: text (free text), select (from enum), relation (from vault query), multi-input (comma-separated list)"
         },
         "label": {
           "type": "string",

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -995,7 +995,7 @@ async function promptField(
       return selected;
     }
 
-    case 'dynamic': {
+    case 'relation': {
       if (!field.source) return field.default;
       const dynamicOptions = await queryByType(schema, vaultDir, field.source, field.filter);
       if (dynamicOptions.length === 0) {

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -261,7 +261,7 @@ async function promptFieldDefinition(
     1: 'select',
     2: 'date',
     3: 'multi-input',
-    4: 'dynamic',
+    4: 'relation',
     5: 'value',
   };
   const promptType = promptTypeMap[promptTypeIndex];
@@ -290,7 +290,7 @@ async function promptFieldDefinition(
     }
     
     // For dynamic, get source type
-    if (promptType === 'dynamic') {
+    if (promptType === 'relation') {
       const typeNames = getTypeNames(schema).filter(t => t !== 'meta');
       if (typeNames.length === 0) {
         printError('No types defined in schema yet.');
@@ -537,9 +537,9 @@ function buildFieldFromOptions(
     field.value = options.value;
   } else if (promptType) {
     // Validate prompt type
-    const validPromptTypes = ['text', 'select', 'date', 'multi-input', 'dynamic'];
+    const validPromptTypes = ['text', 'select', 'date', 'multi-input', 'relation'];
     if (!validPromptTypes.includes(promptType)) {
-      throw new Error(`Invalid prompt type "${promptType}". Valid types: text, select, date, multi-input, dynamic, fixed`);
+      throw new Error(`Invalid prompt type "${promptType}". Valid types: text, select, date, multi-input, relation, fixed`);
     }
     
     field.prompt = promptType as Field['prompt'];
@@ -556,7 +556,7 @@ function buildFieldFromOptions(
     }
     
     // Handle dynamic type
-    if (promptType === 'dynamic') {
+    if (promptType === 'relation') {
       if (!options.source) {
         throw new Error('--source is required for dynamic type');
       }
@@ -638,7 +638,7 @@ async function promptSingleFieldDefinition(
     1: 'select',
     2: 'date',
     3: 'multi-input',
-    4: 'dynamic',
+    4: 'relation',
     5: 'value',
   };
   const promptType = promptTypeMap[promptTypeIndex];
@@ -666,7 +666,7 @@ async function promptSingleFieldDefinition(
     }
     
     // For dynamic, get source type
-    if (promptType === 'dynamic') {
+    if (promptType === 'relation') {
       const typeNames = getTypeNames(schema).filter(t => t !== 'meta');
       if (typeNames.length === 0) {
         throw new Error('No types defined in schema yet.');
@@ -1927,12 +1927,12 @@ function printFieldDetails(
   }
 
   // Show format for dynamic fields
-  if (field.prompt === 'dynamic' && field.format) {
+  if (field.prompt === 'relation' && field.format) {
     line += chalk.gray(` format=${field.format}`);
   }
 
   // Show filter summary for dynamic fields
-  if (field.prompt === 'dynamic' && field.filter) {
+  if (field.prompt === 'relation' && field.filter) {
     const filterKeys = Object.keys(field.filter);
     if (filterKeys.length > 0) {
       line += chalk.gray(` filter=[${filterKeys.join(',')}]`);
@@ -1972,8 +1972,8 @@ function getFieldType(field: Field): string {
       return chalk.blue('text');
     case 'date':
       return chalk.blue('date');
-    case 'dynamic':
-      return field.source ? chalk.blue(`dynamic:${field.source}`) : chalk.blue('dynamic');
+    case 'relation':
+      return field.source ? chalk.blue(`dynamic:${field.source}`) : chalk.blue('relation');
     default:
       return chalk.gray('auto');
   }
@@ -2412,7 +2412,7 @@ newCommand
             throw new Error(`Invalid field definition: "${fieldDef}". Use "name:type" format.`);
           }
           // Map simple type strings to field definitions
-          const promptType = fieldType as 'text' | 'select' | 'date' | 'dynamic';
+          const promptType = fieldType as 'text' | 'select' | 'date' | 'relation';
           fields[fieldName] = { prompt: promptType };
         }
       } else if (!jsonMode) {
@@ -2897,7 +2897,7 @@ editCommand
         }
 
         if (choice === 'Change prompt type') {
-          const promptOptions = ['text', 'select', 'multi-input', 'date', 'dynamic'];
+          const promptOptions = ['text', 'select', 'multi-input', 'date', 'relation'];
           const newPrompt = await promptSelection('Prompt type', promptOptions);
           const fieldEntry = rawTypeEntry.fields?.[fieldName];
           if (newPrompt !== null && fieldEntry) {

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -735,7 +735,7 @@ async function promptFieldDefault(
       return selected;
     }
 
-    case 'dynamic': {
+    case 'relation': {
       if (!field.source) return undefined;
       const dynamicOptions = await queryByType(schema, vaultDir, field.source, field.filter);
       if (dynamicOptions.length === 0) return undefined;
@@ -1191,7 +1191,7 @@ async function promptFieldDefaultEdit(
       return selected;
     }
 
-    case 'dynamic': {
+    case 'relation': {
       if (!field.source) return currentValue;
       const dynamicOptions = await queryByType(schema, vaultDir, field.source, field.filter);
       if (dynamicOptions.length === 0) return currentValue;

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -356,7 +356,7 @@ async function promptFieldEdit(
       return selected;
     }
 
-    case 'dynamic': {
+    case 'relation': {
       if (!field.source) return currentValue;
       const dynamicOptions = await queryByType(schema, vaultDir, field.source, field.filter);
       if (dynamicOptions.length === 0) {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -145,7 +145,7 @@ export function resolveSchema(schema: Schema): LoadedSchema {
       }
       
       type.fields['parent'] = {
-        prompt: 'dynamic',
+        prompt: 'relation',
         source,
         format: 'wikilink',
         required: false,

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -14,16 +14,16 @@ export const FilterConditionSchema = z.object({
 
 /**
  * Field definition for type frontmatter.
- * Fields can be static values, prompted inputs, or dynamic queries.
+ * Fields can be static values, prompted inputs, or relation queries.
  */
 export const FieldSchema = z.object({
   // Prompt type (how the field is collected)
-  prompt: z.enum(['text', 'select', 'multi-input', 'date', 'dynamic']).optional(),
+  prompt: z.enum(['text', 'select', 'multi-input', 'date', 'relation']).optional(),
   // Static value (no prompting)
   value: z.string().optional(),
   // Enum reference for select prompts
   enum: z.string().optional(),
-  // Type name(s) for dynamic prompts (e.g., "milestone", "objective")
+  // Type name(s) for relation prompts (e.g., "milestone", "objective")
   // When specified, queryByType() fetches notes of this type (and descendants)
   // Can be an array to allow multiple valid types (e.g., for recursive types with extends)
   source: z.union([z.string(), z.array(z.string())]).optional(),

--- a/tests/fixtures/test_schema.json
+++ b/tests/fixtures/test_schema.json
@@ -24,7 +24,7 @@
           "default": "raw"
         },
         "milestone": {
-          "prompt": "dynamic",
+          "prompt": "relation",
           "source": "milestone",
           "filter": { "status": { "not_in": ["settled"] } },
           "format": "quoted-wikilink"

--- a/tests/fixtures/vault/.bwrb/schema.json
+++ b/tests/fixtures/vault/.bwrb/schema.json
@@ -24,7 +24,7 @@
           "default": "raw"
         },
         "milestone": {
-          "prompt": "dynamic",
+          "prompt": "relation",
           "source": "milestone",
           "filter": { "status": { "not_in": ["settled"] } },
           "format": "quoted-wikilink"

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -1446,12 +1446,12 @@ unknownField: should warn
           extends: 'objective',
           fields: {
             milestone: {
-              prompt: 'dynamic',
+              prompt: 'relation',
               source: 'milestone',  // Type-based source
               format: 'wikilink',
             },
             parent: {
-              prompt: 'dynamic',
+              prompt: 'relation',
               source: 'objective',  // Accepts objective or any descendant
               format: 'wikilink',
             },
@@ -1640,7 +1640,7 @@ status: raw
             fields: {
               ...V2_SCHEMA.types.task.fields,
               milestones: {
-                prompt: 'dynamic',
+                prompt: 'relation',
                 source: 'milestone',
                 format: 'wikilink',
                 multiple: true,

--- a/tests/ts/commands/new.pty.test.ts
+++ b/tests/ts/commands/new.pty.test.ts
@@ -46,7 +46,7 @@ const FULL_SCHEMA = {
         type: { value: 'task' },
         status: { prompt: 'select', enum: 'status', default: 'raw' },
         milestone: {
-          prompt: 'dynamic',
+          prompt: 'relation',
           source: 'milestone',
           filter: { status: { not_in: ['settled'] } },
           format: 'quoted-wikilink',

--- a/tests/ts/commands/schema-add-field.pty.test.ts
+++ b/tests/ts/commands/schema-add-field.pty.test.ts
@@ -233,7 +233,7 @@ describePty('bwrb schema add-field PTY tests', () => {
           const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
           const schema = JSON.parse(schemaContent);
           expect(schema.types.task.fields['parent-project']).toMatchObject({
-            prompt: 'dynamic',
+            prompt: 'relation',
             source: 'project',
             format: 'wikilink',
             required: false,
@@ -539,7 +539,7 @@ describePty('bwrb schema add-field PTY tests', () => {
           const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
           const schema = JSON.parse(schemaContent);
           expect(schema.types.note.fields.parent).toMatchObject({
-            prompt: 'dynamic',
+            prompt: 'relation',
             source: 'note',
           });
         },

--- a/tests/ts/commands/schema-add-field.test.ts
+++ b/tests/ts/commands/schema-add-field.test.ts
@@ -115,19 +115,19 @@ describe('schema add-field command', () => {
 
     it('should add a dynamic field with source and format', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'task', 'project', '--type', 'dynamic', '--source', 'project', '--format', 'wikilink', '--output', 'json'],
+        ['schema', 'add-field', 'task', 'project', '--type', 'relation', '--source', 'project', '--format', 'wikilink', '--output', 'json'],
         tempVaultDir
       );
 
       expect(result.exitCode).toBe(0);
       const json = JSON.parse(result.stdout);
-      expect(json.data.definition.prompt).toBe('dynamic');
+      expect(json.data.definition.prompt).toBe('relation');
       expect(json.data.definition.source).toBe('project');
       expect(json.data.definition.format).toBe('wikilink');
 
       const schema = JSON.parse(await readFile(join(tempVaultDir, '.bwrb', 'schema.json'), 'utf-8'));
       expect(schema.types.task.fields.project).toEqual({
-        prompt: 'dynamic',
+        prompt: 'relation',
         source: 'project',
         format: 'wikilink',
       });
@@ -295,7 +295,7 @@ describe('schema add-field command', () => {
 
     it('should reject dynamic without --source', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'parent', '--type', 'dynamic', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'parent', '--type', 'relation', '--output', 'json'],
         tempVaultDir
       );
 
@@ -307,7 +307,7 @@ describe('schema add-field command', () => {
 
     it('should reject dynamic with non-existent source type', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'parent', '--type', 'dynamic', '--source', 'nonexistent', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'parent', '--type', 'relation', '--source', 'nonexistent', '--output', 'json'],
         tempVaultDir
       );
 
@@ -331,7 +331,7 @@ describe('schema add-field command', () => {
 
     it('should reject invalid format value', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'parent', '--type', 'dynamic', '--source', 'note', '--format', 'invalid', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'parent', '--type', 'relation', '--source', 'note', '--format', 'invalid', '--output', 'json'],
         tempVaultDir
       );
 
@@ -519,7 +519,7 @@ describe('schema add-field command', () => {
     it('should detect enum value confusion and provide helpful message', async () => {
       // 'high' is a value in the 'priority' enum, not a type name
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'urgency', '--type', 'dynamic', '--source', 'high', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'urgency', '--type', 'relation', '--source', 'high', '--output', 'json'],
         tempVaultDir
       );
 
@@ -534,7 +534,7 @@ describe('schema add-field command', () => {
     it('should detect path format and suggest using type name directly', async () => {
       // note/task uses path format; task is a valid type
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'related', '--type', 'dynamic', '--source', 'note/task', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'related', '--type', 'relation', '--source', 'note/task', '--output', 'json'],
         tempVaultDir
       );
 
@@ -547,7 +547,7 @@ describe('schema add-field command', () => {
 
     it('should detect path format when neither segment is a valid type', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'related', '--type', 'dynamic', '--source', 'foo/bar', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'related', '--type', 'relation', '--source', 'foo/bar', '--output', 'json'],
         tempVaultDir
       );
 
@@ -561,7 +561,7 @@ describe('schema add-field command', () => {
     it('should suggest similar type names for typos', async () => {
       // 'projec' is close to 'project'
       const result = await runCLI(
-        ['schema', 'add-field', 'note', 'parent-project', '--type', 'dynamic', '--source', 'projec', '--output', 'json'],
+        ['schema', 'add-field', 'note', 'parent-project', '--type', 'relation', '--source', 'projec', '--output', 'json'],
         tempVaultDir
       );
 
@@ -574,7 +574,7 @@ describe('schema add-field command', () => {
 
     it('should list available types when no close match exists', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'related', '--type', 'dynamic', '--source', 'completely-unknown', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'related', '--type', 'relation', '--source', 'completely-unknown', '--output', 'json'],
         tempVaultDir
       );
 
@@ -590,7 +590,7 @@ describe('schema add-field command', () => {
 
     it('should still accept valid source types', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'related-task', '--type', 'dynamic', '--source', 'task', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'related-task', '--type', 'relation', '--source', 'task', '--output', 'json'],
         tempVaultDir
       );
 

--- a/tests/ts/commands/schema-add-type.pty.test.ts
+++ b/tests/ts/commands/schema-add-type.pty.test.ts
@@ -454,7 +454,7 @@ describePty('bwrb schema add-type PTY tests', () => {
           const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
           const schema = JSON.parse(schemaContent);
           expect(schema.types.task.fields['parent-project']).toMatchObject({
-            prompt: 'dynamic',
+            prompt: 'relation',
             source: 'project',
             format: 'wikilink',
             required: false,

--- a/tests/ts/fixtures/setup.ts
+++ b/tests/ts/fixtures/setup.ts
@@ -46,7 +46,7 @@ export const TEST_SCHEMA = {
           required: true,
         },
         milestone: {
-          prompt: 'dynamic',
+          prompt: 'relation',
           source: 'milestone',
           filter: { status: { not_in: ['settled'] } },
           format: 'quoted-wikilink',
@@ -105,7 +105,7 @@ export const TEST_SCHEMA = {
           required: true,
         },
         research: {
-          prompt: 'dynamic',
+          prompt: 'relation',
           source: 'research',
           owned: true,
           format: 'quoted-wikilink',

--- a/tests/ts/lib/numberedSelect.pty.test.ts
+++ b/tests/ts/lib/numberedSelect.pty.test.ts
@@ -553,7 +553,7 @@ describePty('NumberedSelectPrompt PTY tests', () => {
             fields: {
               type: { value: 'item' },
               // Reference a type that doesn't exist - will return no results
-              ref: { prompt: 'dynamic', source: 'nonexistent_type', format: 'wikilink' },
+              ref: { prompt: 'relation', source: 'nonexistent_type', format: 'wikilink' },
             },
             field_order: ['type', 'ref'],
           },

--- a/tests/ts/lib/ownership.test.ts
+++ b/tests/ts/lib/ownership.test.ts
@@ -36,14 +36,14 @@ const createTestVault = () => {
         output_dir: 'drafts',
         fields: {
           research: {
-            prompt: 'dynamic',
+            prompt: 'relation',
             source: 'research',
             format: 'wikilink',
             multiple: true,
             owned: true,
           },
           related: {
-            prompt: 'dynamic',
+            prompt: 'relation',
             source: 'research',
             format: 'wikilink',
             multiple: true,
@@ -60,7 +60,7 @@ const createTestVault = () => {
         output_dir: 'projects',
         fields: {
           notes: {
-            prompt: 'dynamic',
+            prompt: 'relation',
             source: 'research',
             format: 'wikilink',
             multiple: true,

--- a/tests/ts/lib/schema.test.ts
+++ b/tests/ts/lib/schema.test.ts
@@ -387,7 +387,7 @@ describe('schema', () => {
                 fields: {
                   title: { prompt: 'text' },
                   parent: {
-                    prompt: 'dynamic',
+                    prompt: 'relation',
                     source: 'task',
                     format: 'quoted-wikilink',
                     required: true,


### PR DESCRIPTION
## Summary

Renames the `dynamic` prompt type to `relation` as part of the Field Primitives Refactor (#159).

**BREAKING CHANGE**: The prompt type `dynamic` has been renamed to `relation`.

## Changes

- Updated `FieldSchema` prompt enum from `dynamic` to `relation`
- Updated `schema.schema.json` validation
- Updated all command handlers (new, edit, template, schema)
- Updated all documentation examples
- Updated test fixtures and assertions
- All 1313 tests pass

## Migration

Update your schemas:
```json
// Before
{ "prompt": "dynamic", "source": "milestone" }

// After
{ "prompt": "relation", "source": "milestone" }
```

## Rationale

"Relation" is the industry standard term (Notion, Capacities, Airtable) for typed links to other records. This makes the schema more intuitive and aligns with user expectations.

Closes #161
Part of #159