### PR TITLE
fix: normalize YAML date objects to YYYY-MM-DD in edit command

### DIFF
--- a/tests/ts/lib/frontmatter.test.ts
+++ b/tests/ts/lib/frontmatter.test.ts
@@ -55,6 +55,17 @@ Body content`;
       const fm = parseFrontmatter(content);
       expect(fm).toEqual({ type: 'idea', status: 'raw' });
     });
+
+    it('should normalize YAML-parsed Date values to strings', () => {
+      const content = `---
+type: idea
+creation-date: 2026-01-08
+---
+Body content`;
+      const fm = parseFrontmatter(content);
+      expect(typeof fm['creation-date']).toBe('string');
+      expect(String(fm['creation-date'])).toBe('2026-01-08');
+    });
   });
 
   describe('serializeFrontmatter', () => {


### PR DESCRIPTION
## Summary
- Fix `bwrb edit --json` failing when notes have date fields (e.g., `creation-date: 2026-01-08`)
- Normalize YAML-parsed Date objects to canonical `YYYY-MM-DD` strings at frontmatter parse time
- Use UTC components to preserve the original date value (avoids timezone drift)

## Changes
- **src/lib/frontmatter.ts**: Add `formatYamlDate()` and `normalizeMatterValue()` to convert Date→string at parse time
- **src/lib/validation.ts**: Export `normalizeToIsoDate()` helper; validator accepts Date objects
- **src/lib/edit.ts**: Add `normalizeDateFields()` for defense-in-depth before write
- **tests/**: Add regression tests for date normalization

## Root Cause
gray-matter (YAML parser) converts date-like strings into JS Date objects at midnight UTC. The validator then failed with "expected date string, got object" when editing unrelated fields.

Fixes #314