### PR TITLE
feat!: add boolean field primitive type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **New `boolean` field primitive** (#163)
+  - Fields can now use `prompt: "boolean"` for yes/no values
+  - Uses Y/n confirmation prompt during note creation
+  - Stored as YAML boolean literals: `completed: true` or `archived: false`
+  - Example: `{ "completed": { "prompt": "boolean", "default": false } }`
+
 ### Changed (Breaking)
 
 - **Renamed `input` prompt type to `text`** (#160)

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -122,8 +122,8 @@
         },
         "prompt": {
           "type": "string",
-          "enum": ["text", "select", "relation", "list", "date"],
-          "description": "Type of prompt: text (free text), select (from enum), relation (from vault query), list (comma-separated list), date (date picker)"
+          "enum": ["text", "select", "relation", "list", "date", "boolean"],
+          "description": "Type of prompt: text (free text), select (from enum), relation (from vault query), list (comma-separated list), date (date picker), boolean (yes/no)"
         },
         "label": {
           "type": "string",

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1065,6 +1065,15 @@ async function promptField(
       return value;
     }
 
+    case 'boolean': {
+      const label = field.label ?? fieldName;
+      const result = await promptConfirm(label);
+      if (result === null) {
+        throw new UserCancelledError();
+      }
+      return result;
+    }
+
     default:
       return field.default;
   }

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -250,6 +250,7 @@ async function promptFieldDefinition(
     'date',
     'list (multi-value)',
     'relation (from other notes)',
+    'boolean (yes/no)',
     'fixed value',
   ];
   const promptTypeResult = await promptSelection('Prompt type', promptTypes);
@@ -262,7 +263,8 @@ async function promptFieldDefinition(
     2: 'date',
     3: 'list',
     4: 'relation',
-    5: 'value',
+    5: 'boolean',
+    6: 'value',
   };
   const promptType = promptTypeMap[promptTypeIndex];
   
@@ -537,9 +539,9 @@ function buildFieldFromOptions(
     field.value = options.value;
   } else if (promptType) {
     // Validate prompt type
-    const validPromptTypes = ['text', 'select', 'date', 'list', 'relation'];
+    const validPromptTypes = ['text', 'select', 'date', 'list', 'relation', 'boolean'];
     if (!validPromptTypes.includes(promptType)) {
-      throw new Error(`Invalid prompt type "${promptType}". Valid types: text, select, date, list, relation, fixed`);
+      throw new Error(`Invalid prompt type "${promptType}". Valid types: text, select, date, list, relation, boolean, fixed`);
     }
     
     field.prompt = promptType as Field['prompt'];
@@ -627,6 +629,7 @@ async function promptSingleFieldDefinition(
     'date',
     'list (multi-value)',
     'relation (from other notes)',
+    'boolean (yes/no)',
     'fixed value',
   ];
   const promptTypeResult = await promptSelection('Prompt type', promptTypes);
@@ -639,7 +642,8 @@ async function promptSingleFieldDefinition(
     2: 'date',
     3: 'list',
     4: 'relation',
-    5: 'value',
+    5: 'boolean',
+    6: 'value',
   };
   const promptType = promptTypeMap[promptTypeIndex];
   
@@ -1974,6 +1978,8 @@ function getFieldType(field: Field): string {
       return chalk.blue('date');
     case 'relation':
       return field.source ? chalk.blue(`relation:${field.source}`) : chalk.blue('relation');
+    case 'boolean':
+      return chalk.blue('boolean');
     default:
       return chalk.gray('auto');
   }
@@ -2412,7 +2418,7 @@ newCommand
             throw new Error(`Invalid field definition: "${fieldDef}". Use "name:type" format.`);
           }
           // Map simple type strings to field definitions
-          const promptType = fieldType as 'text' | 'select' | 'date' | 'relation';
+          const promptType = fieldType as 'text' | 'select' | 'date' | 'list' | 'relation' | 'boolean';
           fields[fieldName] = { prompt: promptType };
         }
       } else if (!jsonMode) {
@@ -2897,7 +2903,7 @@ editCommand
         }
 
         if (choice === 'Change prompt type') {
-          const promptOptions = ['text', 'select', 'list', 'date', 'relation'];
+          const promptOptions = ['text', 'select', 'list', 'date', 'relation', 'boolean'];
           const newPrompt = await promptSelection('Prompt type', promptOptions);
           const fieldEntry = rawTypeEntry.fields?.[fieldName];
           if (newPrompt !== null && fieldEntry) {

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -389,6 +389,18 @@ async function promptFieldEdit(
       return newValue || currentValue;
     }
 
+    case 'boolean': {
+      const label = field.label ?? fieldName;
+      const currentBool = currentValue === true || currentValue === 'true';
+      const displayCurrent = currentBool ? 'yes' : 'no';
+      printInfo(`Current ${label}: ${displayCurrent}`);
+      const result = await promptConfirm(`New ${label}`);
+      if (result === null) {
+        throw new UserCancelledError();
+      }
+      return result;
+    }
+
     default:
       return currentValue;
   }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -212,6 +212,21 @@ function validateFieldType(
     return null;
   }
 
+  // Boolean fields
+  if (field.prompt === 'boolean') {
+    // Accept actual booleans, or string representations
+    if (typeof value !== 'boolean' && value !== 'true' && value !== 'false') {
+      return {
+        type: 'invalid_type',
+        field: fieldName,
+        value,
+        message: `Invalid type for ${fieldName}: expected boolean, got ${typeof value}`,
+        expected: 'boolean (true/false)',
+      };
+    }
+    return null;
+  }
+
   // String fields (most common)
   // Allow strings, numbers, and booleans as they can be serialized
   if (typeof value === 'object' && !Array.isArray(value) && value !== null) {

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -18,7 +18,7 @@ export const FilterConditionSchema = z.object({
  */
 export const FieldSchema = z.object({
   // Prompt type (how the field is collected)
-  prompt: z.enum(['text', 'select', 'list', 'date', 'relation']).optional(),
+  prompt: z.enum(['text', 'select', 'list', 'date', 'relation', 'boolean']).optional(),
   // Static value (no prompting)
   value: z.string().optional(),
   // Enum reference for select prompts

--- a/tests/ts/commands/schema-add-field.pty.test.ts
+++ b/tests/ts/commands/schema-add-field.pty.test.ts
@@ -251,7 +251,7 @@ describePty('bwrb schema add-field PTY tests', () => {
           await proc.typeAndEnter('type');
 
           await proc.waitFor('Prompt type');
-          proc.write('6'); // fixed value
+          proc.write('7'); // fixed value
 
           await proc.waitFor('Fixed value');
           await proc.typeAndEnter('project');
@@ -447,7 +447,7 @@ describePty('bwrb schema add-field PTY tests', () => {
           await proc.typeAndEnter('type');
 
           await proc.waitFor('Prompt type');
-          proc.write('6'); // fixed value
+          proc.write('7'); // fixed value
 
           await proc.waitFor('Fixed value');
           proc.write(Keys.CTRL_C);

--- a/tests/ts/commands/schema-add-type.pty.test.ts
+++ b/tests/ts/commands/schema-add-type.pty.test.ts
@@ -481,7 +481,7 @@ describePty('bwrb schema add-type PTY tests', () => {
           await proc.typeAndEnter('type');
 
           await proc.waitFor('Prompt type');
-          proc.write('6'); // fixed value
+          proc.write('7'); // fixed value
 
           await proc.waitFor('Fixed value');
           await proc.typeAndEnter('task');


### PR DESCRIPTION
## Summary

Add `boolean` as a new prompt type for true/false fields in schemas.

- Add `'boolean'` to prompt enum in schema types
- Add boolean case handler in `new.ts` using `promptConfirm()`
- Add boolean case handler in `edit.ts` with current value display
- Update schema wizard to include boolean as option 6
- Add boolean validation in `validation.ts`
- Update `schema.schema.json` with boolean enum value
- Fix PTY tests for updated wizard option numbering

**BREAKING CHANGE**: Schema changes - new prompt type available

## Usage

```json
{
  "fields": {
    "completed": {
      "prompt": "boolean",
      "description": "Is this task completed?"
    }
  }
}
```

When creating/editing notes, users will see a yes/no confirm prompt.

## Testing

- All 1313 tests pass
- PTY tests updated for new wizard option numbering

Closes #163