### PR TITLE
feat(audit): add Phase 2 hygiene auto-fixes

### DIFF
--- a/src/lib/audit/output.ts
+++ b/src/lib/audit/output.ts
@@ -83,6 +83,11 @@ export function outputJsonResults(results: FileAuditResult[], summary: AuditSumm
         ...(i.currentDirectory && { currentDirectory: i.currentDirectory }),
         ...(i.expectedDirectory && { expectedDirectory: i.expectedDirectory }),
         ...(i.wikilinkCount !== undefined && { wikilinkCount: i.wikilinkCount }),
+        // Phase 2: Hygiene fields
+        ...(i.canonicalKey && { canonicalKey: i.canonicalKey }),
+        ...(i.canonicalValue && { canonicalValue: i.canonicalValue }),
+        ...(i.hasConflict !== undefined && { hasConflict: i.hasConflict }),
+        ...(i.conflictValue !== undefined && { conflictValue: i.conflictValue }),
       })),
     })),
     summary,

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -31,7 +31,14 @@ export type IssueCode =
   | 'invalid-source-type'
   | 'owned-note-referenced'
   | 'owned-wrong-location'
-  | 'parent-cycle';
+  | 'parent-cycle'
+  // Phase 2: Low-risk hygiene auto-fixes
+  | 'trailing-whitespace' // NOTE: Not currently detectable (YAML parser strips whitespace)
+  | 'frontmatter-key-casing'
+  | 'unknown-enum-casing'
+  | 'duplicate-list-values'
+  | 'invalid-boolean-coercion'
+  | 'singular-plural-mismatch';
 
 /**
  * A single audit issue.
@@ -73,6 +80,14 @@ export interface AuditIssue {
   expectedDirectory?: string | undefined;
   /** For wrong-directory/owned-wrong-location: number of wikilinks that reference this file */
   wikilinkCount?: number | undefined;
+  /** For key-casing/singular-plural: the canonical key name from schema */
+  canonicalKey?: string | undefined;
+  /** For enum-casing: the canonical enum value from schema */
+  canonicalValue?: string | undefined;
+  /** For singular-plural-mismatch: whether this key conflicts with existing key */
+  hasConflict?: boolean | undefined;
+  /** For singular-plural-mismatch with conflict: the value of the existing key */
+  conflictValue?: unknown;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements GitHub issue #269 - "audit --fix Phase 2: Low-risk hygiene auto-fixes"

- Adds 5 new auto-fixable audit issue types to reduce noise in audit output
- Implements smart conflict detection and merge logic for key-casing issues
- Fixes false positive detection when case-variant keys exist

## New Issue Types

| Code | Description | Example Fix |
|------|-------------|-------------|
| `frontmatter-key-casing` | Wrong key casing | `Status:` → `status:` |
| `unknown-enum-casing` | Wrong enum value casing | `Raw` → `raw` |
| `duplicate-list-values` | Duplicate array items | `["tag", "Tag"]` → `["tag"]` |
| `invalid-boolean-coercion` | String booleans | `"true"` → `true` |
| `singular-plural-mismatch` | Singular/plural key mismatch | `tag:` → `tags:` |

## Key Implementation Details

- **Conflict handling**: When both `Status` and `status` exist with values, the issue is queued for manual review rather than auto-fixed. If one is empty, auto-merge proceeds.
- **Avoided false positives**: The `missing-required` check now skips fields that have a case-variant present (caught by `frontmatter-key-casing` instead)
- **trailing-whitespace**: Detection is NOT possible because gray-matter YAML parser strips whitespace during parsing. Tests are skipped, code commented out for future implementation.

## Testing

- Added comprehensive test suites for all 5 issue types
- Tests cover both detection (JSON output) and auto-fix behavior
- All 1540 tests pass (6 skipped, including the trailing-whitespace tests)

## Future Improvements (noted by devex review)

- Refactor `applyFix()` to avoid `issue.code` override pattern
- Hoist vault-wide caches in `runAutoFix()` to avoid repeated scans
- Consider discriminated union for `AuditIssue` type

Fixes #269