### PR TITLE
feat(dashboard): add picker and default dashboard support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Added
 
+- **Dashboard picker and default dashboard support** (#198)
+  - `bwrb dashboard` (no args) shows an interactive picker to select from saved dashboards
+  - Picker shows dashboard names with type info (e.g., "my-tasks (task)")
+  - Configure default dashboard in schema: `config.default_dashboard: "dashboard-name"`
+  - Default dashboard runs automatically when configured
+  - Graceful fallback: warns and shows picker if configured default doesn't exist
+  - JSON mode: `--output json` returns list of available dashboards
+  - Helpful message when no dashboards exist
+
 - **`--save-as` flag for list command to save queries as dashboards** (#204)
   - `bwrb list --type task --where "status='active'" --save-as "active-tasks"` saves query as reusable dashboard
   - Saves all query parameters: type, path, where, body, output, and fields


### PR DESCRIPTION
## Summary

- Implements `bwrb dashboard` (no args) to show an interactive picker or run the configured default dashboard
- Adds comprehensive tests for all behaviors (unit tests + PTY tests)

## Changes

When `bwrb dashboard` is called without arguments:
- **Shows interactive picker** to select from saved dashboards
- **Picker displays type info**: e.g., "my-tasks (task)"
- **Runs default dashboard** if `config.default_dashboard` is set in schema
- **Warns and falls back to picker** if configured default doesn't exist
- **In non-TTY mode**: returns helpful error listing available dashboards
- **JSON mode** (`--output json`): returns `{dashboards: [...], default: "name" | null}`
- **Empty state**: shows helpful message with guidance on creating dashboards

## Testing

- Added 9 new unit tests for empty state, JSON mode, default dashboard, and non-TTY fallback
- Added 4 new PTY tests for picker interaction, cancellation, and default dashboard behavior
- All 1317 tests pass

Fixes #198