### PR TITLE
feat(dashboard): add storage format and persistence layer

### DIFF
--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -6,8 +6,8 @@
 
 ## Version Philosophy
 
-**v1: Schema** — Rock-solid schema enforcement, inheritance model, type safety
-**v2: PKM** — Plugins, ecosystem, dashboards, visibility into your knowledge
+**v1: Schema + Dashboards** — Rock-solid schema enforcement, inheritance model, type safety, and saved queries
+**v2: PKM** — Plugins, ecosystem, visibility into your knowledge
 **v3: AI** — Built-in AI features, ingest, automation
 
 ---
@@ -52,6 +52,21 @@ After inheritance model is in place:
 | P2 | `bwrb-oay` | Template spawning with ownership |
 | P2 | `bwrb-xy1` | Remove name_field, standardize on 'name' |
 
+#### Phase 5: Dashboards
+Dashboards are saved `bwrb list` queries that can be recalled by name. This minimal implementation builds on existing list infrastructure.
+
+| Priority | Issue | Title |
+|----------|-------|-------|
+| P1 | #196 | Storage format and persistence layer |
+| P1 | #197 | `dashboard <name>` - Run saved query |
+| P1 | #199 | `dashboard list` - List saved dashboards |
+| P1 | #200 | `dashboard new` - Create dashboard |
+| P2 | #198 | `dashboard` (no args) - Picker or default |
+| P2 | #201 | `dashboard edit` - Modify dashboard |
+| P2 | #202 | `dashboard delete` - Remove dashboard |
+| P2 | #203 | Default dashboard support |
+| P2 | #204 | List `--save-as` flag |
+
 ### v1.0 Exit Criteria
 
 - [ ] Renamed to Bowerbird (CLI, config, docs, repo)
@@ -60,6 +75,7 @@ After inheritance model is in place:
 - [ ] Context field validation in audit
 - [ ] Schema management CLI (schema new/edit/delete/list)
 - [ ] Field primitives: text, number, boolean, date, select, relation, list
+- [ ] Dashboard system (storage, CRUD commands, list --save-as)
 - [ ] All tests passing with new schema format
 - [ ] Documentation updated
 
@@ -75,7 +91,6 @@ Make the schema useful for knowledge work.
 |---------|-------|-------------|
 | Neovim plugin | `bwrb-tic` | Full CLI parity in Neovim |
 | LSP | `bwrb-0wp` | Real-time schema validation in editors |
-| Dashboards | `bwrb-f9u` | Saved queries, visibility into notes |
 | Link validation | `bwrb-6f0` | Broken link detection in audit |
 | Command consolidation | `bwrb-fkd` | Merge list/search/open |
 
@@ -83,7 +98,6 @@ Make the schema useful for knowledge work.
 
 - [ ] Neovim plugin with core functionality
 - [ ] LSP server for schema validation
-- [ ] Dashboard system for saved queries
 - [ ] Comprehensive link validation
 - [ ] Polished, consistent CLI surface
 
@@ -126,4 +140,4 @@ Optional AI-powered features for automation.
 - **Product Vision:** `docs/product/vision.md`
 - **Type System (overview):** `docs/product/type-system.md`
 - **Type System (technical):** `docs/technical/inheritance.md`
