### PR TITLE
feat(schema): warn on missing output_dir

### DIFF
--- a/docs-site/src/content/docs/reference/commands/schema.md
+++ b/docs-site/src/content/docs/reference/commands/schema.md
@@ -117,7 +117,9 @@ Validates the schema.json file against the expected structure:
 - Field types are valid
 - Enum values are properly defined
 - Type hierarchies are consistent
-- Output directories are specified
+- Types missing `output_dir` emit a warning (computed directory included)
+
+Warnings are printed to stderr in text mode. In JSON mode, warnings are included in `data.warnings`.
 
 ### Examples
 


### PR DESCRIPTION
## Summary
- `bwrb schema validate` emits a warning for each type missing an explicit `output_dir` and includes the computed directory.
- JSON mode includes warnings in `data.warnings` while still returning success.
- Updates docs and adds coverage for text + JSON warning behavior.

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm typecheck`

Fixes #309