### PR TITLE
feat!: add number field primitive type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to Bowerbird are documented in this file.
   - Stored as YAML boolean literals: `completed: true` or `archived: false`
   - Example: `{ "completed": { "prompt": "boolean", "default": false } }`
 
+- **New `number` field primitive** (#164)
+  - Fields can now use `prompt: "number"` for numeric values
+  - Supports both integers and floating-point numbers
+  - Stored as YAML number literals: `priority: 1` or `rating: 4.5`
+  - Example: `{ "priority": { "prompt": "number", "default": 0 } }`
+
 ### Changed (Breaking)
 
 - **Renamed `input` prompt type to `text`** (#160)

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -122,8 +122,8 @@
         },
         "prompt": {
           "type": "string",
-          "enum": ["text", "select", "relation", "list", "date", "boolean"],
-          "description": "Type of prompt: text (free text), select (from enum), relation (from vault query), list (comma-separated list), date (date picker), boolean (yes/no)"
+          "enum": ["text", "select", "relation", "list", "date", "boolean", "number"],
+          "description": "Type of prompt: text (free text), select (from enum), relation (from vault query), list (comma-separated list), date (date picker), boolean (yes/no), number (numeric input)"
         },
         "label": {
           "type": "string",

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1074,6 +1074,27 @@ async function promptField(
       return result;
     }
 
+    case 'number': {
+      const label = field.label ?? fieldName;
+      const defaultVal = field.default !== undefined ? String(field.default) : undefined;
+      // Loop until valid input
+      while (true) {
+        const value = await promptInput(label, defaultVal);
+        if (value === null) {
+          throw new UserCancelledError();
+        }
+        if (value === '') {
+          return field.default;
+        }
+        const parsed = parseFloat(value);
+        if (isNaN(parsed)) {
+          printWarning(`Invalid number: "${value}". Please enter a valid number.`);
+          continue;
+        }
+        return parsed;
+      }
+    }
+
     default:
       return field.default;
   }

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -251,6 +251,7 @@ async function promptFieldDefinition(
     'list (multi-value)',
     'relation (from other notes)',
     'boolean (yes/no)',
+    'number (numeric)',
     'fixed value',
   ];
   const promptTypeResult = await promptSelection('Prompt type', promptTypes);
@@ -264,7 +265,8 @@ async function promptFieldDefinition(
     3: 'list',
     4: 'relation',
     5: 'boolean',
-    6: 'value',
+    6: 'number',
+    7: 'value',
   };
   const promptType = promptTypeMap[promptTypeIndex];
   
@@ -539,9 +541,9 @@ function buildFieldFromOptions(
     field.value = options.value;
   } else if (promptType) {
     // Validate prompt type
-    const validPromptTypes = ['text', 'select', 'date', 'list', 'relation', 'boolean'];
+    const validPromptTypes = ['text', 'select', 'date', 'list', 'relation', 'boolean', 'number'];
     if (!validPromptTypes.includes(promptType)) {
-      throw new Error(`Invalid prompt type "${promptType}". Valid types: text, select, date, list, relation, boolean, fixed`);
+      throw new Error(`Invalid prompt type "${promptType}". Valid types: text, select, date, list, relation, boolean, number, fixed`);
     }
     
     field.prompt = promptType as Field['prompt'];
@@ -630,6 +632,7 @@ async function promptSingleFieldDefinition(
     'list (multi-value)',
     'relation (from other notes)',
     'boolean (yes/no)',
+    'number (numeric)',
     'fixed value',
   ];
   const promptTypeResult = await promptSelection('Prompt type', promptTypes);
@@ -643,7 +646,8 @@ async function promptSingleFieldDefinition(
     3: 'list',
     4: 'relation',
     5: 'boolean',
-    6: 'value',
+    6: 'number',
+    7: 'value',
   };
   const promptType = promptTypeMap[promptTypeIndex];
   
@@ -1980,6 +1984,8 @@ function getFieldType(field: Field): string {
       return field.source ? chalk.blue(`relation:${field.source}`) : chalk.blue('relation');
     case 'boolean':
       return chalk.blue('boolean');
+    case 'number':
+      return chalk.blue('number');
     default:
       return chalk.gray('auto');
   }
@@ -2418,7 +2424,7 @@ newCommand
             throw new Error(`Invalid field definition: "${fieldDef}". Use "name:type" format.`);
           }
           // Map simple type strings to field definitions
-          const promptType = fieldType as 'text' | 'select' | 'date' | 'list' | 'relation' | 'boolean';
+          const promptType = fieldType as 'text' | 'select' | 'date' | 'list' | 'relation' | 'boolean' | 'number';
           fields[fieldName] = { prompt: promptType };
         }
       } else if (!jsonMode) {
@@ -2903,7 +2909,7 @@ editCommand
         }
 
         if (choice === 'Change prompt type') {
-          const promptOptions = ['text', 'select', 'list', 'date', 'relation', 'boolean'];
+          const promptOptions = ['text', 'select', 'list', 'date', 'relation', 'boolean', 'number'];
           const newPrompt = await promptSelection('Prompt type', promptOptions);
           const fieldEntry = rawTypeEntry.fields?.[fieldName];
           if (newPrompt !== null && fieldEntry) {

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -401,6 +401,28 @@ async function promptFieldEdit(
       return result;
     }
 
+    case 'number': {
+      const label = field.label ?? fieldName;
+      const currentNum = typeof currentValue === 'number' ? currentValue : parseFloat(String(currentValue));
+      const displayCurrent = isNaN(currentNum) ? '<empty>' : String(currentNum);
+      // Loop until valid input
+      while (true) {
+        const newValue = await promptInput(`New ${label} (or Enter to keep "${displayCurrent}")`);
+        if (newValue === null) {
+          throw new UserCancelledError();
+        }
+        if (newValue === '') {
+          return currentValue;
+        }
+        const parsed = parseFloat(newValue);
+        if (isNaN(parsed)) {
+          printWarning(`Invalid number: "${newValue}". Please enter a valid number.`);
+          continue;
+        }
+        return parsed;
+      }
+    }
+
     default:
       return currentValue;
   }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -227,6 +227,27 @@ function validateFieldType(
     return null;
   }
 
+  // Number fields
+  if (field.prompt === 'number') {
+    // Accept numbers or numeric strings
+    if (typeof value === 'number') {
+      return null;
+    }
+    if (typeof value === 'string') {
+      const parsed = parseFloat(value);
+      if (!isNaN(parsed)) {
+        return null;
+      }
+    }
+    return {
+      type: 'invalid_type',
+      field: fieldName,
+      value,
+      message: `Invalid type for ${fieldName}: expected number, got ${typeof value}`,
+      expected: 'number',
+    };
+  }
+
   // String fields (most common)
   // Allow strings, numbers, and booleans as they can be serialized
   if (typeof value === 'object' && !Array.isArray(value) && value !== null) {

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -18,7 +18,7 @@ export const FilterConditionSchema = z.object({
  */
 export const FieldSchema = z.object({
   // Prompt type (how the field is collected)
-  prompt: z.enum(['text', 'select', 'list', 'date', 'relation', 'boolean']).optional(),
+  prompt: z.enum(['text', 'select', 'list', 'date', 'relation', 'boolean', 'number']).optional(),
   // Static value (no prompting)
   value: z.string().optional(),
   // Enum reference for select prompts

--- a/tests/ts/commands/schema-add-field.pty.test.ts
+++ b/tests/ts/commands/schema-add-field.pty.test.ts
@@ -251,7 +251,7 @@ describePty('bwrb schema add-field PTY tests', () => {
           await proc.typeAndEnter('type');
 
           await proc.waitFor('Prompt type');
-          proc.write('7'); // fixed value
+          proc.write('8'); // fixed value
 
           await proc.waitFor('Fixed value');
           await proc.typeAndEnter('project');
@@ -447,7 +447,7 @@ describePty('bwrb schema add-field PTY tests', () => {
           await proc.typeAndEnter('type');
 
           await proc.waitFor('Prompt type');
-          proc.write('7'); // fixed value
+          proc.write('8'); // fixed value
 
           await proc.waitFor('Fixed value');
           proc.write(Keys.CTRL_C);

--- a/tests/ts/commands/schema-add-type.pty.test.ts
+++ b/tests/ts/commands/schema-add-type.pty.test.ts
@@ -481,7 +481,7 @@ describePty('bwrb schema add-type PTY tests', () => {
           await proc.typeAndEnter('type');
 
           await proc.waitFor('Prompt type');
-          proc.write('7'); // fixed value
+          proc.write('8'); // fixed value
 
           await proc.waitFor('Fixed value');
           await proc.typeAndEnter('task');


### PR DESCRIPTION
## Summary

Add `number` as a new prompt type for numeric fields in schemas.

- Add `'number'` to prompt enum in schema types
- Add number case handler in `new.ts` with validation loop (re-prompts on invalid input)
- Add number case handler in `edit.ts` with validation loop
- Update schema wizard to include number as option 7
- Add number validation in `validation.ts` (accepts numbers and numeric strings)
- Update `schema.schema.json` with number enum value
- Fix PTY tests for updated wizard option numbering

**BREAKING CHANGE**: Schema changes - new prompt type available

## Usage

```json
{
  "fields": {
    "priority": {
      "prompt": "number",
      "default": 0
    }
  }
}
```

Values are stored as YAML number literals: `priority: 5` or `rating: 4.5`

## Use Cases
- Priority levels (1-5)
- Word counts
- Ratings/scores
- Sort order
- Revision numbers

## Testing

- All 1313 tests pass
- Invalid input re-prompts user rather than silently defaulting to 0
- PTY tests updated for new wizard option numbering

Closes #164