### PR TITLE
fix: allow template new --name to bypass interactive prompts

### DIFF
--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -617,6 +617,13 @@ templateCommand
         return;
       }
 
+      // Non-interactive shortcut: if --name is provided and stdin is not a TTY,
+      // create a minimal template without prompting (fixes #541)
+      if (options.name && !process.stdin.isTTY) {
+        await createTemplateMinimal(schema, vaultDir, resolvedTypePath, options);
+        return;
+      }
+
       await createTemplateInteractive(schema, vaultDir, resolvedTypePath, options);
     } catch (err) {
       if (err instanceof UserCancelledError) {
@@ -717,6 +724,48 @@ async function createTemplateFromJson(
     path: relative(vaultDir, templatePath),
     message: 'Template created successfully',
   }));
+}
+
+/**
+ * Create a minimal template non-interactively when --name is provided
+ * in a non-TTY context (e.g., piped scripts). This avoids hanging on
+ * interactive prompts while still creating a usable template.
+ */
+async function createTemplateMinimal(
+  _schema: LoadedSchema,
+  vaultDir: string,
+  typePath: string,
+  options: TemplateNewOptions
+): Promise<void> {
+  const name = options.name!;
+
+  // Check if template already exists
+  const existing = await findTemplateByName(vaultDir, typePath, name);
+  if (existing) {
+    printError(`Template already exists: ${name}`);
+    process.exit(1);
+  }
+
+  const templateDir = getTemplateDir(vaultDir, typePath);
+  const templatePath = join(templateDir, `${name}.md`);
+
+  // Build template content
+  const frontmatter: Record<string, unknown> = {
+    type: 'template',
+    'template-for': typePath,
+  };
+
+  if (options.description) {
+    frontmatter.description = options.description;
+  }
+
+  const body = '# {title}\n\n[Template body - customize this section]';
+
+  // Create directory and write template
+  await mkdir(templateDir, { recursive: true });
+  await writeNote(templatePath, frontmatter, body, ['type', 'template-for', 'description']);
+
+  printSuccess(`Template created: ${relative(vaultDir, templatePath)}`);
 }
 
 /**


### PR DESCRIPTION
## Summary

When running `bwrb template new idea --name my-template` in a non-interactive context (e.g., piped into from another command, CI scripts, or any non-TTY environment), the command would fall through to `createTemplateInteractive()` which hangs waiting for user input on description and defaults.

This PR adds a `createTemplateMinimal()` path that activates when:
- `--name` is provided
- stdin is not a TTY (non-interactive context)

The minimal template includes:
- `type: template` and `template-for` frontmatter
- Optional `description` (if `--description` is also provided)
- Default body placeholder

**Before:**
```bash
echo '' | bwrb template new idea --name quick-note
# Hangs waiting for interactive input, then errors
```

**After:**
```bash
echo '' | bwrb template new idea --name quick-note
# Template created: .bwrb/templates/idea/quick-note.md
```

This does NOT change behavior when running interactively in a terminal — the full interactive flow still runs as before.

Fixes #541