### PR TITLE
test: add comprehensive tests for config command

### DIFF
--- a/tests/ts/commands/config.pty.test.ts
+++ b/tests/ts/commands/config.pty.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  withTempVault,
+  shouldSkipPtyTests,
+  readVaultFile,
+  killAllPtyProcesses,
+  Keys,
+} from '../lib/pty-helpers.js';
+
+const describePty = shouldSkipPtyTests() ? describe.skip : describe;
+
+// Minimal schema for config tests
+const CONFIG_TEST_SCHEMA = {
+  version: 2,
+  types: {
+    meta: {},
+    note: {
+      extends: 'meta',
+      output_dir: 'Notes',
+      fields: {
+        type: { value: 'note' },
+      },
+    },
+  },
+};
+
+describePty('config command PTY tests', () => {
+  afterEach(() => {
+    killAllPtyProcesses();
+  });
+
+  describe('config edit (interactive option picker)', () => {
+    it('should show option picker when no option specified', async () => {
+      await withTempVault(
+        ['config', 'edit'],
+        async (proc, _vaultPath) => {
+          // Should prompt for which option to edit
+          await proc.waitFor('Select option to edit', 10000);
+
+          // Should show available options
+          expect(proc.getOutput()).toContain('link_format');
+          expect(proc.getOutput()).toContain('editor');
+          expect(proc.getOutput()).toContain('open_with');
+
+          // Cancel with Ctrl+C
+          proc.write(Keys.CTRL_C);
+          await proc.waitForExit(5000);
+        },
+        { schema: CONFIG_TEST_SCHEMA }
+      );
+    }, 20000);
+
+    it('should edit enum option (link_format) interactively', async () => {
+      await withTempVault(
+        ['config', 'edit', 'link_format'],
+        async (proc, vaultPath) => {
+          // Should show current value and options
+          await proc.waitFor('Link Format', 10000);
+
+          // Navigate to 'markdown' option
+          // Options are: wikilink, markdown
+          // Press down to select markdown
+          proc.write(Keys.DOWN);
+          await proc.waitFor('markdown', 2000);
+
+          // Select it
+          proc.write(Keys.ENTER);
+
+          // Wait for completion
+          await proc.waitFor('Set link_format', 5000);
+          await proc.waitForExit(5000);
+
+          // Verify the change was persisted
+          const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.config.link_format).toBe('markdown');
+        },
+        { schema: CONFIG_TEST_SCHEMA }
+      );
+    }, 20000);
+
+    it('should edit enum option (open_with) interactively', async () => {
+      await withTempVault(
+        ['config', 'edit', 'open_with'],
+        async (proc, vaultPath) => {
+          // Should show current value and options
+          await proc.waitFor('Open With', 10000);
+
+          // Options are: system, editor, visual, obsidian
+          // Navigate to 'obsidian'
+          proc.write(Keys.DOWN); // editor
+          proc.write(Keys.DOWN); // visual
+          proc.write(Keys.DOWN); // obsidian
+          await proc.waitFor('obsidian', 2000);
+
+          // Select it
+          proc.write(Keys.ENTER);
+
+          // Wait for completion
+          await proc.waitFor('Set open_with', 5000);
+          await proc.waitForExit(5000);
+
+          // Verify the change was persisted
+          const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.config.open_with).toBe('obsidian');
+        },
+        { schema: CONFIG_TEST_SCHEMA }
+      );
+    }, 20000);
+
+    it('should cancel on Ctrl+C during option selection', async () => {
+      await withTempVault(
+        ['config', 'edit', 'link_format'],
+        async (proc, vaultPath) => {
+          // Wait for the option picker
+          await proc.waitFor('Link Format', 10000);
+
+          // Cancel
+          proc.write(Keys.CTRL_C);
+          await proc.waitForExit(5000);
+
+          // Verify no config was created
+          const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.config).toBeUndefined();
+        },
+        { schema: CONFIG_TEST_SCHEMA }
+      );
+    }, 20000);
+  });
+
+  describe('config edit (string option smoke test)', () => {
+    it('should show menu for string options', async () => {
+      await withTempVault(
+        ['config', 'edit', 'editor'],
+        async (proc, _vaultPath) => {
+          // Should show menu with options
+          await proc.waitFor('Editor', 10000);
+
+          // Should show the limited menu options
+          const output = proc.getOutput();
+          expect(output).toContain('keep current');
+          expect(output).toContain('clear');
+
+          // Cancel
+          proc.write(Keys.CTRL_C);
+          await proc.waitForExit(5000);
+        },
+        { schema: CONFIG_TEST_SCHEMA }
+      );
+    }, 20000);
+
+    it('should clear string option when "(clear)" is selected', async () => {
+      // Start with a vault that has editor set
+      const schemaWithEditor = {
+        ...CONFIG_TEST_SCHEMA,
+        config: {
+          editor: 'existing-editor',
+        },
+      };
+
+      await withTempVault(
+        ['config', 'edit', 'editor'],
+        async (proc, vaultPath) => {
+          // Wait for the menu
+          await proc.waitFor('Editor', 10000);
+
+          // Navigate to "(clear)" option
+          proc.write(Keys.DOWN); // from "(keep current)" to "(clear)"
+          await proc.waitFor('clear', 2000);
+
+          // Select it
+          proc.write(Keys.ENTER);
+
+          // Wait for completion
+          await proc.waitFor('Cleared editor', 5000);
+          await proc.waitForExit(5000);
+
+          // Verify the value was cleared
+          const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.config.editor).toBeUndefined();
+        },
+        { schema: schemaWithEditor }
+      );
+    }, 20000);
+  });
+
+  describe('config edit (full flow from picker)', () => {
+    it('should pick option from menu and edit value', async () => {
+      await withTempVault(
+        ['config', 'edit'],
+        async (proc, vaultPath) => {
+          // Wait for option picker
+          await proc.waitFor('Select option to edit', 10000);
+
+          // Type 'l' to filter/jump to link_format
+          proc.write('l');
+          await proc.waitFor('link_format', 2000);
+
+          // Select it
+          proc.write(Keys.ENTER);
+
+          // Now we should see the link_format value picker
+          await proc.waitFor('Link Format', 5000);
+
+          // Navigate to 'markdown' and select
+          proc.write(Keys.DOWN);
+          await proc.waitFor('markdown', 2000);
+          proc.write(Keys.ENTER);
+
+          // Wait for completion
+          await proc.waitFor('Set link_format', 5000);
+          await proc.waitForExit(5000);
+
+          // Verify the change was persisted
+          const schemaContent = await readVaultFile(vaultPath, '.bwrb/schema.json');
+          const schema = JSON.parse(schemaContent);
+          expect(schema.config.link_format).toBe('markdown');
+        },
+        { schema: CONFIG_TEST_SCHEMA }
+      );
+    }, 25000);
+  });
+});

