### PR TITLE
docs: write comprehensive schema reference

### DIFF
--- a/docs-site/src/content/docs/concepts/schema.md
+++ b/docs-site/src/content/docs/concepts/schema.md
@@ -21,16 +21,18 @@ A schema defines:
 
 - **Types** — Categories of notes (e.g., `task`, `idea`, `person`)
 - **Fields** — Properties each type has (e.g., `status`, `priority`, `deadline`)
-- **Enums** — Reusable option sets (e.g., status values)
-- **Config** — Vault-wide settings
+- **Config** — Vault-wide settings (link format, default editor, etc.)
+- **Audit** — Configuration for schema validation
 
 ```json
 {
   "types": { ... },
-  "enums": { ... },
-  "config": { ... }
+  "config": { ... },
+  "audit": { ... }
 }
 ```
+
+See the [Schema Reference](/reference/schema/) for complete property documentation.
 
 ## Schema is King
 
@@ -42,5 +44,6 @@ The schema is the source of truth. Notes must conform.
 
 ## Next Steps
 
+- [Schema Reference](/reference/schema/) — Complete property reference
 - [Types and Inheritance](/concepts/types-and-inheritance/) — How types relate to each other
 - [Validation and Audit](/concepts/validation-and-audit/) — Keeping notes in sync with schema

--- a/docs-site/src/content/docs/concepts/types-and-inheritance.md
+++ b/docs-site/src/content/docs/concepts/types-and-inheritance.md
@@ -7,28 +7,7 @@ Bowerbird uses strict type inheritance to reduce duplication and ensure consiste
 
 ## Type Hierarchy
 
-Types can be nested to create hierarchies:
-
-```json
-{
-  "types": {
-    "objective": {
-      "subtypes": {
-        "task": { ... },
-        "milestone": { ... },
-        "project": { ... }
-      }
-    },
-    "idea": { ... }
-  }
-}
-```
-
-Reference types with slash notation: `objective/task`, `objective/milestone`.
-
-## Inheritance
-
-Child types inherit all fields from their parent types.
+Types form a single-inheritance tree. Every type extends exactly one parent, and all types ultimately inherit from `meta`:
 
 ```
 meta (global fields)
@@ -43,20 +22,57 @@ meta (global fields)
     └── place
 ```
 
-## Field Definitions
+## Defining Types
 
-Each type needs:
+Types are defined with the `extends` property linking to their parent:
 
-- `output_dir` — Where notes are saved
-- `frontmatter` — Field definitions
+```json
+{
+  "types": {
+    "meta": {
+      "fields": {
+        "status": { "prompt": "select", "options": ["raw", "active", "done"] },
+        "created": { "value": "$NOW" }
+      }
+    },
+    "objective": {
+      "fields": {
+        "deadline": { "prompt": "date" }
+      }
+    },
+    "task": {
+      "extends": "objective",
+      "fields": {
+        "priority": { "prompt": "select", "options": ["low", "medium", "high"] }
+      }
+    }
+  }
+}
+```
 
-Fields can be:
-- **Static** — Fixed value: `{ "value": "task" }`
-- **Select** — Choose from options: `{ "prompt": "select", "options": [...] }`
+A `task` note gets:
+- `status` and `created` from `meta`
+- `deadline` from `objective`  
+- `priority` from itself
+
+## Inheritance Rules
+
+1. **Single inheritance** — Each type has exactly one parent
+2. **Unique names** — Type names must be unique across the entire schema
+3. **No cycles** — A type cannot extend its own descendant
+4. **Override defaults only** — Child types can override `default` values, but not field structure
+
+## Field Types
+
+Fields define what data each note type collects:
+
+- **Static** — Fixed value: `{ "value": "$NOW" }`
 - **Text** — Free input: `{ "prompt": "text" }`
-- **Relation** — Link to other notes: `{ "prompt": "relation", "source": "objective/milestone" }`
+- **Select** — Choose from options: `{ "prompt": "select", "options": [...] }`
+- **Relation** — Link to other notes: `{ "prompt": "relation", "source": "milestone" }`
+- **Number**, **Boolean**, **Date**, **List** — Other prompt types
 
 ## Next Steps
 
