### PR TITLE
feat: standardize -x shorthand for --execute across destructive commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Added
 
+- **Standardized `-x` shorthand for `--execute`** (#142)
+  - Added `-x` as alias for `--execute` on `bulk`, `schema delete`, and `schema migrate` commands
+  - Consistent with existing `-x` shorthand on `delete` command
+  - Reduces keystrokes for common dry-run → execute workflow
+
 - **Unified opener with config.open_with integration** (#183)
   - New `system` and `visual` app modes for opening notes
   - App modes: `system` (OS default), `editor` ($EDITOR), `visual` ($VISUAL), `obsidian`, `print`

--- a/src/commands/bulk.ts
+++ b/src/commands/bulk.ts
@@ -148,7 +148,7 @@ Examples:
   .option('--move <path>', 'Move files to path (auto-updates wikilinks)')
   .option('-w, --where <expression...>', 'Filter with expression (multiple are ANDed)')
   .option('-a, --all', 'Target all files (requires explicit intent)')
-  .option('--execute', 'Actually apply changes (dry-run by default)')
+  .option('-x, --execute', 'Actually apply changes (dry-run by default)')
   .option('--backup', 'Create backup before changes')
   .option('--limit <n>', 'Limit to n files')
   .option('--verbose', 'Show detailed changes per file')

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -1775,7 +1775,7 @@ deleteCommand
   .command('type [name]')
   .description('Delete a type (dry-run by default)')
   .option('-o, --output <format>', 'Output format: text (default) or json')
-  .option('--execute', 'Actually perform the deletion (default is dry-run)')
+  .option('-x, --execute', 'Actually perform the deletion (default is dry-run)')
   .action(async (name: string | undefined, options: DeleteCommandOptions, cmd: Command) => {
     const jsonMode = options.output === 'json';
     const dryRun = !options.execute;
@@ -1876,7 +1876,7 @@ deleteCommand
   .command('field [type] [name]')
   .description('Delete a field from a type (dry-run by default)')
   .option('-o, --output <format>', 'Output format: text (default) or json')
-  .option('--execute', 'Actually perform the deletion (default is dry-run)')
+  .option('-x, --execute', 'Actually perform the deletion (default is dry-run)')
   .action(async (typeName: string | undefined, fieldName: string | undefined, options: DeleteCommandOptions, cmd: Command) => {
     const jsonMode = options.output === 'json';
     const dryRun = !options.execute;
@@ -2248,7 +2248,7 @@ schemaCommand
   .command('migrate')
   .description('Apply schema changes to existing notes')
   .option('-o, --output <format>', 'Output format: text (default) or json')
-  .option('--execute', 'Actually apply the migration (default is dry-run)')
+  .option('-x, --execute', 'Actually apply the migration (default is dry-run)')
   .option('--no-backup', 'Skip backup creation (not recommended)')
   .addHelpText('after', `
 Examples:


### PR DESCRIPTION
## Summary

- Add `-x` as shorthand for `--execute` on `bulk`, `schema delete type`, `schema delete field`, and `schema migrate` commands
- Provides consistent UX matching the existing `-x` shorthand on `delete` command
- Reduces keystrokes for the common dry-run → execute workflow

## Changes

| Command | Before | After |
|---------|--------|-------|
| `bulk` | `--execute` only | `-x, --execute` |
| `schema delete type` | `--execute` only | `-x, --execute` |
| `schema delete field` | `--execute` only | `-x, --execute` |
| `schema migrate` | `--execute` only | `-x, --execute` |

## Testing

- All 1185 existing tests pass
- Manual verification: `-x` works identically to `--execute` on all affected commands

Fixes #142