--- a/tests/ts/commands/config.test.ts
+++ b/tests/ts/commands/config.test.ts
@@ -1,0 +1,503 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { writeFile, rm, mkdir, readFile } from 'fs/promises';
+import { join } from 'path';
+import { mkdtemp } from 'fs/promises';
+import { tmpdir } from 'os';
+import { createTestVault, cleanupTestVault, runCLI } from '../fixtures/setup.js';
+
+describe('config command', () => {
+  let vaultDir: string;
+
+  beforeAll(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterAll(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  // ============================================================================
+  // config list
+  // ============================================================================
+
+  describe('config list (all options)', () => {
+    it('should show all configuration options', async () => {
+      const result = await runCLI(['config', 'list'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Configuration:');
+      expect(result.stdout).toContain('link_format');
+      expect(result.stdout).toContain('editor');
+      expect(result.stdout).toContain('visual');
+      expect(result.stdout).toContain('open_with');
+      expect(result.stdout).toContain('obsidian_vault');
+    });
+
+    it('should show default values when config is not set', async () => {
+      const result = await runCLI(['config', 'list'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      // Default for link_format is wikilink
+      expect(result.stdout).toContain('wikilink');
+      // open_with should have some value (default behavior varies by environment)
+      expect(result.stdout).toContain('open_with');
+    });
+
+    it('should output JSON when --output json is specified', async () => {
+      const result = await runCLI(['config', 'list', '-o', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data).toBeDefined();
+      expect(json.data.link_format).toBe('wikilink');
+      // open_with should be one of the valid options
+      expect(['system', 'editor', 'visual', 'obsidian']).toContain(json.data.open_with);
+    });
+
+    it('should show explicit config values', async () => {
+      // Create a vault with explicit config
+      const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-config-explicit-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          types: { meta: {} },
+          config: {
+            link_format: 'markdown',
+            open_with: 'obsidian',
+            editor: 'nvim',
+          },
+        })
+      );
+
+      try {
+        const result = await runCLI(['config', 'list', '-o', 'json'], tempVaultDir);
+
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.data.link_format).toBe('markdown');
+        expect(json.data.open_with).toBe('obsidian');
+        expect(json.data.editor).toBe('nvim');
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('config list <option> (specific option)', () => {
+    it('should show details for a specific option', async () => {
+      const result = await runCLI(['config', 'list', 'link_format'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Link Format');
+      expect(result.stdout).toContain('link_format');
+      expect(result.stdout).toContain('Format for relation links');
+      expect(result.stdout).toContain('wikilink, markdown');
+    });
+
+    it('should output JSON for specific option', async () => {
+      const result = await runCLI(['config', 'list', 'link_format', '-o', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.key).toBe('link_format');
+      expect(json.data.value).toBe('wikilink');
+      expect(json.data.description).toBeDefined();
+    });
+
+    it('should error on unknown option', async () => {
+      const result = await runCLI(['config', 'list', 'nonexistent'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown config option');
+      expect(result.stderr).toContain('nonexistent');
+    });
+
+    it('should list available options on error', async () => {
+      const result = await runCLI(['config', 'list', 'invalid_option'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain('Available options');
+      expect(result.stdout).toContain('link_format');
+    });
+
+    it('should output JSON error for unknown option', async () => {
+      const result = await runCLI(['config', 'list', 'nonexistent', '-o', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('Unknown config option');
+    });
+  });
+
+  // ============================================================================
+  // config edit --json (programmatic)
+  // ============================================================================
+
+  describe('config edit --json (programmatic)', () => {
+    let tempVaultDir: string;
+
+    beforeEach(async () => {
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-config-edit-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          types: { meta: {} },
+        })
+      );
+    });
+
+    afterEach(async () => {
+      await rm(tempVaultDir, { recursive: true, force: true });
+    });
+
+    it('should set an enum value', async () => {
+      const result = await runCLI(
+        ['config', 'edit', 'link_format', '--json', '"markdown"'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Set link_format');
+
+      // Verify the change persisted
+      const verifyResult = await runCLI(['config', 'list', 'link_format', '-o', 'json'], tempVaultDir);
+      const json = JSON.parse(verifyResult.stdout);
+      expect(json.data.value).toBe('markdown');
+    });
+
+    it('should set a string value', async () => {
+      const result = await runCLI(
+        ['config', 'edit', 'editor', '--json', '"nvim"'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Set editor');
+
+      // Verify the change persisted
+      const verifyResult = await runCLI(['config', 'list', 'editor', '-o', 'json'], tempVaultDir);
+      const json = JSON.parse(verifyResult.stdout);
+      expect(json.data.value).toBe('nvim');
+    });
+
+    it('should reject invalid enum value', async () => {
+      const result = await runCLI(
+        ['config', 'edit', 'link_format', '--json', '"invalid"'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Invalid value');
+      expect(result.stderr).toContain('wikilink, markdown');
+    });
+
+    it('should error on unknown option', async () => {
+      const result = await runCLI(
+        ['config', 'edit', 'nonexistent', '--json', '"value"'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown config option');
+    });
+
+    it('should error when option name is missing with --json', async () => {
+      const result = await runCLI(
+        ['config', 'edit', '--json', '"value"'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Option name required');
+    });
+
+    it('should output JSON on success when -o json is specified', async () => {
+      const result = await runCLI(
+        ['config', 'edit', 'link_format', '--json', '"markdown"', '-o', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.key).toBe('link_format');
+      expect(json.data.value).toBe('markdown');
+    });
+
+    it('should output JSON on error when -o json is specified', async () => {
+      const result = await runCLI(
+        ['config', 'edit', 'link_format', '--json', '"invalid"', '-o', 'json'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('Invalid value');
+    });
+  });
+
+  // ============================================================================
+  // Config persistence
+  // ============================================================================
+
+  describe('config persistence', () => {
+    let tempVaultDir: string;
+
+    beforeEach(async () => {
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-config-persist-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          types: { meta: {} },
+        })
+      );
+    });
+
+    afterEach(async () => {
+      await rm(tempVaultDir, { recursive: true, force: true });
+    });
+
+    it('should persist changes to schema.json', async () => {
+      await runCLI(['config', 'edit', 'link_format', '--json', '"markdown"'], tempVaultDir);
+
+      // Read the schema file directly
+      const schemaContent = await readFile(join(tempVaultDir, '.bwrb', 'schema.json'), 'utf-8');
+      const schema = JSON.parse(schemaContent);
+
+      expect(schema.config).toBeDefined();
+      expect(schema.config.link_format).toBe('markdown');
+    });
+
+    it('should reflect changes in subsequent list commands', async () => {
+      // Initial state
+      const before = await runCLI(['config', 'list', '-o', 'json'], tempVaultDir);
+      const beforeJson = JSON.parse(before.stdout);
+      expect(beforeJson.data.link_format).toBe('wikilink'); // default
+
+      // Make change
+      await runCLI(['config', 'edit', 'link_format', '--json', '"markdown"'], tempVaultDir);
+
+      // Verify change
+      const after = await runCLI(['config', 'list', '-o', 'json'], tempVaultDir);
+      const afterJson = JSON.parse(after.stdout);
+      expect(afterJson.data.link_format).toBe('markdown');
+    });
+
+    it('should create config block if it does not exist', async () => {
+      // Schema starts without config block
+      const schemaBefore = JSON.parse(
+        await readFile(join(tempVaultDir, '.bwrb', 'schema.json'), 'utf-8')
+      );
+      expect(schemaBefore.config).toBeUndefined();
+
+      // Set a config value
+      await runCLI(['config', 'edit', 'editor', '--json', '"vim"'], tempVaultDir);
+
+      // Config block should now exist
+      const schemaAfter = JSON.parse(
+        await readFile(join(tempVaultDir, '.bwrb', 'schema.json'), 'utf-8')
+      );
+      expect(schemaAfter.config).toBeDefined();
+      expect(schemaAfter.config.editor).toBe('vim');
+    });
+  });
+
+  // ============================================================================
+  // Environment variable precedence
+  // ============================================================================
+
+  describe('config precedence (explicit > env fallback)', () => {
+    it('should show $EDITOR value when editor is not set', async () => {
+      // The test vault doesn't have editor set explicitly
+      // It should show whatever $EDITOR is set to in the environment
+      const result = await runCLI(['config', 'list', 'editor', '-o', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      // Value should either be the env var or undefined if not set
+      // We can't assert exact value since it depends on test environment
+      expect(json.data.key).toBe('editor');
+    });
+
+    it('should override env fallback when explicitly set', async () => {
+      const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-config-precedence-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          types: { meta: {} },
+          config: {
+            editor: 'explicit-editor',
+          },
+        })
+      );
+
+      try {
+        const result = await runCLI(['config', 'list', 'editor', '-o', 'json'], tempVaultDir);
+
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+        // Explicit value should always be shown, regardless of $EDITOR
+        expect(json.data.value).toBe('explicit-editor');
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  // ============================================================================
+  // Obsidian vault auto-detection
+  // ============================================================================
+
+  describe('obsidian_vault auto-detection', () => {
+    it('should auto-detect obsidian vault name from .obsidian folder', async () => {
+      const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-obsidian-detect-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await mkdir(join(tempVaultDir, '.obsidian'), { recursive: true });
+      
+      // Create schema
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          types: { meta: {} },
+        })
+      );
+
+      // Create .obsidian/app.json with vault name
+      await writeFile(
+        join(tempVaultDir, '.obsidian', 'app.json'),
+        JSON.stringify({})
+      );
+
+      try {
+        const result = await runCLI(['config', 'list', 'obsidian_vault', '-o', 'json'], tempVaultDir);
+
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+        // When .obsidian exists, the vault name is derived from the directory name
+        // The exact value depends on the temp directory name, but it should be set
+        expect(json.data.key).toBe('obsidian_vault');
+        // Value should be defined (auto-detected) when .obsidian folder exists
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should show undefined when no .obsidian folder exists', async () => {
+      const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-no-obsidian-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          types: { meta: {} },
+        })
+      );
+
+      try {
+        const result = await runCLI(['config', 'list', 'obsidian_vault', '-o', 'json'], tempVaultDir);
+
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.data.key).toBe('obsidian_vault');
+        // Value should be undefined when no .obsidian folder
+        expect(json.data.value).toBeUndefined();
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should prefer explicit config over auto-detection', async () => {
+      const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-obsidian-explicit-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await mkdir(join(tempVaultDir, '.obsidian'), { recursive: true });
+      
+      // Create schema with explicit obsidian_vault
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          types: { meta: {} },
+          config: {
+            obsidian_vault: 'my-explicit-vault',
+          },
+        })
+      );
+
+      // Create .obsidian folder (would normally trigger auto-detection)
+      await writeFile(
+        join(tempVaultDir, '.obsidian', 'app.json'),
+        JSON.stringify({})
+      );
+
+      try {
+        const result = await runCLI(['config', 'list', 'obsidian_vault', '-o', 'json'], tempVaultDir);
+
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+        // Explicit value should override auto-detection
+        expect(json.data.value).toBe('my-explicit-vault');
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  // ============================================================================
+  // Edge cases
+  // ============================================================================
+
+  describe('edge cases', () => {
+    it('should work with missing config block in schema', async () => {
+      const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-no-config-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          types: { meta: {} },
+          // No config block
+        })
+      );
+
+      try {
+        const result = await runCLI(['config', 'list', '-o', 'json'], tempVaultDir);
+
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.success).toBe(true);
+        // Should still show defaults
+        expect(json.data.link_format).toBe('wikilink');
+        // open_with should be one of the valid options (default depends on environment)
+        expect(['system', 'editor', 'visual', 'obsidian']).toContain(json.data.open_with);
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should error on missing schema file', async () => {
+      const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-no-schema-'));
+
+      try {
+        const result = await runCLI(['config', 'list'], tempVaultDir);
+
+        expect(result.exitCode).toBe(1);
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `bwrb config list` and `bwrb config edit --json`
- Add PTY tests for interactive config editing
- Test JSON output, validation errors, persistence, and edge cases

## Test Coverage Added
**Unit tests (config.test.ts - 26 tests):**
- `config list`: all options, specific option, JSON output
- `config edit --json`: set enum/string values, validation errors
- Config precedence: explicit values override env fallbacks
- Config persistence: changes reflected in schema.json
- Obsidian vault auto-detection
- Edge cases: missing config block, unknown options

**PTY tests (config.pty.test.ts - 7 tests):**
- Interactive option picker
- Enum option selection (link_format, open_with)
- String option menu smoke test
- Cancellation with Ctrl+C

## Notes
- All 1218 tests pass (including 33 new config tests)
- Typecheck passes
- Follows existing test patterns from schema.test.ts and template.pty.test.ts

Fixes #185