### PR TITLE
chore: remove legacy enum migration operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,15 @@ All notable changes to Bowerbird are documented in this file.
   - Obsidian vault name resolution: `config.obsidian_vault` > auto-detect from `.obsidian/` > folder basename
   - Updated help text across all commands (`open`, `search`, `list`, `edit`, `new`)
 
+### Removed
+
+- **Legacy enum migration operations** (#180)
+  - Removed `EnumMigrationOpSchema` and related types (`add-enum-value`, `remove-enum-value`, `rename-enum-value`)
+  - Removed enum-related `DetectedChange` variants
+  - Removed `valueMappings` parameter from migration execution (was only used for enum value remapping)
+  - Global enums were removed in #165; this cleans up the dead migration code
+  - No user impact: enum migrations were never released
+
 ### Changed
 
 - **Refactored global option handling** (#134)

--- a/src/commands/schema/migrate.ts
+++ b/src/commands/schema/migrate.ts
@@ -57,8 +57,7 @@ function suggestVersionBump(currentVersion: string, diff: MigrationPlan): string
   // Check for breaking changes (non-deterministic usually means breaking)
   const hasBreakingChanges = diff.nonDeterministic.some(op => 
     op.op === 'remove-field' || 
-    op.op === 'remove-type' || 
-    op.op === 'remove-enum-value'
+    op.op === 'remove-type'
   );
   
   if (hasBreakingChanges) {
@@ -68,8 +67,7 @@ function suggestVersionBump(currentVersion: string, diff: MigrationPlan): string
   // Check for additions (minor bump)
   const hasAdditions = diff.deterministic.some(op =>
     op.op === 'add-field' ||
-    op.op === 'add-type' ||
-    op.op === 'add-enum-value'
+    op.op === 'add-type'
   );
   
   if (hasAdditions) {

--- a/src/lib/migration/diff.ts
+++ b/src/lib/migration/diff.ts
@@ -267,14 +267,6 @@ export function describeMigrationOp(op: MigrationOp): string {
       return `Remove field '${op.field}' from type '${op.targetType}'`;
     case 'rename-field':
       return `Rename field '${op.from}' to '${op.to}' on type '${op.targetType}'`;
-    case 'add-enum-value':
-      return `Add value '${op.value}' to enum '${op.enum}'`;
-    case 'remove-enum-value':
-      return op.mapTo
-        ? `Remove value '${op.value}' from enum '${op.enum}' (map to '${op.mapTo}')`
-        : `Remove value '${op.value}' from enum '${op.enum}'`;
-    case 'rename-enum-value':
-      return `Rename enum value '${op.from}' to '${op.to}' in '${op.enum}'`;
     case 'add-type':
       return `Add type '${op.typeName}'`;
     case 'remove-type':
@@ -371,12 +363,6 @@ function formatOpForDisplay(op: MigrationOp): string {
       return `- Remove field "${op.field}" from type "${op.targetType}"`;
     case 'rename-field':
       return `~ Rename field "${op.from}" to "${op.to}" on type "${op.targetType}"`;
-    case 'add-enum-value':
-      return `+ Add value "${op.value}" to enum "${op.enum}"`;
-    case 'remove-enum-value':
-      return `- Remove value "${op.value}" from enum "${op.enum}"${op.mapTo ? ` (map to: ${op.mapTo})` : ''}`;
-    case 'rename-enum-value':
-      return `~ Rename enum value "${op.from}" to "${op.to}" in enum "${op.enum}"`;
     case 'add-type':
       return `+ Add type "${op.typeName}"`;
     case 'remove-type':

--- a/src/types/migration.ts
+++ b/src/types/migration.ts
@@ -31,32 +31,6 @@ export const FieldMigrationOpSchema = z.discriminatedUnion('op', [
 ]);
 
 /**
- * Enum-level migration operations.
- */
-export const EnumMigrationOpSchema = z.discriminatedUnion('op', [
-  // Add a value to an enum
-  z.object({
-    op: z.literal('add-enum-value'),
-    enum: z.string(),
-    value: z.string(),
-  }),
-  // Remove a value from an enum
-  z.object({
-    op: z.literal('remove-enum-value'),
-    enum: z.string(),
-    value: z.string(),
-    mapTo: z.string().optional(), // Value to map existing notes to
-  }),
-  // Rename an enum value
-  z.object({
-    op: z.literal('rename-enum-value'),
-    enum: z.string(),
-    from: z.string(),
-    to: z.string(),
-  }),
-]);
-
-/**
  * Type-level migration operations.
  */
 export const TypeMigrationOpSchema = z.discriminatedUnion('op', [
@@ -90,12 +64,10 @@ export const TypeMigrationOpSchema = z.discriminatedUnion('op', [
  */
 export const MigrationOpSchema = z.union([
   FieldMigrationOpSchema,
-  EnumMigrationOpSchema,
   TypeMigrationOpSchema,
 ]);
 
 export type FieldMigrationOp = z.infer<typeof FieldMigrationOpSchema>;
-export type EnumMigrationOp = z.infer<typeof EnumMigrationOpSchema>;
 export type TypeMigrationOp = z.infer<typeof TypeMigrationOpSchema>;
 export type MigrationOp = z.infer<typeof MigrationOpSchema>;
 
@@ -237,10 +209,6 @@ export type DetectedChange =
   | { kind: 'field-added'; type: string; field: string; hasDefault: boolean }
   | { kind: 'field-removed'; type: string; field: string }
   | { kind: 'field-changed'; type: string; field: string; changes: string[] }
-  | { kind: 'enum-value-added'; enum: string; value: string }
-  | { kind: 'enum-value-removed'; enum: string; value: string }
-  | { kind: 'enum-added'; enum: string; values: string[] }
-  | { kind: 'enum-removed'; enum: string }
   | { kind: 'type-added'; type: string }
   | { kind: 'type-removed'; type: string }
   | { kind: 'type-reparented'; type: string; from?: string; to?: string };


### PR DESCRIPTION
## Summary

Removes dead code from the migration system that handled global enums. Global enums were removed in #165 in favor of inline select options on fields.

- Removed `EnumMigrationOpSchema` and related types (`add-enum-value`, `remove-enum-value`, `rename-enum-value`)
- Removed enum-related `DetectedChange` variants
- Removed `valueMappings` parameter from migration execution (only used for enum value remapping)
- Cleaned up enum case handling in diff, execute, and migrate commands

## Why

The enum migration code was defined but never released to users. With global enums removed from the schema model (#165), this code can never be triggered and adds unnecessary complexity to the migration system.

## Testing

- All 1317 tests pass
- TypeScript compiles cleanly
- No functional behavior changes (dead code removal only)

## Backwards Compatibility

No concern - enum migrations were never released, so no vaults will have enum operations in their history.

Closes #180