### PR TITLE
feat(dashboard): add default dashboard support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Added
 
+- **Default dashboard configuration via `--set-default` flag** (#203)
+  - `bwrb dashboard new my-tasks --type task --set-default` creates and sets as default
+  - `bwrb dashboard edit my-tasks --set-default` sets existing dashboard as default
+  - `bwrb config edit default_dashboard` allows setting/clearing default via config
+  - When configured, `bwrb dashboard` (no args) runs the default instead of showing picker
+
 - **`dashboard edit` command to modify existing dashboards** (#201)
   - `bwrb dashboard edit <name>` opens interactive editor with current values as defaults
   - `bwrb dashboard edit` (no args) shows picker to select dashboard

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -64,6 +64,12 @@ const CONFIG_OPTIONS: ConfigOptionMeta[] = [
     description: 'Obsidian vault name for URI scheme (auto-detected if not set)',
     default: '(auto-detect)',
   },
+  {
+    key: 'default_dashboard',
+    label: 'Default Dashboard',
+    description: 'Dashboard to run when `bwrb dashboard` is called without arguments',
+    default: '(none)',
+  },
 ];
 
 export const configCommand = new Command('config')
@@ -280,6 +286,8 @@ function getConfigValue(config: Partial<Config>, key: keyof Config, vaultDir: st
       return 'system';
     case 'obsidian_vault':
       return detectObsidianVault(vaultDir);
+    case 'default_dashboard':
+      return undefined; // No auto-detection for default_dashboard
     default:
       return undefined;
   }

--- a/src/lib/schema-writer.ts
+++ b/src/lib/schema-writer.ts
@@ -42,4 +42,30 @@ export async function writeSchema(vaultDir: string, schema: Schema): Promise<voi
   await rename(tempPath, schemaPath);
 }
 
-
+/**
+ * Set the default dashboard in vault config.
+ * Updates schema.json with config.default_dashboard.
+ * 
+ * @param vaultDir - Path to the vault directory
+ * @param dashboardName - Name of the dashboard to set as default, or null to clear
+ */
+export async function setDefaultDashboard(
+  vaultDir: string,
+  dashboardName: string | null
+): Promise<void> {
+  const schema = await loadRawSchemaJson(vaultDir);
+  
+  // Ensure config object exists
+  if (!schema.config) {
+    schema.config = {};
+  }
+  
+  if (dashboardName === null) {
+    // Clear the default
+    delete schema.config.default_dashboard;
+  } else {
+    schema.config.default_dashboard = dashboardName;
+  }
+  
+  await writeSchema(vaultDir, schema);
+}


### PR DESCRIPTION
## Summary

- Add `--set-default` flag to `dashboard new` and `dashboard edit` commands
- Add `default_dashboard` to config options for `bwrb config edit`
- Add `setDefaultDashboard` helper in schema-writer for atomic updates

## Changes

### New Features
- `bwrb dashboard new my-tasks --type task --set-default` - creates dashboard and sets as default
- `bwrb dashboard edit my-tasks --set-default` - sets existing dashboard as default  
- `bwrb config edit default_dashboard --json '"my-tasks"'` - set via config command
- `bwrb config edit default_dashboard` with "(clear)" option to unset

### Behavior
- When `default_dashboard` is configured, `bwrb dashboard` (no args) runs it automatically
- If configured default doesn't exist, shows warning and falls back to picker
- JSON mode responses include `isDefault: boolean` field

## Testing

Added comprehensive tests:
- 5 tests for config.test.ts (default_dashboard config option)
- 12 tests for dashboard.test.ts (--set-default flag on new/edit)

All tests pass, typecheck passes, lint passes.

## Acceptance Criteria

- [x] `config.default_dashboard` is recognized
- [x] `bwrb dashboard` runs default when configured
- [x] Warning if configured default doesn't exist
- [x] `--set-default` flag works on new/edit commands

Fixes #203