### PR TITLE
Add interactive parent type selection in schema new type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Added
 
+- **Interactive parent type selection in `schema new type`** (#240)
+  - When creating a new type interactively, now prompts "Extend from type" with list of existing types
+  - Shows "Root (extends meta)" option for creating standalone types
+  - Displays inherited fields after parent selection to help users understand what they're inheriting
+  - `--inherits` CLI flag still works for non-interactive/scripted usage
+
 - **Audit --fix Phase 1: Core directory and type fixes** (#152, #268)
   - `wrong-directory` issues are now auto-fixable with `--execute` flag
     - Files in wrong directories are automatically moved to correct location based on type

--- a/tests/ts/commands/schema.pty.test.ts
+++ b/tests/ts/commands/schema.pty.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import {
+  withTempVault,
+  shouldSkipPtyTests,
+} from '../lib/pty-helpers.js';
+import { BASELINE_SCHEMA } from '../fixtures/schemas.js';
+
+const describePty = shouldSkipPtyTests() ? describe.skip : describe;
+
+describePty('schema new type PTY tests', () => {
+  describe('type inheritance prompt', () => {
+    it('should prompt for parent type when creating a new type', async () => {
+      await withTempVault(
+        ['schema', 'new', 'type', 'subtask'],
+        async (proc, vaultPath) => {
+          // Should prompt for parent type selection
+          await proc.waitFor('Extend from type', 10000);
+
+          // Should show Root option and existing types
+          await proc.waitFor('Root (extends meta)', 5000);
+          await proc.waitFor('task', 3000);
+
+          // Select 'task' as parent (number 7 in the alphabetically sorted list)
+          proc.write('7');
+
+          // Should show inherited fields info
+          await proc.waitFor('Inherited fields from task', 5000);
+
+          // Continue with "Add fields?" prompt
+          await proc.waitFor('Add fields', 5000);
+          proc.write('n');
+
+          // Wait for creation
+          await proc.waitFor('created', 5000);
+
+          // Verify schema was updated correctly
+          const schemaPath = join(vaultPath, '.bwrb/schema.json');
+          const schemaContent = await readFile(schemaPath, 'utf-8');
+          const schema = JSON.parse(schemaContent);
+
+          expect(schema.types.subtask).toBeDefined();
+          expect(schema.types.subtask.extends).toBe('task');
+        },
+        { schema: BASELINE_SCHEMA }
+      );
+    }, 30000);
+
+    it('should allow creating a root type (extends meta)', async () => {
+      await withTempVault(
+        ['schema', 'new', 'type', 'note'],
+        async (proc, vaultPath) => {
+          // Should prompt for parent type selection
+          await proc.waitFor('Extend from type', 10000);
+
+          // Select Root (extends meta)
+          await proc.waitFor('Root (extends meta)', 5000);
+          proc.write('\r'); // First option is selected by default
+
+          // Continue with "Add fields?" prompt (no inherited fields message for root)
+          await proc.waitFor('Add fields', 5000);
+          proc.write('n');
+
+          // Wait for creation
+          await proc.waitFor('created', 5000);
+
+          // Verify schema was updated - no extends field for root type
+          const schemaPath = join(vaultPath, '.bwrb/schema.json');
+          const schemaContent = await readFile(schemaPath, 'utf-8');
+          const schema = JSON.parse(schemaContent);
+
+          expect(schema.types.note).toBeDefined();
+          expect(schema.types.note.extends).toBeUndefined();
+        },
+        { schema: BASELINE_SCHEMA }
+      );
+    }, 30000);
+
+    it('should skip inheritance prompt when --inherits is provided', async () => {
+      await withTempVault(
+        ['schema', 'new', 'type', 'subtask', '--inherits', 'task'],
+        async (proc, vaultPath) => {
+          // Should NOT prompt for parent type, go straight to fields
+          await proc.waitFor('Add fields', 10000);
+          proc.write('n');
+
+          // Wait for creation
+          await proc.waitFor('created', 5000);
+
+          // Verify schema
+          const schemaPath = join(vaultPath, '.bwrb/schema.json');
+          const schemaContent = await readFile(schemaPath, 'utf-8');
+          const schema = JSON.parse(schemaContent);
+
+          expect(schema.types.subtask).toBeDefined();
+          expect(schema.types.subtask.extends).toBe('task');
+        },
+        { schema: BASELINE_SCHEMA }
+      );
+    }, 30000);
+
+    it('should cancel cleanly at parent selection - no schema changes', async () => {
+      await withTempVault(
+        ['schema', 'new', 'type', 'subtask'],
+        async (proc, vaultPath) => {
+          // Get original schema content
+          const schemaPath = join(vaultPath, '.bwrb/schema.json');
+          const originalContent = await readFile(schemaPath, 'utf-8');
+          const originalSchema = JSON.parse(originalContent);
+
+          // Should prompt for parent type selection
+          await proc.waitFor('Extend from type', 10000);
+
+          // Cancel with Ctrl+C
+          proc.write('\x03');
+
+          // Wait for process to exit
+          await proc.waitForExit(5000);
+
+          // Verify schema unchanged
+          const newContent = await readFile(schemaPath, 'utf-8');
+          const newSchema = JSON.parse(newContent);
+
+          expect(newSchema.types.subtask).toBeUndefined();
+          expect(Object.keys(newSchema.types)).toEqual(Object.keys(originalSchema.types));
+        },
+        { schema: BASELINE_SCHEMA }
+      );
+    }, 30000);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds interactive prompt for parent type selection when creating a new type via `bwrb schema new type`
- Shows "Root (extends meta)" option for standalone types plus alphabetically sorted list of existing types
- Displays inherited fields after parent selection to help users understand what they're getting
- `--inherits` CLI flag continues to work for scripted usage

Fixes #240

## Changes

- **src/commands/schema/type.ts**: Added interactive parent type prompt in `registerNewTypeCommand()`, placed before field definition prompts
- **tests/ts/commands/schema.pty.test.ts**: New PTY tests covering parent selection, root type creation, `--inherits` flag bypass, and clean cancellation
- **CHANGELOG.md**: Added entry for this feature

## Testing

All 1533 tests pass. New PTY tests verify:
1. Parent type selection with inherited fields display
2. Root type creation (no `extends` field)
3. `--inherits` flag skips the interactive prompt
4. Cancellation at parent prompt leaves schema unchanged