### PR TITLE
chore(knip): stop exporting unused note-id helpers

### DIFF
--- a/src/lib/note-id.ts
+++ b/src/lib/note-id.ts
@@ -6,7 +6,7 @@ import { dirname, join, relative } from 'path';
 const ID_REGISTRY_RELATIVE_PATH = '.bwrb/ids.jsonl';
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export function getIdRegistryPath(vaultDir: string): string {
+function getIdRegistryPath(vaultDir: string): string {
   return join(vaultDir, ID_REGISTRY_RELATIVE_PATH);
 }
 
@@ -16,7 +16,7 @@ export interface IdRegistryEntry {
   path?: string;
 }
 
-export async function readIssuedIds(vaultDir: string): Promise<Set<string>> {
+async function readIssuedIds(vaultDir: string): Promise<Set<string>> {
   const registryPath = getIdRegistryPath(vaultDir);
   if (!existsSync(registryPath)) return new Set();
 


### PR DESCRIPTION
Fixes Knip unused-export failures by making internal helpers in `src/lib/note-id.ts` non-exported.