### PR TITLE
feat: integrate config.open_with with unified opener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Unified opener with config.open_with integration** (#183)
+  - New `system` and `visual` app modes for opening notes
+  - App modes: `system` (OS default), `editor` ($EDITOR), `visual` ($VISUAL), `obsidian`, `print`
+  - Precedence chain: `--app` flag > `BWRB_DEFAULT_APP` env > `config.open_with` > `system`
+  - Default changed from `obsidian` to `system` for broader compatibility
+  - Obsidian vault name resolution: `config.obsidian_vault` > auto-detect from `.obsidian/` > folder basename
+  - Updated help text across all commands (`open`, `search`, `list`, `edit`, `new`)
+
 ### Fixed
 
 - **Date macros now use local timezone** (#184)

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -54,8 +54,8 @@ const CONFIG_OPTIONS: ConfigOptionMeta[] = [
     key: 'open_with',
     label: 'Open With',
     description: 'Default behavior for --open flag',
-    options: ['editor', 'visual', 'obsidian'],
-    default: 'visual',
+    options: ['system', 'editor', 'visual', 'obsidian'],
+    default: 'system',
   },
   {
     key: 'obsidian_vault',
@@ -278,7 +278,7 @@ function getConfigValue(config: Partial<Config>, key: keyof Config, vaultDir: st
     case 'visual':
       return process.env.VISUAL ?? undefined;
     case 'open_with':
-      return 'visual';
+      return 'system';
     case 'obsidian_vault':
       return detectObsidianVault(vaultDir);
     default:

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -15,7 +15,7 @@ import { printJson, jsonSuccess, jsonError, ExitCodes, exitWithResolutionError }
 import { buildNoteIndex, type ManagedFile } from '../lib/navigation.js';
 import { parsePickerMode, resolveAndPick, type PickerMode } from '../lib/picker.js';
 import { editNoteFromJson, editNoteInteractive } from '../lib/edit.js';
-import { openNote, parseAppMode } from './open.js';
+import { openNote, resolveAppMode } from './open.js';
 import { parseFilters, validateFilters } from '../lib/query.js';
 import { resolveTargets, hasAnyTargeting, type TargetingOptions } from '../lib/targeting.js';
 
@@ -48,7 +48,7 @@ export const editCommand = new Command('edit')
   .option('-b, --body <pattern>', 'Filter by body content')
   .option('--json <patch>', 'Non-interactive patch/merge mode')
   .option('-o, --open', 'Open the note in Obsidian after editing')
-  .option('--app <mode>', 'App mode for --open: obsidian, editor, print, reveal')
+  .option('--app <mode>', 'App mode for --open: system (default), editor, visual, obsidian, print')
   .addHelpText('after', `
 Targeting Options:
   All targeting options compose (AND logic):
@@ -127,15 +127,15 @@ Examples:
               updated: editResult.updatedFields,
             }));
             if (options.open) {
-              const appMode = parseAppMode(options.app || "default");
-              await openNote(vaultDir, query, appMode, true);
+              const appMode = resolveAppMode(options.app, schema.config);
+              await openNote(vaultDir, query, appMode, schema.config, true);
             }
           } else {
             await editNoteInteractive(schema, vaultDir, query, {});
             printSuccess(`Updated ${basename(query, '.md')}`);
             if (options.open) {
-              const appMode = parseAppMode(options.app || "default");
-              await openNote(vaultDir, query, appMode, false);
+              const appMode = resolveAppMode(options.app, schema.config);
+              await openNote(vaultDir, query, appMode, schema.config, false);
             }
           }
           process.exit(0);
@@ -228,8 +228,8 @@ Examples:
 
         // Open after edit if requested
         if (options.open) {
-          const appMode = parseAppMode(options.app || "default");
-          await openNote(vaultDir, targetFile.path, appMode, true);
+          const appMode = resolveAppMode(options.app, schema.config);
+          await openNote(vaultDir, targetFile.path, appMode, schema.config, true);
         }
       } else {
         // Interactive mode
@@ -238,8 +238,8 @@ Examples:
 
         // Open after edit if requested
         if (options.open) {
-          const appMode = parseAppMode(options.app || "default");
-          await openNote(vaultDir, targetFile.path, appMode, false);
+          const appMode = resolveAppMode(options.app, schema.config);
+          await openNote(vaultDir, targetFile.path, appMode, schema.config, false);
         }
       }
     } catch (err) {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -18,7 +18,7 @@ import {
   warnDeprecated,
   type ListOutputFormat,
 } from '../lib/output.js';
-import { openNote, parseAppMode } from './open.js';
+import { openNote, resolveAppMode } from './open.js';
 import { pickFile, parsePickerMode } from '../lib/picker.js';
 import type { LoadedSchema } from '../types/schema.js';
 import {
@@ -115,7 +115,17 @@ Examples:
 
 Open Options:
   --open               Open a note from the results (picker if multiple)
-  --app <mode>         How to open: obsidian (default), editor, system, print
+  --app <mode>         How to open: system (default), editor, visual, obsidian, print
+
+App Modes:
+  system      Open with OS default handler (default)
+  editor      Open in terminal editor ($EDITOR or config.editor)
+  visual      Open in GUI editor ($VISUAL or config.visual)
+  obsidian    Open in Obsidian via URI scheme
+  print       Print the resolved path (for scripting)
+
+Precedence:
+  --app flag > BWRB_DEFAULT_APP env > config.open_with > system
 
 Note: In zsh, use single quotes for expressions with '!' to avoid history expansion:
   bwrb list --type task --where '!isEmpty(deadline)'`)
@@ -131,7 +141,7 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
   .option('-o, --output <format>', 'Output format: text (default), paths, tree, link, json')
   // Open options
   .option('--open', 'Open the first result (or pick from results interactively)')
-  .option('--app <mode>', 'How to open: obsidian (default), editor, system, print')
+  .option('--app <mode>', 'How to open: system (default), editor, visual, obsidian, print')
   // Hierarchy options for recursive types (deprecated in favor of --where functions)
   .option('--roots', 'Only show root notes (deprecated: use --where "isRoot()")')
   .option('--children-of <note>', 'Only show direct children (deprecated: use --where "isChildOf(\'[[Note]]\')")')
@@ -404,7 +414,7 @@ async function listObjects(
       targetPath = filteredFiles[0]!.path;
     }
     
-    await openNote(vaultDir, targetPath, parseAppMode(options.app), jsonMode);
+    await openNote(vaultDir, targetPath, resolveAppMode(options.app, schema.config), schema.config, jsonMode);
     return;
   }
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -148,10 +148,10 @@ Template Discovery:
         
         printJson(jsonSuccess({ path: relative(vaultDir, filePath) }));
         
-        // Open if requested (respects BWRB_DEFAULT_APP)
+        // Open if requested (uses config.open_with as default)
         if (options.open && filePath) {
-          const { openNote, parseAppMode } = await import('./open.js');
-          await openNote(vaultDir, filePath, parseAppMode(), false);
+          const { openNote, resolveAppMode } = await import('./open.js');
+          await openNote(vaultDir, filePath, resolveAppMode(undefined, schema.config), schema.config, false);
         }
         return;
       }
@@ -209,10 +209,10 @@ Template Discovery:
         standalone: options.standalone,
       });
 