-- **Issue Tracker:** `.beads/` (use `bd list`, `bd show`)
+- **Issue Tracker:** GitHub Issues

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -1,0 +1,158 @@
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { join, dirname } from 'path';
+import { existsSync } from 'fs';
+import {
+  DashboardsFileSchema,
+  type DashboardDefinition,
+  type DashboardsFile,
+} from '../types/schema.js';
+
+/**
+ * Dashboard Persistence Layer
+ * ===========================
+ *
+ * Dashboards are saved `bwrb list` queries stored in .bwrb/dashboards.json.
+ * This module provides CRUD operations for managing dashboards.
+ */
+
+// ============================================================================
+// Path Helpers
+// ============================================================================
+
+/**
+ * Get the path to the dashboards.json file.
+ */
+export function getDashboardsPath(vaultDir: string): string {
+  return join(vaultDir, '.bwrb', 'dashboards.json');
+}
+
+// ============================================================================
+// Load / Save
+// ============================================================================
+
+/**
+ * Load and validate dashboards from .bwrb/dashboards.json.
+ * Returns an empty dashboards object if the file doesn't exist.
+ *
+ * @throws Error if file exists but contains invalid JSON or fails schema validation
+ */
+export async function loadDashboards(vaultDir: string): Promise<DashboardsFile> {
+  const path = getDashboardsPath(vaultDir);
+
+  if (!existsSync(path)) {
+    return { dashboards: {} };
+  }
+
+  const content = await readFile(path, 'utf-8');
+  const parsed = JSON.parse(content);
+  return DashboardsFileSchema.parse(parsed);
+}
+
+/**
+ * Save dashboards to .bwrb/dashboards.json.
+ * Creates the .bwrb directory and file if they don't exist.
+ * Validates the data before writing.
+ *
+ * @throws Error if validation fails
+ */
+export async function saveDashboards(
+  vaultDir: string,
+  dashboards: DashboardsFile
+): Promise<void> {
+  // Validate before saving
+  DashboardsFileSchema.parse(dashboards);
+
+  const path = getDashboardsPath(vaultDir);
+
+  // Ensure .bwrb directory exists
+  await mkdir(dirname(path), { recursive: true });
+
+  await writeFile(path, JSON.stringify(dashboards, null, 2) + '\n', 'utf-8');
+}
+
+// ============================================================================
+// Read Operations
+// ============================================================================
+
+/**
+ * Get a single dashboard by name.
+ * Returns null if the dashboard doesn't exist.
+ */
+export async function getDashboard(
+  vaultDir: string,
+  name: string
+): Promise<DashboardDefinition | null> {
+  const data = await loadDashboards(vaultDir);
+  return data.dashboards[name] ?? null;
+}
+
+/**
+ * List all dashboard names, sorted alphabetically.
+ */
+export async function listDashboards(vaultDir: string): Promise<string[]> {
+  const data = await loadDashboards(vaultDir);
+  return Object.keys(data.dashboards).sort((a, b) => a.localeCompare(b));
+}
+
+// ============================================================================
+// Write Operations
+// ============================================================================
+
+/**
+ * Create a new dashboard.
+ *
+ * @throws Error if a dashboard with this name already exists
+ */
+export async function createDashboard(
+  vaultDir: string,
+  name: string,
+  definition: DashboardDefinition
+): Promise<void> {
+  const data = await loadDashboards(vaultDir);
+
+  if (data.dashboards[name] !== undefined) {
+    throw new Error(`Dashboard "${name}" already exists`);
+  }
+
+  data.dashboards[name] = definition;
+  await saveDashboards(vaultDir, data);
+}
+
+/**
+ * Update an existing dashboard.
+ *
+ * @throws Error if the dashboard doesn't exist
+ */
+export async function updateDashboard(
+  vaultDir: string,
+  name: string,
+  definition: DashboardDefinition
+): Promise<void> {
+  const data = await loadDashboards(vaultDir);
+
+  if (data.dashboards[name] === undefined) {
+    throw new Error(`Dashboard "${name}" does not exist`);
+  }
+
+  data.dashboards[name] = definition;
+  await saveDashboards(vaultDir, data);
+}
+
+/**
+ * Delete a dashboard.
+ *
+ * @throws Error if the dashboard doesn't exist
+ */
+export async function deleteDashboard(
+  vaultDir: string,
+  name: string
+): Promise<void> {
+  const data = await loadDashboards(vaultDir);
+
+  if (data.dashboards[name] === undefined) {
+    throw new Error(`Dashboard "${name}" does not exist`);
+  }
+
+  delete data.dashboards[name];
+  await saveDashboards(vaultDir, data);
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -396,6 +396,7 @@ function resolveConfig(config: Schema['config']): ResolvedConfig {
     visual: config?.visual ?? process.env.VISUAL,
     openWith: config?.open_with ?? 'system',
     obsidianVault: config?.obsidian_vault,
+    defaultDashboard: config?.default_dashboard,
   };
 }
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -125,6 +125,8 @@ export const ConfigSchema = z.object({
   open_with: z.enum(['system', 'editor', 'visual', 'obsidian']).optional(),
   // Obsidian vault name for URI scheme (auto-detected from .obsidian if not set)
   obsidian_vault: z.string().optional(),
+  // Default dashboard to run when `bwrb dashboard` is called without arguments
+  default_dashboard: z.string().optional(),
 });
 
 // ============================================================================
