### PR TITLE
feat: configurable excluded directories

### DIFF
--- a/docs/product/cli-targeting.md
+++ b/docs/product/cli-targeting.md
@@ -226,54 +226,35 @@ While selectors narrow the candidate set, ignore rules determine what enters the
 
 ### Exclusion Mechanisms
 
-Bowerbird recognizes four types of exclusion rules:
+Bowerbird recognizes multiple exclusion mechanisms:
 
 | Mechanism | Source | Example |
 |-----------|--------|---------|
 | `.gitignore` patterns | `.gitignore` file in vault root | `Archive/`, `*.tmp` |
-| Audit exclusions (schema) | `schema.audit.ignored_directories` | `["Templates", "Sandbox"]` |
-| Audit exclusions (env) | `BWRB_AUDIT_EXCLUDE` (comma-separated) | `BWRB_AUDIT_EXCLUDE=Archive,Drafts` |
+| Exclusions (schema, canonical) | `schema.config.excluded_directories` | `["Templates", "Archive/Old"]` |
+| Exclusions (schema, legacy alias) | `schema.audit.ignored_directories` | `["Templates", "Archive/Old"]` |
+| Exclusions (env, canonical) | `BWRB_EXCLUDE` (comma-separated) | `BWRB_EXCLUDE=Archive,Drafts` |
+| Exclusions (env, legacy alias) | `BWRB_AUDIT_EXCLUDE` (comma-separated) | `BWRB_AUDIT_EXCLUDE=Archive,Drafts` |
 | Hidden directories | Any directory starting with `.` | `.obsidian/`, `.trash/` |
+| Always excluded | `.bwrb/` | `.bwrb/` |
 
 **Notes:**
 - `.gitignore` is optional. Bowerbird works on any folder of Markdown files, Git-backed or not. Only the vault root `.gitignore` is consulted (not nested `.gitignore` files).
-- Exclusions combine: a path matching *any* exclusion source is excluded.
+- Exclusions combine as a union: a path matching *any* exclusion source is excluded.
 
 ### When Exclusion Rules Apply
 
-Different commands apply exclusion rules differently based on their purpose:
-
-| Command | Type Files | Unmanaged Files | Rationale |
-|---------|------------|-----------------|-----------|
-| `audit` | Respects exclusions | Respects exclusions | Validation scope |
-| `search` / `open` / `edit` | **Bypasses** exclusions | Respects exclusions | Nothing feels lost |
-| `list --type <type>` | **Bypasses** exclusions | N/A | Type discovery |
-| `list` (no type) | Respects exclusions | Respects exclusions | Vault-wide scan |
-
-**Definitions:**
-- **Type files**: Notes in a type's `output_dir` (e.g., `Objectives/Tasks/`). These are schema-managed.
-- **Unmanaged files**: Markdown files outside any type's output directory (e.g., loose files in vault root or non-type folders).
-
-### Rationale
-
-This hybrid approach balances two product principles:
-
-1. **"Nothing feels lost"** — Type-managed notes must always be discoverable. If you created a task via `bwrb new task`, you can always find it via `bwrb search`, `bwrb edit`, or `bwrb open`, regardless of whether the type's directory is in `.gitignore` or `ignored_directories`.
-
-2. **Intentional hiding** — Unmanaged files in excluded directories may be intentionally hidden (e.g., archived content, work-in-progress imports). These respect exclusion rules.
-
-3. **Audit is about validation scope** — The `ignored_directories` setting controls what `bwrb audit` validates, not what exists. A type directory might be excluded from audit (e.g., during migration) while its notes remain fully discoverable.
+Excluded directories apply to **all bwrb operations** consistently. If a file is excluded, it does not enter the candidate set for `list`, `search`/`open`/`edit`, or `audit`.
 
 ### Example
 
 ```bash
-# Schema has: audit.ignored_directories: ["Archive"]
+# Schema has: config.excluded_directories: ["Archive"]
 # Archive/Tasks/ contains "Old Task.md" (a task type note)
 
-bwrb list task                    # Finds "Old Task" (type discovery bypasses exclusions)
-bwrb search "Old Task"            # Finds it (navigation bypasses exclusions for type files)
-bwrb audit task                   # Skips Archive/ (audit respects exclusions)
-bwrb list                         # Skips Archive/ (vault-wide scan respects exclusions)
+bwrb list task            # Does NOT find it
+bwrb search "Old Task"    # Does NOT find it
+bwrb audit task           # Skips Archive/
 ```
 
 ---

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -90,6 +90,7 @@ bwrb supports vault-wide configuration in `.bwrb/schema.json` under the `config`
 | `open_with` | `system`, `editor`, `visual`, `obsidian` | `system` | Default --open behavior |
 | `editor` | Command string | `$EDITOR` | Terminal editor command |
 | `visual` | Command string | `$VISUAL` | GUI editor command |
