### PR TITLE
Improve help text command ordering

### DIFF
--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -249,6 +249,18 @@ bwrb template list [type] [name]   # List all, or show details if both provided
 4. **Dry-run default for destructive ops** — `--execute` to apply
 5. **Discoverable prompts** — Missing required info prompts, doesn't error
 
+### Help Output Ordering
+
+Commands in `bwrb --help` are ordered to reflect the product's priority model and guide users through a logical workflow:
+
+1. **CRUD operations** — `new`, `edit`, `delete` (core note actions)
+2. **Query operations** — `list`, `open`, `search` (discovery and navigation)
+3. **Schema and management** — `schema`, `audit`, `bulk`, `template` (schema enforcement and maintenance)
+4. **Saved queries** — `dashboard` (saved configurations, follows template conceptually)
+5. **Meta/utility** — `init`, `config`, `completion`, `help` (one-time setup and operational commands)
+
+This ordering presents commands as a guided path: create notes → find notes → maintain schema → automate → configure. Utility commands appear last to keep the core workflow prominent.
+
 ---
 
 ## Neovim Plugin

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,20 +49,29 @@ if (completionsIndex !== -1) {
     .option('-v, --vault <path>', 'Path to the vault directory')
     .enablePositionalOptions();
 
+  // CRUD operations
   program.addCommand(newCommand);
   program.addCommand(editCommand);
   program.addCommand(deleteCommand);
+
+  // Query operations
   program.addCommand(listCommand);
   program.addCommand(openCommand);
   program.addCommand(searchCommand);
+
+  // Schema and management
   program.addCommand(schemaCommand);
   program.addCommand(auditCommand);
   program.addCommand(bulkCommand);
   program.addCommand(templateCommand);
-  program.addCommand(completionCommand);
-  program.addCommand(configCommand);
+
+  // Saved queries
   program.addCommand(dashboardCommand);
+
+  // Meta/utility
   program.addCommand(initCommand);
+  program.addCommand(configCommand);
+  program.addCommand(completionCommand);
 
   program.parse();
 }


### PR DESCRIPTION
## Summary

- Reorder commands in `bwrb --help` to reflect the product's priority model
- Add grouping comments to src/index.ts for maintainability
- Document canonical ordering in docs/product/vision.md

Fixes #237

## Command Ordering

| Group | Commands |
|-------|----------|
| CRUD operations | `new`, `edit`, `delete` |
| Query operations | `list`, `open`, `search` |
| Schema and management | `schema`, `audit`, `bulk`, `template` |
| Saved queries | `dashboard` |
| Meta/utility | `init`, `config`, `completion` |

## Related

- Follow-up: #281 (Update website docs to match CLI command ordering)

## Future Improvements (from devex review)

- Consider adding a test that asserts `--help` lists commands in the intended sequence
- Consider centralizing the canonical order in a const to make future diffs harder to mess up