### PR TITLE
fix: resolve self-reference after target disambiguation

### DIFF
--- a/tests/ts/commands/audit-fix.pty.test.ts
+++ b/tests/ts/commands/audit-fix.pty.test.ts
@@ -290,7 +290,7 @@ status: " "
           const content = await readVaultFile(vaultPath, 'Ideas/Empty Required.md');
           expect(content).toContain('status: raw');
         },
-        { files: [emptyRequired], schema: AUDIT_SCHEMA }
+        { files: [emptyRequired], schema: BASELINE_SCHEMA }
       );
     }, 30000);
 
@@ -406,7 +406,7 @@ deadline: 01/02/2026
           const content = await readVaultFile(vaultPath, 'Objectives/Tasks/Bad Date.md');
           expect(content).toContain('deadline: 2026-02-01');
         },
-        { files: [invalidDate], schema: AUDIT_SCHEMA }
+        { files: [invalidDate], schema: BASELINE_SCHEMA }
       );
     }, 30000);
 
@@ -789,7 +789,7 @@ effort: "5"
           expect(content).toContain('archived: false');
           expect(content).toContain('effort: 5');
         },
-        { files: [scalarFile], schema: AUDIT_SCHEMA }
+        { files: [scalarFile], schema: BASELINE_SCHEMA }
       );
     }, 30000);
 

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -78,6 +78,35 @@ parent: "[[Self Task]]"
       expect(result.stdout).toContain('Self-reference detected: parent points to itself');
     });
 
+    it('should prefer ambiguous-link-target over self-reference when target is ambiguous', async () => {
+      await mkdir(join(tempVaultDir, 'Objectives/Tasks/Sub'), { recursive: true });
+
+      await writeFile(
+        join(tempVaultDir, 'Objectives/Tasks', 'Self Task.md'),
+`---
+type: task
+status: backlog
+parent: "[[Self Task]]"
+---
+`
+      );
+
+      await writeFile(
+        join(tempVaultDir, 'Objectives/Tasks/Sub', 'Self Task.md'),
+`---
+type: task
+status: backlog
+---
+`
+      );
+
+      const result = await runCLI(['audit', 'task'], tempVaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Ambiguous link target for parent: 'Self Task'");
+      expect(result.stdout).not.toContain('Self-reference detected');
+    });
+
     it('should detect ambiguous relation target', async () => {
       await mkdir(join(tempVaultDir, 'Objectives/Tasks/Sub'), { recursive: true });
       await writeFile(


### PR DESCRIPTION
## Summary
- resolve self-reference only after relation targets disambiguate, preferring ambiguous-link-target when multiple candidates match
- handle YAML flow-sequence wikilinks for relation fields and parent cycle detection
- apply interactive fixes for ambiguous/self-reference targets and expand audit coverage tests

## Testing
- pnpm build
- pnpm test

Fixes #382