### PR TITLE
chore(release): bump version to 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bwrb",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Schema-driven note management for markdown vaults",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump package version from `0.1.5` to `0.1.6` in `package.json`.
- Validate release build locally with `pnpm build`.