### PR TITLE
chore: rename invalid_enum_value to invalid_option_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Changed (Breaking)
+
+- **Renamed "enum" terminology to "option" for consistency with schema model** (#179)
+  - Validation error type: `invalid_enum_value` → `invalid_option_value`
+  - Audit issue code: `invalid-enum` → `invalid-option`
+  - Export renamed: `suggestEnumValue()` → `suggestOptionValue()`
+  - Background: Global enums were replaced with inline `options` on fields in #165. This aligns error terminology with the current schema model.
+  - Migration: Scripts checking for `type: 'invalid_enum_value'` in JSON output should update to `type: 'invalid_option_value'`. Scripts using `--only invalid-enum` or `--ignore invalid-enum` should update to `invalid-option`.
+
 ### Documentation
 
 - **Complete command reference for all CLI commands** (#213)

--- a/docs/product/cli-targeting.md
+++ b/docs/product/cli-targeting.md
@@ -71,7 +71,7 @@ bwrb audit --where "isEmpty(tags)"
 - Without `--type`: permissive with warnings (supports migration workflows)
 
 **Audit type inference:**
-When running `bwrb audit` without `--type`, each file's type is resolved from its frontmatter `type` field. Files with missing or invalid types report `orphan-file` or `invalid-type` errors and skip type-dependent checks (like `wrong-directory`, `missing-required`, `invalid-enum`). This is by design: audit can't validate fields without knowing the type's schema.
+When running `bwrb audit` without `--type`, each file's type is resolved from its frontmatter `type` field. Files with missing or invalid types report `orphan-file` or `invalid-type` errors and skip type-dependent checks (like `wrong-directory`, `missing-required`, `invalid-option`). This is by design: audit can't validate fields without knowing the type's schema.
 
 **Hierarchy functions** (for recursive types):
 - `isRoot()` — note has no parent

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -139,7 +139,7 @@ Audit resolves each file's type from its frontmatter `type` field. Understanding
 | `orphan-file` | No (reports missing type) |
 | `invalid-type` | No (reports unrecognized type) |
 | `missing-required` | Yes |
-| `invalid-enum` | Yes |
+| `invalid-option` | Yes |
 | `unknown-field` | Yes |
 | `wrong-directory` | Yes |
 | `format-violation` | Yes |

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -59,7 +59,7 @@ Issue Types:
   orphan-file       File in managed directory but no 'type' field
   invalid-type      Type field value not recognized
   missing-required  Required field is missing
-  invalid-enum      Field value not in allowed enum values
+  invalid-option    Field value not in allowed option values
   unknown-field     Field not defined in schema (warning by default)
   wrong-directory   File location doesn't match its type
   format-violation  Field value doesn't match expected format (wikilink, etc.)
@@ -68,7 +68,7 @@ Issue Types:
 Type Resolution:
   Audit resolves each file's type from its frontmatter 'type' field.
   If 'type' is missing or invalid, audit reports orphan-file/invalid-type
-  and skips type-dependent checks (missing-required, invalid-enum, etc.).
+  and skips type-dependent checks (missing-required, invalid-option, etc.).
   Use --type to filter by type; it does not fix missing type fields.
 
 Targeting Options:

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -16,7 +16,7 @@ import {
   getDescendants,
 } from '../schema.js';
 import { parseNote } from '../frontmatter.js';
-import { suggestEnumValue, suggestFieldName } from '../validation.js';
+import { suggestOptionValue, suggestFieldName } from '../validation.js';
 import { applyFrontmatterFilters } from '../query.js';
 import { searchContent } from '../content-search.js';
 import type { LoadedSchema, Field } from '../../types/schema.js';
@@ -306,10 +306,10 @@ export async function auditFile(
       const validOptions = field.options;
       const strValue = String(value);
       if (!validOptions.includes(strValue)) {
-        const suggestion = suggestEnumValue(strValue, validOptions);
+        const suggestion = suggestOptionValue(strValue, validOptions);
         issues.push({
           severity: 'error',
-          code: 'invalid-enum',
+          code: 'invalid-option',
           message: `Invalid ${fieldName} value: '${value}'`,
           field: fieldName,
           value,
@@ -628,7 +628,7 @@ function checkSingleContextValue(
   
   // Type mismatch!
   const validTypesArray = Array.from(validTypes);
-  const suggestion = suggestEnumValue(actualType, validTypesArray);
+  const suggestion = suggestOptionValue(actualType, validTypesArray);
   
   const sourceDisplay = sources.length === 1 ? sources[0] : sources.join(' or ');
   return {

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -66,7 +66,7 @@ async function applyFix(
         }
         break;
       }
-      case 'invalid-enum': {
+      case 'invalid-option': {
         if (issue.field && newValue !== undefined) {
           frontmatter[issue.field] = newValue;
         } else {
@@ -367,8 +367,8 @@ async function handleInteractiveFix(
       return handleOrphanFileFix(schema, result, issue);
     case 'missing-required':
       return handleMissingRequiredFix(schema, result, issue);
-    case 'invalid-enum':
-      return handleInvalidEnumFix(schema, result, issue);
+    case 'invalid-option':
+      return handleInvalidOptionFix(schema, result, issue);
     case 'unknown-field':
       return handleUnknownFieldFix(schema, result, issue);
     case 'format-violation':
@@ -531,7 +531,7 @@ async function handleMissingRequiredFix(
   return 'skipped';
 }
 
-async function handleInvalidEnumFix(
+async function handleInvalidOptionFix(
   schema: LoadedSchema,
   result: FileAuditResult,
   issue: AuditIssue
@@ -667,7 +667,7 @@ async function handleStaleReferenceFix(
     return 'skipped';
   } else if (selected === '[clear field]') {
     // Clear the field by setting it to empty
-    const fixResult = await applyFix(schema, result.path, { ...issue, code: 'invalid-enum' }, '');
+    const fixResult = await applyFix(schema, result.path, { ...issue, code: 'invalid-option' }, '');
     if (fixResult.action === 'fixed') {
       console.log(chalk.green(`    ✓ Cleared ${issue.field}`));
       return 'fixed';
@@ -677,7 +677,7 @@ async function handleStaleReferenceFix(
     }
   } else {
     // User selected a similar file
-    const fixResult = await applyFix(schema, result.path, { ...issue, code: 'invalid-enum' }, selected);
+    const fixResult = await applyFix(schema, result.path, { ...issue, code: 'invalid-option' }, selected);
     if (fixResult.action === 'fixed') {
       console.log(chalk.green(`    ✓ Updated ${issue.field}: ${selected}`));
       return 'fixed';
@@ -728,7 +728,7 @@ async function handleOwnedNoteReferencedFix(
     return 'quit';
   } else if (selected === '[clear reference]') {
     // Clear the field
-    const fixResult = await applyFix(schema, result.path, { ...issue, code: 'invalid-enum' }, '');
+    const fixResult = await applyFix(schema, result.path, { ...issue, code: 'invalid-option' }, '');
     if (fixResult.action === 'fixed') {
       console.log(chalk.green(`    ✓ Cleared ${issue.field}`));
       return 'fixed';

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -22,7 +22,7 @@ export type IssueCode =
   | 'orphan-file'
   | 'invalid-type'
   | 'missing-required'
-  | 'invalid-enum'
+  | 'invalid-option'
   | 'unknown-field'
   | 'wrong-directory'
   | 'type-mismatch'

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -9,7 +9,7 @@ import { expandStaticValue } from './local-date.js';
  */
 type ValidationErrorType =
   | 'required_field_missing'
-  | 'invalid_enum_value'
+  | 'invalid_option_value'
   | 'invalid_type'
   | 'unknown_field'
   | 'invalid_date'
@@ -87,9 +87,9 @@ export function validateFrontmatter(
       if (field.multiple && Array.isArray(value)) {
         for (const item of value) {
           if (!validOptions.includes(String(item))) {
-            const suggestion = suggestEnumValue(String(item), validOptions);
+            const suggestion = suggestOptionValue(String(item), validOptions);
             errors.push({
-              type: 'invalid_enum_value',
+              type: 'invalid_option_value',
               field: fieldName,
               value: item,
               message: `Invalid value for ${fieldName}: "${item}"`,
@@ -100,9 +100,9 @@ export function validateFrontmatter(
         }
       } else if (!Array.isArray(value) && !validOptions.includes(String(value))) {
         // Single-select validation
-        const suggestion = suggestEnumValue(String(value), validOptions);
+        const suggestion = suggestOptionValue(String(value), validOptions);
         errors.push({
-          type: 'invalid_enum_value',
+          type: 'invalid_option_value',
           field: fieldName,
           value,
           message: `Invalid value for ${fieldName}: "${value}"`,
@@ -332,9 +332,9 @@ function levenshteinDistance(a: string, b: string): number {
 }
 
 /**
- * Suggest a similar enum value using fuzzy matching.
+ * Suggest a similar option value using fuzzy matching.
  */
-export function suggestEnumValue(
+export function suggestOptionValue(
   value: string,
   allowed: string[]
 ): string | undefined {

--- a/tests/test_list.sh
+++ b/tests/test_list.sh
@@ -315,14 +315,14 @@ test_filter_invalid_field_error() {
     assert_contains "$output" "Valid fields:" "Should list valid fields"
 }
 
-test_filter_invalid_enum_value_error() {
+test_filter_invalid_option_value_error() {
     local output
     output=$(run_ovault "" list idea --status=invalid-status 2>&1)
     local exit_code=$?
 
-    assert_equals "1" "$exit_code" "Should exit with error for invalid enum value"
+    assert_equals "1" "$exit_code" "Should exit with error for invalid option value"
     assert_contains "$output" "Invalid value" "Should report invalid value"
-    assert_contains "$output" "Valid values:" "Should list valid enum values"
+    assert_contains "$output" "Valid values:" "Should list valid option values"
 }
 
 test_filter_typo_in_field_name() {

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -332,7 +332,7 @@ customField: value
     });
 
     it('should filter by --only issue type', async () => {
-      const result = await runCLI(['audit', 'idea', '--only', 'invalid-enum'], tempVaultDir);
+      const result = await runCLI(['audit', 'idea', '--only', 'invalid-option'], tempVaultDir);
 
       expect(result.stdout).toContain('Invalid status value');
       expect(result.stdout).not.toContain('Unknown field');
@@ -436,7 +436,7 @@ priority: medium
       const json = JSON.parse(result.stdout);
       const issue = json.files[0].issues[0];
       expect(issue.severity).toBe('error');
-      expect(issue.code).toBe('invalid-enum');
+      expect(issue.code).toBe('invalid-option');
       expect(issue.field).toBe('status');
       expect(issue.value).toBe('wip');
       expect(issue.expected).toContain('raw');

--- a/tests/ts/lib/validation.test.ts
+++ b/tests/ts/lib/validation.test.ts
@@ -3,7 +3,7 @@ import {
   validateFrontmatter,
   validateContextFields,
   applyDefaults,
-  suggestEnumValue,
+  suggestOptionValue,
   suggestFieldName,
   formatValidationErrors,
 } from '../../../src/lib/validation.js';
@@ -36,7 +36,7 @@ describe('validation', () => {
       expect(result.errors).toHaveLength(0);
     });
 
-    it('should fail on invalid enum value', () => {
+    it('should fail on invalid option value', () => {
       const result = validateFrontmatter(schema, 'idea', {
         type: 'idea',
         status: 'invalid-status',
@@ -44,11 +44,11 @@ describe('validation', () => {
 
       expect(result.valid).toBe(false);
       expect(result.errors).toHaveLength(1);
-      expect(result.errors[0].type).toBe('invalid_enum_value');
+      expect(result.errors[0].type).toBe('invalid_option_value');
       expect(result.errors[0].field).toBe('status');
     });
 
-    it('should suggest similar enum values', () => {
+    it('should suggest similar option values', () => {
       const result = validateFrontmatter(schema, 'idea', {
         type: 'idea',
         status: 'rae', // typo for 'raw'
@@ -78,7 +78,7 @@ describe('validation', () => {
 
       expect(result.valid).toBe(false);
       expect(result.errors).toHaveLength(1);
-      expect(result.errors[0].type).toBe('invalid_enum_value');
+      expect(result.errors[0].type).toBe('invalid_option_value');
       expect(result.errors[0].field).toBe('labels');
       expect(result.errors[0].value).toBe('invalid-label');
     });
@@ -191,26 +191,26 @@ describe('validation', () => {
     });
   });
 
-  describe('suggestEnumValue', () => {
+  describe('suggestOptionValue', () => {
     it('should return exact match with different case', () => {
-      expect(suggestEnumValue('RAW', ['raw', 'backlog'])).toBe('raw');
+      expect(suggestOptionValue('RAW', ['raw', 'backlog'])).toBe('raw');
     });
 
     it('should return prefix match', () => {
-      expect(suggestEnumValue('back', ['raw', 'backlog'])).toBe('backlog');
+      expect(suggestOptionValue('back', ['raw', 'backlog'])).toBe('backlog');
     });
 
     it('should return close match by Levenshtein distance', () => {
-      expect(suggestEnumValue('bakclog', ['raw', 'backlog'])).toBe('backlog');
+      expect(suggestOptionValue('bakclog', ['raw', 'backlog'])).toBe('backlog');
     });
 
     it('should return undefined for no close match', () => {
-      expect(suggestEnumValue('xyz', ['raw', 'backlog'])).toBeUndefined();
+      expect(suggestOptionValue('xyz', ['raw', 'backlog'])).toBeUndefined();
     });
 
     it('should handle in-progress style values', () => {
-      expect(suggestEnumValue('wip', ['draft', 'in-progress', 'done'])).toBeUndefined();
-      expect(suggestEnumValue('in-prog', ['draft', 'in-progress', 'done'])).toBe('in-progress');
+      expect(suggestOptionValue('wip', ['draft', 'in-progress', 'done'])).toBeUndefined();
+      expect(suggestOptionValue('in-prog', ['draft', 'in-progress', 'done'])).toBe('in-progress');
     });
   });
 
@@ -232,7 +232,7 @@ describe('validation', () => {
     it('should format single error', () => {
       const output = formatValidationErrors([
         {
-          type: 'invalid_enum_value',
+          type: 'invalid_option_value',
           field: 'status',
           value: 'bad',
           message: 'Invalid value for status: "bad"',
@@ -248,7 +248,7 @@ describe('validation', () => {
     it('should include suggestion when available', () => {
       const output = formatValidationErrors([
         {
-          type: 'invalid_enum_value',
+          type: 'invalid_option_value',
           field: 'status',
           value: 'rae',
           message: 'Invalid value for status: "rae"',


### PR DESCRIPTION
## Summary

Aligns "enum" terminology with the current schema model by renaming to "option" terminology throughout the codebase.

- Validation error type: `invalid_enum_value` → `invalid_option_value`
- Audit issue code: `invalid-enum` → `invalid-option`
- Export renamed: `suggestEnumValue()` → `suggestOptionValue()`

## Background

Global enums were replaced with inline `options` on fields in #165. This PR completes the terminology alignment by updating error types and codes that still referenced the old "enum" naming.

## Breaking Changes

**JSON API output changes:**
- Scripts checking for `type: 'invalid_enum_value'` in validation output should update to `type: 'invalid_option_value'`
- Scripts using `--only invalid-enum` or `--ignore invalid-enum` should update to `invalid-option`
- External code importing `suggestEnumValue()` should import `suggestOptionValue()` instead

## Files Changed

- `src/lib/validation.ts` - Type and function rename
- `src/lib/audit/types.ts` - Issue code rename
- `src/lib/audit/detection.ts` - Import and usage updates
- `src/lib/audit/fix.ts` - Case statement and function updates
- `src/commands/audit.ts` - Help text updates
- `docs/` - Documentation updates
- `tests/` - Test assertion updates

## Testing

All tests pass: `pnpm test` (1315 passed)
Typecheck passes: `pnpm typecheck`

Fixes #179