### PR TITLE
fix(docs): add schema reference to sidebar

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -38,6 +38,7 @@ export default defineConfig({
 					label: 'CLI Reference',
 					items: [
 						{ slug: 'reference/targeting' },
+						{ slug: 'reference/schema' },
 						{
 							label: 'Commands',
 							collapsed: true,


### PR DESCRIPTION
## Summary

- Adds the Schema Reference (`reference/schema.md`) to the docs sidebar under CLI Reference
- The 645-line schema format reference doc was created but never linked in navigation

## Context

The Schema Reference documents the `.bwrb/schema.json` file format (fields, types, inheritance, config, etc.) - distinct from the `bwrb schema` command docs which are already in the sidebar.

Users couldn't discover this important reference doc without knowing the direct URL.

Fixes the missing sidebar link by placing "Schema Reference" between "Targeting Model" and "Commands" in the CLI Reference section.