### PR TITLE
Warn on unsafe note filenames

### DIFF
--- a/docs-site/src/content/docs/automation/json-mode.md
+++ b/docs-site/src/content/docs/automation/json-mode.md
@@ -32,6 +32,8 @@ bwrb edit "My Task" --json '{"status": "settled"}'
 bwrb bulk --type task --set status=archived
 ```
 
+`bwrb new --json` reports filename safety metadata when relevant: `nameTransformed` appears when the requested name is normalized for the filesystem, and `pathLengthWarning` appears for relative paths longer than 200 characters. Paths longer than 260 characters are rejected.
+
 ## Scripting Examples
 
 ### Create Note from Script

--- a/docs-site/src/content/docs/reference/commands/new.md
+++ b/docs-site/src/content/docs/reference/commands/new.md
@@ -112,6 +112,22 @@ bwrb new project --json '{"name": "My Project"}' --template with-research
 
 The `_body` field accepts section names as keys, with string or string array values.
 
+If the note name or resolved filename pattern contains characters that are not portable in filenames, `bwrb new` normalizes the filename by removing invalid characters, collapsing doubled whitespace, and trimming the result. Interactive creation prints a warning. JSON mode includes `nameTransformed` metadata:
+
+```json
+{
+  "success": true,
+  "path": "Ideas/What if we used slashes.md",
+  "nameTransformed": {
+    "original": "What if we used / slashes?",
+    "sanitized": "What if we used slashes",
+    "filename": "What if we used slashes.md"
+  }
+}
+```
+
+Paths longer than 200 characters include `pathLengthWarning` in JSON mode and print a warning in interactive mode. Paths longer than 260 characters are rejected.
+
 JSON output for templates with instances includes an `instances` object:
 
 ```json

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -169,7 +169,9 @@ bwrb new task --template epic --no-instances --json '{"name": "Ship feature"}'
 
 Some templates and schema types define **instance scaffolding** (child notes created alongside the main note). By default, `bwrb new` creates those instances; pass `--no-instances` to skip child creation.
 
