### PR TITLE
feat!: rename 'multi-input' prompt type to 'list'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to Bowerbird are documented in this file.
   - Update your schemas: `{ "prompt": "dynamic" }` → `{ "prompt": "relation" }`
   - CLI flag updated: `--type dynamic` → `--type relation`
 
+- **Renamed `multi-input` prompt type to `list`** (#162)
+  - The prompt type `multi-input` has been renamed to `list` to describe the value type
+  - Update your schemas: `{ "prompt": "multi-input" }` → `{ "prompt": "list" }`
+  - Body sections also updated: `{ "prompt": "multi-input" }` → `{ "prompt": "list" }`
+  - CLI flag updated: `--type multi-input` → `--type list`
+
 ### Fixed
 
 - **Audit similar files suggestions no longer match unrelated files**

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Define document structure after frontmatter:
       "title": "Steps",
       "level": 2,
       "content_type": "checkboxes",
-      "prompt": "multi-input",
+      "prompt": "list",
       "prompt_label": "Steps (comma-separated)"
     },
     {

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -122,8 +122,8 @@
         },
         "prompt": {
           "type": "string",
-          "enum": ["text", "select", "relation", "multi-input"],
-          "description": "Type of prompt: text (free text), select (from enum), relation (from vault query), multi-input (comma-separated list)"
+          "enum": ["text", "select", "relation", "list", "date"],
+          "description": "Type of prompt: text (free text), select (from enum), relation (from vault query), list (comma-separated list), date (date picker)"
         },
         "label": {
           "type": "string",
@@ -153,7 +153,7 @@
         "list_format": {
           "type": "string",
           "enum": ["yaml-array", "comma-separated"],
-          "description": "For multi-input fields, how to format the list"
+          "description": "For list fields, how to format the list"
         }
       }
     },