-- [Schema reference](/concepts/schema/) — Full schema documentation
+- [Schema Reference](/reference/schema/) — Complete property reference
 - [Migrations](/concepts/migrations/) — Evolving your type system

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -1,0 +1,644 @@
+---
+title: Schema Reference
+description: Complete reference for .bwrb/schema.json structure and properties
+---
+
+The schema file defines your vault's type system: what kinds of notes exist, what fields they have, and how they relate to each other.
+
+For conceptual overview, see [Schema](/concepts/schema/) and [Types and Inheritance](/concepts/types-and-inheritance/).
+
+## File Location
+
+The schema lives at `.bwrb/schema.json` in your vault root:
+
+```
+my-vault/
+├── .bwrb/
+│   └── schema.json    # Your schema definition
+├── Ideas/
+├── Objectives/
+└── ...
+```
+
+## Top-Level Structure
+
+```json
+{
+  "$schema": "https://bwrb.dev/schema.schema.json",
+  "version": 2,
+  "schemaVersion": "1.0.0",
+  "types": { ... },
+  "config": { ... },
+  "audit": { ... }
+}
+```
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `$schema` | string | No | JSON Schema URI for editor validation |
+| `version` | integer | No | Schema format version (default: `2`) |
+| `schemaVersion` | string | No | User-controlled version for migrations (semver) |
+| `types` | object | **Yes** | Type definitions |
+| `config` | object | No | Vault-wide settings |
+| `audit` | object | No | Audit command configuration |
+
+---
+
+## Types
+
+Types define categories of notes. Each type has a name (the object key) and a definition.
+
+### Minimal Type
+
+```json
+{
+  "types": {
+    "idea": {
+      "fields": {
+        "status": { "prompt": "select", "options": ["raw", "developing", "mature"] }
+      }
+    }
+  }
+}
+```
+
+### Type Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `extends` | string | `"meta"` | Parent type name |
+| `fields` | object | `{}` | Field definitions |
+| `field_order` | array | — | Order of fields in frontmatter |
+| `body_sections` | array | — | Body structure after frontmatter |
+| `recursive` | boolean | `false` | Whether type can contain instances of itself |
+| `plural` | string | auto | Custom plural for folder naming (e.g., `"research"` instead of `"researchs"`) |
+
+### Inheritance
+
+All types inherit from `meta` (implicitly created if not defined). Types form a single-inheritance tree:
+
+```json
+{
+  "types": {
+    "meta": {
+      "fields": {
+        "status": { "prompt": "select", "options": ["raw", "active", "done"] },
+        "created": { "value": "$NOW" }
+      }
+    },
+    "objective": {
+      "extends": "meta",
+      "fields": {
+        "deadline": { "prompt": "date" }
+      }
+    },
+    "task": {
+      "extends": "objective",
+      "fields": {
+        "status": { "default": "inbox" },
+        "assignee": { "prompt": "relation", "source": "person" }
+      }
+    }
+  }
+}
+```
+
+A `task` inherits:
+- `status` and `created` from `meta`
+- `deadline` from `objective`
+- Adds `assignee`, overrides `status` default to `"inbox"`
+
+**Inheritance rules:**
+- Type names must be unique across the entire schema
+- No cycles allowed (a type cannot extend its own descendant)
+- Child types can only override `default` values, not field structure
+
+### Recursive Types
+
+Types with `recursive: true` can have a `parent` field pointing to the same type:
+
+```json
+{
+  "task": {
+    "extends": "objective",
+    "recursive": true,
+    "fields": {
+      "parent": {
+        "prompt": "relation",
+        "source": "task"
+      }
+    }
+  }
+}
+```
+
+This enables subtasks, nested chapters, etc. Cycles are prevented—a note cannot be its own ancestor.
+
+---
+
+## Fields
+
+Fields define the frontmatter properties of a note. Each field has a name (the object key) and a definition specifying how values are collected and stored.
+
+### Field Types Overview
+
+| Type | Prompt | Stored As | Use Case |
+|------|--------|-----------|----------|
+| Static | — | as defined | Fixed values, computed dates |
+| `text` | Single-line input | `string` | Names, descriptions |
+| `number` | Numeric input | `number` | Priority, counts |
+| `boolean` | Y/n confirm | `true`/`false` | Flags, toggles |
+| `date` | Date input | `string` (YYYY-MM-DD) | Deadlines, dates |
+| `select` | Picker from options | `string` or `string[]` | Status, category |
+| `relation` | Picker from vault | `string` (wikilink) | Links to other notes |
+| `list` | Comma-separated input | `string[]` | Tags, aliases |
+
+### Static Fields
+
+Fields with `value` are not prompted—they're computed automatically:
+
+```json
+{
+  "type": { "value": "task" },
+  "created": { "value": "$NOW" },
+  "date": { "value": "$TODAY" }
+}
+```
+
+**Special values:**
+- `$NOW` — Current datetime: `2025-01-07 14:30`
+- `$TODAY` — Current date: `2025-01-07`
+
+### text
+
+Free-form single-line input.
+
+```json
+{
+  "description": {
+    "prompt": "text",
+    "label": "Brief description",
+    "required": false
+  }
+}
+```
+
+### number
+
+Numeric input with validation.
+
+```json
+{
+  "priority": {
+    "prompt": "number",
+    "default": "3"
+  }
+}
+```
+
+### boolean
+
+Yes/no confirmation prompt.
+
+```json
+{
+  "archived": {
+    "prompt": "boolean",
+    "default": "false"
+  }
+}
+```
+
+Stored as `true` or `false` (YAML booleans).
+
+### date
+
+Date input with YYYY-MM-DD format.
+
+```json
+{
+  "deadline": {
+    "prompt": "date",
+    "required": false
+  }
+}
+```
+
+### select
+
+Choose from predefined options.
+
+```json
+{
+  "status": {
+    "prompt": "select",
+    "options": ["raw", "inbox", "in-flight", "done", "dropped"],
+    "default": "raw",
+    "required": true
+  }
+}
+```
+
+For multi-select (array output):
+
+```json
+{
+  "tags": {
+    "prompt": "select",
+    "options": ["urgent", "blocked", "waiting", "review"],
+    "multiple": true
+  }
+}
+```
+
+### relation
+
+Link to other notes in the vault. Shows a picker filtered by type.
+
+```json
+{
+  "milestone": {
+    "prompt": "relation",
+    "source": "milestone",
+    "required": false
+  }
+}
+```
+
+**Source options:**
+- Specific type: `"source": "milestone"` — only milestones
+- Type branch: `"source": "objective"` — objectives and all descendants (task, milestone, project, etc.)
+- Any note: `"source": "any"` — entire vault
+
+**Filtering results:**
+
+```json
+{
+  "milestone": {
+    "prompt": "relation",
+    "source": "milestone",
+    "filter": {
+      "status": { "not_in": ["done", "dropped"] }
+    }
+  }
+}
+```
+
+Filter conditions:
+- `equals`: Field must equal value
+- `not_equals`: Field must not equal value
+- `in`: Field must be one of values
+- `not_in`: Field must not be one of values
+
+**Multiple relations:**
+
+```json
+{
+  "related": {
+    "prompt": "relation",
+    "source": "any",
+    "multiple": true
+  }
+}
+```
+
+**Owned relations:**
+
+When `owned: true`, referenced notes are private to the parent and colocate in the parent's folder:
+
+```json
+{
+  "chapters": {
+    "prompt": "relation",
+    "source": "chapter",
+    "multiple": true,
+    "owned": true
+  }
+}
+```
+
+Owned notes:
+- Live in the owner's subfolder (e.g., `drafts/My Novel/chapters/`)
+- Cannot be referenced by other notes' frontmatter fields
+- Are still discoverable via `bwrb list` and `bwrb search`
+
+### list
+
+Comma-separated input stored as an array.
+
+```json
+{
+  "aliases": {
+    "prompt": "list",
+    "label": "Aliases (comma-separated)"
+  }
+}
+```
+
+Output format controlled by `list_format`:
+- `yaml-array` (default): `["one", "two", "three"]`
+- `comma-separated`: `"one, two, three"`
+
+---
+
+## Field Properties Reference
+
+Complete list of field properties:
+
+| Property | Type | Applies To | Description |
+|----------|------|------------|-------------|
+| `value` | string | static | Fixed value (mutually exclusive with `prompt`) |
+| `prompt` | string | prompted | Prompt type: `text`, `number`, `boolean`, `date`, `select`, `relation`, `list` |
+| `label` | string | prompted | Custom label shown during prompting |
+| `required` | boolean | prompted | Whether field must have a value (default: `false`) |
+| `default` | string | prompted | Default value if user skips prompt |
+| `options` | array | `select` | Allowed values for selection |
+| `multiple` | boolean | `select`, `relation` | Allow multiple values (default: `false`) |
+| `source` | string | `relation` | Type name to filter picker, or `"any"` |
+| `filter` | object | `relation` | Filter conditions for source query |
+| `owned` | boolean | `relation` | Whether referenced notes are owned/colocated (default: `false`) |
+| `list_format` | string | `list` | Output format: `yaml-array` or `comma-separated` |
+
+---
+
+## Body Sections
+
+Define document structure after frontmatter:
+
+```json
+{
+  "body_sections": [
+    {
+      "title": "Description",
+      "level": 2,
+      "content_type": "paragraphs"
+    },
+    {
+      "title": "Steps",
+      "level": 2,
+      "content_type": "checkboxes",
+      "prompt": "list",
+      "prompt_label": "Steps (comma-separated)"
+    },
+    {
+      "title": "Notes",
+      "level": 2,
+      "content_type": "bullets",
+      "children": [
+        { "title": "Blockers", "level": 3 }
+      ]
+    }
+  ]
+}
+```
+
+### Section Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `title` | string | **Yes** | Section heading text |
+| `level` | integer | No | Heading level 2-6 (default: `2`) |
+| `content_type` | string | No | Placeholder type: `none`, `paragraphs`, `bullets`, `checkboxes` |
+| `prompt` | string | No | If `"list"`, prompts for initial content during creation |
+| `prompt_label` | string | No | Label for the content prompt |
+| `children` | array | No | Nested subsections |
+
+---
+
+## Config
+
+Vault-wide settings:
+
+```json
+{
+  "config": {
+    "link_format": "wikilink",
+    "open_with": "obsidian",
+    "editor": "nvim",
+    "visual": "code",
+    "obsidian_vault": "My Vault"
+  }
+}
+```
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `link_format` | string | `"wikilink"` | Link format for relations: `wikilink` (`[[Note]]`) or `markdown` (`[Note](Note.md)`) |
+| `open_with` | string | `"visual"` | Default for `--open`: `editor`, `visual`, or `obsidian` |
+| `editor` | string | `$EDITOR` | Terminal editor command |
+| `visual` | string | `$VISUAL` | GUI editor command |
+| `obsidian_vault` | string | auto | Obsidian vault name for URI scheme |
+
+---
+
+## Audit Config
+
+Configure the [`bwrb audit`](/reference/commands/audit/) command:
+
+```json
+{
+  "audit": {
+    "ignored_directories": ["Archive", ".obsidian", "Templates"],
+    "allowed_extra_fields": ["aliases", "cssclass", "publish"]
+  }
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ignored_directories` | array | Directories to skip during audit |
+| `allowed_extra_fields` | array | Extra frontmatter fields that won't trigger warnings |
+
+---
+
+## IDE Integration
+
+Add `$schema` to your schema file for editor autocomplete and validation:
+
+```json
+{
+  "$schema": "https://bwrb.dev/schema.schema.json",
+  "types": { ... }
+}
+```
+
+### VS Code
+
+If the URL isn't reachable, configure the schema manually in `.vscode/settings.json`:
+
+```json
+{
+  "json.schemas": [
+    {
+      "fileMatch": ["**/.bwrb/schema.json"],
+      "url": "./node_modules/bwrb/schema.schema.json"
+    }
+  ]
+}
+```
+
+Or reference a local copy of `schema.schema.json` from the bwrb repository.
+
+### Neovim
+
+With `nvim-lspconfig` and `jsonls`:
+
+```lua
+require('lspconfig').jsonls.setup({
+  settings = {
+    json = {
+      schemas = {
+        {
+          fileMatch = { "*/.bwrb/schema.json" },
+          url = "https://bwrb.dev/schema.schema.json"
+        }
+      }
+    }
+  }
+})
+```
+
+---
+
+## Complete Example
+
+A full schema demonstrating inheritance, relations, body sections, and config:
+
+```json
+{
+  "$schema": "https://bwrb.dev/schema.schema.json",
+  "version": 2,
+  "schemaVersion": "1.0.0",
+  
+  "config": {
+    "link_format": "wikilink",
+    "open_with": "obsidian"
+  },
+  
+  "audit": {
+    "ignored_directories": [".obsidian", "Templates"],
+    "allowed_extra_fields": ["aliases", "cssclass"]
+  },
+  
+  "types": {
+    "meta": {
+      "fields": {
+        "status": {
+          "prompt": "select",
+          "options": ["raw", "active", "settled", "dropped"],
+          "default": "raw"
+        },
+        "created": { "value": "$NOW" }
+      }
+    },
+    
+    "idea": {
+      "fields": {
+        "tags": {
+          "prompt": "select",
+          "options": ["shower-thought", "research", "project-idea"],
+          "multiple": true
+        }
+      },
+      "body_sections": [
+        { "title": "Description", "level": 2, "content_type": "paragraphs" }
+      ]
+    },
+    
+    "objective": {
+      "fields": {
+        "deadline": { "prompt": "date" }
+      }
+    },
+    
+    "task": {
+      "extends": "objective",
+      "recursive": true,
+      "fields": {
+        "status": { "default": "inbox" },
+        "priority": {
+          "prompt": "select",
+          "options": ["low", "medium", "high"],
+          "default": "medium"
+        },
+        "milestone": {
+          "prompt": "relation",
+          "source": "milestone",
+          "filter": {
+            "status": { "not_in": ["settled", "dropped"] }
+          }
+        },
+        "parent": {
+          "prompt": "relation",
+          "source": "task"
+        }
+      },
+      "body_sections": [
+        {
+          "title": "Steps",
+          "level": 2,
+          "content_type": "checkboxes",
+          "prompt": "list",
+          "prompt_label": "Steps (comma-separated)"
+        },
+        { "title": "Notes", "level": 2, "content_type": "bullets" }
+      ]
+    },
+    
+    "milestone": {
+      "extends": "objective",
+      "fields": {
+        "project": {
+          "prompt": "relation",
+          "source": "project"
+        }
+      }
+    },
+    
+    "project": {
+      "extends": "objective"
+    },
+    
+    "draft": {
+      "fields": {
+        "draft-status": {
+          "prompt": "select",
+          "options": ["idea", "outlining", "drafting", "revising", "done"],
+          "default": "idea"
+        },
+        "chapters": {
+          "prompt": "relation",
+          "source": "chapter",
+          "multiple": true,
+          "owned": true
+        }
+      }
+    },
+    
+    "chapter": {
+      "extends": "draft",
+      "recursive": true,
+      "fields": {
+        "word-count": { "prompt": "number" }
+      }
+    },
+    
+    "person": {
+      "fields": {
+        "email": { "prompt": "text" },
+        "company": { "prompt": "text" }
+      }
+    }
+  }
+}
+```
+
+---
+
+## See Also
+
+- [Schema concept](/concepts/schema/) — Why schema matters
+- [Types and Inheritance](/concepts/types-and-inheritance/) — Mental model for type hierarchies
+- [Validation and Audit](/concepts/validation-and-audit/) — Keeping notes in sync
+- [`bwrb schema`](/reference/commands/schema/) — Schema management commands
+- [`bwrb audit`](/reference/commands/audit/) — Validate notes against schema


