### PR TITLE
feat: add multiple: true support for multi-select fields (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Added
 
+- **Multi-select support for select fields** (#166)
+  - Select fields can now allow multiple selections via `multiple: true`
+  - Interactive prompt uses checkboxes (Space to select, Enter to confirm)
+  - Values stored as YAML arrays: `tags: [urgent, blocked]`
+  - Validation ensures all selected values are valid options
+  - Example: `{ "tags": { "prompt": "select", "options": ["urgent", "blocked", "review"], "multiple": true } }`
+
 - **New `boolean` field primitive** (#163)
   - Fields can now use `prompt: "boolean"` for yes/no values
   - Uses Y/n confirmation prompt during note creation

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -24,6 +24,7 @@ import {
 } from '../lib/vault.js';
 import {
   promptSelection,
+  promptMultiSelect,
   promptInput,
   promptRequired,
   promptMultiInput,
@@ -971,6 +972,17 @@ async function promptField(
       if (!field.options || field.options.length === 0) return field.default;
       const selectOptions = field.options;
       
+      // Multi-select mode
+      if (field.multiple) {
+        const selected = await promptMultiSelect(`Select ${fieldName}:`, selectOptions);
+        if (selected === null) {
+          throw new UserCancelledError();
+        }
+        // Return array (may be empty if nothing selected)
+        return selected.length > 0 ? selected : (field.default ?? []);
+      }
+      
+      // Single-select mode
       // For optional fields, add a skip option
       let options: string[];
       let skipLabel: string | undefined;

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -16,6 +16,7 @@ import { parseNote, writeNote, generateBodySections } from './frontmatter.js';
 import { queryByType, formatValue } from './vault.js';
 import {
   promptSelection,
+  promptMultiSelect,
   promptInput,
   promptConfirm,
   printSuccess,
@@ -339,6 +340,22 @@ async function promptFieldEdit(
       if (!field.options || field.options.length === 0) return currentValue;
       const selectOptions = field.options;
       
+      // Multi-select mode
+      if (field.multiple) {
+        // Convert current value to array for display
+        const currentArr = Array.isArray(currentValue) ? currentValue : 
+          (currentValue ? [String(currentValue)] : []);
+        console.log(`Current ${fieldName}: ${currentArr.length > 0 ? currentArr.join(', ') : '(none)'}`);
+        
+        const selected = await promptMultiSelect(`New ${fieldName}:`, selectOptions);
+        if (selected === null) {
+          throw new UserCancelledError();
+        }
+        // Return current value if nothing selected (keep current)
+        return selected.length > 0 ? selected : currentValue;
+      }
+      
+      // Single-select mode
       // Add a "keep current" option at the top
       const keepLabel = '(keep current)';
       const options = [keepLabel, ...selectOptions];

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -61,6 +61,36 @@ export async function promptSelection(
   return numberedSelect(message, options);
 }
 
+/**
+ * Prompt for multi-selection from a list of options (checkboxes).
+ * Returns the array of selected values, or null if user cancels (Ctrl+C/Escape).
+ * An empty selection (no items checked) returns an empty array, not null.
+ * 
+ * Features:
+ * - Space to toggle selection
+ * - Arrow keys for navigation
+ * - Enter to confirm selection
+ * - 'a' to toggle all
+ */
+export async function promptMultiSelect(
+  message: string,
+  options: string[]
+): Promise<PromptResult<string[]>> {
+  const response = await prompts({
+    type: 'multiselect',
+    name: 'value',
+    message,
+    choices: options.map(opt => ({ title: opt, value: opt })),
+    hint: '- Space to select. Enter to submit',
+  });
+
+  // prompts returns {} on Ctrl+C, so response.value is undefined
+  if (response.value === undefined) {
+    return null; // User cancelled
+  }
+  return response.value as string[];
+}
+
 // ============================================================================
 // Text Input Prompts (powered by prompts npm package)
 // ============================================================================

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -81,7 +81,24 @@ export function validateFrontmatter(
     // Validate select fields with options
     if (hasValue && field.options && field.options.length > 0) {
       const validOptions = field.options;
-      if (!validOptions.includes(String(value))) {
+      
+      // Handle multi-select (array values)
+      if (field.multiple && Array.isArray(value)) {
+        for (const item of value) {
+          if (!validOptions.includes(String(item))) {
+            const suggestion = suggestEnumValue(String(item), validOptions);
+            errors.push({
+              type: 'invalid_enum_value',
+              field: fieldName,
+              value: item,
+              message: `Invalid value for ${fieldName}: "${item}"`,
+              expected: validOptions,
+              ...(suggestion && { suggestion: `Did you mean '${suggestion}'?` }),
+            });
+          }
+        }
+      } else if (!Array.isArray(value) && !validOptions.includes(String(value))) {
+        // Single-select validation
         const suggestion = suggestEnumValue(String(value), validOptions);
         errors.push({
           type: 'invalid_enum_value',

--- a/tests/ts/commands/bulk.test.ts
+++ b/tests/ts/commands/bulk.test.ts
@@ -308,12 +308,12 @@ describe('bulk command', () => {
     });
 
     it('should create array for new field', async () => {
-      const result = await runCLI(['bulk', 'idea', '--all', '--append', 'labels=first', '--execute'], tempVaultDir);
+      const result = await runCLI(['bulk', 'idea', '--all', '--append', 'labels=urgent', '--execute'], tempVaultDir);
       
       expect(result.exitCode).toBe(0);
 
       const { frontmatter } = await parseNote(join(tempVaultDir, 'Ideas', 'Sample Idea.md'));
-      expect(frontmatter.labels).toEqual(['first']);
+      expect(frontmatter.labels).toEqual(['urgent']);
     });
 
     it('should convert scalar to array when appending', async () => {

--- a/tests/ts/commands/template.pty.test.ts
+++ b/tests/ts/commands/template.pty.test.ts
@@ -134,6 +134,10 @@ describePty('template command PTY tests', () => {
           await proc.waitFor('priority', 5000);
           proc.write('1'); // Select (skip)
 
+          // Wait for labels prompt (multi-select) and skip
+          await proc.waitFor('labels', 5000);
+          proc.write('\r'); // Just press Enter to skip (no selections)
+
           // Force prompt for fields
           await proc.waitFor('Force prompting', 5000);
           proc.write('n');

--- a/tests/ts/fixtures/setup.ts
+++ b/tests/ts/fixtures/setup.ts
@@ -86,8 +86,13 @@ export const TEST_SCHEMA = {
           required: true,
         },
         priority: { prompt: 'select', options: ['low', 'medium', 'high'] },
+        labels: {
+          prompt: 'select',
+          options: ['urgent', 'blocked', 'review', 'wip'],
+          multiple: true,
+        },
       },
-      field_order: ['type', 'status', 'priority'],
+      field_order: ['type', 'status', 'priority', 'labels'],
     },
     // Ownership types - project owns research notes
     project: {

--- a/tests/ts/lib/validation.test.ts
+++ b/tests/ts/lib/validation.test.ts
@@ -58,6 +58,42 @@ describe('validation', () => {
       expect(result.errors[0].suggestion).toContain('raw');
     });
 
+    it('should validate multi-select fields with valid array values', () => {
+      const result = validateFrontmatter(schema, 'idea', {
+        type: 'idea',
+        status: 'raw',
+        labels: ['urgent', 'blocked'],
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should fail multi-select fields with invalid array values', () => {
+      const result = validateFrontmatter(schema, 'idea', {
+        type: 'idea',
+        status: 'raw',
+        labels: ['urgent', 'invalid-label'],
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].type).toBe('invalid_enum_value');
+      expect(result.errors[0].field).toBe('labels');
+      expect(result.errors[0].value).toBe('invalid-label');
+    });
+
+    it('should validate empty array for multi-select fields', () => {
+      const result = validateFrontmatter(schema, 'idea', {
+        type: 'idea',
+        status: 'raw',
+        labels: [],
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
     it('should warn on unknown fields in non-strict mode', () => {
       const result = validateFrontmatter(schema, 'idea', {
         type: 'idea',


### PR DESCRIPTION
## Summary

- Adds `multiple: true` support for select fields, enabling multi-select with checkboxes
- Values stored as YAML arrays: `tags: [urgent, blocked]`
- Validation ensures all selected values are valid options

Closes #166

## Changes

- `src/lib/prompt.ts` - Added `promptMultiSelect()` using prompts multiselect type
- `src/commands/new.ts` - Uses multi-select prompt when `field.multiple` is true
- `src/lib/edit.ts` - Handles multi-select editing
- `src/lib/validation.ts` - Validates array values against options
- Added multi-select tests to `tests/ts/lib/validation.test.ts`
- Added `labels` multi-select field to test fixtures

## Example

```json
{
  "tags": {
    "prompt": "select",
    "options": ["urgent", "blocked", "review", "wip"],
    "multiple": true
  }
}
```

## Testing

All 1277 tests pass (3 new tests added for multi-select validation).

## Future Considerations

Product/devex reviews noted these edge cases for potential follow-up:
- Semantics of `required: true` + `multiple: true` (at least one selection?)
- Clearing multi-select values to empty in edit mode
- Type enforcement when scalar provided for multi-select field