### PR TITLE
fix(note-id): add max attempts for UUID generation

### DIFF
--- a/src/lib/note-id.ts
+++ b/src/lib/note-id.ts
@@ -5,6 +5,7 @@ import { dirname, join, relative } from 'path';
 
 const ID_REGISTRY_RELATIVE_PATH = '.bwrb/ids.jsonl';
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_ID_GENERATION_ATTEMPTS = 1000;
 
 function getIdRegistryPath(vaultDir: string): string {
   return join(vaultDir, ID_REGISTRY_RELATIVE_PATH);
@@ -49,10 +50,14 @@ async function readIssuedIds(vaultDir: string): Promise<Set<string>> {
 export async function generateUniqueNoteId(vaultDir: string): Promise<string> {
   const issued = await readIssuedIds(vaultDir);
 
-  while (true) {
+  for (let attempt = 0; attempt < MAX_ID_GENERATION_ATTEMPTS; attempt++) {
     const id = randomUUID();
     if (!issued.has(id)) return id;
   }
+
+  throw new Error(
+    `Failed to generate a unique note ID after ${MAX_ID_GENERATION_ATTEMPTS} attempts`
+  );
 }
 
 export async function registerIssuedNoteId(


### PR DESCRIPTION
Implements Greptile suggestion: cap UUID generation attempts (1000) and throw if uniqueness can't be achieved, avoiding a theoretical infinite loop.