### PR TITLE
Fix schema list mixed --type conflict detection for equals form

### DIFF
--- a/src/commands/schema/list.ts
+++ b/src/commands/schema/list.ts
@@ -34,7 +34,12 @@ interface ListCommandOptions {
 const RESERVED_LIST_NOUNS = new Set(['types', 'fields', 'type']);
 
 function hasTypeAliasFlagToken(): boolean {
-  return process.argv.includes('--type') || process.argv.includes('-t');
+  return process.argv.some((arg: string) =>
+    arg === '--type' ||
+    arg.startsWith('--type=') ||
+    arg === '-t' ||
+    arg.startsWith('-t=')
+  );
 }
 
 function ensureNoTypeAliasConflict(options: ListCommandOptions, usage: string): void {

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -640,6 +640,13 @@ describe('schema command', () => {
       expect(result.stderr).toContain('Cannot combine positional type path');
     });
 
+    it('should error when positional typePath and --type=<value> are both provided', async () => {
+      const result = await runCLI(['schema', 'list', 'idea', '--type=task'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Cannot combine positional type path');
+    });
+
     it('should error when schema list type and --type are mixed', async () => {
       const result = await runCLI(['schema', 'list', 'type', 'idea', '--type', 'task'], vaultDir);
 
@@ -647,8 +654,22 @@ describe('schema command', () => {
       expect(result.stderr).toContain("Cannot combine 'bwrb schema list type idea' with --type/-t");
     });
 
+    it('should error when schema list type and --type=<value> are mixed', async () => {
+      const result = await runCLI(['schema', 'list', 'type', 'idea', '--type=task'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Cannot combine 'bwrb schema list type idea' with --type/-t");
+    });
+
     it('should error when schema list fields and --type are mixed', async () => {
       const result = await runCLI(['schema', 'list', 'fields', '--type', 'task'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Cannot use --type with 'bwrb schema list fields'");
+    });
+
+    it('should error when schema list fields and --type=<value> are mixed', async () => {
+      const result = await runCLI(['schema', 'list', 'fields', '--type=task'], vaultDir);
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain("Cannot use --type with 'bwrb schema list fields'");


### PR DESCRIPTION
## Summary
- make `schema list` mixed-form conflict detection treat `--type value` and `--type=<value>` consistently in subcommand conflict paths
- keep current valid targeting forms unchanged and deterministic for existing commands
- add regression tests for `--type=<value>` conflict cases (positional alias mix, `schema list type`, and `schema list fields`)

Closes #495