### PR TITLE
feat: validate select field values in --where expressions

### DIFF
--- a/src/lib/expression-validation.ts
+++ b/src/lib/expression-validation.ts
@@ -1,0 +1,317 @@
+/**
+ * Expression validation for --where filters.
+ *
+ * This module validates select field values in filter expressions against
+ * the schema. When --type is specified, we can validate that comparison
+ * values match the allowed options for select fields.
+ */
+
+import type { Expression, BinaryExpression, UnaryExpression, CallExpression, Identifier, Literal } from 'jsep';
+import { parseExpression } from './expression.js';
+import type { LoadedSchema, Field } from '../types/schema.js';
+import { getFieldsForType, getAllFieldsForType } from './schema.js';
+import { suggestOptionValue } from './validation.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * A field comparison extracted from an expression.
+ */
+export interface FieldComparison {
+  /** The field name being compared */
+  field: string;
+  /** The comparison operator (==, !=, contains, etc.) */
+  operator: string;
+  /** The literal value being compared against (null if not a literal) */
+  value: string | null;
+}
+
+/**
+ * A single validation error for a --where expression.
+ */
+export interface WhereValidationError {
+  /** The original expression string */
+  expression: string;
+  /** The field that has an invalid value */
+  field: string;
+  /** The invalid value */
+  value: string;
+  /** Human-readable error message */
+  message: string;
+  /** List of valid options for this field */
+  validOptions: string[];
+  /** Suggested correction (if a close match exists) */
+  suggestion?: string;
+}
+
+/**
+ * Result of validating --where expressions.
+ */
+export interface WhereValidationResult {
+  /** Whether all expressions are valid */
+  valid: boolean;
+  /** List of validation errors */
+  errors: WhereValidationError[];
+}
+
+// ============================================================================
+// Expression Analysis
+// ============================================================================
+
+/**
+ * Extract field comparisons from a parsed expression.
+ * Walks the AST to find patterns like:
+ * - field == 'value'
+ * - field != 'value'
+ * - contains(field, 'value')
+ */
+export function extractFieldComparisons(expr: Expression): FieldComparison[] {
+  const comparisons: FieldComparison[] = [];
+
+  function walk(node: Expression): void {
+    switch (node.type) {
+      case 'BinaryExpression': {
+        const binary = node as BinaryExpression;
+
+        // Handle comparison operators: ==, !=
+        if (binary.operator === '==' || binary.operator === '!=') {
+          const comparison = extractBinaryComparison(binary);
+          if (comparison) {
+            comparisons.push(comparison);
+          }
+        }
+
+        // Handle logical operators: &&, ||
+        if (binary.operator === '&&' || binary.operator === '||') {
+          walk(binary.left);
+          walk(binary.right);
+        }
+        break;
+      }
+
+      case 'CallExpression': {
+        const call = node as CallExpression;
+        const comparison = extractCallComparison(call);
+        if (comparison) {
+          comparisons.push(comparison);
+        }
+        break;
+      }
+
+      case 'UnaryExpression': {
+        // Handle !expression
+        const unary = node as UnaryExpression;
+        walk(unary.argument);
+        break;
+      }
+    }
+  }
+
+  walk(expr);
+  return comparisons;
+}
+
+/**
+ * Extract a comparison from a binary expression (field == 'value').
+ */
+function extractBinaryComparison(expr: BinaryExpression): FieldComparison | null {
+  let field: string | null = null;
+  let value: string | null = null;
+
+  // Check if left is identifier and right is literal
+  if (expr.left.type === 'Identifier' && expr.right.type === 'Literal') {
+    field = (expr.left as Identifier).name;
+    value = getLiteralValue(expr.right as Literal);
+  }
+  // Check if right is identifier and left is literal
+  else if (expr.right.type === 'Identifier' && expr.left.type === 'Literal') {
+    field = (expr.right as Identifier).name;
+    value = getLiteralValue(expr.left as Literal);
+  }
+
+  if (field && value !== null) {
+    return { field, operator: expr.operator, value };
+  }
+
+  return null;
+}
+
+/**
+ * Extract a comparison from a function call (contains(field, 'value')).
+ */
+function extractCallComparison(expr: CallExpression): FieldComparison | null {
+  const callee = expr.callee as Identifier;
+  if (!callee || callee.type !== 'Identifier') return null;
+
+  const fnName = callee.name;
+
+  // Handle contains(field, 'value') pattern
+  if (fnName === 'contains' && expr.arguments.length >= 2) {
+    const [arg1, arg2] = expr.arguments;
+    if (arg1?.type === 'Identifier' && arg2?.type === 'Literal') {
+      return {
+        field: (arg1 as Identifier).name,
+        operator: 'contains',
+        value: getLiteralValue(arg2 as Literal),
+      };
+    }
+  }
+
+  // Handle hasTag('value') pattern - tags is implicit
+  if (fnName === 'hasTag' && expr.arguments.length >= 1) {
+    const [arg] = expr.arguments;
+    if (arg?.type === 'Literal') {
+      return {
+        field: 'tags',
+        operator: 'hasTag',
+        value: getLiteralValue(arg as Literal),
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get the string value from a literal node.
+ */
+function getLiteralValue(literal: Literal): string | null {
+  const val = literal.value;
+  if (typeof val === 'string') return val;
+  if (typeof val === 'number') return String(val);
+  if (typeof val === 'boolean') return String(val);
+  return null;
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/**
+ * Validate --where expressions against a schema type.
+ *
+ * When a type is specified, this validates that:
+ * 1. Fields with select options use valid option values
+ * 2. Invalid values get helpful error messages with suggestions
+ *
+ * @param expressions - Array of --where expression strings
+ * @param schema - The loaded schema
+ * @param typeName - The type to validate against
+ * @returns Validation result with any errors
+ */
+export function validateWhereExpressions(
+  expressions: string[],
+  schema: LoadedSchema,
+  typeName: string
+): WhereValidationResult {
+  const errors: WhereValidationError[] = [];
+  const fields = getFieldsForType(schema, typeName);
+  const allFieldNames = getAllFieldsForType(schema, typeName);
+
+  for (const exprString of expressions) {
+    try {
+      const expr = parseExpression(exprString);
+      const comparisons = extractFieldComparisons(expr);
+
+      for (const comparison of comparisons) {
+        // Skip if no literal value to validate
+        if (comparison.value === null) continue;
+
+        // Skip if field is not in this type's schema
+        if (!allFieldNames.has(comparison.field)) continue;
+
+        // Get the field definition
+        const field = fields[comparison.field];
+        if (!field) continue;
+
+        // Only validate fields with options (select fields)
+        if (!field.options || field.options.length === 0) continue;
+
+        // Validate the value against options
+        const error = validateFieldValue(
+          exprString,
+          comparison.field,
+          comparison.value,
+          field
+        );
+
+        if (error) {
+          errors.push(error);
+        }
+      }
+    } catch {
+      // Parse errors are handled separately by the expression evaluator
+      // We skip validation for unparseable expressions
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Validate a single field value against its options.
+ */
+function validateFieldValue(
+  expression: string,
+  fieldName: string,
+  value: string,
+  field: Field
+): WhereValidationError | null {
+  const options = field.options ?? [];
+  if (options.length === 0) return null;
+
+  // Check if value is valid
+  if (options.includes(value)) {
+    return null; // Valid
+  }
+
+  // Invalid value - build error with suggestion
+  const suggestion = suggestOptionValue(value, options);
+
+  return {
+    expression,
+    field: fieldName,
+    value,
+    message: `Invalid value '${value}' for field '${fieldName}'`,
+    validOptions: options,
+    ...(suggestion && { suggestion }),
+  };
+}
+
+/**
+ * Format validation errors for human-readable output.
+ */
+export function formatWhereValidationErrors(errors: WhereValidationError[]): string {
+  if (errors.length === 0) return '';
+
+  if (errors.length === 1) {
+    const err = errors[0]!;
+    let msg = `Error: ${err.message}.\n`;
+    msg += `  Valid options: ${err.validOptions.join(', ')}`;
+    if (err.suggestion) {
+      msg += `\n  Did you mean '${err.suggestion}'?`;
+    }
+    return msg;
+  }
+
+  const lines: string[] = ['Expression validation errors:'];
+  for (const err of errors) {
+    let line = `  - ${err.message}`;
+    if (err.validOptions.length <= 5) {
+      line += `. Valid options: ${err.validOptions.join(', ')}`;
+    } else {
+      line += `. Valid options: ${err.validOptions.slice(0, 5).join(', ')}... (${err.validOptions.length} total)`;
+    }
+    if (err.suggestion) {
+      line += ` Did you mean '${err.suggestion}'?`;
+    }
+    lines.push(line);
+  }
+
+  return lines.join('\n');
+}

--- a/tests/ts/commands/dashboard.test.ts
+++ b/tests/ts/commands/dashboard.test.ts
@@ -259,7 +259,8 @@ describe('dashboard command', () => {
         dashboards: {
           'no-matches': {
             type: 'idea',
-            where: ["status == 'nonexistent-status'"],
+            // 'settled' is a valid status for idea, but no ideas in test vault have this status
+            where: ["status == 'settled'"],
           },
         },
       });

--- a/tests/ts/commands/list.test.ts
+++ b/tests/ts/commands/list.test.ts
@@ -251,11 +251,21 @@ describe('list command', () => {
     });
 
     it('should handle where expressions that match nothing', async () => {
-      // Where expressions that don't match any notes return empty results, not errors
-      const result = await runCLI(['list', 'idea', '--where', "status == 'nonexistent'"], vaultDir);
+      // Where expressions with valid values that don't match any notes return empty results
+      // Using 'settled' which is a valid status but has no matching notes
+      const result = await runCLI(['list', 'idea', '--where', "status == 'settled'"], vaultDir);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('No notes found matching');
+    });
+
+    it('should error on invalid select field value in where expression', async () => {
+      // When --type is specified, select field values are validated
+      const result = await runCLI(['list', 'idea', '--where', "status == 'nonexistent'"], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Invalid value 'nonexistent' for field 'status'");
+      expect(result.stderr).toContain('Valid options:');
     });
 
     it('should list all notes when no selectors provided (implicit --all for read-only)', async () => {

--- a/tests/ts/lib/expression-validation.test.ts
+++ b/tests/ts/lib/expression-validation.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { LoadedSchema } from '../../../src/types/schema.js';
+import {
+  extractFieldComparisons,
+  validateWhereExpressions,
+  formatWhereValidationErrors,
+} from '../../../src/lib/expression-validation.js';
+import { parseExpression } from '../../../src/lib/expression.js';
+import { loadSchema } from '../../../src/lib/schema.js';
+import { createTestVault, cleanupTestVault } from '../fixtures/setup.js';
+
+describe('expression-validation', () => {
+  let vaultDir: string;
+  let schema: LoadedSchema;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+    schema = await loadSchema(vaultDir);
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  describe('extractFieldComparisons', () => {
+    it('extracts simple equality comparison', () => {
+      const expr = parseExpression("status == 'done'");
+      const comparisons = extractFieldComparisons(expr);
+      expect(comparisons).toEqual([
+        { field: 'status', operator: '==', value: 'done' },
+      ]);
+    });
+
+    it('extracts reversed equality comparison', () => {
+      const expr = parseExpression("'done' == status");
+      const comparisons = extractFieldComparisons(expr);
+      expect(comparisons).toEqual([
+        { field: 'status', operator: '==', value: 'done' },
+      ]);
+    });
+
+    it('extracts inequality comparison', () => {
+      const expr = parseExpression("status != 'pending'");
+      const comparisons = extractFieldComparisons(expr);
+      expect(comparisons).toEqual([
+        { field: 'status', operator: '!=', value: 'pending' },
+      ]);
+    });
+
+    it('extracts multiple comparisons from AND expression', () => {
+      const expr = parseExpression("status == 'active' && priority == 'high'");
+      const comparisons = extractFieldComparisons(expr);
+      expect(comparisons).toEqual([
+        { field: 'status', operator: '==', value: 'active' },
+        { field: 'priority', operator: '==', value: 'high' },
+      ]);
+    });
+
+    it('extracts comparisons from OR expression', () => {
+      const expr = parseExpression("status == 'done' || status == 'settled'");
+      const comparisons = extractFieldComparisons(expr);
+      expect(comparisons).toEqual([
+        { field: 'status', operator: '==', value: 'done' },
+        { field: 'status', operator: '==', value: 'settled' },
+      ]);
+    });
+
+    it('extracts comparisons from NOT expression', () => {
+      const expr = parseExpression("!(status == 'done')");
+      const comparisons = extractFieldComparisons(expr);
+      expect(comparisons).toEqual([
+        { field: 'status', operator: '==', value: 'done' },
+      ]);
+    });
+
+    it('extracts contains function call', () => {
+      const expr = parseExpression("contains(tags, 'urgent')");
+      const comparisons = extractFieldComparisons(expr);
+      expect(comparisons).toEqual([
+        { field: 'tags', operator: 'contains', value: 'urgent' },
+      ]);
+    });
+
+    it('extracts hasTag function call', () => {
+      const expr = parseExpression("hasTag('urgent')");
+      const comparisons = extractFieldComparisons(expr);
+      expect(comparisons).toEqual([
+        { field: 'tags', operator: 'hasTag', value: 'urgent' },
+      ]);
+    });
+
+    it('extracts numeric comparison values', () => {
+      const expr = parseExpression("count == 5");
+      const comparisons = extractFieldComparisons(expr);
+      expect(comparisons).toEqual([
+        { field: 'count', operator: '==', value: '5' },
+      ]);
+    });
+
+    it('handles complex nested expressions', () => {
+      const expr = parseExpression("(status == 'active' && priority == 'high') || status == 'urgent'");
+      const comparisons = extractFieldComparisons(expr);
+      expect(comparisons).toHaveLength(3);
+      expect(comparisons).toContainEqual({ field: 'status', operator: '==', value: 'active' });
+      expect(comparisons).toContainEqual({ field: 'priority', operator: '==', value: 'high' });
+      expect(comparisons).toContainEqual({ field: 'status', operator: '==', value: 'urgent' });
+    });
+
+    it('ignores identifier vs identifier comparisons', () => {
+      const expr = parseExpression("a == b");
+      const comparisons = extractFieldComparisons(expr);
+      expect(comparisons).toEqual([]);
+    });
+
+    it('ignores function calls without field/value pattern', () => {
+      const expr = parseExpression("isEmpty(status)");
+      const comparisons = extractFieldComparisons(expr);
+      expect(comparisons).toEqual([]);
+    });
+  });
+
+  describe('validateWhereExpressions', () => {
+    it('passes for valid select value', () => {
+      // task.status has options: raw, backlog, in-flight, settled
+      const result = validateWhereExpressions(
+        ["status == 'backlog'"],
+        schema,
+        'task'
+      );
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('passes for all valid options', () => {
+      const options = ['raw', 'backlog', 'in-flight', 'settled'];
+      for (const option of options) {
+        const result = validateWhereExpressions(
+          [`status == '${option}'`],
+          schema,
+          'task'
+        );
+        expect(result.valid).toBe(true);
+      }
+    });
+
+    it('fails for invalid select value', () => {
+      const result = validateWhereExpressions(
+        ["status == 'invalid'"],
+        schema,
+        'task'
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]!.field).toBe('status');
+      expect(result.errors[0]!.value).toBe('invalid');
+      expect(result.errors[0]!.validOptions).toContain('backlog');
+    });
+
+    it('suggests similar option for typo', () => {
+      const result = validateWhereExpressions(
+        ["status == 'bcklog'"],  // typo for 'backlog'
+        schema,
+        'task'
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]!.suggestion).toBe('backlog');
+    });
+
+    it('skips validation for non-select fields', () => {
+      // deadline is a text field, not select
+      const result = validateWhereExpressions(
+        ["deadline == '2024-01-01'"],
+        schema,
+        'task'
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('skips validation for unknown fields', () => {
+      // unknown_field is not in the schema
+      const result = validateWhereExpressions(
+        ["unknown_field == 'value'"],
+        schema,
+        'task'
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('validates multiple expressions', () => {
+      const result = validateWhereExpressions(
+        ["status == 'invalid1'", "status == 'invalid2'"],
+        schema,
+        'task'
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(2);
+    });
+
+    it('validates idea type with priority field', () => {
+      // idea.priority has options: low, medium, high
+      const result = validateWhereExpressions(
+        ["priority == 'highest'"],
+        schema,
+        'idea'
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]!.validOptions).toEqual(['low', 'medium', 'high']);
+    });
+
+    it('handles complex expressions with valid values', () => {
+      const result = validateWhereExpressions(
+        ["status == 'backlog' && status != 'settled'"],
+        schema,
+        'task'
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('catches invalid value in complex expression', () => {
+      const result = validateWhereExpressions(
+        ["status == 'backlog' || status == 'invalid'"],
+        schema,
+        'task'
+      );
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]!.value).toBe('invalid');
+    });
+
+    it('handles parse errors gracefully', () => {
+      const result = validateWhereExpressions(
+        ["status =="],  // invalid syntax
+        schema,
+        'task'
+      );
+      // Should not throw, just skip unparseable expressions
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('formatWhereValidationErrors', () => {
+    it('formats single error', () => {
+      const errors = [{
+        expression: "status == 'invalid'",
+        field: 'status',
+        value: 'invalid',
+        message: "Invalid value 'invalid' for field 'status'",
+        validOptions: ['raw', 'backlog', 'in-flight', 'settled'],
+      }];
+      const formatted = formatWhereValidationErrors(errors);
+      expect(formatted).toContain("Invalid value 'invalid' for field 'status'");
+      expect(formatted).toContain('Valid options:');
+      expect(formatted).toContain('backlog');
+    });
+
+    it('formats single error with suggestion', () => {
+      const errors = [{
+        expression: "status == 'bcklog'",
+        field: 'status',
+        value: 'bcklog',
+        message: "Invalid value 'bcklog' for field 'status'",
+        validOptions: ['raw', 'backlog', 'in-flight', 'settled'],
+        suggestion: 'backlog',
+      }];
+      const formatted = formatWhereValidationErrors(errors);
+      expect(formatted).toContain("Did you mean 'backlog'?");
+    });
+
+    it('formats multiple errors', () => {
+      const errors = [
+        {
+          expression: "status == 'invalid1'",
+          field: 'status',
+          value: 'invalid1',
+          message: "Invalid value 'invalid1' for field 'status'",
+          validOptions: ['raw', 'backlog'],
+        },
+        {
+          expression: "priority == 'invalid2'",
+          field: 'priority',
+          value: 'invalid2',
+          message: "Invalid value 'invalid2' for field 'priority'",
+          validOptions: ['low', 'high'],
+        },
+      ];
+      const formatted = formatWhereValidationErrors(errors);
+      expect(formatted).toContain('Expression validation errors:');
+      expect(formatted).toContain('invalid1');
+      expect(formatted).toContain('invalid2');
+    });
+
+    it('truncates long option lists for multiple errors', () => {
+      // Truncation only applies when there are multiple errors (to save space)
+      const errors = [
+        {
+          expression: "status == 'x'",
+          field: 'status',
+          value: 'x',
+          message: "Invalid value 'x' for field 'status'",
+          validOptions: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],  // 8 options
+        },
+        {
+          expression: "priority == 'y'",
+          field: 'priority',
+          value: 'y',
+          message: "Invalid value 'y' for field 'priority'",
+          validOptions: ['low', 'high'],
+        },
+      ];
+      const formatted = formatWhereValidationErrors(errors);
+      expect(formatted).toContain('8 total');
+    });
+
+    it('shows all options for single error', () => {
+      // Single error shows all options (user needs to see valid choices)
+      const errors = [{
+        expression: "status == 'x'",
+        field: 'status',
+        value: 'x',
+        message: "Invalid value 'x' for field 'status'",
+        validOptions: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+      }];
+      const formatted = formatWhereValidationErrors(errors);
+      expect(formatted).toContain('a, b, c, d, e, f, g, h');
+    });
+
+    it('returns empty string for no errors', () => {
+      expect(formatWhereValidationErrors([])).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #245

When `--type` is specified, `--where` filter expressions are now validated against the schema before execution. This catches typos and invalid values for select fields immediately, rather than silently returning no results.

- Invalid select field values produce a clear error with valid options
- Typos get helpful "Did you mean...?" suggestions
- Validation happens early (before file discovery) for fast feedback
- Without `--type`, behavior remains permissive (supports migration workflows)

## Example

Before:
```bash
bwrb list task --where "status == 'on-deck'"
# Silently returns empty results
```

After:
```bash
bwrb list task --where "status == 'on-deck'"
# Error: Invalid value 'on-deck' for field 'status'.
#   Valid options: raw, backlog, in-flight, settled
#   Did you mean 'backlog'?
```

## Changes

- **New**: `src/lib/expression-validation.ts` - Expression validation module (317 lines)
- **Modified**: `src/lib/targeting.ts` - Added validation call in `resolveTargets()` (14 lines)
- **Tests**: 29 new unit tests + 1 new integration test
- **Test fixes**: Updated tests that used invalid values for "no matches" scenarios

## Testing

All 1628 tests pass. Manual testing confirms the error message format and suggestion behavior.