### PR TITLE
feat!: remove deprecated simple filter flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Removed (Breaking)
+
+- **Simple filter flags (`--status=active`, `--priority=high`, etc.) have been removed** (#220)
+  - These deprecated flags are no longer supported on `list`, `search`, `bulk`, and `edit` commands
+  - Use `--where` expressions instead:
+    ```bash
+    # Before (no longer works):
+    bwrb list task --status=active
+    bwrb bulk idea --priority=high --set reviewed=true
+    
+    # After:
+    bwrb list task --where "status == 'active'"
+    bwrb bulk idea --where "priority == 'high'" --set reviewed=true
+    ```
+  - Migration notes:
+    - Equality: `--status=active` → `--where "status == 'active'"`
+    - Negation: `--status!=active` → `--where "status != 'active'"`
+    - Multiple values (OR): `--status=active,done` → `--where "status == 'active' || status == 'done'"`
+    - Multiple filters (AND): `--status=active --priority=high` → `--where "status == 'active'" --where "priority == 'high'"`
+  - Rationale: `--where` is more powerful (supports operators, functions, boolean logic), reduces flag proliferation, and provides a consistent query interface
+
 ### Added
 
 - **Dashboard picker and default dashboard support** (#198)

--- a/docs/product/cli-targeting.md
+++ b/docs/product/cli-targeting.md
@@ -246,24 +246,6 @@ bwrb search "TODO" --output content      # Full file with matches
 
 ---
 
-## Deprecations
-
-### Simple filter flags (e.g., `--status=active`)
-
-**Deprecated.** Use `--where` instead.
-
-```bash
-# Old (deprecated):
-bwrb list task --status=active
-
-# New:
-bwrb list task --where "status == 'active'"
-```
-
-**Rationale:** `--where` is more powerful, consistent, and reduces flag proliferation. Simple filters will emit deprecation warnings and be removed in a future version.
-
----
-
 ## Examples
 
 ### Onboarding/migration workflow

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -142,8 +142,6 @@ async function runDashboard(
     const listOpts: ListOptions = {
       outputFormat: effectiveFormat,
       fields: dashboard.fields,
-      filters: [],
-      whereExpressions: [],
     };
 
     await listObjects(schema, vaultDir, targeting.type, targetResult.files, listOpts);

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -17,7 +17,6 @@ import { buildNoteIndex, type ManagedFile } from '../lib/navigation.js';
 import { parsePickerMode, resolveAndPick, type PickerMode } from '../lib/picker.js';
 import { editNoteFromJson, editNoteInteractive } from '../lib/edit.js';
 import { openNote, resolveAppMode } from './open.js';
-import { parseFilters, validateFilters } from '../lib/query.js';
 import { resolveTargets, hasAnyTargeting, type TargetingOptions } from '../lib/targeting.js';
 
 // ============================================================================
@@ -55,12 +54,8 @@ Targeting Options:
   All targeting options compose (AND logic):
   -t, --type <type>    Filter by note type (e.g., task, idea)
   -p, --path <glob>    Filter by path pattern (e.g., "Projects/**")
-  -w, --where <expr>   Filter by frontmatter (e.g., "status=active")
+  -w, --where <expr>   Filter by frontmatter (e.g., "status == 'active'")
   -b, --body <pattern> Filter by body content
-
-Simple Filters (shorthand for --where):
-  field=value          Match where field equals value
-  field!=value         Exclude where field equals value
 
 Examples:
   # Interactive editing
@@ -70,7 +65,7 @@ Examples:
 
   # Non-interactive JSON mode (scripting)
   bwrb edit "My Task" --json '{"status":"done"}'
-  bwrb edit -t task --where "status=active" "Deploy" --json '{"priority":"high"}'
+  bwrb edit -t task --where "status == 'active'" "Deploy" --json '{"priority":"high"}'
 
   # Edit and open
   bwrb edit "My Note" --open                # Open the note after editing
@@ -92,25 +87,6 @@ Examples:
             process.exit(ExitCodes.VALIDATION_ERROR);
           }
           printError(error);
-          process.exit(1);
-        }
-      }
-
-      // Parse simple filters from remaining arguments
-      const filterArgs = cmd.args.slice(query ? 1 : 0);
-      const simpleFilters = parseFilters(filterArgs);
-
-      // Validate filters if type is specified
-      if (options.type && simpleFilters.length > 0) {
-        const validation = validateFilters(schema, options.type, simpleFilters);
-        if (!validation.valid) {
-          if (jsonMode) {
-            printJson(jsonError(validation.errors.join('; ')));
-            process.exit(ExitCodes.VALIDATION_ERROR);
-          }
-          for (const error of validation.errors) {
-            printError(error);
-          }
           process.exit(1);
         }
       }

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -93,7 +93,6 @@ export async function runAudit(
     );
     
     const filtered = await applyFrontmatterFilters(filesWithFrontmatter, {
-      filters: [],
       whereExpressions: options.whereExpressions,
       vaultDir,
       silent: true,

--- a/src/lib/bulk/execute.ts
+++ b/src/lib/bulk/execute.ts
@@ -6,7 +6,6 @@ import { relative, dirname, basename } from 'path';
 import { stat } from 'fs/promises';
 import { parseNote, writeNote } from '../frontmatter.js';
 import { matchesExpression, type EvalContext } from '../expression.js';
-import { matchesAllFilters } from '../query.js';
 import { discoverManagedFiles } from '../discovery.js';
 import { searchContent } from '../content-search.js';
 import { filterByPath } from '../targeting.js';
@@ -37,7 +36,6 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
     textQuery,
     operations,
     whereExpressions,
-    simpleFilters,
     execute,
     backup,
     limit,
@@ -102,13 +100,6 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
   for (const file of files) {
     try {
       const { frontmatter, body } = await parseNote(file.path);
-
-      // Apply simple filters (--field=value syntax)
-      if (simpleFilters.length > 0) {
-        if (!matchesAllFilters(frontmatter, simpleFilters)) {
-          continue;
-        }
-      }
 
       // Apply where expression filters
       if (whereExpressions.length > 0) {
@@ -201,7 +192,6 @@ async function executeBulkWithMove(
     pathGlob,
     textQuery,
     whereExpressions,
-    simpleFilters,
     execute,
     backup,
     limit,
@@ -263,13 +253,6 @@ async function executeBulkWithMove(
   for (const file of files) {
     try {
       const { frontmatter } = await parseNote(file.path);
-
-      // Apply simple filters (--field=value syntax)
-      if (simpleFilters.length > 0) {
-        if (!matchesAllFilters(frontmatter, simpleFilters)) {
-          continue;
-        }
-      }
 
       // Apply where expression filters
       if (whereExpressions.length > 0) {

--- a/src/lib/bulk/types.ts
+++ b/src/lib/bulk/types.ts
@@ -84,15 +84,6 @@ export interface WikilinkUpdateInfo {
 }
 
 /**
- * Simple filter (--field=value syntax).
- */
-export interface SimpleFilter {
-  field: string;
-  operator: 'eq' | 'neq';
-  values: string[];
-}
-
-/**
  * Options for bulk execution.
  */
 export interface BulkOptions {
@@ -101,7 +92,6 @@ export interface BulkOptions {
   textQuery?: string;
   operations: BulkOperation[];
   whereExpressions: string[];
-  simpleFilters: SimpleFilter[];
   execute: boolean;
   backup: boolean;
   limit?: number;

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1,101 +1,9 @@
 import { basename } from 'path';
 import type { LoadedSchema } from '../types/schema.js';
-import { getAllFieldsForType, getOptionsForField } from './schema.js';
+import { getAllFieldsForType } from './schema.js';
 import { matchesExpression, buildEvalContext, type HierarchyData } from './expression.js';
 import { printError } from './prompt.js';
 import { extractWikilinkTarget } from './audit/types.js';
-
-export interface Filter {
-  field: string;
-  operator: 'eq' | 'neq';
-  values: string[];
-}
-
-/**
- * Parse filter arguments from CLI (e.g., --status=active, --status!=done).
- */
-export function parseFilters(args: string[]): Filter[] {
-  const filters: Filter[] = [];
-
-  for (const arg of args) {
-    if (!arg.startsWith('--')) continue;
-
-    const withoutPrefix = arg.slice(2);
-
-    // Check for negation filter: --field!=value
-    if (withoutPrefix.includes('!=')) {
-      const [field, value] = withoutPrefix.split('!=', 2);
-      if (field) {
-        filters.push({
-          field,
-          operator: 'neq',
-          values: value ? value.split(',') : [],
-        });
-      }
-    }
-    // Check for equality filter: --field=value
-    else if (withoutPrefix.includes('=')) {
-      const [field, value] = withoutPrefix.split('=', 2);
-      if (field) {
-        filters.push({
-          field,
-          operator: 'eq',
-          values: value ? value.split(',') : [],
-        });
-      }
-    }
-  }
-
-  return filters;
-}
-
-/**
- * Check if a single filter matches a frontmatter value.
- */
-export function matchesFilter(
-  frontmatterValue: unknown,
-  filter: Filter
-): boolean {
-  const strValue = String(frontmatterValue ?? '');
-  const isEmpty = frontmatterValue === undefined || frontmatterValue === null || frontmatterValue === '';
-
-  // Handle empty filter value (checking for missing/empty field)
-  if (filter.values.length === 0) {
-    if (filter.operator === 'eq') {
-      // --field= : match if field is empty/missing
-      return isEmpty;
-    } else {
-      // --field!= : match if field is NOT empty (exists with value)
-      return !isEmpty;
-    }
-  }
-
-  // Check if value is in the filter values
-  const found = filter.values.includes(strValue);
-
-  if (filter.operator === 'eq') {
-    // --field=val : match if value is in list
-    return found;
-  } else {
-    // --field!=val : match if value is NOT in list
-    return !found;
-  }
-}
-
-/**
- * Check if all filters match a frontmatter object.
- */
-export function matchesAllFilters(
-  frontmatter: Record<string, unknown>,
-  filters: Filter[]
-): boolean {
-  for (const filter of filters) {
-    if (!matchesFilter(frontmatter[filter.field], filter)) {
-      return false;
-    }
-  }
-  return true;
-}
 
 /**
  * Validate that a field name is valid for a type.
@@ -119,75 +27,9 @@ export function validateFieldForType(
 }
 
 /**
- * Validate that filter values are valid for a field (if it's an enum field).
- */
-export function validateFilterValues(
-  schema: LoadedSchema,
-  typeName: string,
-  fieldName: string,
-  values: string[]
-): { valid: boolean; error?: string } {
-  // Empty values are always valid (means "field is missing")
-  if (values.length === 0) {
-    return { valid: true };
-  }
-
-  const validOptions = getOptionsForField(schema, typeName, fieldName);
-  if (validOptions.length === 0) {
-    // Not a select field with options, any value is valid
-    return { valid: true };
-  }
-
-  for (const val of values) {
-    if (!validOptions.includes(val)) {
-      const validList = validOptions.join(', ');
-      return {
-        valid: false,
-        error: `Invalid value '${val}' for field '${fieldName}'. Valid values: ${validList}`,
-      };
-    }
-  }
-
-  return { valid: true };
-}
-
-/**
- * Validate all filters for a type.
- */
-export function validateFilters(
-  schema: LoadedSchema,
-  typeName: string,
-  filters: Filter[]
-): { valid: boolean; errors: string[] } {
-  const errors: string[] = [];
-
-  for (const filter of filters) {
-    // Validate field name
-    const fieldResult = validateFieldForType(schema, typeName, filter.field);
-    if (!fieldResult.valid && fieldResult.error) {
-      errors.push(fieldResult.error);
-      continue;
-    }
-
-    // Validate filter values
-    const valuesResult = validateFilterValues(schema, typeName, filter.field, filter.values);
-    if (!valuesResult.valid && valuesResult.error) {
-      errors.push(valuesResult.error);
-    }
-  }
-
-  return {
-    valid: errors.length === 0,
-    errors,
-  };
-}
-
-/**
  * Options for applyFrontmatterFilters.
  */
 export interface FrontmatterFilterOptions {
-  /** Simple field=value filters */
-  filters: Filter[];
   /** Expression-based filters (--where) */
   whereExpressions: string[];
   /** Vault directory for building eval context */
@@ -256,8 +98,8 @@ export interface FileWithFrontmatter {
 /**
  * Apply frontmatter filters to a list of files.
  * 
- * Filters files using both simple filters (--field=value) and 
- * expression filters (--where). Returns only files that match all criteria.
+ * Filters files using expression filters (--where).
+ * Returns only files that match all criteria.
  * 
  * @param files - Array of objects with path and frontmatter
  * @param options - Filter options
@@ -267,7 +109,7 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
   files: T[],
   options: FrontmatterFilterOptions
 ): Promise<T[]> {
-  const { filters, whereExpressions, vaultDir, silent = false } = options;
+  const { whereExpressions, vaultDir, silent = false } = options;
   const result: T[] = [];
 
   // Build hierarchy data if any expression uses hierarchy functions
@@ -278,11 +120,6 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
   }
 
   for (const file of files) {
-    // Apply simple filters first (--field=value style)
-    if (!matchesAllFilters(file.frontmatter, filters)) {
-      continue;
-    }
-
     // Apply expression filters (--where style)
     if (whereExpressions.length > 0) {
       const context = await buildEvalContext(file.path, vaultDir, file.frontmatter);

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -23,11 +23,7 @@ import {
   loadGitignore,
 } from './discovery.js';
 import { parseNote } from './frontmatter.js';
-import {
-  applyFrontmatterFilters,
-  parseFilters,
-  type Filter,
-} from './query.js';
+import { applyFrontmatterFilters } from './query.js';
 import { searchContent } from './content-search.js';
 import { getTypeNames } from './schema.js';
 
@@ -186,40 +182,6 @@ export function parsePositionalArg(
 }
 
 // ============================================================================
-// Deprecation Warnings
-// ============================================================================
-
-/**
- * Check for deprecated simple filter flags and return warnings.
- * Simple filters like --status=active should use --where instead.
- */
-export function checkDeprecatedFilters(
-  args: string[]
-): { filters: Filter[]; warnings: string[] } {
-  const filters = parseFilters(args);
-  const warnings: string[] = [];
-
-  if (filters.length > 0) {
-    const filterStrs = filters.map(f => {
-      const op = f.operator === 'eq' ? '=' : '!=';
-      return `--${f.field}${op}${f.values.join(',')}`;
-    });
-
-    warnings.push(
-      `Deprecation warning: Simple filter flags (${filterStrs.join(', ')}) are deprecated.\n` +
-      `Use --where instead:\n` +
-      filters.map(f => {
-        const op = f.operator === 'eq' ? '=' : '!=';
-        const val = f.values.length === 1 ? f.values[0] : `(${f.values.join(',')})`;
-        return `  --where '${f.field}${op}${val}'`;
-      }).join('\n')
-    );
-  }
-
-  return { filters, warnings };
-}
-
-// ============================================================================
 // Path Filtering
 // ============================================================================
 
@@ -362,7 +324,6 @@ export async function resolveTargets(
     // Step 5: Filter by --where expressions
     if (options.where && options.where.length > 0) {
       const filtered = await applyFrontmatterFilters(filesWithFrontmatter, {
-        filters: [], // No simple filters in new model
         whereExpressions: options.where,
         vaultDir,
         silent: true,

--- a/tests/ts/commands/json-io.test.ts
+++ b/tests/ts/commands/json-io.test.ts
@@ -483,7 +483,7 @@ describe('JSON I/O', () => {
 
     it('should return empty array for no matches', async () => {
       const result = await runCLI(
-        ['list', 'idea', '--status=settled', '--output', 'json'],
+        ['list', 'idea', '--where', "status == 'settled'", '--output', 'json'],
         vaultDir
       );
 
@@ -494,7 +494,7 @@ describe('JSON I/O', () => {
 
     it('should apply filters in JSON mode', async () => {
       const result = await runCLI(
-        ['list', 'idea', '--status=raw', '--output', 'json'],
+        ['list', 'idea', '--where', "status == 'raw'", '--output', 'json'],
         vaultDir
       );
 

--- a/tests/ts/commands/relative-paths.test.ts
+++ b/tests/ts/commands/relative-paths.test.ts
@@ -50,7 +50,7 @@ describe('relative vault path handling', () => {
     });
 
     it('should filter correctly with relative path', async () => {
-      const result = await runCLI(['--vault', relativeVaultPath, 'list', 'idea', '--status=raw']);
+      const result = await runCLI(['--vault', relativeVaultPath, 'list', 'idea', '--where', "status == 'raw'"]);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Sample Idea');

--- a/tests/ts/commands/search.test.ts
+++ b/tests/ts/commands/search.test.ts
@@ -503,10 +503,10 @@ Some content
       }
     });
 
-    it('should filter results with simple --field=value syntax', async () => {
+    it('should filter results with --where expression', async () => {
       const result = await runCLI([
         'search', 'status', '--body', '--type', 'idea',
-        '--status=raw',
+        '--where', "status == 'raw'",
         '--no-context'
       ], vaultDir);
 
@@ -518,10 +518,10 @@ Some content
       }
     });
 
-    it('should filter results with negation --field!=value syntax', async () => {
+    it('should filter results with negation using --where', async () => {
       const result = await runCLI([
         'search', 'status', '--body', '--type', 'idea',
-        '--status!=raw',
+        '--where', "status != 'raw'",
         '--no-context'
       ], vaultDir);
 
@@ -571,69 +571,11 @@ Some content
       expect(result.stdout).toContain('--limit');
     });
 
-    describe('filter validation with --type', () => {
-      it('should error on invalid filter field when --type is specified', async () => {
+    describe('--where validation with --type', () => {
+      it('should accept valid --where with --type', async () => {
         const result = await runCLI([
           'search', 'status', '--body', '--type', 'idea',
-          '--nonexistent=value'
-        ], vaultDir);
-
-        expect(result.exitCode).toBe(1);
-        expect(result.stderr).toContain('Unknown field');
-        expect(result.stderr).toContain('nonexistent');
-      });
-
-      it('should error on invalid enum value when --type is specified', async () => {
-        const result = await runCLI([
-          'search', 'status', '--body', '--type', 'idea',
-          '--status=invalid'
-        ], vaultDir);
-
-        expect(result.exitCode).toBe(1);
-        expect(result.stderr).toContain('Invalid value');
-        expect(result.stderr).toContain('invalid');
-      });
-
-      it('should output JSON error for invalid field when --type is specified', async () => {
-        const result = await runCLI([
-          'search', 'status', '--body', '--type', 'idea',
-          '--nonexistent=value', '--output', 'json'
-        ], vaultDir);
-
-        expect(result.exitCode).toBe(1);
-        const json = JSON.parse(result.stdout);
-        expect(json.success).toBe(false);
-        expect(json.error).toContain('Unknown field');
-      });
-
-      it('should output JSON error for invalid enum value when --type is specified', async () => {
-        const result = await runCLI([
-          'search', 'status', '--body', '--type', 'idea',
-          '--status=invalid', '--output', 'json'
-        ], vaultDir);
-
-        expect(result.exitCode).toBe(1);
-        const json = JSON.parse(result.stdout);
-        expect(json.success).toBe(false);
-        expect(json.error).toContain('Invalid value');
-      });
-
-      it('should NOT validate filters when --type is NOT specified', async () => {
-        // Without --type, there's no schema context, so filters are not validated
-        // They just silently won't match anything
-        const result = await runCLI([
-          'search', 'status', '--body',
-          '--nonexistent=value'
-        ], vaultDir);
-
-        // Should succeed (no validation error) but return no matches
-        expect(result.exitCode).toBe(0);
-      });
-
-      it('should accept valid filter with --type', async () => {
-        const result = await runCLI([
-          'search', 'status', '--body', '--type', 'idea',
-          '--status=raw', '--no-context'
+          '--where', "status == 'raw'", '--no-context'
         ], vaultDir);
 
         expect(result.exitCode).toBe(0);

--- a/tests/ts/lib/query.test.ts
+++ b/tests/ts/lib/query.test.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { join } from 'path';
 import {
-  parseFilters,
-  matchesFilter,
-  matchesAllFilters,
   validateFieldForType,
-  validateFilterValues,
-  validateFilters,
   applyFrontmatterFilters,
   type FileWithFrontmatter,
 } from '../../../src/lib/query.js';
@@ -27,100 +22,6 @@ describe('query', () => {
     await cleanupTestVault(vaultDir);
   });
 
-  describe('parseFilters', () => {
-    it('should parse equality filter', () => {
-      const filters = parseFilters(['--status=raw']);
-      expect(filters).toHaveLength(1);
-      expect(filters[0]).toEqual({
-        field: 'status',
-        operator: 'eq',
-        values: ['raw'],
-      });
-    });
-
-    it('should parse negation filter', () => {
-      const filters = parseFilters(['--status!=settled']);
-      expect(filters).toHaveLength(1);
-      expect(filters[0]).toEqual({
-        field: 'status',
-        operator: 'neq',
-        values: ['settled'],
-      });
-    });
-
-    it('should parse multiple values', () => {
-      const filters = parseFilters(['--status=raw,backlog']);
-      expect(filters[0]?.values).toEqual(['raw', 'backlog']);
-    });
-
-    it('should parse empty value filter', () => {
-      const filters = parseFilters(['--deadline=']);
-      expect(filters[0]).toEqual({
-        field: 'deadline',
-        operator: 'eq',
-        values: [],
-      });
-    });
-
-    it('should ignore non-filter arguments', () => {
-      const filters = parseFilters(['idea', '--status=raw', 'extra']);
-      expect(filters).toHaveLength(1);
-    });
-  });
-
-  describe('matchesFilter', () => {
-    it('should match equality filter', () => {
-      const filter = { field: 'status', operator: 'eq' as const, values: ['raw'] };
-      expect(matchesFilter('raw', filter)).toBe(true);
-      expect(matchesFilter('backlog', filter)).toBe(false);
-    });
-
-    it('should match negation filter', () => {
-      const filter = { field: 'status', operator: 'neq' as const, values: ['settled'] };
-      expect(matchesFilter('raw', filter)).toBe(true);
-      expect(matchesFilter('settled', filter)).toBe(false);
-    });
-
-    it('should match multiple values (OR)', () => {
-      const filter = { field: 'status', operator: 'eq' as const, values: ['raw', 'backlog'] };
-      expect(matchesFilter('raw', filter)).toBe(true);
-      expect(matchesFilter('backlog', filter)).toBe(true);
-      expect(matchesFilter('settled', filter)).toBe(false);
-    });
-
-    it('should handle empty filter (missing field check)', () => {
-      const filter = { field: 'deadline', operator: 'eq' as const, values: [] };
-      expect(matchesFilter(undefined, filter)).toBe(true);
-      expect(matchesFilter('2024-01-15', filter)).toBe(false);
-    });
-
-    it('should handle non-empty filter (exists check)', () => {
-      const filter = { field: 'deadline', operator: 'neq' as const, values: [] };
-      expect(matchesFilter('2024-01-15', filter)).toBe(true);
-      expect(matchesFilter(undefined, filter)).toBe(false);
-    });
-  });
-
-  describe('matchesAllFilters', () => {
-    it('should match all filters', () => {
-      const frontmatter = { type: 'idea', status: 'raw', priority: 'high' };
-      const filters = [
-        { field: 'status', operator: 'eq' as const, values: ['raw'] },
-        { field: 'priority', operator: 'eq' as const, values: ['high'] },
-      ];
-      expect(matchesAllFilters(frontmatter, filters)).toBe(true);
-    });
-
-    it('should fail if any filter does not match', () => {
-      const frontmatter = { type: 'idea', status: 'raw', priority: 'low' };
-      const filters = [
-        { field: 'status', operator: 'eq' as const, values: ['raw'] },
-        { field: 'priority', operator: 'eq' as const, values: ['high'] },
-      ];
-      expect(matchesAllFilters(frontmatter, filters)).toBe(false);
-    });
-  });
-
   describe('validateFieldForType', () => {
     it('should accept valid fields', () => {
       const result = validateFieldForType(schema, 'idea', 'status');
@@ -134,51 +35,12 @@ describe('query', () => {
     });
   });
 
-  describe('validateFilterValues', () => {
-    it('should accept valid enum values', () => {
-      const result = validateFilterValues(schema, 'idea', 'status', ['raw', 'backlog']);
-      expect(result.valid).toBe(true);
-    });
-
-    it('should reject invalid enum values', () => {
-      const result = validateFilterValues(schema, 'idea', 'status', ['invalid']);
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain('Invalid value');
-    });
-
-    it('should accept any value for non-enum fields', () => {
-      const result = validateFilterValues(schema, 'task', 'deadline', ['anything']);
-      expect(result.valid).toBe(true);
-    });
-  });
-
-  describe('validateFilters', () => {
-    it('should validate all filters', () => {
-      const filters = [
-        { field: 'status', operator: 'eq' as const, values: ['raw'] },
-      ];
-      const result = validateFilters(schema, 'idea', filters);
-      expect(result.valid).toBe(true);
-      expect(result.errors).toHaveLength(0);
-    });
-
-    it('should collect all errors', () => {
-      const filters = [
-        { field: 'unknown', operator: 'eq' as const, values: ['value'] },
-        { field: 'status', operator: 'eq' as const, values: ['invalid'] },
-      ];
-      const result = validateFilters(schema, 'idea', filters);
-      expect(result.valid).toBe(false);
-      expect(result.errors.length).toBeGreaterThan(0);
-    });
-  });
-
   describe('applyFrontmatterFilters', () => {
     // Helper to create test files with frontmatter
     const makeFiles = (data: Array<{ path: string; fm: Record<string, unknown> }>): FileWithFrontmatter[] =>
       data.map(d => ({ path: join(vaultDir, d.path), frontmatter: d.fm }));
 
-    it('should filter by simple equality filter', async () => {
+    it('should filter by where expression for equality', async () => {
       const files = makeFiles([
         { path: 'a.md', fm: { status: 'active' } },
         { path: 'b.md', fm: { status: 'done' } },
@@ -186,8 +48,7 @@ describe('query', () => {
       ]);
 
       const result = await applyFrontmatterFilters(files, {
-        filters: [{ field: 'status', operator: 'eq', values: ['active'] }],
-        whereExpressions: [],
+        whereExpressions: ["status == 'active'"],
         vaultDir,
         silent: true,
       });
@@ -196,7 +57,7 @@ describe('query', () => {
       expect(result.map(f => f.frontmatter.status)).toEqual(['active', 'active']);
     });
 
-    it('should filter by simple negation filter', async () => {
+    it('should filter by where expression for inequality', async () => {
       const files = makeFiles([
         { path: 'a.md', fm: { status: 'active' } },
         { path: 'b.md', fm: { status: 'done' } },
@@ -204,8 +65,7 @@ describe('query', () => {
       ]);
 
       const result = await applyFrontmatterFilters(files, {
-        filters: [{ field: 'status', operator: 'neq', values: ['done'] }],
-        whereExpressions: [],
+        whereExpressions: ["status != 'done'"],
         vaultDir,
         silent: true,
       });
@@ -214,7 +74,7 @@ describe('query', () => {
       expect(result.map(f => f.frontmatter.status)).toEqual(['active', 'pending']);
     });
 
-    it('should filter by where expression', async () => {
+    it('should filter by numeric comparison', async () => {
       const files = makeFiles([
         { path: 'a.md', fm: { priority: 1 } },
         { path: 'b.md', fm: { priority: 3 } },
@@ -222,7 +82,6 @@ describe('query', () => {
       ]);
 
       const result = await applyFrontmatterFilters(files, {
-        filters: [],
         whereExpressions: ['priority < 3'],
         vaultDir,
         silent: true,
@@ -232,7 +91,7 @@ describe('query', () => {
       expect(result.map(f => f.frontmatter.priority)).toEqual([1, 2]);
     });
 
-    it('should combine simple filters and where expressions', async () => {
+    it('should combine multiple where expressions (ANDed)', async () => {
       const files = makeFiles([
         { path: 'a.md', fm: { status: 'active', priority: 1 } },
         { path: 'b.md', fm: { status: 'active', priority: 3 } },
@@ -241,8 +100,7 @@ describe('query', () => {
       ]);
 
       const result = await applyFrontmatterFilters(files, {
-        filters: [{ field: 'status', operator: 'eq', values: ['active'] }],
-        whereExpressions: ['priority < 3'],
+        whereExpressions: ["status == 'active'", 'priority < 3'],
         vaultDir,
         silent: true,
       });
@@ -252,24 +110,6 @@ describe('query', () => {
       expect(result[1]?.frontmatter).toEqual({ status: 'active', priority: 2 });
     });
 
-    it('should apply multiple where expressions (ANDed)', async () => {
-      const files = makeFiles([
-        { path: 'a.md', fm: { status: 'active', priority: 1 } },
-        { path: 'b.md', fm: { status: 'done', priority: 1 } },
-        { path: 'c.md', fm: { status: 'active', priority: 3 } },
-      ]);
-
-      const result = await applyFrontmatterFilters(files, {
-        filters: [],
-        whereExpressions: ["status == 'active'", 'priority < 2'],
-        vaultDir,
-        silent: true,
-      });
-
-      expect(result).toHaveLength(1);
-      expect(result[0]?.frontmatter).toEqual({ status: 'active', priority: 1 });
-    });
-
     it('should return empty array when no files match', async () => {
       const files = makeFiles([
         { path: 'a.md', fm: { status: 'done' } },
@@ -277,8 +117,7 @@ describe('query', () => {
       ]);
 
       const result = await applyFrontmatterFilters(files, {
-        filters: [{ field: 'status', operator: 'eq', values: ['active'] }],
-        whereExpressions: [],
+        whereExpressions: ["status == 'active'"],
         vaultDir,
         silent: true,
       });
@@ -293,7 +132,6 @@ describe('query', () => {
       ]);
 
       const result = await applyFrontmatterFilters(files, {
-        filters: [],
         whereExpressions: [],
         vaultDir,
         silent: true,
@@ -307,7 +145,6 @@ describe('query', () => {
       const files = [originalFile];
 
       const result = await applyFrontmatterFilters(files, {
-        filters: [],
         whereExpressions: [],
         vaultDir,
         silent: true,
@@ -324,7 +161,6 @@ describe('query', () => {
       ]);
 
       const result = await applyFrontmatterFilters(files, {
-        filters: [],
         whereExpressions: ['!isEmpty(deadline)'],
         vaultDir,
         silent: true,

--- a/tests/ts/lib/targeting.test.ts
+++ b/tests/ts/lib/targeting.test.ts
@@ -3,7 +3,6 @@ import type { LoadedSchema } from '../../../src/types/schema.js';
 import {
   detectPositionalType,
   parsePositionalArg,
-  checkDeprecatedFilters,
   filterByPath,
   resolveTargets,
   validateDestructiveTargeting,
@@ -104,22 +103,6 @@ describe('targeting', () => {
       expect(result.error).toContain('--path=');
       expect(result.error).toContain('--where=');
       expect(result.error).toContain('Known types:');
-    });
-  });
-
-  describe('checkDeprecatedFilters', () => {
-    it('detects simple filter flags', () => {
-      const result = checkDeprecatedFilters(['--status=active', '--priority=high']);
-      expect(result.filters).toHaveLength(2);
-      expect(result.warnings).toHaveLength(1);
-      expect(result.warnings[0]).toContain('Deprecation warning');
-      expect(result.warnings[0]).toContain('--where');
-    });
-
-    it('returns empty for non-filter args', () => {
-      const result = checkDeprecatedFilters(['--type', 'task', '--path', 'Projects/**']);
-      expect(result.filters).toHaveLength(0);
-      expect(result.warnings).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## Summary

Removes the deprecated simple filter flags (`--status=active`, `--priority=high`, etc.) from all commands. Users should use `--where` expressions instead.

Fixes #220

## Breaking Change

Simple filter flags are no longer supported:
- `--status=active` → `--where "status == 'active'"`
- `--status!=active` → `--where "status != 'active'"`
- `--status=active,done` → `--where "status == 'active' || status == 'done'"`
- `--status=active --priority=high` → `--where "status == 'active'" --where "priority == 'high'"`

## Changes

- Remove `Filter` interface, `parseFilters()`, `matchesFilter()`, `matchesAllFilters()`, `validateFilterValues()`, `validateFilters()` from `lib/query.ts`
- Remove `checkDeprecatedFilters()` from `lib/targeting.ts`
- Remove `SimpleFilter` interface and `simpleFilters` from `lib/bulk/types.ts`
- Remove `.allowUnknownOption(true)` and filter parsing from list, search, bulk, edit commands
- Remove Simple Filters help text sections
- Update all tests to use `--where` syntax
- Update CHANGELOG.md with breaking change documentation
- Remove deprecation section from `docs/product/cli-targeting.md`

## Stats

- 17 files changed
- 81 insertions, 724 deletions (net reduction of 643 lines)