@@ -181,7 +181,7 @@
         },
         "prompt": {
           "type": "string",
-          "enum": ["multi-input"],
+          "enum": ["list"],
           "description": "If set, prompts user for initial content during creation"
         },
         "prompt_label": {

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -751,7 +751,7 @@ async function buildNoteContent(
   // If no template, prompt for schema body_sections from scratch
   let body = '';
   const bodySections = typeDef.bodySections;
-  const promptableSections = bodySections?.filter(s => s.prompt === 'multi-input') ?? [];
+  const promptableSections = bodySections?.filter(s => s.prompt === 'list') ?? [];
   
   if (template?.body) {
     // Start with processed template body
@@ -1043,7 +1043,7 @@ async function promptField(
       return value;
     }
 
-    case 'multi-input': {
+    case 'list': {
       const label = field.label ?? fieldName;
       const items = await promptMultiInput(label);
       if (items === null) {
@@ -1098,7 +1098,7 @@ async function promptBodySections(
   const content = new Map<string, string[]>();
 
   for (const section of sections) {
-    if (section.prompt === 'multi-input' && section.prompt_label) {
+    if (section.prompt === 'list' && section.prompt_label) {
       // If we have a template body, extract existing items and show them
       if (templateBody) {
         const existingItems = extractSectionItems(

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -747,7 +747,7 @@ async function promptFieldDefault(
       return formatValue(selected, field.format);
     }
 
-    case 'multi-input': {
+    case 'list': {
       console.log(`Default ${label} (comma-separated values, or Enter to skip):`);
       const values = await promptMultiInput('');
       if (values === null) throw new UserCancelledError();
@@ -1204,7 +1204,7 @@ async function promptFieldDefaultEdit(
       return formatValue(selected, field.format);
     }
 
-    case 'multi-input': {
+    case 'list': {
       console.log(`New ${label} (comma-separated, Enter to keep, "clear" to remove):`);
       const input = await promptInput('');
       if (input === null) throw new UserCancelledError();

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -133,7 +133,7 @@ export function generateBodySections(sections: BodySection[]): string {
 }
 
 /**
- * Generate body content with prompted values for multi-input sections.
+ * Generate body content with prompted values for list sections.
  */
 export function generateBodyWithContent(
   sections: BodySection[],

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -536,7 +536,7 @@ function validateFieldValue(
   }
   
   // Validate prompt type compatibility
-  if (field.prompt === 'multi-input' && !Array.isArray(value)) {
+  if (field.prompt === 'list' && !Array.isArray(value)) {
     issues.push({
       severity: 'warning',
       message: `Field '${fieldName}' expects an array but got ${typeof value}`,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -172,8 +172,8 @@ function validateFieldType(
   value: unknown,
   field: Field
 ): ValidationError | null {
-  // Handle array fields (multi-input)
-  if (field.prompt === 'multi-input' || field.list_format) {
+  // Handle list fields (multi-value arrays or comma-separated strings)
+  if (field.prompt === 'list' || field.list_format) {
     // Accept both arrays and strings for list fields
     if (!Array.isArray(value) && typeof value !== 'string') {
       return {

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -18,7 +18,7 @@ export const FilterConditionSchema = z.object({
  */
 export const FieldSchema = z.object({
   // Prompt type (how the field is collected)
-  prompt: z.enum(['text', 'select', 'multi-input', 'date', 'relation']).optional(),
+  prompt: z.enum(['text', 'select', 'list', 'date', 'relation']).optional(),
   // Static value (no prompting)
   value: z.string().optional(),
   // Enum reference for select prompts
@@ -52,7 +52,7 @@ export const BodySectionSchema: z.ZodType<BodySection, z.ZodTypeDef, BodySection
     title: z.string(),
     level: z.number().optional().default(2),
     content_type: z.enum(['none', 'paragraphs', 'bullets', 'checkboxes']).optional(),
-    prompt: z.enum(['none', 'multi-input']).optional(),
+    prompt: z.enum(['none', 'list']).optional(),
     prompt_label: z.string().optional(),
     children: z.array(BodySectionSchema).optional(),
   })
@@ -138,7 +138,7 @@ export type BodySection = {
   title: string;
   level?: number | undefined;
   content_type?: 'none' | 'paragraphs' | 'bullets' | 'checkboxes' | undefined;
-  prompt?: 'none' | 'multi-input' | undefined;
+  prompt?: 'none' | 'list' | undefined;
   prompt_label?: string | undefined;
   children?: BodySection[] | undefined;
 };
@@ -146,7 +146,7 @@ export type BodySectionInput = {
   title: string;
   level?: number | undefined;
   content_type?: 'none' | 'paragraphs' | 'bullets' | 'checkboxes' | undefined;
-  prompt?: 'none' | 'multi-input' | undefined;
+  prompt?: 'none' | 'list' | undefined;
   prompt_label?: string | undefined;
   children?: BodySectionInput[] | undefined;
 };

--- a/tests/fixtures/test_schema.json
+++ b/tests/fixtures/test_schema.json
@@ -44,7 +44,7 @@
           "title": "Steps",
           "level": 2,
           "content_type": "checkboxes",
-          "prompt": "multi-input",
+          "prompt": "list",
           "prompt_label": "Steps (comma-separated)"
         },
         {

--- a/tests/fixtures/vault/.bwrb/schema.json
+++ b/tests/fixtures/vault/.bwrb/schema.json
@@ -44,7 +44,7 @@
           "title": "Steps",
           "level": 2,
           "content_type": "checkboxes",
-          "prompt": "multi-input",
+          "prompt": "list",
           "prompt_label": "Steps (comma-separated)"
         },
         {

--- a/tests/ts/commands/new.pty.test.ts
+++ b/tests/ts/commands/new.pty.test.ts
@@ -54,7 +54,7 @@ const FULL_SCHEMA = {
       },
       field_order: ['type', 'status', 'milestone'],
       body_sections: [
-        { title: 'Steps', level: 2, content_type: 'checkboxes', prompt: 'multi-input', prompt_label: 'Steps' },
+        { title: 'Steps', level: 2, content_type: 'checkboxes', prompt: 'list', prompt_label: 'Steps' },
         { title: 'Notes', level: 2, content_type: 'paragraphs' },
       ],
     },

--- a/tests/ts/commands/schema-add-field.pty.test.ts
+++ b/tests/ts/commands/schema-add-field.pty.test.ts
@@ -195,7 +195,7 @@ describePty('bwrb schema add-field PTY tests', () => {
           const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
           const schema = JSON.parse(schemaContent);
           expect(schema.types.project.fields.tags).toMatchObject({
-            prompt: 'multi-input',
+            prompt: 'list',
             required: false,
           });
         },

--- a/tests/ts/commands/schema-add-field.test.ts
+++ b/tests/ts/commands/schema-add-field.test.ts
@@ -101,16 +101,16 @@ describe('schema add-field command', () => {
 
     it('should add a multi-input field', async () => {
       const result = await runCLI(
-        ['schema', 'add-field', 'project', 'tags', '--type', 'multi-input', '--output', 'json'],
+        ['schema', 'add-field', 'project', 'tags', '--type', 'list', '--output', 'json'],
         tempVaultDir
       );
 
       expect(result.exitCode).toBe(0);
       const json = JSON.parse(result.stdout);
-      expect(json.data.definition.prompt).toBe('multi-input');
+      expect(json.data.definition.prompt).toBe('list');
 
       const schema = JSON.parse(await readFile(join(tempVaultDir, '.bwrb', 'schema.json'), 'utf-8'));
-      expect(schema.types.project.fields.tags).toEqual({ prompt: 'multi-input' });
+      expect(schema.types.project.fields.tags).toEqual({ prompt: 'list' });
     });
 
     it('should add a dynamic field with source and format', async () => {

--- a/tests/ts/commands/schema-add-type.pty.test.ts
+++ b/tests/ts/commands/schema-add-type.pty.test.ts
@@ -402,7 +402,7 @@ describePty('bwrb schema add-type PTY tests', () => {
           const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
           const schema = JSON.parse(schemaContent);
           expect(schema.types.task.fields.tags).toMatchObject({
-            prompt: 'multi-input',
+            prompt: 'list',
             required: false,
           });
         },

--- a/tests/ts/fixtures/setup.ts
+++ b/tests/ts/fixtures/setup.ts
@@ -54,14 +54,14 @@ export const TEST_SCHEMA = {
         'creation-date': { value: '$NOW' },
         deadline: { prompt: 'text', label: 'Deadline (YYYY-MM-DD)' },
         tags: {
-          prompt: 'multi-input',
+          prompt: 'list',
           list_format: 'yaml-array',
           default: [],
         },
       },
       field_order: ['type', 'status', 'milestone', 'creation-date', 'deadline', 'tags'],
       body_sections: [
-        { title: 'Steps', level: 2, content_type: 'checkboxes', prompt: 'multi-input', prompt_label: 'Steps' },
+        { title: 'Steps', level: 2, content_type: 'checkboxes', prompt: 'list', prompt_label: 'Steps' },
         { title: 'Notes', level: 2, content_type: 'paragraphs' },
       ],
     },

--- a/tests/ts/lib/migration/diff.test.ts
+++ b/tests/ts/lib/migration/diff.test.ts
@@ -30,7 +30,7 @@ describe("diffSchemas", () => {
       note: {
         output_dir: "Notes",
         fields: {
-          tags: { prompt: "multi-input" },
+          tags: { prompt: "list" },
         },
       },
     },

--- a/tests/ts/lib/prompt-multiinput.pty.test.ts
+++ b/tests/ts/lib/prompt-multiinput.pty.test.ts
@@ -40,7 +40,7 @@ const TASK_SCHEMA = {
           title: 'Steps',
           level: 2,
           content_type: 'checkboxes',
-          prompt: 'multi-input',
+          prompt: 'list',
           prompt_label: 'Steps (comma-separated)',
         },
         {


### PR DESCRIPTION
## Summary

Renames the `multi-input` prompt type to `list` as part of the Field Primitives Refactor (#159).

**BREAKING CHANGE**: The prompt type `multi-input` has been renamed to `list`.

## Changes

- Updated `FieldSchema` prompt enum from `multi-input` to `list`
- Updated `BodySectionSchema` prompt enum from `multi-input` to `list`
- Updated `schema.schema.json` validation
- Updated all command handlers (new, edit, template, schema)
- Updated all documentation examples
- Updated test fixtures and assertions
- All 1313 tests pass

## Migration

Update your schemas:
```json
// Before (field)
{ "prompt": "multi-input" }

// After (field)
{ "prompt": "list" }

// Before (body section)
{ "prompt": "multi-input", "prompt_label": "Items" }

// After (body section)
{ "prompt": "list", "prompt_label": "Items" }
```

## Rationale

The name `list` describes the **value type** (an array of strings), not the UX (multi-input).

Closes #162
Part of #159