### PR TITLE
fix: align JSON Schema with runtime schema

### DIFF
--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -424,7 +424,7 @@ Vault-wide settings:
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `link_format` | string | `"wikilink"` | Link format for relations: `wikilink` (`[[Note]]`) or `markdown` (`[Note](Note.md)`) |
-| `open_with` | string | `"visual"` | Default for `--open`: `editor`, `visual`, or `obsidian` |
+| `open_with` | string | `"system"` | Default for `--open`: `system`, `editor`, `visual`, or `obsidian` |
 | `editor` | string | `$EDITOR` | Terminal editor command |
 | `visual` | string | `$VISUAL` | GUI editor command |
 | `obsidian_vault` | string | auto | Obsidian vault name for URI scheme |

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -56,13 +56,21 @@
         },
         "open_with": {
           "type": "string",
-          "enum": ["editor", "visual", "obsidian"],
-          "default": "visual",
+          "enum": ["system", "editor", "visual", "obsidian"],
+          "default": "system",
           "description": "Default behavior for --open flag"
         },
         "obsidian_vault": {
           "type": "string",
           "description": "Obsidian vault name for URI scheme (auto-detected if not set)"
+        },
+        "default_dashboard": {
+          "type": "string",
+          "description": "Dashboard to run when `bwrb dashboard` is called without arguments"
+        },
+        "date_format": {
+          "type": "string",
+          "description": "Date format for date fields (defaults to YYYY-MM-DD)"
         }
       }
     },
@@ -91,6 +99,10 @@
         "output_dir": {
           "type": "string",
           "description": "Directory path relative to vault root where files of this type are created"
+        },
+        "filename": {
+          "type": "string",
+          "description": "Filename pattern"
         },
         "frontmatter": {
           "type": "object",
@@ -126,6 +138,7 @@
           }
         },
         "output_dir": { "type": "string" },
+        "filename": { "type": "string", "description": "Filename pattern" },
         "frontmatter": {
           "$ref": "#/definitions/typeDefinition/properties/frontmatter"
         },
@@ -182,8 +195,11 @@
           "description": "Allowed values for select fields (inline options)"
         },
         "source": {
-          "type": "string",
-          "description": "Type name(s) for relation prompts"
+          "description": "Type name(s) for relation prompts",
+          "anyOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "filter": {
           "type": "object",
@@ -201,8 +217,11 @@
           "description": "Whether children referenced by this field are owned (colocate with parent)"
         },
         "default": {
-          "type": "string",
-          "description": "Default value if user skips the prompt"
+          "description": "Default value if user skips the prompt",
+          "anyOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "required": {
           "type": "boolean",
@@ -239,7 +258,7 @@
         },
         "prompt": {
           "type": "string",
-          "enum": ["list"],
+          "enum": ["none", "list"],
           "description": "If set, prompts user for initial content during creation"
         },
         "prompt_label": {

--- a/tests/ts/lib/schema-schema-drift.test.ts
+++ b/tests/ts/lib/schema-schema-drift.test.ts
@@ -1,0 +1,73 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+
+/**
+ * Regression guard for Issue #247.
+ * Ensures `schema.schema.json` matches runtime Zod behavior for key fields.
+ */
+describe('schema.schema.json drift guards', () => {
+  let metaSchema: any;
+
+  beforeAll(async () => {
+    const schemaUrl = new URL('../../../schema.schema.json', import.meta.url);
+    metaSchema = JSON.parse(await readFile(schemaUrl, 'utf-8'));
+  });
+
+  it('includes config.open_with system option and default', () => {
+    const openWith = metaSchema.definitions.config.properties.open_with;
+    expect(openWith).toBeDefined();
+    expect(openWith.enum).toContain('system');
+    expect(openWith.enum).toContain('editor');
+    expect(openWith.enum).toContain('visual');
+    expect(openWith.enum).toContain('obsidian');
+    expect(openWith.default).toBe('system');
+  });
+
+  it('includes runtime config keys in JSON schema', () => {
+    const configProps = metaSchema.definitions.config.properties;
+
+    expect(configProps.default_dashboard).toBeDefined();
+    expect(configProps.default_dashboard.type).toBe('string');
+
+    expect(configProps.date_format).toBeDefined();
+    expect(configProps.date_format.type).toBe('string');
+  });
+
+  it('allows array forms for relation field.source and field.default', () => {
+    const fieldProps = metaSchema.definitions.frontmatterField.properties;
+
+    const source = fieldProps.source;
+    expect(source).toBeDefined();
+    expect(source.anyOf).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'string' }),
+        expect.objectContaining({ type: 'array' }),
+      ])
+    );
+
+    const def = fieldProps.default;
+    expect(def).toBeDefined();
+    expect(def.anyOf).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'string' }),
+        expect.objectContaining({ type: 'array' }),
+      ])
+    );
+  });
+
+  it('allows body section prompt to be none or list', () => {
+    const prompt = metaSchema.definitions.bodySection.properties.prompt;
+    expect(prompt).toBeDefined();
+    expect(prompt.enum).toEqual(expect.arrayContaining(['none', 'list']));
+  });
+
+  it('includes filename on type definitions', () => {
+    const typeDefProps = metaSchema.definitions.typeDefinition.properties;
+    expect(typeDefProps.filename).toBeDefined();
+    expect(typeDefProps.filename.type).toBe('string');
+
+    const typeNodeProps = metaSchema.definitions.typeNode.properties;
+    expect(typeNodeProps.filename).toBeDefined();
+    expect(typeNodeProps.filename.type).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes drift between schema.schema.json and runtime Zod schema
- Adds regression test to prevent future drift

Fixes #247