### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bwrb",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Schema-driven note management for markdown vaults",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bumps `package.json` version to `0.1.4` so we can re-cut `v0.1.4` and publish to npm.

After merge:
- Delete + recreate the existing `v0.1.4` git tag
- Delete + recreate the GitHub release `v0.1.4`

This ensures the tag/release point at the version-bump commit on `main` (instead of the previous rollup commit).