### PR TITLE
docs: document audit type inference behavior

### DIFF
--- a/docs/product/cli-targeting.md
+++ b/docs/product/cli-targeting.md
@@ -70,6 +70,9 @@ bwrb audit --where "isEmpty(tags)"
 - With `--type`: strict validation (error on unknown fields)
 - Without `--type`: permissive with warnings (supports migration workflows)
 
+**Audit type inference:**
+When running `bwrb audit` without `--type`, each file's type is resolved from its frontmatter `type` field. Files with missing or invalid types report `orphan-file` or `invalid-type` errors and skip type-dependent checks (like `wrong-directory`, `missing-required`, `invalid-enum`). This is by design: audit can't validate fields without knowing the type's schema.
+
 **Hierarchy functions** (for recursive types):
 - `isRoot()` — note has no parent
 - `isChildOf('[[Note]]')` — direct child of specified note

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -120,6 +120,41 @@ bwrb audit --fix
 bwrb audit --fix --auto  # Auto-apply unambiguous fixes
 ```
 
+#### Type Inference and Check Dependencies
+
+Audit resolves each file's type from its frontmatter `type` field. Understanding this is critical for automation:
+
+- **Type resolution**: Each file's `type` field is read and matched to the schema by short name (e.g., `task`, not `objective/task`)
+- **Early termination**: If `type` is missing or invalid, audit reports `orphan-file` or `invalid-type` and **skips all type-dependent checks**
+- **Filtering vs fixing**: `--type` filters which files to audit; it does not fix missing type fields
+
+**Check dependency table:**
+
+| Check | Requires Type Resolution |
+|-------|-------------------------|
+| `orphan-file` | No (reports missing type) |
+| `invalid-type` | No (reports unrecognized type) |
+| `missing-required` | Yes |
+| `invalid-enum` | Yes |
+| `unknown-field` | Yes |
+| `wrong-directory` | Yes |
+| `format-violation` | Yes |
+| `stale-reference` | Partial (body wikilinks always checked; frontmatter relation fields require type) |
+
+**Workflow for files with type issues:**
+
+```bash
+# Step 1: Find files with type problems
+bwrb audit --only orphan-file --output json
+bwrb audit --only invalid-type --output json
+
+# Step 2: Fix type field (bulk or individual)
+bwrb bulk --path "SomeDir/" --set type=task --execute
+
+# Step 3: Re-run full audit to catch type-dependent issues
+bwrb audit
+```
+
 ### Dashboards (Saved Queries)
 
 Dashboards save common list queries for reuse:

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -65,6 +65,12 @@ Issue Types:
   format-violation  Field value doesn't match expected format (wikilink, etc.)
   stale-reference   Wikilink points to non-existent file
 
+Type Resolution:
+  Audit resolves each file's type from its frontmatter 'type' field.
+  If 'type' is missing or invalid, audit reports orphan-file/invalid-type
+  and skips type-dependent checks (missing-required, invalid-enum, etc.).
+  Use --type to filter by type; it does not fix missing type fields.
+
 Targeting Options:
   --type <type>     Filter by type (e.g., idea, objective/task)
   --path <glob>     Filter by file path pattern

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -206,7 +206,7 @@ export async function auditFile(
     issues.push({
       severity: 'error',
       code: 'orphan-file',
-      message: "No 'type' field (in managed directory)",
+      message: "No 'type' field (in managed directory). Type-dependent checks skipped.",
       autoFixable: Boolean(file.expectedType),
       ...(file.expectedType && { inferredType: file.expectedType }),
     });
@@ -221,7 +221,7 @@ export async function auditFile(
     issues.push({
       severity: 'error',
       code: 'invalid-type',
-      message: `Invalid type: '${typeValue}'`,
+      message: `Invalid type: '${typeValue}'. Type-dependent checks skipped.`,
       field: 'type',
       value: typeValue,
       ...(suggestion && { suggestion: `Did you mean '${suggestion}'?` }),
@@ -236,7 +236,7 @@ export async function auditFile(
     issues.push({
       severity: 'error',
       code: 'invalid-type',
-      message: `Invalid type path: '${resolvedTypePath}'`,
+      message: `Invalid type path: '${resolvedTypePath}'. Type-dependent checks skipped.`,
       field: 'type',
       value: typeValue,
       autoFixable: false,


### PR DESCRIPTION
## Summary
- Document how audit resolves types from frontmatter and which checks depend on successful type resolution
- Add "Type Resolution" section to `bwrb audit --help`
- Add type inference subsection with dependency table to agent skill docs (SKILL.md)
- Update error messages to explicitly state when type-dependent checks are skipped

## Changes
| File | Change |
|------|--------|
| `src/commands/audit.ts` | Add Type Resolution section to help text |
| `src/lib/audit/detection.ts` | Update orphan-file/invalid-type messages |
| `docs/skill/SKILL.md` | Add type inference subsection with check dependency table |
| `docs/product/cli-targeting.md` | Add audit type inference note |

## Testing
All 1315 tests pass. The help text now clearly explains:
- Audit resolves type from frontmatter `type` field (short name only)
- Missing/invalid types report orphan-file/invalid-type and skip type-dependent checks
- `--type` filters files but does not fix missing type fields

Fixes #69