@@ -229,6 +231,8 @@ export interface ResolvedConfig {
   openWith: 'system' | 'editor' | 'visual' | 'obsidian';
   /** Obsidian vault name (from config or auto-detected) */
   obsidianVault: string | undefined;
+  /** Default dashboard to run when `bwrb dashboard` is called without arguments */
+  defaultDashboard: string | undefined;
 }
 
 /**
@@ -369,4 +373,37 @@ export interface Template {
   body: string;
 }
 
+// ============================================================================
+// Dashboard Types
+// ============================================================================
 
+/**
+ * Dashboard definition - a saved list query.
+ * All fields are optional; a dashboard with no fields will list all notes.
+ */
+export const DashboardDefinitionSchema = z.object({
+  /** Type filter (e.g., "task", "objective/milestone") */
+  type: z.string().optional(),
+  /** Glob pattern for file paths (e.g., "Projects/**") */
+  path: z.string().optional(),
+  /** Filter expressions (same as --where in list command) */
+  where: z.array(z.string()).optional(),
+  /** Body content search query */
+  body: z.string().optional(),
+  /** Default output format */
+  output: z.enum(['default', 'text', 'paths', 'tree', 'link', 'json']).optional(),
+  /** Fields to display in table output */
+  fields: z.array(z.string()).optional(),
+});
+
+export type DashboardDefinition = z.infer<typeof DashboardDefinitionSchema>;
+
+/**
+ * Dashboards file schema (.bwrb/dashboards.json).
+ * Contains all saved dashboards for a vault.
+ */
+export const DashboardsFileSchema = z.object({
+  dashboards: z.record(DashboardDefinitionSchema),
+});
+
+export type DashboardsFile = z.infer<typeof DashboardsFileSchema>;