+| `excluded_directories` | `string[]` | `[]` | Directory prefixes to exclude from discovery/targeting |
 
 ### Date Format
 
@@ -105,11 +106,14 @@ Ambiguous dates like `01/02/2026` (where both parts are ≤12) are rejected.
 
 ```bash
 # View current config
-bwrb config
+bwrb config list
 
 # Edit config option
 bwrb config edit date_format  # Interactive
-bwrb config set date_format "MM/DD/YYYY"  # Non-interactive
+bwrb config edit date_format --json '"MM/DD/YYYY"'  # Non-interactive
+
+# Exclude directories globally
+bwrb config edit excluded_directories --json '["Archive","Templates"]'
 ```
 
 ## Core Commands for Agents

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -122,10 +122,10 @@ export async function runAudit(
   }
 
   // Build set of all markdown files for stale reference checking
-  const allFiles = await collectAllMarkdownFilenames(vaultDir);
+  const allFiles = await collectAllMarkdownFilenames(schema, vaultDir);
 
   // Build map from note names to relative paths for ownership checking
-  const notePathMap = await buildNotePathMap(vaultDir);
+  const notePathMap = await buildNotePathMap(schema, vaultDir);
 
   // Build ownership index for ownership violation checking
   const ownershipIndex = await buildOwnershipIndex(schema, vaultDir);

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -127,6 +127,9 @@ export const ConfigSchema = z.object({
   obsidian_vault: z.string().optional(),
   // Default dashboard to run when `bwrb dashboard` is called without arguments
   default_dashboard: z.string().optional(),
+  // Directories to exclude from all discovery/targeting operations
+  // Values are vault-root-relative directory prefixes (e.g., "Archive", "Templates", "Archive/Old")
+  excluded_directories: z.array(z.string()).optional(),
   // Date format for date fields in frontmatter
   // YYYY-MM-DD: ISO 8601 format (default)
   // MM/DD/YYYY: US format

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -811,7 +811,7 @@ priority: medium
       expect(result.stdout).not.toContain('temp.tmp.md');
     });
 