### PR DESCRIPTION
## Summary
- Add complete Schema Reference documentation at `reference/schema.md`
- Update concepts pages to use v2 schema model and link to reference

## What's Covered

The Schema Reference is a single, Ctrl+F-able page covering:

- **Schema file location and top-level structure**
- **Type definitions** - extends, fields, recursive, plural, field_order
- **All 7 field types** - text, number, boolean, date, select, relation, list
- **Complete field properties table** - value, prompt, label, required, default, options, multiple, source, filter, owned, list_format
- **Body sections** - title, level, content_type, prompt, children
- **Config block** - link_format, editor, visual, open_with, obsidian_vault
- **Audit config** - ignored_directories, allowed_extra_fields
- **IDE integration** - VS Code and Neovim setup
- **Complete working example** - Full schema.json demonstrating all features

## Related Updates

- `concepts/types-and-inheritance.md` - Replaced outdated `subtypes`/`frontmatter` syntax with v2 model (`extends`/`fields`)
- `concepts/schema.md` - Removed outdated "enums" reference, added links to Schema Reference

## Follow-up Needed

Devex review identified drift between `schema.schema.json` and runtime Zod schema:
- `config.open_with` - Runtime allows `"system"` but JSON Schema doesn't
- `field.source` - Runtime allows arrays, JSON Schema only allows string
- `body_sections.prompt` - Runtime allows `"none"`, JSON Schema only allows `"list"`
- Missing from JSON Schema: `config.default_dashboard`, type `filename` property

These are code issues (not docs issues) and should be tracked separately. This PR documents what the JSON Schema validates, which is what IDE autocomplete/validation will enforce.

Fixes #214