### PR TITLE
docs: write complete command reference for all CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Documentation
+
+- **Complete command reference for all CLI commands** (#213)
+  - Enhanced targeting reference with full selector documentation, command matrix, and safety gates
+  - Updated all 13 command pages: `new`, `edit`, `list`, `search`, `open`, `delete`, `audit`, `bulk`, `schema`, `template`, `config`, `completion`, `dashboard`
+  - Added subcommand pages for `schema` (list, validate, diff, migrate, history)
+  - Added subcommand pages for `template` (list, new, edit, delete, validate)
+  - Added subcommand pages for `config` (list, edit)
+  - Comprehensive options tables with short flags (-t, -p, -w, -b, -x, -o)
+  - Two-gate safety model documentation for destructive commands
+  - JSON mode examples for scripting and automation
+  - Cross-linked related commands throughout
+
 ### Changed (Internal)
 
 - **Consolidated test schemas into shared fixtures** (#65)

--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -3,54 +3,138 @@ title: bwrb audit
 description: Validate notes against schema
 ---
 
-Check your vault for schema violations.
+Validate vault files against schema and report issues, with optional interactive repair.
 
-## Usage
-
-```bash
-bwrb audit [options]
-```
-
-## Examples
+## Synopsis
 
 ```bash
-# Audit entire vault
-bwrb audit
-
-# Audit specific type
-bwrb audit --type task
-
-# Show and apply fixes
-bwrb audit --fix
-bwrb audit --fix --execute
-
-# JSON output for CI
-bwrb audit --output json
+bwrb audit [options] [target]
 ```
+
+The target argument is auto-detected as type, path (contains `/`), or where expression.
 
 ## Options
 
+### Targeting
+
 | Option | Description |
 |--------|-------------|
-| `--type <type>` | Audit specific type only |
-| `--path <dir>` | Audit specific directory |
-| `--fix` | Show available fixes |
-| `-x, --execute` | Apply fixes |
-| `--output json` | JSON output |
+| `-t, --type <type>` | Filter by type path |
+| `-p, --path <glob>` | Filter by file path pattern |
+| `-w, --where <expr>` | Filter by frontmatter expression (repeatable) |
+| `-b, --body <query>` | Filter by body content |
 
-## Exit Codes
+### Issue Filtering
 
-- `0` — No violations
-- `1` — Violations found
+| Option | Description |
+|--------|-------------|
+| `--only <issue-type>` | Only report specific issue type |
+| `--ignore <issue-type>` | Ignore specific issue type |
+| `--strict` | Treat unknown fields as errors instead of warnings |
+| `--allow-field <fields>` | Allow additional fields beyond schema (repeatable) |
 
-## CI Integration
+### Repair
+
+| Option | Description |
+|--------|-------------|
+| `--fix` | Interactive repair mode |
+| `--auto` | With `--fix`: automatically apply unambiguous fixes |
+
+### Output
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <format>` | Output format: `text`, `json` |
+
+## Issue Types
+
+| Type | Description |
+|------|-------------|
+| `orphan-file` | File in managed directory but no `type` field |
+| `invalid-type` | Type field value not recognized in schema |
+| `missing-required` | Required field is missing |
+| `invalid-enum` | Field value not in allowed enum values |
+| `unknown-field` | Field not defined in schema (warning by default) |
+| `wrong-directory` | File location doesn't match its type's output_dir |
+| `format-violation` | Field value doesn't match expected format (wikilink, etc.) |
+| `stale-reference` | Wikilink points to non-existent file |
+
+## Examples
+
+### Basic Auditing
 
 ```bash
+# Check all files (report only)
+bwrb audit
+
+# Check only tasks
+bwrb audit --type objective/task
+
+# Check specific directory
+bwrb audit --path "Ideas/**"
+
+# Check files with specific status
+bwrb audit --where "status=active"
+
+# Check files containing TODO
+bwrb audit --body "TODO"
+```
+
+### Issue Filtering
+
+```bash
+# Only missing required fields
+bwrb audit --only missing-required
+
+# Ignore unknown fields
+bwrb audit --ignore unknown-field
+
+# Strict mode: unknown fields are errors
+bwrb audit --strict
+
+# Allow specific extra fields
+bwrb audit --allow-field custom --allow-field legacy
+```
+
+### Repair Mode
+
+```bash
+# Interactive fix mode
+bwrb audit --fix
+
+# Auto-apply unambiguous fixes
+bwrb audit --fix --auto
+```
+
+### CI Integration
+
+```bash
+# JSON output for CI
+bwrb audit --output json
+
 # Fail build on schema violations
 bwrb audit --output json || exit 1
 ```
 
+## Type Resolution
+
+Audit resolves each file's type from its frontmatter `type` field:
+
+- If `type` is missing: reports `orphan-file` and skips type-dependent checks
+- If `type` is invalid: reports `invalid-type` and skips type-dependent checks
+- Type-dependent checks (`missing-required`, `invalid-enum`, `wrong-directory`) require valid type resolution
+
+Use `--type` to filter by type; it does not fix missing type fields.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | No violations found |
+| `1` | Violations found |
+
 ## See Also
 
-- [Validation and Audit](/concepts/validation-and-audit/)
-- [bwrb bulk](/reference/commands/bulk/)
+- [Validation and Audit](/concepts/validation-and-audit/) — Audit concepts
+- [bwrb bulk](/reference/commands/bulk/) — Batch fix operations
+- [Targeting Model](/reference/targeting/) — Selector reference

--- a/docs-site/src/content/docs/reference/commands/bulk.md
+++ b/docs-site/src/content/docs/reference/commands/bulk.md
@@ -3,50 +3,164 @@ title: bwrb bulk
 description: Batch frontmatter operations
 ---
 
-Perform batch operations on multiple notes.
+Perform batch operations on multiple notes with targeting and safety gates.
 
-## Usage
+## Synopsis
 
 ```bash
-bwrb bulk <operation> [options]
+bwrb bulk [options] [target]
+```
+
+The target argument is auto-detected as type, path (contains `/`), or where expression.
+
+## Options
+
+### Targeting
+
+| Option | Description |
+|--------|-------------|
+| `-t, --type <type>` | Filter by type |
+| `-p, --path <glob>` | Filter by file path (supports globs) |
+| `-w, --where <expr>` | Filter by frontmatter expression (repeatable, ANDed) |
+| `-b, --body <query>` | Filter by body content |
+| `-a, --all` | Target all files (requires explicit intent) |
+
+### Operations
+
+| Option | Description |
+|--------|-------------|
+| `--set <field>=<value>` | Set field value (or clear with `--set field=`) |
+| `--rename <old>=<new>` | Rename field |
+| `--delete <field>` | Delete field |
+| `--append <field>=<value>` | Append to list field |
+| `--remove <field>=<value>` | Remove from list field |
+| `--move <path>` | Move files to path (auto-updates wikilinks) |
+
+### Execution
+
+| Option | Description |
+|--------|-------------|
+| `-x, --execute` | Actually apply changes (dry-run by default) |
+| `--backup` | Create backup before changes |
+| `--limit <n>` | Limit to n files |
+
+### Output
+
+| Option | Description |
+|--------|-------------|
+| `--verbose` | Show detailed changes per file |
+| `--quiet` | Only show summary |
+| `-o, --output <format>` | Output format: `text`, `json` |
+
+## Safety: Two-Gate Model
+
+Bulk operations require **two explicit gates** to prevent accidents:
+
+1. **Targeting gate**: Specify selectors (`--type`, `--path`, `--where`, `--body`) OR use `--all`
+2. **Execution gate**: Use `--execute` to apply changes (dry-run by default)
+
+```bash
+# Error: no targeting specified
+bwrb bulk --set status=done
+# "No files selected. Use --type, --path, --where, --body, or --all."
+
+# Dry-run: shows what would change
+bwrb bulk --type task --set status=done
+
+# Actually applies changes
+bwrb bulk --type task --set status=done --execute
 ```
 
 ## Examples
 
+### Set Operations
+
 ```bash
-# Set field on all matching notes
-bwrb bulk set status=done --type task --where "status = 'active'"
+# Set field on matching notes
+bwrb bulk --type task --where "status == 'in-progress'" --set status=done --execute
 
-# Preview changes
-bwrb bulk set priority=high --type task
+# Clear a field
+bwrb bulk --type task --set old_field= --execute
 
-# Apply changes
-bwrb bulk set priority=high --type task --execute
+# Set multiple fields
+bwrb bulk --type task --where "status == 'done'" --set archived=true --set "archived-date=2025-01-15" --execute
 ```
 
-## Operations
+### Field Management
 
-- `set <field>=<value>` — Set field to value
-- `remove <field>` — Remove field
-- `rename <old>=<new>` — Rename field
+```bash
+# Rename a field
+bwrb bulk --all --rename old-field=new-field --execute
 
-## Options
+# Delete a field
+bwrb bulk --type task --delete legacy_field --execute
+```
 
-| Option | Description |
-|--------|-------------|
-| `--type <type>` | Target type |
-| `--path <dir>` | Target directory |
-| `--where <expr>` | Filter expression |
-| `-x, --execute` | Apply changes |
-| `--output json` | JSON output |
+### List Field Operations
 
-## Safety
+```bash
+# Append to a list field
+bwrb bulk --type task --where "priority == 'high'" --append tags=urgent --execute
 
-- **Dry-run by default** — Shows preview
-- **Backup created** — Original files preserved
-- **Transaction safety** — All-or-nothing
+# Remove from a list field
+bwrb bulk --type task --remove tags=deprecated --execute
+```
+
+### File Movement
+
+```bash
+# Move files to archive (updates wikilinks automatically)
+bwrb bulk --type idea --where "status == 'settled'" --move Archive/Ideas --execute
+```
+
+### Targeting
+
+```bash
+# By type
+bwrb bulk --type task --set status=done --execute
+
+# By path
+bwrb bulk --path "Archive/**" --set archived=true --execute
+
+# By content
+bwrb bulk --body "TODO" --set needs-review=true --execute
+
+# By frontmatter
+bwrb bulk --where "status == 'active' && priority < 3" --set urgent=true --execute
+
+# All files
+bwrb bulk --all --set reviewed=true --execute
+```
+
+### Safety Options
+
+```bash
+# Create backup before changes
+bwrb bulk --type task --all --set status=archived --execute --backup
+
+# Limit scope
+bwrb bulk --type task --set status=done --execute --limit 10
+
+# Preview with verbose output
+bwrb bulk --type task --set status=done --verbose
+```
+
+## Migration Workflows
+
+```bash
+# Bulk-add type to existing files by location
+bwrb bulk --path "Reflections/Daily Notes" --set type=daily-note --execute
+
+# Find files with legacy frontmatter
+bwrb list --where "!isEmpty(old_field)"
+# Warning: 'old_field' not in schema
+
+# Rename field across all notes of a type
+bwrb bulk --type task --rename old_field=new_field --execute
+```
 
 ## See Also
 
-- [Targeting model](/reference/targeting/)
-- [bwrb audit](/reference/commands/audit/)
+- [Targeting Model](/reference/targeting/) — Full selector reference
+- [bwrb audit](/reference/commands/audit/) — Validate notes
+- [bwrb delete](/reference/commands/delete/) — Delete notes

--- a/docs-site/src/content/docs/reference/commands/completion.md
+++ b/docs-site/src/content/docs/reference/commands/completion.md
@@ -5,13 +5,19 @@ description: Shell completion scripts
 
 Generate shell completion scripts for tab completion.
 
-## Usage
+## Synopsis
 
 ```bash
 bwrb completion <shell>
 ```
 
-## Shells
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `shell` | Shell type: `bash`, `zsh`, `fish` |
+
+## Installation
 
 ### Bash
 
@@ -31,7 +37,7 @@ eval "$(bwrb completion zsh)"
 
 ### Fish
 
-Run once:
+Run once to install:
 
 ```fish
 bwrb completion fish > ~/.config/fish/completions/bwrb.fish
@@ -39,11 +45,20 @@ bwrb completion fish > ~/.config/fish/completions/bwrb.fish
 
 ## What Gets Completed
 
-- **Commands** — `bwrb <TAB>` shows `new`, `edit`, `list`, etc.
-- **Options** — `bwrb list -<TAB>` shows available flags
-- **Types** — `bwrb new <TAB>` shows types from schema
-- **Paths** — `bwrb list --path <TAB>` shows directories
+| Context | Completions |
+|---------|-------------|
+| `bwrb <TAB>` | Commands: `new`, `edit`, `list`, `open`, etc. |
+| `bwrb list -<TAB>` | Options: `--type`, `--path`, `--where`, etc. |
+| `bwrb new <TAB>` | Types from your schema |
+| `bwrb list --type <TAB>` | Types from your schema |
+| `bwrb list --path <TAB>` | Directories in your vault |
+
+## Notes
+
+- Completions are generated dynamically from your vault's schema
+- Ensure `BWRB_VAULT` is set or run from within a vault directory
+- Restart your shell after adding the completion script
 
 ## See Also
 
-- [Shell completion guide](/automation/shell-completion/)
+- [Shell completion guide](/automation/shell-completion/) — Detailed setup

--- a/docs-site/src/content/docs/reference/commands/config.md
+++ b/docs-site/src/content/docs/reference/commands/config.md
@@ -5,7 +5,7 @@ description: Vault configuration settings
 
 Manage vault-wide configuration options.
 
-## Usage
+## Synopsis
 
 ```bash
 bwrb config <subcommand>
@@ -13,22 +13,25 @@ bwrb config <subcommand>
 
 ## Subcommands
 
-### list
+| Subcommand | Description |
+|------------|-------------|
+| [list](/reference/commands/config/list/) | Show configuration values |
+| [edit](/reference/commands/config/edit/) | Edit configuration values |
 
-View configuration:
-
-```bash
-bwrb config list              # All options
-bwrb config list link_format  # Specific option
-```
-
-### edit
-
-Modify configuration:
+## Quick Examples
 
 ```bash
-bwrb config edit link_format
-bwrb config edit --json '{"link_format": "markdown"}'
+# Show all configuration
+bwrb config list
+
+# Show specific option
+bwrb config list open_with
+
+# Edit configuration
+bwrb config edit open_with
+
+# Set via JSON
+bwrb config edit open_with --json '"editor"'
 ```
 
 ## Available Options
@@ -36,11 +39,15 @@ bwrb config edit --json '{"link_format": "markdown"}'
 | Option | Description | Values |
 |--------|-------------|--------|
 | `link_format` | How relations are formatted | `wikilink`, `markdown` |
-| `editor` | Editor command | Path or command |
-| `visual` | Visual editor | Path or command |
-| `open_with` | Default open app | `system`, `editor`, `obsidian` |
-| `obsidian_vault` | Obsidian vault name | String |
+| `editor` | Terminal editor command | Path or command |
+| `visual` | GUI editor command | Path or command |
+| `open_with` | Default app for opening notes | `system`, `editor`, `visual`, `obsidian` |
+| `obsidian_vault` | Obsidian vault name for URI scheme | String |
+
+## Configuration Location
+
+Configuration is stored in `.bwrb/schema.json` under the `config` key.
 
 ## See Also
 
-- [Schema concepts](/concepts/schema/)
+- [Schema concepts](/concepts/schema/) — Schema structure

--- a/docs-site/src/content/docs/reference/commands/config/edit.md
+++ b/docs-site/src/content/docs/reference/commands/config/edit.md
@@ -1,0 +1,53 @@
+---
+title: config edit
+description: Edit configuration values
+---
+
+Modify vault configuration values.
+
+## Synopsis
+
+```bash
+bwrb config edit [options] [option]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `option` | Specific option to edit (prompts if omitted) |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--json <value>` | Set value directly (JSON mode) |
+| `-o, --output <format>` | Output format: `text`, `json` |
+
+## Examples
+
+### Interactive Editing
+
+```bash
+# Edit with picker
+bwrb config edit
+
+# Edit specific option
+bwrb config edit open_with
+bwrb config edit link_format
+```
+
+### Non-interactive (JSON) Mode
+
+```bash
+# Set string value
+bwrb config edit open_with --json '"editor"'
+
+# Set complex value
+bwrb config edit obsidian_vault --json '"My Vault"'
+```
+
+## See Also
+
+- [bwrb config](/reference/commands/config/) — Config command overview
+- [config list](/reference/commands/config/list/) — View configuration

--- a/docs-site/src/content/docs/reference/commands/config/list.md
+++ b/docs-site/src/content/docs/reference/commands/config/list.md
@@ -1,0 +1,43 @@
+---
+title: config list
+description: Show configuration values
+---
+
+Display vault configuration values.
+
+## Synopsis
+
+```bash
+bwrb config list [options] [option]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `option` | Specific option to show (shows all if omitted) |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <format>` | Output format: `text`, `json` |
+
+## Examples
+
+```bash
+# Show all configuration
+bwrb config list
+
+# Show specific option
+bwrb config list open_with
+bwrb config list link_format
+
+# JSON output
+bwrb config list --output json
+```
+
+## See Also
+
+- [bwrb config](/reference/commands/config/) — Config command overview
+- [config edit](/reference/commands/config/edit/) — Modify configuration

--- a/docs-site/src/content/docs/reference/commands/dashboard.md
+++ b/docs-site/src/content/docs/reference/commands/dashboard.md
@@ -1,36 +1,80 @@
 ---
 title: bwrb dashboard
-description: Run saved queries
+description: Run and manage saved queries
 ---
 
-Execute saved list queries (dashboards).
+A dashboard is a saved list query. Run dashboards to execute saved queries and manage them with subcommands.
 
-## Usage
-
-```bash
-bwrb dashboard <name>
-```
-
-## Creating Dashboards
-
-Save a query with `--save-as`:
+## Synopsis
 
 ```bash
-bwrb list task --where "status = 'active'" --save-as "active-tasks"
+bwrb dashboard [options] [name]
+bwrb dashboard <subcommand>
 ```
 
 ## Running Dashboards
 
+Execute a saved dashboard by name:
+
 ```bash
-bwrb dashboard active-tasks
+bwrb dashboard my-tasks
+bwrb dashboard inbox --output json   # Override output format
 ```
 
-## Listing Dashboards
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <format>` | Override output format: `text`, `paths`, `tree`, `link`, `json` |
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List all saved dashboards |
+| `new <name>` | Create a new dashboard |
+| `edit [name]` | Edit an existing dashboard |
+
+## Creating Dashboards
+
+### From `bwrb list`
+
+Save any list query as a dashboard:
 
 ```bash
+bwrb list task --where "status='active'" --save-as "active-tasks"
+bwrb list task --output tree --save-as "task-tree" --force
+```
+
+### With `dashboard new`
+
+Create a dashboard directly:
+
+```bash
+bwrb dashboard new my-query --type task --where "status=active"
+```
+
+## Examples
+
+```bash
+# Run a dashboard
+bwrb dashboard my-tasks
+
+# Override output format
+bwrb dashboard inbox --output json
+
+# List all dashboards
 bwrb dashboard list
+bwrb dashboard list --output json
+
+# Create a new dashboard
+bwrb dashboard new my-query --type task --where "status=active"
+
+# Edit a dashboard
+bwrb dashboard edit my-tasks
 ```
 
 ## See Also
 
-- [bwrb list](/reference/commands/list/)
+- [bwrb list](/reference/commands/list/) — List and filter notes
+- [Targeting Model](/reference/targeting/) — Selector reference

--- a/docs-site/src/content/docs/reference/commands/delete.md
+++ b/docs-site/src/content/docs/reference/commands/delete.md
@@ -1,43 +1,116 @@
 ---
 title: bwrb delete
-description: Remove notes with backlink warnings
+description: Remove notes from the vault
 ---
 
-Delete notes from your vault with safety checks.
+Delete notes from your vault with safety checks and bulk mode support.
 
-## Usage
+## Synopsis
 
 ```bash
-bwrb delete <query>
+bwrb delete [options] [query]
+```
+
+## Modes
+
+Delete operates in two modes:
+
+- **Single-file mode** (default): Delete a specific note by name/query
+- **Bulk mode**: Delete multiple notes matching targeting selectors
+
+## Options
+
+### Targeting
+
+| Option | Description |
+|--------|-------------|
+| `-t, --type <type>` | Filter by type |
+| `-p, --path <glob>` | Filter by path glob |
+| `-w, --where <expr>` | Filter by frontmatter expression (repeatable) |
+| `-b, --body <query>` | Filter by body content search |
+| `-a, --all` | Select all notes (required for bulk delete without other targeting) |
+
+### Execution
+
+| Option | Description |
+|--------|-------------|
+| `-x, --execute` | Actually delete files (default is dry-run for bulk) |
+| `-f, --force` | Skip confirmation prompt (single-file mode) |
+| `--picker <mode>` | Selection mode: `auto`, `fzf`, `numbered`, `none` |
+| `-o, --output <format>` | Output format: `text`, `json` |
+
+## Safety: Two-Gate Model
+
+Bulk delete requires **two explicit gates** to prevent accidents:
+
+1. **Targeting gate**: Must specify at least one selector (`--type`, `--path`, `--where`, `--body`) OR use `--all`
+2. **Execution gate**: Must use `--execute` to actually delete (dry-run by default)
+
+```bash
+# Error: no targeting specified
+bwrb delete
+# "No files selected. Use --type, --path, --where, --body, or --all."
+
+# Dry-run: shows what would be deleted
+bwrb delete --type task
+
+# Actually deletes
+bwrb delete --type task --execute
 ```
 
 ## Examples
 
+### Single-file Mode
+
 ```bash
-# Delete with confirmation
-bwrb delete "Old Note"
+# Delete specific note with confirmation
+bwrb delete "My Note"
 
 # Skip confirmation
-bwrb delete "Old Note" --execute
+bwrb delete "My Note" --force
 
-# JSON mode
-bwrb delete "Old Note" --output json
+# Scripting mode
+bwrb delete "My Note" -o json --force
 ```
 
-## Options
+### Bulk Mode
 
-| Option | Description |
-|--------|-------------|
-| `-x, --execute` | Skip confirmation prompt |
-| `--picker <mode>` | Picker for ambiguous matches |
-| `--output json` | JSON output |
+```bash
+# Preview deletions (dry-run)
+bwrb delete --type task
 
-## Safety Features
+# Actually delete all tasks
+bwrb delete --type task --execute
 
-- **Backlink warnings** — Shows notes that link to the target
-- **Confirmation prompt** — Requires explicit confirmation
-- **Dry-run by default** — Shows what would be deleted
+# Delete all notes in Archive
+bwrb delete --path "Archive/**" -x
+
+# Delete by content
+bwrb delete --body "DELETE ME" --execute
+
+# Delete with frontmatter filter
+bwrb delete --where "status=archived" --execute
+
+# Delete ALL notes (dangerous!)
+bwrb delete --all --execute
+```
+
+## Picker Modes
+
+When query is ambiguous (single-file mode):
+
+| Mode | Behavior |
+|------|----------|
+| `auto` | Use fzf if available, else numbered select (default) |
+| `fzf` | Force fzf (error if unavailable) |
+| `numbered` | Force numbered select |
+| `none` | Error on ambiguity (for non-interactive use) |
+
+## Recovery
+
+Deletion is permanent. Use version control (git) to recover deleted notes if needed.
 
 ## See Also
 
-- [bwrb bulk](/reference/commands/bulk/)
+- [bwrb bulk](/reference/commands/bulk/) — Batch operations (non-destructive)
+- [Targeting Model](/reference/targeting/) — Selector reference

--- a/docs-site/src/content/docs/reference/commands/edit.md
+++ b/docs-site/src/content/docs/reference/commands/edit.md
@@ -3,45 +3,86 @@ title: bwrb edit
 description: Modify existing note frontmatter
 ---
 
-Edit the frontmatter of an existing note.
+Edit the frontmatter of an existing note. This is an alias for `search --edit`.
 
-## Usage
-
-```bash
-bwrb edit <path>
-bwrb edit [query]
-```
-
-## Examples
+## Synopsis
 
 ```bash
-# Edit by path
-bwrb edit "Projects/My Task.md"
-
-# Edit by query (picker if ambiguous)
-bwrb edit "My Task"
-
-# JSON mode
-bwrb edit "My Task" --json '{"status": "done"}'
+bwrb edit [options] [query]
 ```
 
 ## Options
 
 | Option | Description |
 |--------|-------------|
-| `--json <data>` | Update fields from JSON |
-| `--picker <mode>` | Picker for ambiguous matches: `auto`, `fzf`, `numbered`, `none` |
-| `--output json` | Output result as JSON |
+| `-t, --type <type>` | Filter by note type |
+| `-p, --path <glob>` | Filter by path pattern |
+| `-w, --where <expr>` | Filter by frontmatter expression (repeatable) |
+| `-b, --body <pattern>` | Filter by body content |
+| `--json <patch>` | Non-interactive patch/merge mode |
+| `-o, --open` | Open the note after editing |
+| `--app <mode>` | App mode for `--open`: `system`, `editor`, `visual`, `obsidian`, `print` |
+| `--picker <mode>` | Picker mode: `fzf`, `numbered`, `none` |
 
-## Behavior
+## Examples
 
-1. Resolves target file
-2. Loads current frontmatter
-3. Prompts for field updates
-4. Preserves body content
-5. Writes updated file
+### Interactive Editing
+
+```bash
+# Find and edit interactively
+bwrb edit "My Note"
+
+# Edit a task by name
+bwrb edit -t task "Review"
+
+# Edit within Projects folder
+bwrb edit --path "Projects/**" "Design"
+```
+
+### Non-interactive JSON Mode
+
+For scripting and automation:
+
+```bash
+# Update a single field
+bwrb edit "My Task" --json '{"status":"done"}'
+
+# Update multiple fields
+bwrb edit -t task --where "status == 'active'" "Deploy" --json '{"priority":"high"}'
+```
+
+### Edit and Open
+
+```bash
+# Open the note after editing
+bwrb edit "My Note" --open
+
+# Edit then open in $EDITOR
+bwrb edit "My Note" --open --app editor
+```
+
+## Targeting
+
+Edit supports all four targeting selectors. See [Targeting Model](/reference/targeting/) for details.
+
+```bash
+# Combine selectors to narrow results
+bwrb edit -t task -p "Work/**" -w "status == 'active'" "Deploy"
+```
+
+## Picker Modes
+
+When multiple notes match your query:
+
+| Mode | Behavior |
+|------|----------|
+| `fzf` | Interactive fuzzy finder (default) |
+| `numbered` | Numbered list selection |
+| `none` | Error on ambiguity (for scripting) |
 
 ## See Also
 
-- [bwrb open](/reference/commands/open/)
-- [bwrb bulk](/reference/commands/bulk/)
+- [bwrb search](/reference/commands/search/) — Full search command (edit is an alias)
+- [bwrb open](/reference/commands/open/) — Open notes without editing
+- [bwrb bulk](/reference/commands/bulk/) — Batch frontmatter changes
+- [Targeting Model](/reference/targeting/) — Selector reference

--- a/docs-site/src/content/docs/reference/commands/list.md
+++ b/docs-site/src/content/docs/reference/commands/list.md
@@ -3,15 +3,57 @@ title: bwrb list
 description: Query and filter notes by type and fields
 ---
 
-List notes matching type and filter criteria.
+List notes matching filter criteria with flexible output formats.
 
-## Usage
+## Synopsis
 
 ```bash
-bwrb list [type] [options]
+bwrb list [options] [positional]
 ```
 
+The positional argument is auto-detected as type, path (contains `/`), or where expression (contains operators).
+
+## Options
+
+### Targeting
+
+| Option | Description |
+|--------|-------------|
+| `-t, --type <type>` | Filter by type path (e.g., `idea`, `objective/task`) |
+| `-p, --path <glob>` | Filter by file path glob (e.g., `Projects/**`, `Ideas/`) |
+| `-w, --where <expr>` | Filter with expression (repeatable, ANDed together) |
+| `-b, --body <query>` | Filter by body content search |
+
+### Output
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <format>` | Output format: `text`, `paths`, `tree`, `link`, `json` |
+| `--fields <fields>` | Show frontmatter fields in a table (comma-separated) |
+| `-L, --depth <n>` | Limit tree depth |
+
+### Actions
+
+| Option | Description |
+|--------|-------------|
+| `--open` | Open the first result (or pick interactively) |
+| `--app <mode>` | How to open: `system`, `editor`, `visual`, `obsidian`, `print` |
+| `--save-as <name>` | Save this query as a dashboard |
+| `--force` | Overwrite existing dashboard when using `--save-as` |
+
+## Output Formats
+
+| Format | Description |
+|--------|-------------|
+| `text` | Note names (default) |
+| `paths` | Vault-relative file paths |
+| `tree` | Hierarchical tree view |
+| `link` | Wikilinks (`[[Note Name]]`) |
+| `json` | Full JSON data |
+
 ## Examples
+
+### Basic Listing
 
 ```bash
 # List all notes of a type
@@ -20,35 +62,73 @@ bwrb list objective/milestone
 
 # With field columns
 bwrb list task --fields=status,priority
-
-# Filter with expressions
-bwrb list task --where "status = 'active'"
-
-# Output paths
-bwrb list task --output paths
-
-# JSON output
-bwrb list task --output json
 ```
 
-## Options
+### Filtering
 
-| Option | Description |
-|--------|-------------|
-| `--type <type>` | Filter by type |
-| `--path <dir>` | Filter by directory |
-| `--where <expr>` | Filter expression |
-| `--fields <list>` | Columns to display |
-| `--output <format>` | Output format: `names`, `paths`, `json` |
-| `--save-as <name>` | Save query as dashboard |
+```bash
+# By frontmatter values
+bwrb list --type task --where "status == 'in-progress'"
+bwrb list --type task --where "priority < 3 && !isEmpty(deadline)"
 
-## Output Formats
+# By date
+bwrb list --type task --where "deadline < today() + '7d'"
 
-- `names` — Note names only (default)
-- `paths` — Vault-relative paths
-- `json` — Full JSON data
+# By body content
+bwrb list --body "TODO" --where "status == 'draft'"
+
+# By path
+bwrb list --path "Projects/**" --body "TODO"
+```
+
+### Hierarchy Functions
+
+For recursive types with parent-child relationships:
+
+```bash
+# Root notes only
+bwrb list --type task --where "isRoot()"
+
+# Direct children
+bwrb list --type task --where "isChildOf('[[Epic]]')"
+
+# All descendants (with depth limit)
+bwrb list --type task --where "isDescendantOf('[[Q1 Goals]]')" --depth 2
+```
+
+### Output Formats
+
+```bash
+bwrb list --type task --output json
+bwrb list --type task --output paths
+bwrb list --type task --output link      # [[Task 1]], [[Task 2]], ...
+bwrb list --type task --output tree      # Hierarchical display
+```
+
+### Open from Results
+
+```bash
+bwrb list --type task --open                    # Pick from tasks and open
+bwrb list --type task --where "status=inbox" --open
+```
+
+### Save as Dashboard
+
+```bash
+bwrb list --type task --where "status='active'" --save-as "active-tasks"
+bwrb list --type task --output tree --save-as "task-tree" --force
+```
+
+## Shell Note
+
+In zsh, use single quotes for expressions with `!` to avoid history expansion:
+
+```bash
+bwrb list --type task --where '!isEmpty(deadline)'
+```
 
 ## See Also
 
-- [Targeting model](/reference/targeting/)
-- [bwrb dashboard](/reference/commands/dashboard/)
+- [Targeting Model](/reference/targeting/) — Full selector reference
+- [bwrb dashboard](/reference/commands/dashboard/) — Run saved queries
+- [bwrb search](/reference/commands/search/) — Interactive search with picker

--- a/docs-site/src/content/docs/reference/commands/new.md
+++ b/docs-site/src/content/docs/reference/commands/new.md
@@ -5,50 +5,102 @@ description: Create new notes with schema-driven prompts
 
 Create a new note with interactive prompts based on your schema.
 
-## Usage
+## Synopsis
 
 ```bash
-bwrb new [type]
-```
-
-## Examples
-
-```bash
-# Interactive type selection
-bwrb new
-
-# Direct creation
-bwrb new task
-bwrb new objective/milestone
-
-# With template
-bwrb new task --template bug-report
-
-# Skip templates
-bwrb new task --no-template
-
-# JSON mode (scripting)
-bwrb new task --json '{"name": "Fix login", "priority": "high"}'
+bwrb new [options] [type]
 ```
 
 ## Options
 
 | Option | Description |
 |--------|-------------|
-| `--template <name>` | Use specific template |
-| `--no-template` | Skip template system |
-| `--json <data>` | Provide field values as JSON |
-| `--output json` | Output result as JSON |
+| `-t, --type <type>` | Type of note to create (alternative to positional argument) |
+| `--open` | Open the note after creation |
+| `--json <frontmatter>` | Create note non-interactively with JSON frontmatter |
+| `--template <name>` | Use a specific template (use "default" for default.md) |
+| `--no-template` | Skip template selection, use schema only |
+| `--owner <wikilink>` | Owner note for owned types (e.g., `"[[My Novel]]"`) |
+| `--standalone` | Create as standalone (skip owner selection for ownable types) |
+
+## Examples
+
+### Basic Creation
+
+```bash
+# Interactive type selection
+bwrb new
+
+# Direct creation by type
+bwrb new idea
+bwrb new objective/task
+
+# Create and open immediately
+bwrb new draft --open
+```
+
+### Templates
+
+```bash
+# Use specific template
+bwrb new task --template bug-report
+
+# Use default.md template explicitly
+bwrb new task --template default
+
+# Skip templates, use schema only
+bwrb new task --no-template
+```
+
+### Ownership
+
+Some types support ownership relationships. When creating an owned type:
+
+```bash
+# Prompted: standalone or owned?
+bwrb new research
+
+# Create in shared location (standalone)
+bwrb new research --standalone
+
+# Create owned by specific note
+bwrb new research --owner "[[My Novel]]"
+```
+
+### Non-interactive (JSON) Mode
+
+For scripting and automation:
+
+```bash
+# Basic JSON creation
+bwrb new idea --json '{"name": "My Idea", "status": "raw"}'
+
+# With template
+bwrb new task --json '{"name": "Bug"}' --template bug-report
+
+# With body sections
+bwrb new task --json '{"name": "Fix bug", "_body": {"Steps": ["Step 1", "Step 2"]}}'
+```
+
+The `_body` field accepts section names as keys, with string or string array values.
 
 ## Behavior
 
-1. Prompts for type (if not specified)
-2. Loads template (if available)
-3. Prompts for each required field
-4. Creates file in `output_dir`
-5. Returns path to created file
+1. **Type resolution**: Prompts for type if not specified (with subtype navigation)
+2. **Template loading**: Loads matching template if available (unless `--no-template`)
+3. **Field prompts**: Prompts for each field defined in schema/template
+4. **File creation**: Creates file in the type's `output_dir`
+5. **Output**: Returns path to created file
+
+## Template Discovery
+
+Templates are stored in `.bwrb/templates/{type}/{subtype}/*.md`:
+- If `default.md` exists, it's used automatically
+- If multiple templates exist without `default.md`, you'll be prompted to select
+- Use `--no-template` to skip template system entirely
 
 ## See Also
 
-- [Templates](/templates/overview/)
-- [Schema](/concepts/schema/)
+- [Templates Overview](/templates/overview/) — Template system concepts
+- [bwrb template](/reference/commands/template/) — Template management
+- [Schema](/concepts/schema/) — Schema structure and field types

--- a/docs-site/src/content/docs/reference/commands/open.md
+++ b/docs-site/src/content/docs/reference/commands/open.md
@@ -3,46 +3,96 @@ title: bwrb open
 description: Open notes in editor or Obsidian
 ---
 
-Open a note by query in your preferred application.
+Open a note by query in your preferred application. This is an alias for `search --open`.
 
-## Usage
-
-```bash
-bwrb open [query]
-```
-
-## Examples
+## Synopsis
 
 ```bash
-# Browse all notes with picker
-bwrb open
-
-# Open specific note
-bwrb open "My Note"
-
-# Open in editor
-bwrb open "My Note" --app editor
-
-# Just print the path
-bwrb open "My Note" --app print
+bwrb open [options] [query]
 ```
 
 ## Options
 
 | Option | Description |
 |--------|-------------|
-| `--app <mode>` | App mode: `system`, `editor`, `visual`, `obsidian`, `print` |
-| `--picker <mode>` | Picker: `auto`, `fzf`, `numbered`, `none` |
-| `--output json` | JSON output (implies `--app print`) |
+| `-a, --app <mode>` | Application to open with |
+| `--picker <mode>` | Picker mode: `fzf`, `numbered`, `none` |
+| `-o, --output <format>` | Output format: `text`, `json` |
+| `--preview` | Show preview in fzf picker |
+| `-t, --type <type>` | Filter by note type |
+| `-p, --path <glob>` | Filter by path pattern |
+| `-w, --where <expr>` | Filter by frontmatter expression (repeatable) |
+| `-b, --body <pattern>` | Filter by body content pattern |
 
 ## App Modes
 
-- `system` — OS default handler (default)
-- `editor` — `$EDITOR` environment variable
-- `visual` — `$VISUAL` environment variable
-- `obsidian` — Obsidian via URI scheme
-- `print` — Just print the resolved path
+| Mode | Description |
+|------|-------------|
+| `system` | Open with OS default handler (default) |
+| `editor` | Open in terminal editor (`$EDITOR` or `config.editor`) |
+| `visual` | Open in GUI editor (`$VISUAL` or `config.visual`) |
+| `obsidian` | Open in Obsidian via URI scheme |
+| `print` | Print path to stdout (for scripting) |
+
+## Examples
+
+### Basic Usage
+
+```bash
+# Browse all notes with picker
+bwrb open
+
+# Open specific note (uses config default)
+bwrb open "My Note"
+
+# Open in Obsidian
+bwrb open "My Note" --app obsidian
+
+# Open in $EDITOR
+bwrb open "My Note" --app editor
+```
+
+### With Targeting
+
+```bash
+# Pick from all tasks
+bwrb open --type task
+
+# Pick from active notes
+bwrb open --where "status=active"
+
+# Open high-priority task
+bwrb open -t task -w "priority=high"
+
+# Find and open note containing TODO
+bwrb open --body "TODO"
+```
+
+## App Mode Precedence
+
+The default app is determined by:
+
+1. `--app` flag (explicit)
+2. `BWRB_DEFAULT_APP` environment variable
+3. `config.open_with` in `.bwrb/schema.json`
+4. Fallback: `system`
+
+```bash
+# Set default via environment
+export BWRB_DEFAULT_APP=editor
+bwrb open "My Note"  # Opens in $EDITOR
+```
+
+## Picker Modes
+
+| Mode | Behavior |
+|------|----------|
+| `fzf` | Interactive fuzzy finder (default) |
+| `numbered` | Numbered list selection |
+| `none` | No picker - fail if ambiguous |
 
 ## See Also
 
-- [bwrb search](/reference/commands/search/)
+- [bwrb search](/reference/commands/search/) — Full search command
+- [bwrb edit](/reference/commands/edit/) — Edit note frontmatter
+- [Targeting Model](/reference/targeting/) — Selector reference

--- a/docs-site/src/content/docs/reference/commands/schema.md
+++ b/docs-site/src/content/docs/reference/commands/schema.md
@@ -1,11 +1,11 @@
 ---
 title: bwrb schema
-description: Inspect and manage schema
+description: Schema introspection and management
 ---
 
-Manage your vault's schema definition.
+Inspect and manage your vault's schema definition.
 
-## Usage
+## Synopsis
 
 ```bash
 bwrb schema <subcommand>
@@ -13,57 +13,34 @@ bwrb schema <subcommand>
 
 ## Subcommands
 
-### list
+| Subcommand | Description |
+|------------|-------------|
+| [list](/reference/commands/schema/list/) | List schema contents |
+| [validate](/reference/commands/schema/validate/) | Validate schema structure |
+| [diff](/reference/commands/schema/diff/) | Show pending schema changes |
+| [migrate](/reference/commands/schema/migrate/) | Apply schema changes to notes |
+| [history](/reference/commands/schema/history/) | Show migration history |
 
-View schema contents:
-
-```bash
-bwrb schema list              # Overview
-bwrb schema list types        # All types
-bwrb schema list type task    # Specific type
-bwrb schema list enums        # All enums
-bwrb schema list fields       # All fields
-```
-
-### new
-
-Create schema elements:
+## Quick Examples
 
 ```bash
-bwrb schema new type
-bwrb schema new field
-bwrb schema new enum
-```
+# List all types
+bwrb schema list
 
-### edit
+# Show specific type details
+bwrb schema list type task
 
-Modify schema elements:
+# Validate schema structure
+bwrb schema validate
 
-```bash
-bwrb schema edit type task
-bwrb schema edit field status
-bwrb schema edit enum priority
-```
+# Preview migration
+bwrb schema diff
 
-### delete
-
-Remove schema elements:
-
-```bash
-bwrb schema delete type idea
-bwrb schema delete field old-field --execute
-```
-
-### migrate
-
-Apply schema changes to notes:
-
-```bash
-bwrb schema migrate           # Preview
-bwrb schema migrate --execute # Apply
+# Apply migration
+bwrb schema migrate --execute
 ```
 
 ## See Also
 
-- [Schema concepts](/concepts/schema/)
-- [Migrations](/concepts/migrations/)
+- [Schema concepts](/concepts/schema/) — Understanding schema structure
+- [Migrations](/concepts/migrations/) — Migration workflow

--- a/docs-site/src/content/docs/reference/commands/schema/diff.md
+++ b/docs-site/src/content/docs/reference/commands/schema/diff.md
@@ -1,0 +1,50 @@
+---
+title: schema diff
+description: Show pending schema changes
+---
+
+Show changes to the schema since the last migration.
+
+## Synopsis
+
+```bash
+bwrb schema diff [options]
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <format>` | Output format: `text`, `json` |
+
+## Description
+
+Compares the current schema.json against the last migration snapshot to show:
+
+- New types added
+- Types removed
+- Fields added to types
+- Fields removed from types
+- Field definitions changed
+- Enum values changed
+
+## Examples
+
+```bash
+# Show what changed
+bwrb schema diff
+
+# JSON output for scripting
+bwrb schema diff --output json
+```
+
+## Workflow
+
+1. Make changes to `.bwrb/schema.json`
+2. Run `bwrb schema diff` to preview changes
+3. Run `bwrb schema migrate` to apply changes to existing notes
+
+## See Also
+
+- [bwrb schema migrate](/reference/commands/schema/migrate/) — Apply schema changes
+- [Migrations](/concepts/migrations/) — Migration workflow

--- a/docs-site/src/content/docs/reference/commands/schema/history.md
+++ b/docs-site/src/content/docs/reference/commands/schema/history.md
@@ -1,0 +1,41 @@
+---
+title: schema history
+description: Show migration history
+---
+
+View the history of schema migrations applied to your vault.
+
+## Synopsis
+
+```bash
+bwrb schema history [options]
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <format>` | Output format: `text`, `json` |
+
+## Description
+
+Shows a log of all migrations that have been applied:
+
+- Migration timestamp
+- Changes included
+- Files affected
+
+## Examples
+
+```bash
+# Show migration history
+bwrb schema history
+
+# JSON output
+bwrb schema history --output json
+```
+
+## See Also
+
+- [bwrb schema migrate](/reference/commands/schema/migrate/) — Apply migrations
+- [Migrations](/concepts/migrations/) — Migration concepts

--- a/docs-site/src/content/docs/reference/commands/schema/list.md
+++ b/docs-site/src/content/docs/reference/commands/schema/list.md
@@ -1,0 +1,56 @@
+---
+title: schema list
+description: List schema contents
+---
+
+List schema contents including types, fields, and detailed type information.
+
+## Synopsis
+
+```bash
+bwrb schema list [options]
+bwrb schema list types [options]
+bwrb schema list fields [options]
+bwrb schema list type [options] <name>
+```
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| (none) | Show full schema overview |
+| `types` | List type names only |
+| `fields` | List all fields across all types |
+| `type <name>` | Show details for a specific type |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <format>` | Output format: `text`, `json` |
+
+## Examples
+
+```bash
+# Show full schema overview
+bwrb schema list
+
+# List all type names
+bwrb schema list types
+
+# List all fields across types
+bwrb schema list fields
+
+# Show details for a specific type
+bwrb schema list type task
+bwrb schema list type objective/milestone
+
+# JSON output for scripting
+bwrb schema list --output json
+bwrb schema list type task --output json
+```
+
+## See Also
+
+- [bwrb schema](/reference/commands/schema/) — Schema command overview
+- [Schema concepts](/concepts/schema/) — Schema structure

--- a/docs-site/src/content/docs/reference/commands/schema/migrate.md
+++ b/docs-site/src/content/docs/reference/commands/schema/migrate.md
@@ -1,0 +1,61 @@
+---
+title: schema migrate
+description: Apply schema changes to notes
+---
+
+Apply schema changes to existing notes in your vault.
+
+## Synopsis
+
+```bash
+bwrb schema migrate [options]
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-x, --execute` | Actually apply the migration (default is dry-run) |
+| `--no-backup` | Skip backup creation (not recommended) |
+| `-o, --output <format>` | Output format: `text`, `json` |
+
+## Description
+
+Migrations update existing notes when the schema changes:
+
+- Add new required fields with default values
+- Remove deleted fields
+- Rename fields
+- Update enum values
+- Move files to new output directories
+
+## Safety
+
+- **Dry-run by default**: Shows what would change without modifying files
+- **Automatic backup**: Creates a backup before applying changes
+- **Atomic operations**: All changes succeed or none are applied
+
+## Examples
+
+```bash
+# Preview migration (dry-run)
+bwrb schema migrate
+
+# Apply migration with backup
+bwrb schema migrate --execute
+
+# Apply without backup (not recommended)
+bwrb schema migrate --execute --no-backup
+```
+
+## Workflow
+
+1. Make changes to `.bwrb/schema.json`
+2. Run `bwrb schema diff` to preview changes
+3. Run `bwrb schema migrate` to preview note updates
+4. Run `bwrb schema migrate --execute` to apply
+
+## See Also
+
+- [bwrb schema diff](/reference/commands/schema/diff/) — Preview schema changes
+- [Migrations](/concepts/migrations/) — Migration concepts

--- a/docs-site/src/content/docs/reference/commands/schema/validate.md
+++ b/docs-site/src/content/docs/reference/commands/schema/validate.md
@@ -1,0 +1,50 @@
+---
+title: schema validate
+description: Validate schema structure
+---
+
+Validate your schema.json file for structural correctness.
+
+## Synopsis
+
+```bash
+bwrb schema validate [options]
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <format>` | Output format: `text`, `json` |
+
+## Description
+
+Validates the schema.json file against the expected structure:
+
+- Required fields are present
+- Field types are valid
+- Enum values are properly defined
+- Type hierarchies are consistent
+- Output directories are specified
+
+## Examples
+
+```bash
+# Validate schema
+bwrb schema validate
+
+# JSON output for CI
+bwrb schema validate --output json
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Schema is valid |
+| `1` | Validation errors found |
+
+## See Also
+
+- [bwrb schema](/reference/commands/schema/) — Schema command overview
+- [bwrb audit](/reference/commands/audit/) — Validate notes against schema

--- a/docs-site/src/content/docs/reference/commands/search.md
+++ b/docs-site/src/content/docs/reference/commands/search.md
@@ -1,48 +1,149 @@
 ---
 title: bwrb search
-description: Find notes and generate wikilinks
+description: Find notes by name or content
 ---
 
-Search for notes and optionally generate wikilinks.
+Search for notes by name or content, with interactive selection and multiple output formats.
 
-## Usage
-
-```bash
-bwrb search [query]
-```
-
-## Examples
+## Synopsis
 
 ```bash
-# Browse all notes
-bwrb search
-
-# Find and output name
-bwrb search "My Note"
-
-# Generate wikilink
-bwrb search "My Note" --wikilink
-# Output: [[My Note]]
-
-# JSON output for scripting
-bwrb search "My Note" --output json
+bwrb search [options] [query]
 ```
+
+## Modes
+
+Search operates in two modes:
+
+- **Name search** (default): Searches by note name, basename, or path
+- **Content search** (`--body`): Full-text search across note contents using ripgrep
 
 ## Options
 
+### Output
+
 | Option | Description |
 |--------|-------------|
-| `--wikilink` | Output as wikilink format |
-| `--picker <mode>` | Picker: `auto`, `fzf`, `numbered`, `none` |
-| `--output json` | JSON output |
+| `-o, --output <format>` | Output format: `text`, `paths`, `link`, `content`, `json` |
+| `--preview` | Show file preview in fzf picker |
+| `--picker <mode>` | Selection mode: `auto`, `fzf`, `numbered`, `none` |
+
+### Actions
+
+| Option | Description |
+|--------|-------------|
+| `--open` | Open the selected note after search |
+| `--edit` | Edit the selected note's frontmatter after search |
+| `--json <patch>` | JSON patch data for `--edit` mode (non-interactive) |
+| `--app <mode>` | How to open: `system`, `editor`, `visual`, `obsidian`, `print` |
+
+### Targeting
+
+| Option | Description |
+|--------|-------------|
+| `-t, --type <type>` | Restrict search to a type |
+| `-p, --path <pattern>` | Filter by file path glob pattern |
+| `-w, --where <expr>` | Filter results by frontmatter expression (repeatable) |
+| `-b, --body` | Enable content search mode |
+
+### Content Search Options
+
+| Option | Description |
+|--------|-------------|
+| `-C, --context <lines>` | Lines of context around matches (default: 2) |
+| `--no-context` | Do not show context lines |
+| `-S, --case-sensitive` | Case-sensitive search (default: case-insensitive) |
+| `-E, --regex` | Treat pattern as regex (default: literal) |
+| `-l, --limit <count>` | Maximum files to return (default: 100) |
+
+## Output Formats
+
+| Format | Description |
+|--------|-------------|
+| `text` | Note name (default) |
+| `paths` | Vault-relative path with extension |
+| `link` | Wikilink format (`[[Note Name]]`) |
+| `content` | Full file contents (frontmatter + body) |
+| `json` | JSON with metadata and matches |
+
+## Examples
+
+### Name Search
+
+```bash
+# Find by name
+bwrb search "My Note"
+
+# Output as wikilink
+bwrb search "My Note" --output link
+# Output: [[My Note]]
+
+# Find and open in Obsidian
+bwrb search "My Note" --open
+
+# Find and open in $EDITOR
+bwrb search "My Note" --open --app editor
+
+# Find and edit frontmatter
+bwrb search "My Note" --edit
+
+# Non-interactive edit
+bwrb search "My Note" --edit --json '{"status":"done"}'
+```
+
+### Content Search
+
+```bash
+# Search all notes for "deploy"
+bwrb search "deploy" --body
+
+# Search only in tasks
+bwrb search "deploy" -b -t task
+
+# Filter by frontmatter
+bwrb search "TODO" -b --where "status != 'done'"
+
+# Regex search
+bwrb search "error.*log" -b --regex
+
+# JSON output with matches
+bwrb search "deploy" -b --output json
+
+# Search and open first match
+bwrb search "deploy" -b --open
+```
+
+### Piping
+
+```bash
+# Open results in VS Code
+bwrb search "bug" --output paths | xargs -I {} code {}
+```
+
+## Picker Modes
+
+| Mode | Behavior |
+|------|----------|
+| `auto` | Use fzf if available, else numbered select (default) |
+| `fzf` | Force fzf (error if unavailable) |
+| `numbered` | Force numbered select |
+| `none` | Error on ambiguity (for non-interactive use) |
 
 ## Wikilink Format
 
 Uses shortest unambiguous form:
-
 - Unique basename: `[[My Note]]`
-- Ambiguous: `[[Ideas/My Note]]`
+- Ambiguous (multiple notes with same name): `[[Ideas/My Note]]`
+
+## App Mode Precedence
+
+1. `--app` flag (explicit)
+2. `BWRB_DEFAULT_APP` environment variable
+3. `config.open_with` in `.bwrb/schema.json`
+4. Fallback: `system`
 
 ## See Also
 
-- [bwrb open](/reference/commands/open/)
+- [bwrb open](/reference/commands/open/) — Alias for `search --open`
+- [bwrb edit](/reference/commands/edit/) — Alias for `search --edit`
+- [Targeting Model](/reference/targeting/) — Selector reference

--- a/docs-site/src/content/docs/reference/commands/template.md
+++ b/docs-site/src/content/docs/reference/commands/template.md
@@ -1,11 +1,11 @@
 ---
 title: bwrb template
-description: Manage note templates
+description: Template management
 ---
 
 Manage reusable templates for note creation.
 
-## Usage
+## Synopsis
 
 ```bash
 bwrb template <subcommand>
@@ -13,53 +13,34 @@ bwrb template <subcommand>
 
 ## Subcommands
 
-### list
+| Subcommand | Description |
+|------------|-------------|
+| [list](/reference/commands/template/list/) | List templates |
+| [new](/reference/commands/template/new/) | Create a new template |
+| [edit](/reference/commands/template/edit/) | Edit an existing template |
+| [delete](/reference/commands/template/delete/) | Delete a template |
+| [validate](/reference/commands/template/validate/) | Validate templates against schema |
 
-View templates:
-
-```bash
-bwrb template list                    # All templates
-bwrb template list task               # Templates for type
-bwrb template list task bug-report    # Specific template
-```
-
-### new
-
-Create a template:
+## Quick Examples
 
 ```bash
-bwrb template new task
+# List all templates
+bwrb template list
+
+# List templates for a type
+bwrb template list task
+
+# Create a new template
 bwrb template new task --name bug-report
-bwrb template new task --json '{"defaults": {"priority": "high"}}'
-```
 
-### edit
+# Edit a template
+bwrb template edit task bug-report
 
-Modify a template:
-
-```bash
-bwrb template edit task default
-bwrb template edit task bug-report --json '{"defaults": {"status": "backlog"}}'
-```
-
-### delete
-
-Remove a template:
-
-```bash
-bwrb template delete task bug-report
-```
-
-### validate
-
-Check templates against schema:
-
-```bash
-bwrb template validate          # All templates
-bwrb template validate task     # Type's templates
+# Validate all templates
+bwrb template validate
 ```
 
 ## See Also
 
-- [Templates overview](/templates/overview/)
-- [Creating templates](/templates/creating-templates/)
+- [Templates Overview](/templates/overview/) — Template concepts
+- [Creating Templates](/templates/creating-templates/) — Template authoring guide

--- a/docs-site/src/content/docs/reference/commands/template/delete.md
+++ b/docs-site/src/content/docs/reference/commands/template/delete.md
@@ -1,0 +1,46 @@
+---
+title: template delete
+description: Delete a template
+---
+
+Delete a template from your vault.
+
+## Synopsis
+
+```bash
+bwrb template delete [options] [type] [name]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `type` | Type of template to delete |
+| `name` | Template name (shows picker if omitted) |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-f, --force` | Skip confirmation prompt |
+| `-o, --output <format>` | Output format: `text`, `json` |
+
+## Examples
+
+```bash
+# Delete with confirmation
+bwrb template delete task bug-report
+
+# Delete with picker
+bwrb template delete
+
+# Skip confirmation
+bwrb template delete task bug-report --force
+
+# Scripting mode
+bwrb template delete task bug-report -f -o json
+```
+
+## See Also
+
+- [bwrb template](/reference/commands/template/) — Template command overview

--- a/docs-site/src/content/docs/reference/commands/template/edit.md
+++ b/docs-site/src/content/docs/reference/commands/template/edit.md
@@ -1,0 +1,53 @@
+---
+title: template edit
+description: Edit an existing template
+---
+
+Edit an existing template interactively or via JSON patch.
+
+## Synopsis
+
+```bash
+bwrb template edit [options] [type] [name]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `type` | Type of template to edit |
+| `name` | Template name (shows picker if omitted) |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--json <data>` | Update template non-interactively (patch/merge semantics) |
+
+## Examples
+
+### Interactive Editing
+
+```bash
+# Edit with picker
+bwrb template edit
+
+# Edit specific template
+bwrb template edit task bug-report
+bwrb template edit objective/task default
+```
+
+### Non-interactive (JSON) Mode
+
+```bash
+# Update specific fields
+bwrb template edit task bug-report --json '{"defaults": {"priority": "high"}}'
+
+# Update description
+bwrb template edit idea default --json '{"description": "Updated description"}'
+```
+
+## See Also
+
+- [bwrb template](/reference/commands/template/) — Template command overview
+- [Creating Templates](/templates/creating-templates/) — Template authoring guide

--- a/docs-site/src/content/docs/reference/commands/template/list.md
+++ b/docs-site/src/content/docs/reference/commands/template/list.md
@@ -1,0 +1,47 @@
+---
+title: template list
+description: List templates
+---
+
+List templates in your vault, optionally filtered by type.
+
+## Synopsis
+
+```bash
+bwrb template list [options] [type] [name]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `type` | Filter to templates for this type (e.g., `task`, `objective/milestone`) |
+| `name` | Show details for a specific template |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <format>` | Output format: `text`, `json` |
+
+## Examples
+
+```bash
+# List all templates
+bwrb template list
+
+# List templates for a specific type
+bwrb template list task
+bwrb template list objective/task
+
+# Show specific template details
+bwrb template list task bug-report
+
+# JSON output
+bwrb template list --output json
+```
+
+## See Also
+
+- [bwrb template](/reference/commands/template/) — Template command overview
+- [Templates Overview](/templates/overview/) — Template concepts

--- a/docs-site/src/content/docs/reference/commands/template/new.md
+++ b/docs-site/src/content/docs/reference/commands/template/new.md
@@ -1,0 +1,64 @@
+---
+title: template new
+description: Create a new template
+---
+
+Create a new template for a specific note type.
+
+## Synopsis
+
+```bash
+bwrb template new [options] [type]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `type` | Type to create template for (prompts if omitted) |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--name <name>` | Template name (without .md extension) |
+| `--description <desc>` | Template description |
+| `--json <data>` | Create template non-interactively from JSON |
+
+## Examples
+
+### Interactive Creation
+
+```bash
+# Create template with prompts
+bwrb template new task
+
+# Specify name
+bwrb template new task --name bug-report
+
+# With description
+bwrb template new task --name bug-report --description "Bug report with repro steps"
+```
+
+### Non-interactive (JSON) Mode
+
+```bash
+# Create from JSON
+bwrb template new task --name quick --json '{"defaults": {"status": "raw"}}'
+
+# Full template definition
+bwrb template new idea --name research --json '{
+  "description": "Research note template",
+  "defaults": {"status": "raw", "priority": "medium"},
+  "prompt-fields": ["deadline"]
+}'
+```
+
+## Template Location
+
+Templates are created in `.bwrb/templates/{type}/{subtype}/{name}.md`.
+
+## See Also
+
+- [bwrb template](/reference/commands/template/) — Template command overview
+- [Creating Templates](/templates/creating-templates/) — Template authoring guide

--- a/docs-site/src/content/docs/reference/commands/template/validate.md
+++ b/docs-site/src/content/docs/reference/commands/template/validate.md
@@ -1,0 +1,60 @@
+---
+title: template validate
+description: Validate templates against schema
+---
+
+Validate templates to ensure they're compatible with the current schema.
+
+## Synopsis
+
+```bash
+bwrb template validate [options] [type]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `type` | Validate templates for specific type only |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <format>` | Output format: `text`, `json` |
+
+## Description
+
+Checks templates for:
+
+- Valid `template-for` type reference
+- Default field values match schema types
+- Default enum values are valid
+- Prompt-fields reference existing fields
+- No references to removed schema fields
+
+## Examples
+
+```bash
+# Validate all templates
+bwrb template validate
+
+# Validate templates for specific type
+bwrb template validate task
+bwrb template validate objective/milestone
+
+# JSON output for CI
+bwrb template validate --output json
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All templates valid |
+| `1` | Validation errors found |
+
+## See Also
+
+- [bwrb template](/reference/commands/template/) — Template command overview
+- [bwrb schema validate](/reference/commands/schema/validate/) — Validate schema

--- a/docs-site/src/content/docs/reference/targeting.md
+++ b/docs-site/src/content/docs/reference/targeting.md
@@ -1,60 +1,201 @@
 ---
 title: Targeting Model
-description: How to specify which notes commands operate on
+description: How Bowerbird commands select which notes to operate on
 ---
 
-Most Bowerbird commands need to know which notes to operate on. The targeting model provides a consistent way to specify this across all commands.
+Bowerbird uses a unified targeting model across all commands that operate on sets of notes. Once you understand the four selectors, you can use any command.
 
-## Target Types
+**Core principle:** All targeting selectors compose via AND (intersection). Each selector narrows the set of matched files.
 
-### By Type
+## The Four Selectors
 
-Specify the note type:
+### Type (`-t, --type <type>`)
 
-```bash
-bwrb list task
-bwrb list objective/milestone
-```
-
-### By Path
-
-Target notes in a specific directory:
+Filter by schema type.
 
 ```bash
-bwrb list --path "Projects/"
-bwrb audit --path "Archive/"
+bwrb list --type task
+bwrb bulk --type reflection --set reviewed=true
+bwrb audit --type objective
 ```
 
-### By Query
+**Behavior:**
+- Accepts short names (`task`) or full paths (`objective/task`)
+- Short names are unambiguous since types cannot share names
+- When specified, enables strict validation of `--where` fields
 
-Filter using expressions:
+**Positional shortcut:** Type can be provided as a positional argument:
+```bash
+bwrb list task              # Same as: bwrb list --type task
+bwrb bulk task --set x=y    # Same as: bwrb bulk --type task --set x=y
+```
+
+### Path (`-p, --path <glob>`)
+
+Filter by file location in the vault.
 
 ```bash
-bwrb list task --where "status = 'active'"
-bwrb list --where "priority = 'high' && status != 'done'"
+bwrb list --path "Ideas/"
+bwrb bulk --path "Reflections/Daily Notes" --set status=reviewed
+bwrb audit --path "Work/**"
 ```
 
-## Query Syntax
+**Behavior:**
+- Accepts directory paths or glob patterns
+- Paths are relative to vault root
+- Supports glob syntax (`*`, `**`, `?`)
 
-Bowerbird uses a simple expression language:
+### Query (`-w, --where <expression>`)
 
-| Operator | Meaning |
-|----------|---------|
-| `=` | Equals |
-| `!=` | Not equals |
-| `>`, `<`, `>=`, `<=` | Comparison |
-| `&&` | And |
-| `\|\|` | Or |
-| `contains()` | String contains |
-
-## Combining Targets
-
-Targets can be combined:
+Filter by frontmatter field values.
 
 ```bash
-bwrb list task --path "Projects/" --where "status = 'active'"
+bwrb list --where "status == 'active'"
+bwrb bulk --where "priority < 3 && !isEmpty(deadline)" --set urgent=true
+bwrb audit --where "isEmpty(tags)"
 ```
 
-## Next Steps
+**Behavior:**
+- Supports comparison operators: `==`, `!=`, `<`, `>`, `<=`, `>=`
+- Supports boolean operators: `&&`, `||`, `!`
+- Supports functions: `isEmpty()`, `contains()`, `startsWith()`
+- Multiple `--where` flags are ANDed together
 
-- [Commands reference](/reference/commands/list/) — See targeting in action
+**Type-checking behavior:**
+- With `--type`: strict validation (error on unknown fields)
+- Without `--type`: permissive with warnings (supports migration workflows)
+
+**Hierarchy functions** (for recursive types):
+- `isRoot()` — note has no parent
+- `isChildOf('[[Note]]')` — direct child of specified note
+- `isDescendantOf('[[Note]]')` — any descendant of specified note
+
+```bash
+bwrb list --type task --where "isRoot()"
+bwrb list --type task --where "isChildOf('[[Epic]]')"
+bwrb list --type task --where "isDescendantOf('[[Q1 Goals]]')" --depth 2
+```
+
+### Body (`-b, --body <query>`)
+
+Filter by body content (full-text search via ripgrep).
+
+```bash
+bwrb list --body "TODO"
+bwrb bulk --body "DEPRECATED" --delete deprecated_field
+bwrb search --body "meeting notes" --type task
+```
+
+**Behavior:**
+- Searches note body content (not frontmatter)
+- Uses ripgrep under the hood for performance
+- Case-insensitive by default
+
+## Selector Composition
+
+**All selectors compose via AND (intersection).** Each additional selector narrows the result set.
+
+```bash
+# Find tasks in Work/ folder with status=active containing "deadline"
+bwrb list --type task --path "Work/" --where "status == 'active'" --body "deadline"
+```
+
+**Union (OR) is not implicit.** To express OR logic, use boolean operators within `--where`:
+```bash
+bwrb list --where "status == 'draft' || status == 'review'"
+```
+
+## Smart Positional Detection
+
+For ergonomics, the first positional argument is auto-detected:
+
+| Input | Detection | Equivalent |
+|-------|-----------|------------|
+| `bwrb list task` | Matches known type | `--type task` |
+| `bwrb list "Ideas/"` | Contains `/`, matches path | `--path "Ideas/"` |
+| `bwrb list "status == 'x'"` | Contains operators | `--where "status == 'x'"` |
+
+**Ambiguity handling:** When detection is ambiguous, Bowerbird errors with a helpful message suggesting explicit flags.
+
+## Command Support Matrix
+
+| Command | `--type` | `--path` | `--where` | `--body` | Picker |
+|---------|----------|----------|-----------|----------|--------|
+| [list](/reference/commands/list/)    | Y | Y | Y | Y | - |
+| [bulk](/reference/commands/bulk/)    | Y | Y | Y | Y | - |
+| [audit](/reference/commands/audit/)   | Y | Y | Y | Y | - |
+| [search](/reference/commands/search/)  | Y | Y | Y | Y | Y |
+| [open](/reference/commands/open/)    | Y | Y | Y | Y | Y |
+| [edit](/reference/commands/edit/)    | Y | Y | Y | Y | Y |
+| [delete](/reference/commands/delete/)  | Y | Y | Y | Y | - |
+
+**Notes:**
+- `open` is an alias for `search --open`
+- `edit` is an alias for `search --edit`
+
+## Default Behavior
+
+Default behavior depends on command destructiveness:
+
+### Read-only commands (`list`, `audit` without `--fix`, `search`)
+
+No selectors = implicit `--all` (operate on entire vault).
+
+```bash
+bwrb list           # Lists all notes
+bwrb audit          # Audits all notes
+```
+
+### Interactive commands (`open`, `edit`)
+
+No selectors = prompt with picker.
+
+### Destructive commands (`bulk`, `delete`, `audit --fix`)
+
+**Two safety gates:**
+
+1. **Targeting required:** No selectors = error. Must specify at least one selector OR explicit `--all`.
+2. **Execution required:** Dry-run by default. Must use `--execute` to apply changes.
+
+```bash
+bwrb bulk --set status=done
+# Error: No files selected. Use --type, --path, --where, --body, or --all.
+
+bwrb bulk --type task --set status=done
+# Dry-run: shows what would change, but doesn't apply
+
+bwrb bulk --type task --set status=done --execute
+# Actually applies the changes
+
+bwrb bulk --all --set status=done --execute
+# Works (explicit targeting + explicit execution)
+```
+
+This two-gate model prevents accidental vault-wide mutations.
+
+## Output Formats
+
+Use `--output <format>` (or `-o`) to control how results are displayed:
+
+| Format | Description |
+|--------|-------------|
+| `text` | Default human-readable |
+| `json` | Machine-readable JSON |
+| `paths` | File paths only |
+| `link` | Wikilinks (`[[Note Name]]`) |
+| `tree` | Hierarchical tree view (list only) |
+| `content` | Full file contents (search only) |
+
+```bash
+bwrb list --type task --output json
+bwrb list --type task --output paths
+bwrb list --type task --output link      # [[Task 1]], [[Task 2]], ...
+bwrb list --type task --output tree      # Hierarchical display
+bwrb search "TODO" --output content      # Full file with matches
+```
+
+## See Also
+
+- [Expression syntax](/concepts/schema/) — Query expression details
+- [bwrb list](/reference/commands/list/) — List and filter notes
+- [bwrb bulk](/reference/commands/bulk/) — Batch operations


### PR DESCRIPTION
## Summary
- Enhanced targeting reference with full selector documentation, command matrix, and two-gate safety model
- Updated all 13 command pages with comprehensive options, examples, and cross-links
- Created subcommand pages for schema, template, and config commands
- Documented JSON mode throughout for scripting and automation

## Changes
- **27 files changed**: 1731 insertions, 334 deletions
- **Targeting reference**: Expanded from 61 to 201 lines with full selector docs, command support matrix, output formats, and safety gates explanation
- **Command pages updated**: new, edit, list, search, open, delete, audit, bulk, schema, template, config, completion, dashboard
- **New subcommand pages**: 
  - `schema/`: list, validate, diff, migrate, history
  - `template/`: list, new, edit, delete, validate
  - `config/`: list, edit

## Documentation Structure
Each command page now includes:
- Synopsis with full option syntax
- Options table with short flags (-t, -p, -w, -b, -x, -o)
- Organized examples by use case
- Cross-links to related commands
- JSON mode examples for automation

## Verification
- Docs site builds successfully: "43 page(s) built in 2.87s"
- All pages indexed by Pagefind search
- Cross-links verified

Fixes #213