### PR TITLE
feat(init): add bwrb init command for vault setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Added
 
+- **Vault initialization command** (#188)
+  - `bwrb init [path]` creates a new vault with `.bwrb/schema.json`
+  - Interactive prompts for link format and editor preferences
+  - Non-interactive mode with `--yes` for scripting
+  - Auto-detects Obsidian vault name from `.obsidian/` directory
+  - `--force` flag to reinitialize existing vaults
+  - JSON Schema hosted at `https://bwrb.dev/schema.json` for editor support
+
 - **Link normalization during schema migration** (#86)
   - When `config.link_format` changes in schema.json, `bwrb schema migrate` automatically normalizes all relation field links to the new format
   - Supports conversion between `wikilink` (`[[Note]]`) and `markdown` (`[Note](Note.md)`) formats

--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -1,0 +1,264 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bwrb.dev/schema.json",
+  "title": "Bowerbird Schema",
+  "description": "Schema for defining types, fields, and configuration for markdown vaults",
+  "type": "object",
+  "required": ["types"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Reference to this JSON Schema for editor support"
+    },
+    "version": {
+      "type": "integer",
+      "default": 2,
+      "description": "Schema format version (2 = inheritance model)"
+    },
+    "schemaVersion": {
+      "type": "string",
+      "description": "User-controlled schema content version for migrations (semver)"
+    },
+    "config": {
+      "$ref": "#/definitions/config"
+    },
+    "types": {
+      "type": "object",
+      "description": "Type definitions with inheritance support",
+      "additionalProperties": {
+        "$ref": "#/definitions/typeNode"
+      }
+    },
+    "audit": {
+      "$ref": "#/definitions/auditConfig"
+    }
+  },
+  "definitions": {
+    "config": {
+      "type": "object",
+      "description": "Vault-wide configuration options",
+      "additionalProperties": false,
+      "properties": {
+        "link_format": {
+          "type": "string",
+          "enum": ["wikilink", "markdown"],
+          "default": "wikilink",
+          "description": "Link format for relation fields: wikilink (\"[[Note]]\") or markdown (\"[Note](Note.md)\")"
+        },
+        "editor": {
+          "type": "string",
+          "description": "Terminal editor command (defaults to $EDITOR)"
+        },
+        "visual": {
+          "type": "string",
+          "description": "GUI editor command (defaults to $VISUAL)"
+        },
+        "open_with": {
+          "type": "string",
+          "enum": ["system", "editor", "visual", "obsidian"],
+          "default": "system",
+          "description": "Default behavior for --open flag"
+        },
+        "obsidian_vault": {
+          "type": "string",
+          "description": "Obsidian vault name for URI scheme (auto-detected if not set)"
+        },
+        "default_dashboard": {
+          "type": "string",
+          "description": "Default dashboard to run when `bwrb dashboard` is called without arguments"
+        }
+      }
+    },
+    "auditConfig": {
+      "type": "object",
+      "description": "Configuration for the audit command",
+      "additionalProperties": false,
+      "properties": {
+        "ignored_directories": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Directories to skip during audit"
+        },
+        "allowed_extra_fields": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Extra frontmatter fields that are allowed without warning"
+        }
+      }
+    },
+    "typeNode": {
+      "type": "object",
+      "description": "Type definition with inheritance support",
+      "additionalProperties": false,
+      "properties": {
+        "extends": {
+          "type": "string",
+          "description": "Parent type name (implicit 'meta' if not specified)"
+        },
+        "fields": {
+          "type": "object",
+          "description": "Field definitions (merged with ancestors at load time)",
+          "additionalProperties": {
+            "$ref": "#/definitions/field"
+          }
+        },
+        "field_order": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Explicit field ordering (optional - defaults to definition order)"
+        },
+        "body_sections": {
+          "type": "array",
+          "description": "Body section definitions",
+          "items": {
+            "$ref": "#/definitions/bodySection"
+          }
+        },
+        "recursive": {
+          "type": "boolean",
+          "description": "Whether this type can contain instances of itself"
+        },
+        "output_dir": {
+          "type": "string",
+          "description": "Output directory (computed from hierarchy if not specified)"
+        },
+        "filename": {
+          "type": "string",
+          "description": "Filename pattern"
+        },
+        "plural": {
+          "type": "string",
+          "description": "Custom plural form for folder naming (e.g., 'research' instead of 'researches')"
+        }
+      }
+    },
+    "field": {
+      "type": "object",
+      "description": "Field definition for type frontmatter",
+      "additionalProperties": false,
+      "properties": {
+        "prompt": {
+          "type": "string",
+          "enum": ["text", "select", "list", "date", "relation", "boolean", "number"],
+          "description": "Prompt type (how the field is collected)"
+        },
+        "value": {
+          "type": "string",
+          "description": "Static value (no prompting)"
+        },
+        "options": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Inline options for select prompts"
+        },
+        "source": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ],
+          "description": "Type name(s) for relation prompts"
+        },
+        "filter": {
+          "type": "object",
+          "description": "Filter conditions for type-based source queries",
+          "additionalProperties": {
+            "$ref": "#/definitions/filterCondition"
+          }
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether the field is required"
+        },
+        "default": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ],
+          "description": "Default value"
+        },
+        "list_format": {
+          "type": "string",
+          "enum": ["yaml-array", "comma-separated"],
+          "description": "How list values are formatted in YAML"
+        },
+        "label": {
+          "type": "string",
+          "description": "Prompt label override"
+        },
+        "multiple": {
+          "type": "boolean",
+          "description": "Whether this field can hold multiple values (for context fields)"
+        },
+        "owned": {
+          "type": "boolean",
+          "description": "Whether children referenced by this field are owned (colocate with parent)"
+        }
+      }
+    },
+    "bodySection": {
+      "type": "object",
+      "required": ["title"],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Section heading text"
+        },
+        "level": {
+          "type": "integer",
+          "minimum": 2,
+          "maximum": 6,
+          "default": 2,
+          "description": "Heading level (2 = ##, 3 = ###, etc.)"
+        },
+        "content_type": {
+          "type": "string",
+          "enum": ["none", "paragraphs", "bullets", "checkboxes"],
+          "default": "none",
+          "description": "Type of content placeholder to add"
+        },
+        "prompt": {
+          "type": "string",
+          "enum": ["none", "list"],
+          "description": "If set, prompts user for initial content during creation"
+        },
+        "prompt_label": {
+          "type": "string",
+          "description": "Label for the content prompt"
+        },
+        "children": {
+          "type": "array",
+          "description": "Nested subsections",
+          "items": {
+            "$ref": "#/definitions/bodySection"
+          }
+        }
+      }
+    },
+    "filterCondition": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "equals": {
+          "type": "string",
+          "description": "Field must equal this value"
+        },
+        "not_equals": {
+          "type": "string",
+          "description": "Field must not equal this value"
+        },
+        "in": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Field must be one of these values"
+        },
+        "not_in": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Field must not be one of these values"
+        }
+      }
+    }
+  }
+}

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -25,6 +25,30 @@ bwrb finds the vault in this order:
 
 Always verify you're targeting the correct vault before operations.
 
