### PR TITLE
feat(list): add --save-as flag to save queries as dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Added
 
+- **`--save-as` flag for list command to save queries as dashboards** (#204)
+  - `bwrb list --type task --where "status='active'" --save-as "active-tasks"` saves query as reusable dashboard
+  - Saves all query parameters: type, path, where, body, output, and fields
+  - Error if dashboard already exists (use `--force` to overwrite)
+  - Confirmation message on stderr to keep stdout clean for piping
+  - Run saved dashboards with `bwrb dashboard <name>`
+
 - **Standardized `-x` shorthand for `--execute`** (#142)
   - Added `-x` as alias for `--execute` on `bulk`, `schema delete`, and `schema migrate` commands
   - Consistent with existing `-x` shorthand on `delete` command


### PR DESCRIPTION
## Summary

- Add `--save-as <name>` flag to save list queries as reusable dashboards
- Add `--force` flag to overwrite existing dashboards
- Pre-flight check ensures clean JSON output when dashboard exists

## Changes

1. **New flags**: `--save-as <name>` and `--force`
2. **Pre-flight check**: Errors before query execution if dashboard exists (keeps JSON output clean)
3. **Smart save logic**: Creates new or updates existing (with --force)
4. **stderr for confirmations**: Keeps stdout clean for piping

## Usage

```bash
# Save a query as a dashboard
bwrb list --type task --where "status='active'" --save-as "active-tasks"

# Overwrite existing dashboard
bwrb list --type task --output tree --save-as "active-tasks" --force

# Run the saved dashboard
bwrb dashboard active-tasks
```

## Testing

10 new test cases covering:
- Basic save, where filters, output format, fields
- Error when dashboard exists, force overwrite
- JSON mode with save-as, empty query, JSON error

Fixes #204