-When `--output json` is used and instance scaffolding runs, the response includes an `instances` object with the created, skipped, and error lists. This object is omitted when `--no-instances` is set.
+When `bwrb new --json` runs instance scaffolding, the response includes an `instances` object with the created, skipped, and error lists. This object is omitted when `--no-instances` is set.
+
+When `bwrb new --json` normalizes a filename (for example removing `/`, `?`, or other non-portable characters), the JSON response includes `nameTransformed` with `original`, `sanitized`, and `filename`. Long relative paths over 200 characters include `pathLengthWarning`; paths over 260 characters are rejected.
 
 ```json
 {

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -116,6 +116,12 @@ Template management:
         );
 
         const jsonOutput: Record<string, unknown> = { path: relative(vaultDir, result.path) };
+        if (result.nameTransformed) {
+          jsonOutput.nameTransformed = result.nameTransformed;
+        }
+        if (result.pathLengthWarning) {
+          jsonOutput.pathLengthWarning = result.pathLengthWarning;
+        }
         if (result.instances) {
           jsonOutput.instances = {
             created: result.instances.created.map(p => relative(vaultDir, p)),

--- a/src/commands/new/interactive.ts
+++ b/src/commands/new/interactive.ts
@@ -180,6 +180,7 @@ async function buildInteractiveNoteContent(
       return {
         ...content,
         itemName: patternResult.filename,
+        ...(patternResult.nameTransformed ? { nameTransformed: patternResult.nameTransformed } : {}),
       };
     }
 

--- a/src/commands/new/json-mode.ts
+++ b/src/commands/new/json-mode.ts
@@ -79,7 +79,7 @@ async function buildJsonNoteContent(
   await validateJsonFrontmatter(schema, vaultDir, typePath, typeDef, mergedInput, template);
   const resolvedFrontmatter = applyDefaults(schema, typePath, mergedInput);
 
-  const itemName = resolveJsonItemName(schema, typeDef, resolvedFrontmatter, template);
+  const itemNameResult = resolveJsonItemName(schema, typeDef, resolvedFrontmatter, template);
   const body = generateBodyForJson(typeDef, resolvedFrontmatter, template, bodyInput, schema.config.dateFormat);
   const orderedFields = resolveOrderedFields(typeDef, resolvedFrontmatter);
 
@@ -87,7 +87,8 @@ async function buildJsonNoteContent(
     frontmatter: resolvedFrontmatter,
     body,
     orderedFields,
-    itemName,
+    itemName: itemNameResult.itemName,
+    ...(itemNameResult.nameTransformed ? { nameTransformed: itemNameResult.nameTransformed } : {}),
   };
 }
 
@@ -225,14 +226,17 @@ function resolveJsonItemName(
   typeDef: ResolvedType,
   frontmatter: Record<string, unknown>,
   template?: Template | null
-): string {
+): Pick<PlannedNoteContent, 'itemName' | 'nameTransformed'> {
   const filenamePattern = getFilenamePattern(template ?? null, typeDef);
 
   if (filenamePattern) {
     const patternResult = resolveFilenamePattern(filenamePattern, frontmatter, schema.config.dateFormat);
 
     if (patternResult.resolved && patternResult.filename) {
-      return patternResult.filename;
+      return {
+        itemName: patternResult.filename,
+        ...(patternResult.nameTransformed ? { nameTransformed: patternResult.nameTransformed } : {}),
+      };
     }
 
     const nameField = frontmatter.name;
@@ -245,7 +249,7 @@ function resolveJsonItemName(
         ExitCodes.VALIDATION_ERROR
       );
     }
-    return nameField;
+    return { itemName: nameField };
   }
 
   const nameField = frontmatter.name;
@@ -253,7 +257,7 @@ function resolveJsonItemName(
     throwJsonError(jsonError("Missing or invalid 'name' field"), ExitCodes.VALIDATION_ERROR);
   }
 
-  return nameField;
+  return { itemName: nameField };
 }
 
 function resolveOrderedFields(typeDef: ResolvedType, frontmatter: Record<string, unknown>): string[] {

--- a/src/commands/new/paths.ts
+++ b/src/commands/new/paths.ts
@@ -1,17 +1,22 @@
 import { join } from 'path';
 import { ExitCodes, jsonError } from '../../lib/output.js';
+import { sanitizeFilenameBase, type FilenameTransformation } from '../../lib/filename.js';
 import type { CreationMode } from './types.js';
 import { throwJsonError } from './errors.js';
 
-// eslint-disable-next-line no-control-regex
-const INVALID_ITEM_NAME_CHARS = /[/\\:*?"<>|\x00-\x1F]/g;
-
-function sanitizeItemNameForFilename(name: string): string {
-  return name.replace(INVALID_ITEM_NAME_CHARS, '').trim();
+export interface NotePathResult {
+  path: string;
+  nameTransformed?: FilenameTransformation;
 }
 
-export function buildNotePath(outputDir: string, itemName: string, mode: CreationMode): string {
-  const sanitizedItemName = sanitizeItemNameForFilename(itemName);
+export function buildNotePath(
+  outputDir: string,
+  itemName: string,
+  mode: CreationMode,
+  existingTransformation?: FilenameTransformation
+): NotePathResult {
+  const sanitization = sanitizeFilenameBase(itemName);
+  const sanitizedItemName = sanitization.sanitized;
   if (!sanitizedItemName) {
     if (mode === 'json') {
       throwJsonError(jsonError('Invalid note name (empty after sanitizing)'), ExitCodes.VALIDATION_ERROR);
@@ -19,5 +24,10 @@ export function buildNotePath(outputDir: string, itemName: string, mode: Creatio
     throw new Error('Invalid name (empty after sanitizing)');
   }
 
-  return join(outputDir, `${sanitizedItemName}.md`);
+  const filename = `${sanitizedItemName}.md`;
+  const nameTransformed = existingTransformation ?? sanitization.transformation;
+  return {
+    path: join(outputDir, filename),
+    ...(nameTransformed ? { nameTransformed } : {}),
+  };
 }

--- a/src/commands/new/types.ts
+++ b/src/commands/new/types.ts
@@ -1,5 +1,6 @@
 import type { LoadedSchema, ResolvedType, Template } from '../../types/schema.js';
 import type { OwnerNoteRef } from '../../lib/vault.js';
+import type { FilenameTransformation } from '../../lib/filename.js';
 
 export interface NewCommandOptions {
   open?: boolean;
@@ -23,10 +24,18 @@ export interface PlannedNoteContent {
   body: string;
   orderedFields: string[];
   itemName: string;
+  nameTransformed?: FilenameTransformation;
 }
 
 export interface NoteCreationResult {
   path: string;
+  nameTransformed?: FilenameTransformation;
+  pathLengthWarning?: {
+    path: string;
+    length: number;
+    threshold: number;
+    max: number;
+  };
   instances?: {
     created: string[];
     skipped: string[];

--- a/src/commands/new/write-plan.ts
+++ b/src/commands/new/write-plan.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { join, relative } from 'path';
 import {
   writeNote,
 } from '../../lib/frontmatter.js';
@@ -11,11 +11,15 @@ import {
 import { ensureOwnedOutputDir, formatValue } from '../../lib/vault.js';
 import { getTypeDefByPath } from '../../lib/schema.js';
 import { ExitCodes, jsonError } from '../../lib/output.js';
+import { printWarning } from '../../lib/prompt.js';
 import type { NoteCreationResult, WritePlanArgs, FileExistsStrategy, OwnershipMode, CreationMode } from './types.js';
 import { buildNotePath } from './paths.js';
 import { throwJsonError } from './errors.js';
 import { handleInstanceScaffolding } from './scaffolding.js';
 import type { LoadedSchema } from '../../types/schema.js';
+
+const PORTABLE_PATH_WARNING_LENGTH = 200;
+const PORTABLE_PATH_MAX_LENGTH = 260;
 
 function getOutputDirForType(schema: LoadedSchema, typePath: string): string | undefined {
   const typeDef = getTypeDefByPath(schema, typePath);
@@ -50,7 +54,31 @@ export async function writeNotePlan(
   skipInstances: boolean
 ): Promise<NoteCreationResult> {
   const outputDir = await resolveOutputDir(args.schema, args.vaultDir, args.typePath, args.ownership, args.mode);
-  const filePath = buildNotePath(outputDir, args.content.itemName, args.mode);
+  const pathResult = buildNotePath(outputDir, args.content.itemName, args.mode, args.content.nameTransformed);
+  const filePath = pathResult.path;
+  const relativePath = relative(args.vaultDir, filePath);
+  const pathLengthWarning = getPathLengthWarning(relativePath);
+
+  if (relativePath.length > PORTABLE_PATH_MAX_LENGTH) {
+    const message = `Note path is ${relativePath.length} characters, exceeding the portable limit of ${PORTABLE_PATH_MAX_LENGTH}: ${relativePath}`;
+    if (args.mode === 'json') {
+      throwJsonError(jsonError(message), ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(message);
+  }
+
+  if (args.mode !== 'json') {
+    if (pathResult.nameTransformed) {
+      printWarning(
+        `Warning: Note name was changed for the filename: "${pathResult.nameTransformed.original}" -> "${pathResult.nameTransformed.filename}"`
+      );
+    }
+    if (pathLengthWarning) {
+      printWarning(
+        `Warning: Note path is ${pathLengthWarning.length} characters; paths over ${pathLengthWarning.threshold} may be less portable: ${pathLengthWarning.path}`
+      );
+    }
+  }
 
   if (existsSync(filePath)) {
     await fileExistsStrategy.onExists(filePath, args.vaultDir);
@@ -81,6 +109,12 @@ export async function writeNotePlan(
   }
 
   const result: NoteCreationResult = { path: filePath };
+  if (pathResult.nameTransformed) {
+    result.nameTransformed = pathResult.nameTransformed;
+  }
+  if (pathLengthWarning) {
+    result.pathLengthWarning = pathLengthWarning;
+  }
   if (args.mode === 'json' && scaffoldResult) {
     result.instances = {
       created: scaffoldResult.created,
@@ -94,4 +128,17 @@ export async function writeNotePlan(
   }
 
   return result;
+}
+
+function getPathLengthWarning(relativePath: string): NoteCreationResult['pathLengthWarning'] | undefined {
+  if (relativePath.length <= PORTABLE_PATH_WARNING_LENGTH) {
+    return undefined;
+  }
+
+  return {
+    path: relativePath,
+    length: relativePath.length,
+    threshold: PORTABLE_PATH_WARNING_LENGTH,
+    max: PORTABLE_PATH_MAX_LENGTH,
+  };
 }

--- a/src/lib/filename.ts
+++ b/src/lib/filename.ts
@@ -1,0 +1,37 @@
+/**
+ * Filename safety helpers shared by note creation and filename patterns.
+ */
+
+// eslint-disable-next-line no-control-regex
+const INVALID_FILENAME_CHARS = /[/\\:*?"<>|\x00-\x1F]/g;
+
+export interface FilenameTransformation {
+  original: string;
+  sanitized: string;
+  filename: string;
+}
+
+export interface FilenameSanitizationResult {
+  sanitized: string;
+  transformation?: FilenameTransformation;
+}
+
+export function sanitizeFilenameBase(name: string): FilenameSanitizationResult {
+  const sanitized = name
+    .replace(INVALID_FILENAME_CHARS, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (sanitized === name) {
+    return { sanitized };
+  }
+
+  return {
+    sanitized,
+    transformation: {
+      original: name,
+      sanitized,
+      filename: `${sanitized}.md`,
+    },
+  };
+}

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -9,6 +9,7 @@ import { matchesExpression, parseExpression, type EvalContext } from './expressi
 import { applyDefaults } from './validation.js';
 import { evaluateTemplateDefault, validateDateExpression, isDateExpression } from './date-expression.js';
 import { formatDateWithPattern, DEFAULT_DATE_FORMAT } from './local-date.js';
+import { sanitizeFilenameBase, type FilenameTransformation } from './filename.js';
 import {
   ensureIdInFieldOrder,
   generateUniqueNoteId,
@@ -715,23 +716,6 @@ function formatDate(date: Date, format: string): string {
 // ============================================================================
 
 /**
- * Characters that are invalid in filenames across common filesystems.
- * Includes: / \ : * ? " < > | and control characters (0x00-0x1F)
- */
-// eslint-disable-next-line no-control-regex
-const INVALID_FILENAME_CHARS = /[/\\:*?"<>|\x00-\x1F]/g;
-
-/**
- * Sanitize a string for use as a filename.
- * Removes invalid characters and trims whitespace.
- */
-function sanitizeFilename(name: string): string {
-  return name
-    .replace(INVALID_FILENAME_CHARS, '')
-    .trim();
-}
-
-/**
  * Result of attempting to resolve a filename pattern.
  */
 export interface FilenamePatternResult {
@@ -741,6 +725,8 @@ export interface FilenamePatternResult {
   filename: string | null;
   /** Fields that were referenced but had no value */
   missingFields: string[];
+  /** Filename transformation metadata, if invalid characters or whitespace were normalized */
+  nameTransformed?: FilenameTransformation;
 }
 
 /**
@@ -835,7 +821,8 @@ export function resolveFilenamePattern(
   }
   
   // Sanitize the result for use as a filename
-  const sanitized = sanitizeFilename(result);
+  const sanitization = sanitizeFilenameBase(result);
+  const sanitized = sanitization.sanitized;
   
   // If sanitization resulted in empty string, treat as unresolved
   if (!sanitized) {
@@ -850,6 +837,7 @@ export function resolveFilenamePattern(
     resolved: true,
     filename: sanitized,
     missingFields: [],
+    ...(sanitization.transformation ? { nameTransformed: sanitization.transformation } : {}),
   };
 }
 

--- a/tests/ts/commands/json-io.test.ts
+++ b/tests/ts/commands/json-io.test.ts
@@ -88,6 +88,59 @@ describe('JSON I/O', () => {
       expect(content).toContain('status: raw'); // default value
     });
 
+    it('should report filename transformations and avoid doubled whitespace', async () => {
+      const originalName = 'What if we used / slashes & ampersands?';
+      const result = await runCLI(
+        ['new', 'idea', '--json', JSON.stringify({ name: originalName, status: 'raw' })],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.path).toBe('Ideas/What if we used slashes & ampersands.md');
+      expect(json.nameTransformed).toEqual({
+        original: originalName,
+        sanitized: 'What if we used slashes & ampersands',
+        filename: 'What if we used slashes & ampersands.md',
+      });
+      expect(result.stderr).toBe('');
+      expect(existsSync(join(vaultDir, json.path))).toBe(true);
+    });
+
+    it('should include a path length warning for long portable paths', async () => {
+      const longName = 'L'.repeat(196);
+      const result = await runCLI(
+        ['new', 'idea', '--json', JSON.stringify({ name: longName, status: 'raw' })],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.path.length).toBeGreaterThan(200);
+      expect(json.pathLengthWarning).toEqual({
+        path: json.path,
+        length: json.path.length,
+        threshold: 200,
+        max: 260,
+      });
+      expect(existsSync(join(vaultDir, json.path))).toBe(true);
+    });
+
+    it('should reject paths above the portable path limit', async () => {
+      const tooLongName = 'L'.repeat(252);
+      const result = await runCLI(
+        ['new', 'idea', '--json', JSON.stringify({ name: tooLongName, status: 'raw' })],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('exceeding the portable limit of 260');
+    });
+
     it('should error on unknown type', async () => {
       const result = await runCLI(
         ['new', 'unknown-type', '--json', '{"name": "Test"}'],
@@ -620,6 +673,36 @@ defaults:
       const json = JSON.parse(result.stdout);
       expect(json.success).toBe(true);
       expect(json.path).toBe('Ideas/My Great Idea.md');
+    });
+
+    it('should report filename transformations from filename patterns', async () => {
+      await mkdir(join(vaultDir, '.bwrb/templates/idea'), { recursive: true });
+      await writeFile(
+        join(vaultDir, '.bwrb/templates/idea', 'unsafe-title.md'),
+        `---
+type: template
+template-for: idea
+filename-pattern: "{title}"
+defaults:
+  status: raw
+---
+`
+      );
+
+      const result = await runCLI(
+        ['new', 'idea', '--json', '{"title": "A/B  Test?"}', '--template', 'unsafe-title'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.path).toBe('Ideas/AB Test.md');
+      expect(json.nameTransformed).toEqual({
+        original: 'A/B  Test?',
+        sanitized: 'AB Test',
+        filename: 'AB Test.md',
+      });
     });
 
     it('should use filename from combined pattern', async () => {


### PR DESCRIPTION
## Summary
- normalize generated note filenames by removing invalid filename characters, collapsing whitespace, and trimming
- report `nameTransformed` and `pathLengthWarning` metadata from `bwrb new --json`
- warn in interactive creation and reject relative note paths longer than 260 characters
- document the new JSON metadata in command and automation docs

Fixes #518

## Verification
- pnpm build
- pnpm verify:pack
- pnpm typecheck
- pnpm lint
- pnpm knip
- pnpm test tests/ts/commands/json-io.test.ts tests/ts/lib/template.test.ts
- pnpm test -- --exclude='**/*.pty.test.ts' (ran full suite: 85 files, 1903 passed, 4 skipped)