--- a/tests/ts/lib/dashboard.test.ts
+++ b/tests/ts/lib/dashboard.test.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdir, writeFile, rm, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { mkdtemp } from 'fs/promises';
+import { existsSync } from 'fs';
+import {
+  getDashboardsPath,
+  loadDashboards,
+  saveDashboards,
+  getDashboard,
+  listDashboards,
+  createDashboard,
+  updateDashboard,
+  deleteDashboard,
+} from '../../../src/lib/dashboard.js';
+import type { DashboardDefinition, DashboardsFile } from '../../../src/types/schema.js';
+
+describe('dashboard library', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'dashboard-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('getDashboardsPath', () => {
+    it('returns correct path for vault directory', () => {
+      const result = getDashboardsPath('/vault');
+      expect(result).toBe('/vault/.bwrb/dashboards.json');
+    });
+
+    it('handles nested vault paths', () => {
+      const result = getDashboardsPath('/path/to/my/vault');
+      expect(result).toBe('/path/to/my/vault/.bwrb/dashboards.json');
+    });
+  });
+
+  describe('loadDashboards', () => {
+    it('returns empty object when file does not exist', async () => {
+      const result = await loadDashboards(tempDir);
+      expect(result).toEqual({ dashboards: {} });
+    });
+
+    it('loads and parses valid dashboards.json', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      const dashboards: DashboardsFile = {
+        dashboards: {
+          'my-tasks': {
+            type: 'task',
+            where: ["status == 'active'"],
+            output: 'tree',
+          },
+          inbox: {
+            type: 'idea',
+            where: ["status == 'raw'"],
+          },
+        },
+      };
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify(dashboards, null, 2)
+      );
+
+      const result = await loadDashboards(tempDir);
+
+      expect(result.dashboards['my-tasks']).toEqual({
+        type: 'task',
+        where: ["status == 'active'"],
+        output: 'tree',
+      });
+      expect(result.dashboards['inbox']).toEqual({
+        type: 'idea',
+        where: ["status == 'raw'"],
+      });
+    });
+
+    it('throws on invalid JSON', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        'not valid json {'
+      );
+
+      await expect(loadDashboards(tempDir)).rejects.toThrow();
+    });
+
+    it('throws on schema validation failure', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      // Invalid: output must be one of the allowed values
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify({
+          dashboards: {
+            bad: { output: 'invalid-format' },
+          },
+        })
+      );
+
+      await expect(loadDashboards(tempDir)).rejects.toThrow();
+    });
+
+    it('accepts dashboard with all optional fields', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      const dashboards: DashboardsFile = {
+        dashboards: {
+          'full-dashboard': {
+            type: 'task',
+            path: 'Projects/**',
+            where: ["status == 'active'", "priority == 'high'"],
+            body: 'urgent',
+            output: 'json',
+            fields: ['name', 'status', 'deadline'],
+          },
+        },
+      };
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify(dashboards, null, 2)
+      );
+
+      const result = await loadDashboards(tempDir);
+
+      expect(result.dashboards['full-dashboard']).toEqual({
+        type: 'task',
+        path: 'Projects/**',
+        where: ["status == 'active'", "priority == 'high'"],
+        body: 'urgent',
+        output: 'json',
+        fields: ['name', 'status', 'deadline'],
+      });
+    });
+
+    it('accepts empty dashboard definition', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      const dashboards: DashboardsFile = {
+        dashboards: {
+          'empty-dashboard': {},
+        },
+      };
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify(dashboards, null, 2)
+      );
+
+      const result = await loadDashboards(tempDir);
+
+      expect(result.dashboards['empty-dashboard']).toEqual({});
+    });
+  });
+
+  describe('saveDashboards', () => {
+    it('creates file if it does not exist', async () => {
+      const dashboards: DashboardsFile = {
+        dashboards: {
+          test: { type: 'task' },
+        },
+      };
+
+      await saveDashboards(tempDir, dashboards);
+
+      expect(existsSync(join(tempDir, '.bwrb', 'dashboards.json'))).toBe(true);
+    });
+
+    it('creates .bwrb directory if needed', async () => {
+      expect(existsSync(join(tempDir, '.bwrb'))).toBe(false);
+
+      await saveDashboards(tempDir, { dashboards: {} });
+
+      expect(existsSync(join(tempDir, '.bwrb'))).toBe(true);
+    });
+
+    it('overwrites existing file', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify({ dashboards: { old: { type: 'idea' } } })
+      );
+
+      await saveDashboards(tempDir, {
+        dashboards: { new: { type: 'task' } },
+      });
+
+      const content = await readFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        'utf-8'
+      );
+      const parsed = JSON.parse(content);
+      expect(parsed.dashboards['new']).toBeDefined();
+      expect(parsed.dashboards['old']).toBeUndefined();
+    });
+
+    it('validates before writing', async () => {
+      // This should throw because output is invalid
+      const invalid = {
+        dashboards: {
+          bad: { output: 'not-a-valid-format' },
+        },
+      } as unknown as DashboardsFile;
+
+      await expect(saveDashboards(tempDir, invalid)).rejects.toThrow();
+      expect(existsSync(join(tempDir, '.bwrb', 'dashboards.json'))).toBe(false);
+    });
+
+    it('writes formatted JSON with trailing newline', async () => {
+      await saveDashboards(tempDir, {
+        dashboards: { test: { type: 'task' } },
+      });
+
+      const content = await readFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        'utf-8'
+      );
+      expect(content).toContain('\n');
+      expect(content.endsWith('\n')).toBe(true);
+    });
+  });
+
+  describe('getDashboard', () => {
+    it('returns dashboard definition when exists', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify({
+          dashboards: {
+            'my-query': { type: 'task', output: 'tree' },
+          },
+        })
+      );
+
+      const result = await getDashboard(tempDir, 'my-query');
+
+      expect(result).toEqual({ type: 'task', output: 'tree' });
+    });
+
+    it('returns null when dashboard not found', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify({ dashboards: {} })
+      );
+
+      const result = await getDashboard(tempDir, 'nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when file does not exist', async () => {
+      const result = await getDashboard(tempDir, 'any-name');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listDashboards', () => {
+    it('returns empty array when no dashboards', async () => {
+      const result = await listDashboards(tempDir);
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns all dashboard names', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify({
+          dashboards: {
+            zebra: { type: 'task' },
+            alpha: { type: 'idea' },
+            beta: {},
+          },
+        })
+      );
+
+      const result = await listDashboards(tempDir);
+
+      expect(result).toContain('alpha');
+      expect(result).toContain('beta');
+      expect(result).toContain('zebra');
+    });
+
+    it('returns names sorted alphabetically', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify({
+          dashboards: {
+            zebra: {},
+            alpha: {},
+            middle: {},
+          },
+        })
+      );
+
+      const result = await listDashboards(tempDir);
+
+      expect(result).toEqual(['alpha', 'middle', 'zebra']);
+    });
+  });
+
+  describe('createDashboard', () => {
+    it('creates new dashboard successfully', async () => {
+      const definition: DashboardDefinition = {
+        type: 'task',
+        where: ["status == 'active'"],
+      };
+
+      await createDashboard(tempDir, 'new-dashboard', definition);
+
+      const result = await getDashboard(tempDir, 'new-dashboard');
+      expect(result).toEqual(definition);
+    });
+
+    it('creates file on first save', async () => {
+      expect(existsSync(join(tempDir, '.bwrb', 'dashboards.json'))).toBe(false);
+
+      await createDashboard(tempDir, 'first', { type: 'task' });
+
+      expect(existsSync(join(tempDir, '.bwrb', 'dashboards.json'))).toBe(true);
+    });
+
+    it('throws if dashboard already exists', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify({
+          dashboards: { existing: { type: 'task' } },
+        })
+      );
+
+      await expect(
+        createDashboard(tempDir, 'existing', { type: 'idea' })
+      ).rejects.toThrow('Dashboard "existing" already exists');
+    });
+
+    it('preserves existing dashboards when adding new', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify({
+          dashboards: { existing: { type: 'task' } },
+        })
+      );
+
+      await createDashboard(tempDir, 'new', { type: 'idea' });
+
+      const all = await listDashboards(tempDir);
+      expect(all).toContain('existing');
+      expect(all).toContain('new');
+    });
+  });
+
+  describe('updateDashboard', () => {
+    it('updates existing dashboard', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify({
+          dashboards: { target: { type: 'task', output: 'default' } },
+        })
+      );
+
+      await updateDashboard(tempDir, 'target', {
+        type: 'task',
+        output: 'tree',
+        where: ["status == 'active'"],
+      });
+
+      const result = await getDashboard(tempDir, 'target');
+      expect(result).toEqual({
+        type: 'task',
+        output: 'tree',
+        where: ["status == 'active'"],
+      });
+    });
+
+    it('throws if dashboard does not exist', async () => {
+      await expect(
+        updateDashboard(tempDir, 'nonexistent', { type: 'task' })
+      ).rejects.toThrow('Dashboard "nonexistent" does not exist');
+    });
+
+    it('preserves other dashboards when updating', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify({
+          dashboards: {
+            target: { type: 'task' },
+            other: { type: 'idea' },
+          },
+        })
+      );
+
+      await updateDashboard(tempDir, 'target', { type: 'milestone' });
+
+      const other = await getDashboard(tempDir, 'other');
+      expect(other).toEqual({ type: 'idea' });
+    });
+  });
+
+  describe('deleteDashboard', () => {
+    it('removes dashboard', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify({
+          dashboards: { target: { type: 'task' } },
+        })
+      );
+
+      await deleteDashboard(tempDir, 'target');
+
+      const result = await getDashboard(tempDir, 'target');
+      expect(result).toBeNull();
+    });
+
+    it('throws if dashboard does not exist', async () => {
+      await expect(deleteDashboard(tempDir, 'nonexistent')).rejects.toThrow(
+        'Dashboard "nonexistent" does not exist'
+      );
+    });
+
+    it('preserves other dashboards when deleting', async () => {
+      await mkdir(join(tempDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempDir, '.bwrb', 'dashboards.json'),
+        JSON.stringify({
+          dashboards: {
+            target: { type: 'task' },
+            keep: { type: 'idea' },
+          },
+        })
+      );
+
+      await deleteDashboard(tempDir, 'target');
+
+      const kept = await getDashboard(tempDir, 'keep');
+      expect(kept).toEqual({ type: 'idea' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements #196 - the foundational storage layer for dashboards (saved list queries).

- Add Zod schemas for `DashboardDefinition` and `DashboardsFile`
- Add `default_dashboard` to config schema (prep for #203)
- Create `src/lib/dashboard.ts` with CRUD operations
- Add 29 comprehensive tests
- Update roadmap to include dashboards in v1.0 scope

## Changes

| File | Description |
|------|-------------|
| `docs/product/roadmap.md` | Add dashboards to v1.0, Phase 5 |
| `src/types/schema.ts` | Dashboard schemas + default_dashboard config |
| `src/lib/schema.ts` | Wire up defaultDashboard in resolveConfig |
| `src/lib/dashboard.ts` | Persistence layer with CRUD operations |
| `tests/ts/lib/dashboard.test.ts` | 29 unit tests |

## API

```typescript
// Path helper
getDashboardsPath(vaultDir) // → .bwrb/dashboards.json

// Read operations
loadDashboards(vaultDir)     // → DashboardsFile (empty if not exists)
getDashboard(vaultDir, name) // → DashboardDefinition | null
listDashboards(vaultDir)     // → string[] (sorted)

// Write operations
createDashboard(vaultDir, name, definition) // throws if exists
updateDashboard(vaultDir, name, definition) // throws if not exists
deleteDashboard(vaultDir, name)             // throws if not exists
saveDashboards(vaultDir, dashboards)        // validates before write
```

## Testing

```bash
pnpm test -- tests/ts/lib/dashboard.test.ts
```

All 29 tests pass, plus full test suite (1239 tests).

Fixes #196