### PR TITLE
feat(dashboard): add edit command for modifying dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Added
 
+- **`dashboard edit` command to modify existing dashboards** (#201)
+  - `bwrb dashboard edit <name>` opens interactive editor with current values as defaults
+  - `bwrb dashboard edit` (no args) shows picker to select dashboard
+  - Flag-based editing: `--type`, `--where`, `--path`, `--body`, `--default-output`, `--fields`
+  - JSON mode: `--json '{"type":"task"}'` replaces entire definition
+  - Preserves unchanged fields when using flags
+
 - **Dashboard picker and default dashboard support** (#198)
   - `bwrb dashboard` (no args) shows an interactive picker to select from saved dashboards
   - Picker shows dashboard names with type info (e.g., "my-tasks (task)")

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -148,11 +148,15 @@ export async function promptRequired(message: string): Promise<PromptResult<stri
  * Returns the array of entered values, or null if user cancels (Ctrl+C/Escape).
  * An empty input (just pressing Enter) returns an empty array, not null.
  */
-export async function promptMultiInput(message: string): Promise<PromptResult<string[]>> {
+export async function promptMultiInput(
+  message: string,
+  defaultValue?: string
+): Promise<PromptResult<string[]>> {
   const response = await prompts({
     type: 'text',
     name: 'value',
     message: `${message} (comma-separated)`,
+    initial: defaultValue,
   });
 
   // prompts returns {} on Ctrl+C, so response.value is undefined


### PR DESCRIPTION
## Summary

Implements #201 - adds `bwrb dashboard edit` command to modify existing dashboard query parameters.

- Interactive mode: `bwrb dashboard edit my-tasks` shows prompts with current values as defaults
- Flag mode: `bwrb dashboard edit my-tasks --type idea --where "status='raw'"` updates specific fields
- JSON mode: `bwrb dashboard edit my-tasks --json '{"type":"task"}'` replaces entire definition
- Picker: `bwrb dashboard edit` (no args) shows picker to select dashboard

## Behavior Notes

- **Flag mode preserves unchanged fields** - only updates what you specify
- **JSON mode replaces entire definition** - overwrites all fields
- **`--where` replaces existing expressions** - not appends (predictable behavior)
- **Empty text input clears optional fields** - consistent with other commands

## Testing

- 357 lines of unit tests covering all flag combinations, JSON mode, error handling
- 287 lines of PTY tests for interactive flow, picker, and cancellation
- All existing tests pass

## Acceptance Criteria

- [x] `bwrb dashboard edit my-query` opens interactive editor
- [x] Current values shown as defaults
- [x] Can modify any parameter
- [x] Error if dashboard doesn't exist
- [x] Picker to select dashboard if name not provided

Closes #201