### PR TITLE
fix(docs): correct JSON structure and pipeline examples in json-mode.md

### DIFF
--- a/docs-site/src/content/docs/automation/json-mode.md
+++ b/docs-site/src/content/docs/automation/json-mode.md
@@ -40,7 +40,7 @@ bwrb new task --json "{
 ### Process Audit Results
 
 ```bash
-bwrb audit --output json | jq '.violations[] | .file'
+bwrb audit --output json | jq '.files[] | .path'
 ```
 
 Audit JSON is report-only. It never performs fixes or deletes. For delete-eligible findings, the issue payload can include recommendation metadata under `meta.recommendation` (for example `{"action":"delete-note","interactiveOnly":true}`).
@@ -49,8 +49,8 @@ Audit JSON is report-only. It never performs fixes or deletes. For delete-eligib
 
 ```bash
 bwrb list task --output json | \
-  jq -r '.[] | select(.status == "done") | .path' | \
-  xargs -I {} bwrb delete {} --execute
+  jq -r '.[] | select(.status == "done") | ._path' | \
+  xargs -I {} bwrb delete {} --force
 ```
 
 ## AI Integration


### PR DESCRIPTION
## Summary

Fixes #539.

Three broken examples on the `automation/json-mode` docs page:

- **Audit jq path:** `.violations[] | .file` → `.files[] | .path` (matches actual output from `src/lib/audit/output.ts`)
- **List output key:** `.path` → `._path` (matches actual key from `src/commands/list.ts`; underscore-prefix avoids frontmatter collisions)
- **Delete flag:** `--execute` → `--force` (the xargs pipeline invokes single-file delete per path, which needs `--force` to skip confirmation — `--execute` is for bulk mode)

## Test plan

- [ ] Review diff confirms only the three targeted lines changed
- [ ] Manually run `bwrb audit --output json`, `bwrb list task --output json`, and `bwrb delete --help` to verify examples match real CLI behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)