-    it('should respect BWRB_AUDIT_EXCLUDE env var', async () => {
+    it('should respect BWRB_EXCLUDE env var', async () => {
       // Create a directory that should be excluded via env var
       await mkdir(join(tempVaultDir, 'Archive'), { recursive: true });
       await writeFile(
@@ -834,8 +834,8 @@ priority: medium
       );
 
       // Set env var and run
-      const originalEnv = process.env.BWRB_AUDIT_EXCLUDE;
-      process.env.BWRB_AUDIT_EXCLUDE = 'Archive';
+      const originalEnv = process.env.BWRB_EXCLUDE;
+      process.env.BWRB_EXCLUDE = 'Archive';
 
       try {
         const result = await runCLI(['audit'], tempVaultDir);
@@ -846,19 +846,21 @@ priority: medium
       } finally {
         // Restore env
         if (originalEnv === undefined) {
-          delete process.env.BWRB_AUDIT_EXCLUDE;
+          delete process.env.BWRB_EXCLUDE;
         } else {
-          process.env.BWRB_AUDIT_EXCLUDE = originalEnv;
+          process.env.BWRB_EXCLUDE = originalEnv;
         }
       }
     });
 
-    it('should respect schema audit.ignored_directories config', async () => {
-      // Update schema with ignored_directories
+    it('should respect config.excluded_directories (and legacy alias)', async () => {
       const schemaWithExclusions = {
         ...TEST_SCHEMA,
+        config: {
+          excluded_directories: ['Templates'],
+        },
         audit: {
-          ignored_directories: ['Templates', 'Archive/Old'],
+          ignored_directories: ['Archive/Old'],
         },
       };
       await writeFile(

--- a/tests/ts/commands/config.test.ts
+++ b/tests/ts/commands/config.test.ts
@@ -31,6 +31,7 @@ describe('config command', () => {
       expect(result.stdout).toContain('visual');
       expect(result.stdout).toContain('open_with');
       expect(result.stdout).toContain('obsidian_vault');
+      expect(result.stdout).toContain('excluded_directories');
     });
 
     it('should show default values when config is not set', async () => {
@@ -51,6 +52,7 @@ describe('config command', () => {
       expect(json.success).toBe(true);
       expect(json.data).toBeDefined();
       expect(json.data.link_format).toBe('wikilink');
+      expect(json.data.excluded_directories).toEqual([]);
       // open_with should be one of the valid options
       expect(['system', 'editor', 'visual', 'obsidian']).toContain(json.data.open_with);
     });
@@ -185,6 +187,20 @@ describe('config command', () => {
       const verifyResult = await runCLI(['config', 'list', 'editor', '--output', 'json'], tempVaultDir);
       const json = JSON.parse(verifyResult.stdout);
       expect(json.data.value).toBe('nvim');
+    });
+
+    it('should set an array value', async () => {
+      const result = await runCLI(
+        ['config', 'edit', 'excluded_directories', '--json', '["Archive","Templates/"]'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Set excluded_directories');
+
+      const verifyResult = await runCLI(['config', 'list', 'excluded_directories', '--output', 'json'], tempVaultDir);
+      const json = JSON.parse(verifyResult.stdout);
+      expect(json.data.value).toEqual(['Archive', 'Templates']);
     });
 
     it('should reject invalid enum value', async () => {

--- a/tests/ts/commands/search.test.ts
+++ b/tests/ts/commands/search.test.ts
@@ -205,32 +205,24 @@ status: backlog
       await cleanupTestVault(tempVaultDir);
     });
 
-    it('should find notes in type directories even when gitignored', async () => {
-      // Gitignore the Ideas directory
+    it('should respect .gitignore for type directories', async () => {
       await writeFile(join(tempVaultDir, '.gitignore'), 'Ideas/\n');
 
-      // Search should still find ideas because type directories ignore exclusion rules
-      const result = await runCLI(['search', 'Sample Idea', '--picker', 'none'], tempVaultDir);
+      const result = await runCLI(['search', 'Idea', '--picker', 'none'], tempVaultDir);
 
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout.trim()).toBe('Sample Idea');
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('No matching notes found');
     });
 
-    it('should find all type files with JSON output when gitignored', async () => {
-      // Gitignore the Ideas directory
+    it('should return JSON error when matches are excluded', async () => {
       await writeFile(join(tempVaultDir, '.gitignore'), 'Ideas/\n');
 
-      // Search with JSON output
       const result = await runCLI(['search', 'Idea', '--output', 'json'], tempVaultDir);
 
-      expect(result.exitCode).toBe(0);
+      expect(result.exitCode).toBe(1);
       const json = JSON.parse(result.stdout);
-      expect(json.success).toBe(true);
-      
-      // Should find both ideas even though Ideas/ is gitignored
-      const names = json.data.map((d: { name: string }) => d.name);
-      expect(names).toContain('Sample Idea');
-      expect(names).toContain('Another Idea');
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('No matching notes found');
     });
 
     it('should exclude unmanaged files in gitignored directories', async () => {


### PR DESCRIPTION
## Summary
- Adds `config.excluded_directories` and exposes it via `bwrb config edit excluded_directories` (supports `--json` for non-interactive use).
- Applies excluded directories consistently across all discovery/targeting (no more type-directory bypass for `search/open/edit` or `list --type`).
- Keeps backwards compatibility by honoring `audit.ignored_directories` and `BWRB_AUDIT_EXCLUDE` as legacy aliases.

## Usage
- Set exclusions: `bwrb config edit excluded_directories --json '["Archive","Templates"]'`
- Env override (global): `BWRB_EXCLUDE=Archive,Drafts bwrb list`

## Notes
- `.bwrb/`, hidden dot-directories, and vault-root `.gitignore` remain exclusion sources.

Closes #290

## Testing
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`