### PR TITLE
fix: bulk --path now matches directory paths correctly

### DIFF
--- a/src/lib/bulk/execute.ts
+++ b/src/lib/bulk/execute.ts
@@ -4,12 +4,12 @@
 
 import { relative, dirname, basename } from 'path';
 import { stat } from 'fs/promises';
-import { minimatch } from 'minimatch';
 import { parseNote, writeNote } from '../frontmatter.js';
 import { matchesExpression, type EvalContext } from '../expression.js';
 import { matchesAllFilters } from '../query.js';
 import { discoverManagedFiles } from '../discovery.js';
 import { searchContent } from '../content-search.js';
+import { filterByPath } from '../targeting.js';
 import { applyOperations } from './operations.js';
 import { createBackup } from './backup.js';
 import { executeBulkMove, findAllMarkdownFiles } from './move.js';
@@ -62,9 +62,9 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
   // Discover files for the specified type
   let files = await discoverManagedFiles(schema, vaultDir, typePath);
 
-  // Apply path glob filter
+  // Apply path glob filter (uses unified targeting module for consistent behavior)
   if (pathGlob) {
-    files = files.filter(file => minimatch(file.relativePath, pathGlob, { matchBase: true }));
+    files = filterByPath(files, pathGlob);
   }
 
   // Apply text content filter
@@ -228,9 +228,9 @@ async function executeBulkWithMove(
   // Discover files for the specified type
   let files = await discoverManagedFiles(schema, vaultDir, typePath);
 
-  // Apply path glob filter
+  // Apply path glob filter (uses unified targeting module for consistent behavior)
   if (pathGlob) {
-    files = files.filter(file => minimatch(file.relativePath, pathGlob, { matchBase: true }));
+    files = filterByPath(files, pathGlob);
   }
 
   // Apply text content filter


### PR DESCRIPTION
## Summary

- Refactors `bulk/execute.ts` to use the unified `filterByPath()` function from `targeting.ts` instead of directly calling minimatch
- Directory paths like `Ideas/` or `Ideas` are now properly normalized to glob patterns, matching documented behavior

## Problem

Users expected `bwrb bulk --path daily-notes/ --set type=daily-note` to work, but it returned "No files match the criteria." They had to use explicit glob syntax like `--path "daily-notes/**"` instead.

The docs in `cli-targeting.md` state that `--path` "Accepts directory paths or glob patterns", but the bulk command was bypassing the path normalization logic.

## Solution

The bulk command now uses the same `filterByPath()` function from `targeting.ts` that other commands use. This function normalizes:
- `path/` → `path/**/*.md`
- `path` (bare directory) → `path/**/*.md`

## Tests

Added 6 new tests verifying:
- `--path Ideas/` (trailing slash) matches files
- `--path Ideas` (bare directory) matches files
- `--path Ideas/**` (explicit glob) still works
- `--path Objectives` matches nested directories
- Combining `--path` with `--type` works correctly
- Non-existent directories return "No files match"

All 1245 tests pass.

Fixes #148