### PR TITLE
chore(ci): run checks on bot/integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, bot/integration]
   pull_request:
-    branches: [main]
+    branches: [main, bot/integration]
 
 # Cancel in-progress runs for the same branch
 concurrency:


### PR DESCRIPTION
## Summary
- Run CI for `bot/integration` by adding it to push and pull_request triggers.

## Testing
- Not run locally (CI-only change).