-      // Open if requested (respects BWRB_DEFAULT_APP)
+      // Open if requested (uses config.open_with as default)
       if (options.open && filePath) {
-        const { openNote, parseAppMode } = await import('./open.js');
-        await openNote(vaultDir, filePath, parseAppMode(), false);
+        const { openNote, resolveAppMode } = await import('./open.js');
+        await openNote(vaultDir, filePath, resolveAppMode(undefined, schema.config), schema.config, false);
       }
     } catch (err) {
       // Handle user cancellation cleanly

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -10,7 +10,7 @@
 import { Command } from "commander";
 import { basename, join } from "node:path";
 import { spawn } from "node:child_process";
-import { loadSchema } from "../lib/schema.js";
+import { loadSchema, detectObsidianVault } from "../lib/schema.js";
 import { resolveVaultDir } from "../lib/vault.js";
 import { buildNoteIndex, type ManagedFile } from "../lib/navigation.js";
 import { resolveAndPick, parsePickerMode } from "../lib/picker.js";
@@ -22,86 +22,202 @@ import {
   exitWithResolutionError,
 } from "../lib/output.js";
 import { resolveTargets, type TargetingOptions } from "../lib/targeting.js";
+import type { ResolvedConfig } from "../types/schema.js";
 
 // App modes for opening notes
-export type AppMode = "editor" | "obsidian" | "print";
+// - system: Open with OS default handler (default)
+// - editor: Open in terminal editor ($EDITOR or config.editor)
+// - visual: Open in GUI editor ($VISUAL or config.visual)
+// - obsidian: Open via Obsidian URI
+// - print: Print path to stdout (for scripting)
+export type AppMode = "system" | "editor" | "visual" | "obsidian" | "print";
 
 /**
- * Parse app mode from string
+ * Parse app mode from string. Returns undefined if value is undefined/empty,
+ * allowing callers to apply their own defaults.
  */
-export function parseAppMode(value?: string): AppMode {
-  // Default to editor mode, respecting BWRB_DEFAULT_APP env var
-  const effectiveValue = value || process.env.BWRB_DEFAULT_APP || 'editor';
-  const normalized = effectiveValue.toLowerCase();
-  if (normalized === "editor" || normalized === "obsidian" || normalized === "print") {
-    return normalized;
+export function parseAppMode(value?: string): AppMode | undefined {
+  if (!value || value === "default") {
+    return undefined;
   }
-  throw new Error(`Invalid app mode: ${effectiveValue}. Must be 'editor', 'obsidian', or 'print'.`);
+  const normalized = value.toLowerCase();
+  const validModes: AppMode[] = ["system", "editor", "visual", "obsidian", "print"];
+  if (validModes.includes(normalized as AppMode)) {
+    return normalized as AppMode;
+  }
+  throw new Error(`Invalid app mode: ${value}. Must be one of: ${validModes.join(", ")}`);
 }
 
 /**
- * Open a note in the specified application
+ * Resolve effective app mode using precedence:
+ * 1. Explicit CLI flag (if provided)
+ * 2. BWRB_DEFAULT_APP environment variable
+ * 3. config.open_with from schema
+ * 4. Fallback to 'system'
+ */
+export function resolveAppMode(
+  cliValue: string | undefined,
+  config: ResolvedConfig
+): AppMode {
+  // 1. Explicit CLI flag
+  const parsed = parseAppMode(cliValue);
+  if (parsed) {
+    return parsed;
+  }
+
+  // 2. Environment variable
+  const envValue = process.env.BWRB_DEFAULT_APP;
+  if (envValue) {
+    const envParsed = parseAppMode(envValue);
+    if (envParsed) {
+      return envParsed;
+    }
+  }
+
+  // 3. Config default
+  return config.openWith;
+}
+
+/**
+ * Open a note in the specified application.
+ * 
+ * @param vaultDir - Vault root directory
+ * @param notePath - Path to note relative to vault (or absolute)
+ * @param appMode - How to open the note
+ * @param config - Resolved config (needed for editor/visual/obsidian_vault settings)
+ * @param jsonMode - Whether to output JSON
  */
 export async function openNote(
   vaultDir: string,
   notePath: string,
   appMode: AppMode,
+  config: ResolvedConfig,
   jsonMode: boolean = false
 ): Promise<void> {
-  const fullPath = join(vaultDir, notePath);
+  // Normalize path - if absolute, use as-is; if relative, join with vaultDir
+  const fullPath = notePath.startsWith('/') ? notePath : join(vaultDir, notePath);
+  const relativePath = notePath.startsWith('/') ? notePath.replace(vaultDir + '/', '') : notePath;
 
-  if (appMode === "print") {
-    if (jsonMode) {
-      printJson({ success: true, data: { relativePath: notePath, fullPath } });
-    } else {
-      console.log(fullPath);
-    }
-    return;
-  }
-
-  if (appMode === "obsidian") {
-    await openInObsidian(vaultDir, notePath);
-    if (jsonMode) {
-      printJson({ success: true, data: { relativePath: notePath, fullPath, app: "obsidian" } });
-    }
-  } else {
-    const editor = process.env['EDITOR'] || process.env['VISUAL'];
-    if (!editor) {
+  switch (appMode) {
+    case "print":
       if (jsonMode) {
-        jsonError("No editor configured. Set EDITOR or VISUAL environment variable.");
-        process.exit(ExitCodes.VALIDATION_ERROR);
+        printJson({ success: true, data: { relativePath, fullPath } });
+      } else {
+        console.log(fullPath);
       }
-      exitWithError("No editor configured. Set EDITOR or VISUAL environment variable.");
-    }
-    const child = spawn(editor, [fullPath], {
-      stdio: "inherit",
-    });
-    await new Promise<void>((resolve, reject) => {
-      child.on("close", (code) => {
-        if (code === 0) {
-          if (jsonMode) {
-            printJson({ success: true, data: { relativePath: notePath, fullPath, app: editor } });
-          }
-          resolve();
-        } else {
-          reject(new Error(`Editor exited with code ${code}`));
+      return;
+
+    case "system":
+      await openWithSystem(fullPath);
+      if (jsonMode) {
+        printJson({ success: true, data: { relativePath, fullPath, app: "system" } });
+      }
+      return;
+
+    case "obsidian":
+      await openInObsidian(vaultDir, relativePath, config);
+      if (jsonMode) {
+        printJson({ success: true, data: { relativePath, fullPath, app: "obsidian" } });
+      }
+      return;
+
+    case "editor": {
+      const editorCmd = config.editor;
+      if (!editorCmd) {
+        const error = "No terminal editor configured. Set $EDITOR or config.editor.";
+        if (jsonMode) {
+          printJson(jsonError(error));
+          process.exit(ExitCodes.VALIDATION_ERROR);
         }
-      });
-      child.on("error", reject);
-    });
+        exitWithError(error);
+      }
+      await openWithCommand(editorCmd!, fullPath, jsonMode);
+      if (jsonMode) {
+        printJson({ success: true, data: { relativePath, fullPath, app: editorCmd } });
+      }
+      return;
+    }
+
+    case "visual": {
+      const visualCmd = config.visual;
+      if (!visualCmd) {
+        const error = "No GUI editor configured. Set $VISUAL or config.visual.";
+        if (jsonMode) {
+          printJson(jsonError(error));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        exitWithError(error);
+      }
+      await openWithCommand(visualCmd!, fullPath, jsonMode);
+      if (jsonMode) {
+        printJson({ success: true, data: { relativePath, fullPath, app: visualCmd } });
+      }
+      return;
+    }
   }
 }
 
 /**
- * Open a note in Obsidian
+ * Open a file with the OS default handler.
+ */
+async function openWithSystem(fullPath: string): Promise<void> {
+  const { exec } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const execAsync = promisify(exec);
+
+  if (process.platform === "darwin") {
+    await execAsync(`open "${fullPath}"`);
+  } else if (process.platform === "win32") {
+    await execAsync(`start "" "${fullPath}"`);
+  } else {
+    await execAsync(`xdg-open "${fullPath}"`);
+  }
+}
+
+/**
+ * Open a file with a specific command (editor/visual).
+ */
+async function openWithCommand(
+  command: string,
+  fullPath: string,
+  _jsonMode: boolean
+): Promise<void> {
+  const child = spawn(command, [fullPath], {
+    stdio: "inherit",
+  });
+  await new Promise<void>((resolve, reject) => {
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} exited with code ${code}`));
+      }
+    });
+    child.on("error", reject);
+  });
+}
+
+/**
+ * Open a note in Obsidian via URI scheme.
+ * 
+ * Vault name resolution (in order of precedence):
+ * 1. config.obsidian_vault (explicit user config)
+ * 2. Auto-detect from .obsidian folder presence (uses folder basename)
+ * 3. Fallback to vault directory basename
  */
 async function openInObsidian(
   vaultDir: string,
-  notePath: string
+  notePath: string,
+  config: ResolvedConfig
 ): Promise<void> {
-  const vaultName = basename(vaultDir);
+  // Resolve vault name using precedence
+  const vaultName = config.obsidianVault 
+    ?? detectObsidianVault(vaultDir) 
+    ?? basename(vaultDir);
+  
+  const encodedVault = encodeURIComponent(vaultName);
   const encodedFile = encodeURIComponent(notePath);
-  const obsidianUri = `obsidian://open?vault=${encodeURIComponent(vaultName)}&file=${encodedFile}`;
+  const obsidianUri = `obsidian://open?vault=${encodedVault}&file=${encodedFile}`;
 
   const { exec } = await import("node:child_process");
   const { promisify } = await import("node:util");
@@ -129,9 +245,9 @@ interface OpenOptions {
 }
 
 export const openCommand = new Command("open")
-  .description("Open a note in editor or Obsidian (alias for search --open)")
+  .description("Open a note (alias for search --open)")
   .argument("[query]", "Note name or path to open")
-  .option("-a, --app <mode>", "Application to open with: editor, obsidian, print", "editor")
+  .option("-a, --app <mode>", "Application to open with: system, editor, visual, obsidian, print")
   .option("--picker <mode>", "Picker mode: fzf, numbered, none", "fzf")
   .option("-o, --output <format>", "Output format: text, json", "text")
   .option("--preview", "Show preview in fzf picker")
@@ -144,8 +260,10 @@ export const openCommand = new Command("open")
     "after",
     `
 App Modes:
-  editor    Open in $EDITOR (default)
-  obsidian  Open in Obsidian app
+  system    Open with OS default handler (default, uses config.open_with)
+  editor    Open in terminal editor ($EDITOR or config.editor)
+  visual    Open in GUI editor ($VISUAL or config.visual)
+  obsidian  Open in Obsidian app (uses config.obsidian_vault or auto-detect)
   print     Print path to stdout (for scripting)
 
 Picker Modes:
@@ -153,16 +271,20 @@ Picker Modes:
   numbered  Numbered list selection
   none      No picker - fail if ambiguous
 
-Environment:
-  BWRB_DEFAULT_APP  Default app mode (editor, obsidian, print)
+Precedence (for default app):
+  1. --app flag (explicit)
+  2. BWRB_DEFAULT_APP environment variable
+  3. config.open_with in .bwrb/schema.json
+  4. Fallback: system
 
 Examples:
-  bwrb open "My Note"              Open note by name
-  bwrb open "My Note" --app obsidian  Open in Obsidian
-  bwrb open --type task            Pick from all tasks
-  bwrb open --where "status=active" Pick from active notes
+  bwrb open "My Note"                   Open note (uses config default)
+  bwrb open "My Note" --app obsidian    Open in Obsidian
+  bwrb open "My Note" --app editor      Open in $EDITOR
+  bwrb open --type task                 Pick from all tasks
+  bwrb open --where "status=active"     Pick from active notes
   bwrb open -t task -w "priority=high"  Open high-priority task
-  bwrb open --body "TODO"          Find and open note containing TODO
+  bwrb open --body "TODO"               Find and open note containing TODO
 `
   )
   .action(async (query: string | undefined, options: OpenOptions, cmd) => {
@@ -178,8 +300,8 @@ Examples:
       // Parse picker mode
       const pickerMode = parsePickerMode(options.picker || "fzf");
 
-      // Parse app mode
-      const appMode = parseAppMode(options.app || "editor");
+      // Resolve app mode using precedence: CLI > env > config > default
+      const appMode = resolveAppMode(options.app, schema.config);
 
       // Check if we have any targeting options
       const hasTargeting = options.type || options.path || options.where?.length || options.body;
@@ -245,7 +367,7 @@ Examples:
       }
 
       // Open the selected note
-      await openNote(vaultDir, result.file.relativePath, appMode, jsonMode);
+      await openNote(vaultDir, result.file.relativePath, appMode, schema.config, jsonMode);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (jsonMode) {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -394,7 +394,7 @@ function resolveConfig(config: Schema['config']): ResolvedConfig {
     linkFormat: config?.link_format ?? 'wikilink',
     editor: config?.editor ?? process.env.EDITOR,
     visual: config?.visual ?? process.env.VISUAL,
-    openWith: config?.open_with ?? 'visual',
+    openWith: config?.open_with ?? 'system',
     obsidianVault: config?.obsidian_vault,
   };
 }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -118,10 +118,11 @@ export const ConfigSchema = z.object({
   // GUI editor command (defaults to $VISUAL)
   visual: z.string().optional(),
   // Default behavior for --open flag
-  // editor: Open in terminal editor
-  // visual: Open in GUI editor (default)
+  // system: Open with OS default handler (default)
+  // editor: Open in terminal editor ($EDITOR)
+  // visual: Open in GUI editor ($VISUAL)
   // obsidian: Open via Obsidian URI
-  open_with: z.enum(['editor', 'visual', 'obsidian']).optional(),
+  open_with: z.enum(['system', 'editor', 'visual', 'obsidian']).optional(),
   // Obsidian vault name for URI scheme (auto-detected from .obsidian if not set)
   obsidian_vault: z.string().optional(),
 });
@@ -225,7 +226,7 @@ export interface ResolvedConfig {
   /** GUI editor command (from config or $VISUAL) */
   visual: string | undefined;
   /** Default behavior for --open flag */
-  openWith: 'editor' | 'visual' | 'obsidian';
+  openWith: 'system' | 'editor' | 'visual' | 'obsidian';
   /** Obsidian vault name (from config or auto-detected) */
   obsidianVault: string | undefined;
 }


### PR DESCRIPTION
## Summary

- Implements unified app mode resolution with config.open_with integration
- Adds `system` (OS default) and `visual` ($VISUAL) app modes
- Changes default from `obsidian` to `system` for broader compatibility
- Implements proper precedence: CLI `--app` > `BWRB_DEFAULT_APP` env > `config.open_with` > `system`

## Changes

### Core Implementation (`src/commands/open.ts`)
- New `parseAppMode()`: Validates app mode strings, returns undefined for empty/default
- New `resolveAppMode()`: Implements precedence chain for consistent resolution
- Refactored `openNote()`: Accepts config parameter, handles all 5 app modes
- Added `openWithSystem()`: Opens with OS default handler (macOS/Windows/Linux)
- Updated `openInObsidian()`: Uses config.obsidian_vault with auto-detection fallback

### Updated Commands
- `open`, `search`, `list`, `edit`, `new` all use `resolveAppMode()` for consistent precedence
- Updated help text across all commands documenting the new modes and precedence

### Tests (`tests/ts/commands/open.test.ts`)
- Unit tests for `parseAppMode()` (valid modes, case-insensitivity, invalid modes)
- Unit tests for `resolveAppMode()` (CLI precedence, env precedence, config fallback)
- CLI tests for invalid app mode error messages

## App Modes

| Mode | Description |
|------|-------------|
| `system` | Open with OS default handler (default) |
| `editor` | Open in terminal editor ($EDITOR or config.editor) |
| `visual` | Open in GUI editor ($VISUAL or config.visual) |
| `obsidian` | Open in Obsidian via URI scheme |
| `print` | Print path to stdout (for scripting) |

## Precedence Chain

1. `--app` flag (explicit CLI)
2. `BWRB_DEFAULT_APP` environment variable
3. `config.open_with` in .bwrb/schema.json
4. Fallback: `system`

Fixes #183