### PR TITLE
docs: configure Vercel deployment for bwrb.dev

### DIFF
--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -19,3 +19,4 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+.vercel

--- a/docs-site/vercel.json
+++ b/docs-site/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "astro",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "installCommand": "npm install"
+}


### PR DESCRIPTION
## Summary

Deploy the documentation site to Vercel and connect the bwrb.dev domain.

- Add `vercel.json` with Astro build configuration
- Configure Vercel project linked to GitHub repo
- Connect bwrb.dev domain
- Initial production deployment complete

## Live Site

**https://bwrb.dev** is now live!

## What was done

1. Created Vercel project `docs-site`
2. Deployed via CLI with `vercel deploy --prod`
3. Added bwrb.dev domain
4. Connected GitHub repo for future deployments

## Manual Step Required

After merging, complete this one-time setup in Vercel dashboard:

1. Go to [Project Settings](https://vercel.com/alice-moores-projects/docs-site/settings/general)
2. Under "Root Directory", click Edit
3. Set to `docs-site`
4. Save

This ensures Git-triggered deployments build from the correct directory.

## Testing

Visit https://bwrb.dev and verify:
- Homepage loads with "Bowerbird" title
- Navigation works
- All pages render

Fixes #211