### PR TITLE
fix(ci): use positional filter for PTY tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,25 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Verify PTY filter
+        # Sanity check: ensure filter matches PTY tests and nothing else
+        run: |
+          FILES=$(pnpm vitest list .pty.test.ts 2>&1 | grep -E "^tests/" | cut -d'>' -f1 | sort -u)
+          COUNT=$(echo "$FILES" | wc -l | tr -d ' ')
+          NON_PTY=$(echo "$FILES" | grep -v ".pty.test.ts" | wc -l | tr -d ' ')
+          if [ "$COUNT" -eq 0 ]; then
+            echo "ERROR: PTY filter matched no tests"
+            exit 1
+          fi
+          if [ "$NON_PTY" -gt 0 ]; then
+            echo "ERROR: PTY filter matched non-PTY tests"
+            echo "$FILES" | grep -v ".pty.test.ts"
+            exit 1
+          fi
+          echo "PTY filter OK: $COUNT test files matched"
+
       - name: Run PTY tests
-        run: pnpm test -- --include='**/*.pty.test.ts' --reporter=verbose
+        run: pnpm test:pty
         env:
           # Force color output for better debugging
           FORCE_COLOR: 1

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:pty": "vitest run --reporter=verbose .pty.test.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
## Summary

- Fix PTY test filtering in CI (vitest has no `--include` CLI flag - it was silently ignored)
- Add `test:pty` script to prevent CI drift
- Add verification step to catch future filter regressions

## Root Cause

The CI workflow used `--include='**/*.pty.test.ts'` but vitest doesn't have a `--include` CLI flag. The flag was silently ignored, causing **all tests** to run in the PTY job instead of just PTY tests.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Replace invalid `--include` with positional filter, add verification step |
| `package.json` | Add `test:pty` script |

## Verification

```bash
# Only matches PTY test files
$ pnpm vitest list .pty.test.ts
tests/ts/commands/audit-fix.pty.test.ts
tests/ts/commands/config.pty.test.ts
... (12 files total)

# Sanity check passes
$ PTY filter OK: 12 test files matched
```

Fixes #176