### PR TITLE
fix: support --output flag for edit --json

### DIFF
--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -32,8 +32,29 @@ interface EditOptions {
   id?: string;
   body?: string;
   json?: string;
+  output?: string;
   open?: boolean;
   app?: string;
+}
+
+function resolveEditJsonMode(options: EditOptions, globalOutput?: string): boolean {
+  const requested = options.output ?? globalOutput;
+  if (requested === undefined) {
+    return options.json !== undefined;
+  }
+  return requested === 'json';
+}
+
+function printEditSuccess(path: string, updatedFields: string[], jsonMode: boolean): void {
+  if (jsonMode) {
+    printJson(jsonSuccess({ path, updated: updatedFields }));
+    return;
+  }
+
+  const updatedText = updatedFields.length > 0
+    ? ` (${updatedFields.join(', ')})`
+    : '';
+  printSuccess(`Updated: ${path}${updatedText}`);
 }
 
 function findExactNameMatches(index: { byPath: Map<string, ManagedFile>; byBasename: Map<string, ManagedFile[]> }, query: string): ManagedFile[] {
@@ -80,6 +101,7 @@ export const editCommand = new Command('edit')
   .option('--id <uuid>', 'Filter by stable note id')
   .option('-b, --body <pattern>', 'Filter by body content')
   .option('--json <patch>', 'Non-interactive patch/merge mode')
+  .option('--output <format>', 'Output format: text (default) or json')
   .option('-o, --open', 'Open the note in Obsidian after editing')
   .option('--app <mode>', 'App mode for --open: system (default), editor, visual, obsidian, print')
   .addHelpText('after', `
@@ -99,16 +121,16 @@ Examples:
 
   # Non-interactive JSON mode (scripting)
   bwrb edit "My Task" --json '{"status":"done"}'
+  bwrb edit "My Task" --json '{"status":"done"}' --output json
   bwrb edit -t task --where "status == 'active'" "Deploy" --json '{"priority":"high"}'
 
   # Edit and open
   bwrb edit "My Note" --open                # Open the note after editing
   bwrb edit "My Note" --open --app editor   # Edit then open in $EDITOR`)
   .action(async (query: string | undefined, options: EditOptions, cmd: Command) => {
-    const jsonMode = options.json !== undefined;
-
     try {
       const globalOpts = getGlobalOpts(cmd);
+      const jsonMode = resolveEditJsonMode(options, globalOpts.output);
       configurePromptMode({
         forcedNonInteractive: globalOpts.nonInteractive === true,
         bypassHint: 'Use --json <patch> to update notes without prompts.',
@@ -143,11 +165,8 @@ Examples:
           await fs.access(query);
           // It's a valid absolute path - use it directly
           if (options.json) {
-            const editResult = await editNoteFromJson(schema, vaultDir, query, options.json, { jsonMode: true });
-            printJson(jsonSuccess({
-              path: relative(vaultDir, query),
-              updated: editResult.updatedFields,
-            }));
+            const editResult = await editNoteFromJson(schema, vaultDir, query, options.json, { jsonMode });
+            printEditSuccess(relative(vaultDir, query), editResult.updatedFields, jsonMode);
             if (options.open) {
               const appMode = resolveAppMode(options.app, schema.config);
               await openNote(vaultDir, query, appMode, schema.config, true);
@@ -259,13 +278,9 @@ Examples:
 
       // Perform the edit
       if (options.json) {
-        // JSON mode: non-interactive patch
-        const editResult = await editNoteFromJson(schema, vaultDir, targetFile.path, options.json, { jsonMode: true });
-        
-        printJson(jsonSuccess({
-          path: targetFile.relativePath,
-          updated: editResult.updatedFields,
-        }));
+        // JSON patch mode: non-interactive patch with selectable output format
+        const editResult = await editNoteFromJson(schema, vaultDir, targetFile.path, options.json, { jsonMode });
+        printEditSuccess(targetFile.relativePath, editResult.updatedFields, jsonMode);
 
         // Open after edit if requested
         if (options.open) {

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -128,9 +128,10 @@ Examples:
   bwrb edit "My Note" --open                # Open the note after editing
   bwrb edit "My Note" --open --app editor   # Edit then open in $EDITOR`)
   .action(async (query: string | undefined, options: EditOptions, cmd: Command) => {
+    let jsonMode = false;
     try {
       const globalOpts = getGlobalOpts(cmd);
-      const jsonMode = resolveEditJsonMode(options, globalOpts.output);
+      jsonMode = resolveEditJsonMode(options, globalOpts.output);
       configurePromptMode({
         forcedNonInteractive: globalOpts.nonInteractive === true,
         bypassHint: 'Use --json <patch> to update notes without prompts.',

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -267,7 +267,7 @@ async function resolveVaultDirForCompletion(options: { vault?: string }): Promis
  */
 const COMMAND_OPTIONS: Record<string, string[]> = {
   new: ['--type', '-t', '--vault', '--non-interactive', '--template', '--json', '--help'],
-  edit: ['--vault', '--non-interactive', '--json', '--help'],
+  edit: ['--type', '-t', '--path', '-p', '--where', '-w', '--id', '--body', '-b', '--picker', '--json', '--output', '--open', '--app', '--vault', '--non-interactive', '--help'],
   list: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--output', '-o', '--vault', '--non-interactive', '--json', '--help'],
   open: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--app', '--vault', '--non-interactive', '--help'],
   search: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--wikilink', '--vault', '--non-interactive', '--help'],

--- a/tests/ts/commands/edit.test.ts
+++ b/tests/ts/commands/edit.test.ts
@@ -177,6 +177,30 @@ status: queued
       expect(updated).toContain('creation-date: 2026-01-08');
       expect(updated).not.toContain('T00:00:00.000Z');
     });
+
+    it('should accept --output json with --json patch mode', async () => {
+      const result = await runCLI(
+        ['edit', 'Ideas/Sample Idea.md', '--json', '{"status": "backlog"}', '--output', 'json'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.path).toBe('Ideas/Sample Idea.md');
+      expect(json.updated).toContain('status');
+    });
+
+    it('should accept --output text with --json patch mode', async () => {
+      const result = await runCLI(
+        ['edit', 'Ideas/Sample Idea.md', '--json', '{"status": "backlog"}', '--output', 'text'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Updated: Ideas/Sample Idea.md');
+      expect(() => JSON.parse(result.stdout)).toThrow();
+    });
   });
 
   describe('stable ids', () => {

--- a/tests/ts/commands/edit.test.ts
+++ b/tests/ts/commands/edit.test.ts
@@ -422,6 +422,23 @@ Backslash: \\ and \\n
   });
 
   describe('error handling', () => {
+    it('should return JSON error on exception when --output json is set', async () => {
+      // Corrupt the schema so loadSchema throws after jsonMode is resolved
+      const schemaPath = join(vaultDir, '.bwrb', 'schema.json');
+      await writeFile(schemaPath, '{ not valid json !!!', 'utf-8');
+
+      const result = await runCLI(
+        ['edit', 'Ideas/Sample Idea.md', '--json', '{"status":"raw"}', '--output', 'json'],
+        vaultDir
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      // Should produce valid JSON error output, not crash with ReferenceError
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(typeof json.error).toBe('string');
+    });
+
 it('should error on file not found', async () => {
       const result = await runCLI(
         ['edit', 'CompletelyUniqueNonexistentFile12345.md', '--json', '{"status": "raw"}'],


### PR DESCRIPTION
## Summary
- allow `bwrb edit --json` to accept `--output json` and `--output text`
- keep JSON patch mode non-interactive while honoring the requested output format
- add regression coverage for both output modes

## Testing
- npm test -- tests/ts/commands/edit.test.ts tests/ts/commands/json-io.test.ts