+## Initializing a Vault
+
+Create a new bwrb vault with `init`:
+
+```bash
+# Initialize in current directory (non-interactive)
+bwrb init --yes
+
+# Initialize at specific path
+bwrb init /path/to/vault --yes
+
+# Reinitialize existing vault (destructive)
+bwrb init --force --yes
+
+# JSON output for scripting
+bwrb init --yes --output json
+```
+
+The command creates `.bwrb/schema.json` with:
+- Version 2 format
+- Default `wikilink` link format
+- Auto-detected Obsidian vault name (if `.obsidian/` exists)
+- Empty `types: {}` (add types with `bwrb schema type new`)
+
 ## Schema Discovery
 
 Before creating or querying notes, understand the vault's schema:

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,256 @@
+/**
+ * Init Command
+ * ============
+ *
+ * Initialize a new bwrb vault with initial configuration.
+ *
+ * Usage:
+ *   bwrb init              - Interactive setup in current directory
+ *   bwrb init /path/to/dir - Initialize at specific path
+ *   bwrb init --yes        - Non-interactive with defaults
+ *   bwrb init --force      - Overwrite existing .bwrb/ directory
+ */
+
+import { Command } from 'commander';
+import { mkdir, rm, readdir, stat } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, resolve } from 'path';
+import chalk from 'chalk';
+
+import { detectObsidianVault } from '../lib/schema.js';
+import { writeSchema } from '../lib/schema-writer.js';
+import {
+  promptSelection,
+  promptInput,
+  promptConfirm,
+  printError,
+  printSuccess,
+  printWarning,
+} from '../lib/prompt.js';
+import { printJson, jsonSuccess, jsonError, ExitCodes } from '../lib/output.js';
+import { UserCancelledError } from '../lib/errors.js';
+import type { Schema, Config } from '../types/schema.js';
+
+const BWRB_DIR = '.bwrb';
+const SCHEMA_URL = 'https://bwrb.dev/schema.json';
+
+interface InitOptions {
+  yes?: boolean;
+  force?: boolean;
+  output?: string;
+}
+
+interface InitResult {
+  vault: string;
+  schema_path: string;
+  config: {
+    link_format: string;
+    obsidian_vault?: string;
+    editor?: string;
+  };
+}
+
+export const initCommand = new Command('init')
+  .description('Initialize a new bwrb vault')
+  .argument('[path]', 'Path to initialize (defaults to current directory)')
+  .option('-y, --yes', 'Skip prompts, use defaults')
+  .option('-f, --force', 'Overwrite existing .bwrb/ directory')
+  .option('-o, --output <format>', 'Output format: text (default) or json')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  bwrb init                    Initialize in current directory
+  bwrb init ~/notes            Initialize at specific path
+  bwrb init --yes              Non-interactive with defaults
+  bwrb init --force            Overwrite existing configuration
+  bwrb init --yes --output json   Machine-readable output`
+  )
+  .action(async (pathArg: string | undefined, options: InitOptions) => {
+    const jsonMode = options.output === 'json';
+
+    try {
+      // Resolve vault path
+      const vaultDir = pathArg ? resolve(pathArg) : process.cwd();
+      const bwrbDir = join(vaultDir, BWRB_DIR);
+
+      // Check if vault directory exists
+      if (!existsSync(vaultDir)) {
+        throw new Error(`Directory does not exist: ${vaultDir}`);
+      }
+
+      // Check for directory (not file)
+      const vaultStat = await stat(vaultDir);
+      if (!vaultStat.isDirectory()) {
+        throw new Error(`Path is not a directory: ${vaultDir}`);
+      }
+
+      // Check for existing .bwrb/
+      if (existsSync(bwrbDir)) {
+        if (!options.force) {
+          throw new Error(
+            `Vault already initialized at ${vaultDir}\nUse --force to reinitialize.`
+          );
+        }
+
+        // Force mode - show warning and get confirmation
+        if (!options.yes) {
+          const contents = await listBwrbContents(bwrbDir);
+          if (contents.length > 0) {
+            printWarning(`\nWarning: ${BWRB_DIR}/ already exists and contains:`);
+            for (const item of contents) {
+              console.log(`  - ${item}`);
+            }
+            console.log();
+
+            const confirmed = await promptConfirm(
+              'Continue? This will delete all existing configuration.'
+            );
+            if (confirmed === null) {
+              throw new UserCancelledError();
+            }
+            if (!confirmed) {
+              console.log('Aborted.');
+              process.exit(0);
+            }
+          }
+        }
+
+        // Remove existing .bwrb/
+        await rm(bwrbDir, { recursive: true });
+      }
+
+      // Gather configuration
+      let linkFormat: 'wikilink' | 'markdown' = 'wikilink';
+      let editor: string | undefined;
+
+      if (!options.yes) {
+        // Interactive mode
+
+        // Link format
+        const linkChoice = await promptSelection('Link format:', [
+          'wikilink - [[Note Name]] (Obsidian-compatible)',
+          'markdown - [Note Name](Note Name.md)',
+        ]);
+        if (linkChoice === null) {
+          throw new UserCancelledError();
+        }
+        linkFormat = linkChoice.startsWith('wikilink') ? 'wikilink' : 'markdown';
+
+        // Editor (optional)
+        const envEditor = process.env.EDITOR || process.env.VISUAL;
+        const editorInput = await promptInput(
+          'Editor command (optional, press Enter to skip):',
+          envEditor
+        );
+        if (editorInput === null) {
+          throw new UserCancelledError();
+        }
+        editor = editorInput.trim() || undefined;
+      }
+
+      // Auto-detect Obsidian vault
+      const obsidianVault = detectObsidianVault(vaultDir);
+
+      // Build config
+      const config: Config = {
+        link_format: linkFormat,
+      };
+
+      if (obsidianVault) {
+        config.obsidian_vault = obsidianVault;
+      }
+
+      if (editor) {
+        config.editor = editor;
+      }
+
+      // Build schema
+      const schema: Schema = {
+        $schema: SCHEMA_URL,
+        version: 2,
+        config,
+        types: {},
+      };
+
+      // Create .bwrb/ directory
+      await mkdir(bwrbDir, { recursive: true });
+
+      // Write schema.json
+      await writeSchema(vaultDir, schema);
+
+      const schemaPath = join(bwrbDir, 'schema.json');
+      const result: InitResult = {
+        vault: vaultDir,
+        schema_path: schemaPath,
+        config: {
+          link_format: linkFormat,
+          ...(obsidianVault && { obsidian_vault: obsidianVault }),
+          ...(editor && { editor }),
+        },
+      };
+
+      // Output result
+      if (jsonMode) {
+        printJson(jsonSuccess({ data: result }));
+      } else {
+        printSuccess(`\nInitialized bwrb vault at ${vaultDir}`);
+        console.log(`\nConfiguration:`);
+        console.log(`  Link format: ${chalk.cyan(linkFormat)}`);
+        if (obsidianVault) {
+          console.log(`  Obsidian vault: ${chalk.cyan(obsidianVault)} (auto-detected)`);
+        }
+        if (editor) {
+          console.log(`  Editor: ${chalk.cyan(editor)}`);
+        }
+        console.log(`\nNext steps:`);
+        console.log(`  ${chalk.gray('1.')} Create a type: ${chalk.cyan('bwrb schema new type')}`);
+        console.log(`  ${chalk.gray('2.')} Create a note: ${chalk.cyan('bwrb new <type>')}`);
+      }
+    } catch (err) {
+      if (err instanceof UserCancelledError) {
+        if (jsonMode) {
+          printJson(jsonError('Cancelled'));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        console.log('Cancelled.');
+        process.exit(0);
+      }
+
+      const message = err instanceof Error ? err.message : String(err);
+      if (jsonMode) {
+        printJson(jsonError(message));
+        process.exit(ExitCodes.IO_ERROR);
+      }
+      printError(message);
+      process.exit(1);
+    }
+  });
+
+/**
+ * List contents of .bwrb/ directory for display in force warning.
+ */
+async function listBwrbContents(bwrbDir: string): Promise<string[]> {
+  const contents: string[] = [];
+
+  try {
+    const entries = await readdir(bwrbDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        // List directory contents recursively (one level)
+        const subEntries = await readdir(join(bwrbDir, entry.name));
+        if (subEntries.length > 0) {
+          contents.push(`${entry.name}/ (${subEntries.length} items)`);
+        } else {
+          contents.push(`${entry.name}/`);
+        }
+      } else {
+        contents.push(entry.name);
+      }
+    }
+  } catch {
+    // If we can't read, just return empty
+  }
+
+  return contents;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { templateCommand } from './commands/template.js';
 import { completionCommand } from './commands/completion.js';
 import { configCommand } from './commands/config.js';
 import { dashboardCommand } from './commands/dashboard.js';
+import { initCommand } from './commands/init.js';
 import { handleCompletionRequest } from './lib/completion.js';
 
 const program = new Command();
@@ -61,6 +62,7 @@ if (completionsIndex !== -1) {
   program.addCommand(completionCommand);
   program.addCommand(configCommand);
   program.addCommand(dashboardCommand);
+  program.addCommand(initCommand);
 
   program.parse();
 }

--- a/tests/ts/commands/init.pty.test.ts
+++ b/tests/ts/commands/init.pty.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import {
+  shouldSkipPtyTests,
+  readVaultFile,
+  killAllPtyProcesses,
+  spawnBowerbird,
+  Keys,
+  PROJECT_ROOT,
+} from '../lib/pty-helpers.js';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+
+const describePty = shouldSkipPtyTests() ? describe.skip : describe;
+
+describePty('init command PTY tests', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    // Create a fresh temp directory for each test
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bwrb-init-pty-'));
+  });
+
+  afterEach(async () => {
+    killAllPtyProcesses();
+    // Clean up temp directory
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe('interactive initialization', () => {
+    it('should prompt for link format', async () => {
+      const proc = spawnBowerbird(['init', tempDir], { cwd: tempDir });
+
+      try {
+        // Should prompt for link format
+        await proc.waitFor('Link format', 10000);
+
+        // Should show options
+        const output = proc.getOutput();
+        expect(output).toContain('wikilink');
+        expect(output).toContain('markdown');
+
+        // Select wikilink (default, first option) and continue
+        proc.write(Keys.ENTER);
+
+        // Should prompt for editor
+        await proc.waitFor('Editor', 5000);
+
+        // Skip editor (just press enter)
+        proc.write(Keys.ENTER);
+
+        // Should complete
+        await proc.waitFor('Initialized bwrb vault', 5000);
+        await proc.waitForExit(5000);
+
+        // Verify schema was created with wikilink
+        const schemaContent = await readVaultFile(tempDir, '.bwrb/schema.json');
+        const schema = JSON.parse(schemaContent);
+        expect(schema.config.link_format).toBe('wikilink');
+      } finally {
+        if (!proc.hasExited()) {
+          proc.kill();
+        }
+      }
+    }, 25000);
+
+    it('should allow selecting markdown link format', async () => {
+      const proc = spawnBowerbird(['init', tempDir], { cwd: tempDir });
+
+      try {
+        // Wait for link format prompt
+        await proc.waitFor('Link format', 10000);
+
+        // Navigate to markdown option (second option)
+        proc.write(Keys.DOWN);
+        await proc.waitFor('markdown', 2000);
+
+        // Select it
+        proc.write(Keys.ENTER);
+
+        // Skip editor prompt
+        await proc.waitFor('Editor', 5000);
+        proc.write(Keys.ENTER);
+
+        // Should complete
+        await proc.waitFor('Initialized bwrb vault', 5000);
+        await proc.waitForExit(5000);
+
+        // Verify schema was created with markdown
+        const schemaContent = await readVaultFile(tempDir, '.bwrb/schema.json');
+        const schema = JSON.parse(schemaContent);
+        expect(schema.config.link_format).toBe('markdown');
+      } finally {
+        if (!proc.hasExited()) {
+          proc.kill();
+        }
+      }
+    }, 25000);
+
+    it('should allow entering custom editor', async () => {
+      const proc = spawnBowerbird(['init', tempDir], { cwd: tempDir });
+
+      try {
+        // Wait for link format prompt and accept default
+        await proc.waitFor('Link format', 10000);
+        proc.write(Keys.ENTER);
+
+        // Wait for editor prompt
+        await proc.waitFor('Editor', 5000);
+
+        // Type a custom editor
+        await proc.typeText('nvim');
+        proc.write(Keys.ENTER);
+
+        // Should complete
+        await proc.waitFor('Initialized bwrb vault', 5000);
+        await proc.waitForExit(5000);
+
+        // Verify schema was created with custom editor
+        const schemaContent = await readVaultFile(tempDir, '.bwrb/schema.json');
+        const schema = JSON.parse(schemaContent);
+        expect(schema.config.editor).toBe('nvim');
+      } finally {
+        if (!proc.hasExited()) {
+          proc.kill();
+        }
+      }
+    }, 25000);
+
+    it('should cancel on Ctrl+C during link format selection', async () => {
+      const proc = spawnBowerbird(['init', tempDir], { cwd: tempDir });
+
+      try {
+        // Wait for link format prompt
+        await proc.waitFor('Link format', 10000);
+
+        // Cancel with Ctrl+C
+        proc.write(Keys.CTRL_C);
+
+        // Should exit
+        await proc.waitForExit(5000);
+
+        // Verify no .bwrb directory was created
+        const exists = await fs.access(path.join(tempDir, '.bwrb'))
+          .then(() => true)
+          .catch(() => false);
+        expect(exists).toBe(false);
+      } finally {
+        if (!proc.hasExited()) {
+          proc.kill();
+        }
+      }
+    }, 20000);
+
+    it('should cancel on Ctrl+C during editor prompt', async () => {
+      const proc = spawnBowerbird(['init', tempDir], { cwd: tempDir });
+
+      try {
+        // Complete link format prompt
+        await proc.waitFor('Link format', 10000);
+        proc.write(Keys.ENTER);
+
+        // Wait for editor prompt
+        await proc.waitFor('Editor', 5000);
+
+        // Cancel with Ctrl+C
+        proc.write(Keys.CTRL_C);
+
+        // Should exit
+        await proc.waitForExit(5000);
+
+        // Verify no .bwrb directory was created
+        const exists = await fs.access(path.join(tempDir, '.bwrb'))
+          .then(() => true)
+          .catch(() => false);
+        expect(exists).toBe(false);
+      } finally {
+        if (!proc.hasExited()) {
+          proc.kill();
+        }
+      }
+    }, 25000);
+  });
+
+  describe('force mode with existing vault', () => {
+    beforeEach(async () => {
+      // Create existing .bwrb/ with content
+      await fs.mkdir(path.join(tempDir, '.bwrb', 'templates', 'task'), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, '.bwrb', 'schema.json'),
+        JSON.stringify({ version: 2, types: { old: {} } })
+      );
+      await fs.writeFile(
+        path.join(tempDir, '.bwrb', 'templates', 'task', 'default.md'),
+        'template content'
+      );
+    });
+
+    it('should show warning and confirm before deleting', async () => {
+      const proc = spawnBowerbird(['init', '--force', tempDir], { cwd: tempDir });
+
+      try {
+        // Should show warning about existing content
+        await proc.waitFor('Warning', 10000);
+        expect(proc.getOutput()).toContain('schema.json');
+        expect(proc.getOutput()).toContain('templates');
+
+        // Should ask for confirmation
+        await proc.waitFor('Continue?', 5000);
+
+        // Confirm with 'y'
+        proc.write('y');
+        proc.write(Keys.ENTER);
+
+        // Should proceed with prompts
+        await proc.waitFor('Link format', 5000);
+        proc.write(Keys.ENTER);
+
+        await proc.waitFor('Editor', 5000);
+        proc.write(Keys.ENTER);
+
+        // Should complete
+        await proc.waitFor('Initialized bwrb vault', 5000);
+        await proc.waitForExit(5000);
+
+        // Verify old content was deleted
+        const files = await fs.readdir(path.join(tempDir, '.bwrb'));
+        expect(files).toEqual(['schema.json']);
+      } finally {
+        if (!proc.hasExited()) {
+          proc.kill();
+        }
+      }
+    }, 30000);
+
+    it('should abort when user declines confirmation', async () => {
+      const proc = spawnBowerbird(['init', '--force', tempDir], { cwd: tempDir });
+
+      try {
+        // Should show warning
+        await proc.waitFor('Warning', 10000);
+
+        // Should ask for confirmation
+        await proc.waitFor('Continue?', 5000);
+
+        // Decline with 'n' (or just Enter since default is no)
+        proc.write('n');
+        proc.write(Keys.ENTER);
+
+        // Should abort
+        await proc.waitFor('Aborted', 5000);
+        await proc.waitForExit(5000);
+
+        // Verify old content was preserved
+        const schemaContent = await readVaultFile(tempDir, '.bwrb/schema.json');
+        const schema = JSON.parse(schemaContent);
+        expect(schema.types.old).toBeDefined();
+      } finally {
+        if (!proc.hasExited()) {
+          proc.kill();
+        }
+      }
+    }, 25000);
+
+    it('should skip confirmation with --force --yes', async () => {
+      const proc = spawnBowerbird(['init', '--force', '--yes', tempDir], { cwd: tempDir });
+
+      try {
+        // Should NOT show warning or ask for confirmation
+        // Should complete directly
+        await proc.waitFor('Initialized bwrb vault', 10000);
+        await proc.waitForExit(5000);
+
+        // Verify schema was replaced
+        const schemaContent = await readVaultFile(tempDir, '.bwrb/schema.json');
+        const schema = JSON.parse(schemaContent);
+        expect(schema.types).toEqual({});
+        expect(schema.types.old).toBeUndefined();
+      } finally {
+        if (!proc.hasExited()) {
+          proc.kill();
+        }
+      }
+    }, 20000);
+  });
+
+  describe('output messages', () => {
+    it('should show next steps after successful init', async () => {
+      const proc = spawnBowerbird(['init', '--yes', tempDir], { cwd: tempDir });
+
+      try {
+        await proc.waitFor('Initialized bwrb vault', 10000);
+        await proc.waitForExit(5000);
+
+        const output = proc.getOutput();
+        expect(output).toContain('Next steps');
+        expect(output).toContain('bwrb schema new type');
+        expect(output).toContain('bwrb new');
+      } finally {
+        if (!proc.hasExited()) {
+          proc.kill();
+        }
+      }
+    }, 15000);
+
+    it('should show detected Obsidian vault name', async () => {
+      // Create .obsidian folder to trigger detection
+      await fs.mkdir(path.join(tempDir, '.obsidian'));
+
+      const proc = spawnBowerbird(['init', '--yes', tempDir], { cwd: tempDir });
+
+      try {
+        await proc.waitFor('Initialized bwrb vault', 10000);
+        await proc.waitForExit(5000);
+
+        const output = proc.getOutput();
+        expect(output).toContain('Obsidian vault');
+        expect(output).toContain('auto-detected');
+      } finally {
+        if (!proc.hasExited()) {
+          proc.kill();
+        }
+      }
+    }, 15000);
+  });
+});

--- a/tests/ts/commands/init.test.ts
+++ b/tests/ts/commands/init.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFile, rm, mkdir, readFile, readdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { mkdtemp } from 'fs/promises';
+import { tmpdir } from 'os';
+import { runCLI } from '../fixtures/setup.js';
+
+describe('init command', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'bwrb-init-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ============================================================================
+  // Basic initialization (non-interactive with --yes)
+  // ============================================================================
+
+  describe('non-interactive initialization (--yes)', () => {
+    it('should create .bwrb directory and schema.json', async () => {
+      // Note: init takes path as positional arg, not via --vault
+      const result = await runCLI(['init', tempDir, '--yes']);
+
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(join(tempDir, '.bwrb'))).toBe(true);
+      expect(existsSync(join(tempDir, '.bwrb', 'schema.json'))).toBe(true);
+    });
+
+    it('should create valid schema with version 2', async () => {
+      await runCLI(['init', tempDir, '--yes']);
+
+      const schemaContent = await readFile(join(tempDir, '.bwrb', 'schema.json'), 'utf-8');
+      const schema = JSON.parse(schemaContent);
+
+      expect(schema.version).toBe(2);
+      expect(schema.$schema).toBe('https://bwrb.dev/schema.json');
+      expect(schema.types).toEqual({});
+    });
+
+    it('should set default link_format to wikilink', async () => {
+      await runCLI(['init', tempDir, '--yes']);
+
+      const schemaContent = await readFile(join(tempDir, '.bwrb', 'schema.json'), 'utf-8');
+      const schema = JSON.parse(schemaContent);
+
+      expect(schema.config.link_format).toBe('wikilink');
+    });
+
+    it('should output success message', async () => {
+      const result = await runCLI(['init', tempDir, '--yes']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Initialized bwrb vault');
+      expect(result.stdout).toContain('Next steps');
+      expect(result.stdout).toContain('bwrb schema new type');
+    });
+
+    it('should output JSON when --output json is specified', async () => {
+      const result = await runCLI(['init', tempDir, '--yes', '--output', 'json']);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.vault).toBe(tempDir);
+      expect(json.data.schema_path).toContain('.bwrb/schema.json');
+      expect(json.data.config.link_format).toBe('wikilink');
+    });
+  });
+
+  // ============================================================================
+  // Path argument
+  // ============================================================================
+
+  describe('path argument', () => {
+    it('should initialize at specified path', async () => {
+      const subDir = join(tempDir, 'my-vault');
+      await mkdir(subDir);
+
+      const result = await runCLI(['init', subDir, '--yes']);
+
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(join(subDir, '.bwrb', 'schema.json'))).toBe(true);
+    });
+
+    it('should error if path does not exist', async () => {
+      const nonExistent = join(tempDir, 'does-not-exist');
+
+      const result = await runCLI(['init', nonExistent, '--yes']);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Directory does not exist');
+    });
+
+    it('should error if path is a file', async () => {
+      const filePath = join(tempDir, 'some-file.txt');
+      await writeFile(filePath, 'content');
+
+      const result = await runCLI(['init', filePath, '--yes']);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('not a directory');
+    });
+  });
+
+  // ============================================================================
+  // Existing vault handling
+  // ============================================================================
+
+  describe('existing vault handling', () => {
+    beforeEach(async () => {
+      // Create existing .bwrb/
+      await mkdir(join(tempDir, '.bwrb'));
+      await writeFile(
+        join(tempDir, '.bwrb', 'schema.json'),
+        JSON.stringify({ version: 2, types: { old: {} } })
+      );
+    });
+
+    it('should error if .bwrb/ already exists without --force', async () => {
+      const result = await runCLI(['init', tempDir, '--yes']);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('already initialized');
+      expect(result.stderr).toContain('--force');
+    });
+
+    it('should output JSON error if vault exists', async () => {
+      const result = await runCLI(['init', tempDir, '--yes', '--output', 'json']);
+
+      expect(result.exitCode).not.toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('already initialized');
+    });
+
+    it('should reinitialize with --force --yes', async () => {
+      const result = await runCLI(['init', tempDir, '--force', '--yes']);
+
+      expect(result.exitCode).toBe(0);
+
+      // Schema should be fresh (empty types)
+      const schemaContent = await readFile(join(tempDir, '.bwrb', 'schema.json'), 'utf-8');
+      const schema = JSON.parse(schemaContent);
+      expect(schema.types).toEqual({});
+    });
+
+    it('should delete all .bwrb/ contents with --force', async () => {
+      // Add some extra files
+      await mkdir(join(tempDir, '.bwrb', 'templates', 'task'), { recursive: true });
+      await writeFile(join(tempDir, '.bwrb', 'templates', 'task', 'default.md'), 'template');
+      await writeFile(join(tempDir, '.bwrb', 'dashboards.json'), '{}');
+
+      await runCLI(['init', tempDir, '--force', '--yes']);
+
+      // Only schema.json should exist
+      const contents = await readdir(join(tempDir, '.bwrb'));
+      expect(contents).toEqual(['schema.json']);
+    });
+  });
+
+  // ============================================================================
+  // Obsidian auto-detection
+  // ============================================================================
+
+  describe('Obsidian auto-detection', () => {
+    it('should auto-detect Obsidian vault name when .obsidian exists', async () => {
+      await mkdir(join(tempDir, '.obsidian'));
+
+      await runCLI(['init', tempDir, '--yes']);
+
+      const schemaContent = await readFile(join(tempDir, '.bwrb', 'schema.json'), 'utf-8');
+      const schema = JSON.parse(schemaContent);
+
+      // The vault name should be the directory name
+      expect(schema.config.obsidian_vault).toBeDefined();
+    });
+
+    it('should include obsidian_vault in JSON output when detected', async () => {
+      await mkdir(join(tempDir, '.obsidian'));
+
+      const result = await runCLI(['init', tempDir, '--yes', '--output', 'json']);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.data.config.obsidian_vault).toBeDefined();
+    });
+
+    it('should not include obsidian_vault when .obsidian does not exist', async () => {
+      await runCLI(['init', tempDir, '--yes']);
+
+      const schemaContent = await readFile(join(tempDir, '.bwrb', 'schema.json'), 'utf-8');
+      const schema = JSON.parse(schemaContent);
+
+      expect(schema.config.obsidian_vault).toBeUndefined();
+    });
+  });
+
+  // ============================================================================
+  // Schema validation
+  // ============================================================================
+
+  describe('generated schema validation', () => {
+    it('should generate schema that passes bwrb schema validate', async () => {
+      await runCLI(['init', tempDir, '--yes']);
+
+      // The schema should be valid and usable by other commands
+      const result = await runCLI(['schema', 'list', '--output', 'json'], tempDir);
+
+      expect(result.exitCode).toBe(0);
+      // schema list --output json returns the raw schema, not a success wrapper
+      const json = JSON.parse(result.stdout);
+      expect(json.version).toBe(2);
+      expect(json.types).toEqual({});
+    });
+
+    it('should generate schema that allows creating types', async () => {
+      await runCLI(['init', tempDir, '--yes']);
+
+      // Should be able to add a type to the fresh schema
+      const result = await runCLI(
+        ['schema', 'new', 'type', 'note', '--output', 'json'],
+        tempDir
+      );
+
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  // ============================================================================
+  // Error handling
+  // ============================================================================
+
+  describe('error handling', () => {
+    it('should handle permission errors gracefully', async () => {
+      // This test is environment-dependent, skip if not applicable
+      // The command should at least not crash with an unhandled error
+      const result = await runCLI(['init', '/root/should-not-exist-12345', '--yes']);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toBeTruthy();
+    });
+
+    it('should output JSON error on failure when --output json', async () => {
+      const result = await runCLI(['init', '/nonexistent/path', '--yes', '--output', 'json']);
+
+      expect(result.exitCode).not.toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toBeDefined();
+    });
+  });
+
+  // ============================================================================
+  // Help and usage
+  // ============================================================================
+
+  describe('help and usage', () => {
+    it('should show help with --help', async () => {
+      const result = await runCLI(['init', '--help']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Initialize a new bwrb vault');
+      expect(result.stdout).toContain('--yes');
+      expect(result.stdout).toContain('--force');
+      expect(result.stdout).toContain('--output');
+    });
+
+    it('should show examples in help', async () => {
+      const result = await runCLI(['init', '--help']);
+
+      expect(result.stdout).toContain('Examples:');
+      expect(result.stdout).toContain('bwrb init');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `bwrb init` command for vault initialization (#188). This is blocking for v1.0 - essential for user onboarding.

Fixes #188

## What's Changed

- **New `bwrb init` command** with:
  - Interactive prompts for link format (wikilink/markdown) and editor
  - Non-interactive mode with `--yes` for scripting
  - Auto-detects Obsidian vault name from `.obsidian/` directory
  - `--force` flag to reinitialize existing vaults (with warning/confirmation)
  - JSON output mode for automation

- **JSON Schema** hosted at `docs-site/public/schema.json` for editor support at https://bwrb.dev/schema.json

- **Documentation updates** to SKILL.md and CHANGELOG.md

## Usage

```bash
# Interactive setup
bwrb init

# Non-interactive with defaults
bwrb init --yes

# Specify vault path
bwrb init /path/to/vault

# Reinitialize existing vault
bwrb init --force

# JSON output for scripting
bwrb init --yes --output json
```

## Testing

- 21 unit tests covering all options and edge cases
- 10 PTY tests for interactive prompt flows
- All 1420 tests pass

## Review Notes

Product and DevEx agents reviewed. Minor refinements suggested for future PRs:
- Could extract helpers to make command thinner
- Exit code consistency (Ctrl+C) could be standardized
- Consider adding `schemaVersion` field for migration tracking