### PR TITLE
Fix May 21 CLI bug batch

### DIFF
--- a/docs-site/src/content/docs/reference/commands/bulk.md
+++ b/docs-site/src/content/docs/reference/commands/bulk.md
@@ -54,6 +54,12 @@ The target argument is auto-detected as type, path (contains `/`), or where expr
 | `--quiet` | Only show summary |
 | `--output <format>` | Output format: `text`, `json` |
 
+In JSON mode, bulk output reports both discovery stages:
+
+- `candidateFiles`: files selected by type/path/body targeting before `--where`
+- `matchedFiles` / `totalFiles`: files remaining after all filters
+- `filesModified`: files that would change or did change
+
 ## Safety: Two-Gate Model
 
 Bulk operations require **two explicit gates** to prevent accidents:

--- a/docs-site/src/content/docs/reference/commands/delete.md
+++ b/docs-site/src/content/docs/reference/commands/delete.md
@@ -79,9 +79,11 @@ bwrb delete "My Note" --force
 # Scripting mode
 bwrb delete "My Note" --output json --force
 
-# Preview delete without removing
-bwrb delete "My Note" --dry-run
+# Preview delete without removing (no --force needed)
+bwrb delete "My Note" --dry-run --output json
 ```
+
+When a note is actually deleted, bwrb also removes the matching path from `.bwrb/ids.jsonl`.
 
 ### Bulk Mode
 

--- a/docs-site/src/content/docs/reference/commands/edit.md
+++ b/docs-site/src/content/docs/reference/commands/edit.md
@@ -51,6 +51,8 @@ bwrb edit "My Task" --json '{"status":"settled"}'
 bwrb edit -t task --where "status == 'active'" "Deploy" --json '{"priority":"high"}'
 ```
 
+`--json` mode rejects patch fields that are not defined for the resolved note type. Existing legacy or unknown fields in the note are preserved unless the patch changes them.
+
 ### Edit and Open
 
 ```bash
@@ -70,13 +72,13 @@ Edit supports all four targeting selectors. See [Targeting Model](/reference/tar
 bwrb edit -t task -p "Work/**" -w "status == 'active'" "Deploy"
 ```
 
-## Exact-name resolution
+## Query Resolution
 
-When you pass an exact note name and omit `--type`, `edit` searches across all types/paths:
+When you pass a note query and omit `--type`, `edit` uses the same name/path matching behavior as `search`:
 
 - **1 match:** edit proceeds
-- **0 matches:** error with suggestions (try `--type <type>` or `bwrb search --output paths`)
-- **>1 match:** error listing candidates; disambiguate with `--type`, `--path`, or a vault-relative path
+- **0 matches:** error
+- **>1 match with `--picker none` or JSON mode:** error listing candidates; disambiguate with `--type`, `--path`, or a vault-relative path
 
 ## Picker Modes
 

--- a/docs-site/src/content/docs/reference/commands/new.md
+++ b/docs-site/src/content/docs/reference/commands/new.md
@@ -110,6 +110,8 @@ bwrb new task --json '{"name": "Fix bug", "_body": {"Steps": ["Step 1", "Step 2"
 bwrb new project --json '{"name": "My Project"}' --template with-research
 ```
 
+`--json` mode validates the merged frontmatter before writing. Unknown fields in the JSON input or selected template defaults are rejected unless they are built-in bwrb fields such as `name`.
+
 The `_body` field accepts section names as keys, with string or string array values.
 
 If the note name or resolved filename pattern contains characters that are not portable in filenames, `bwrb new` normalizes the filename by removing invalid characters, collapsing doubled whitespace, and trimming the result. Interactive creation prints a warning. JSON mode includes `nameTransformed` metadata:

--- a/docs-site/src/content/docs/reference/commands/schema.md
+++ b/docs-site/src/content/docs/reference/commands/schema.md
@@ -103,6 +103,8 @@ bwrb schema list -t objective/milestone
 
 # JSON output for scripting
 bwrb schema list --output json
+bwrb schema list types --output json
+bwrb schema list fields --output json
 bwrb schema list type task --output json
 bwrb schema list -t task --output json
 ```

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -204,6 +204,7 @@ bwrb edit --type task --where "status == 'active'" "Deploy" --json '{"status": "
 
 Notes:
 - If multiple notes share the same name, `bwrb edit` errors and lists candidates. Disambiguate with `--type`, `--path`, or a vault-relative path.
+- `bwrb new --json` rejects unknown frontmatter fields after merging template defaults. `bwrb edit --json` rejects unknown fields in the patch.
 
 ### Deleting Notes
 
@@ -219,6 +220,9 @@ bwrb delete --type task
 
 # Explicit dry-run preview
 bwrb delete --type task --dry-run
+
+# Single-file JSON dry-run does not need --force
+bwrb delete "Note Name" --dry-run --output json
 
 # Bulk delete with confirmation (skip with --force)
 bwrb delete --type task --execute --force

--- a/src/commands/bulk.ts
+++ b/src/commands/bulk.ts
@@ -529,6 +529,8 @@ function outputJsonResult(result: BulkResult): void {
   const jsonOutput = {
     success: result.errors.length === 0,
     dryRun: result.dryRun,
+    candidateFiles: result.candidateFiles,
+    matchedFiles: result.matchedFiles,
     totalFiles: result.totalFiles,
     filesModified: result.affectedFiles,
     ...(result.backupPath && { backupPath: result.backupPath }),

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -40,6 +40,7 @@ import {
   hasAnyTargeting,
   type TargetingOptions,
 } from '../lib/targeting.js';
+import { unregisterIssuedNotePath } from '../lib/note-id.js';
 
 // ============================================================================
 // Types
@@ -317,7 +318,7 @@ async function handleSingleDelete(
   const effectivePickerMode: PickerMode = jsonMode ? 'none' : pickerMode;
 
   // JSON mode requires --force (no interactive confirmation)
-  if (jsonMode && !options.force) {
+  if (jsonMode && !options.force && !options.dryRun) {
     printJson(jsonError('JSON mode requires --force flag (no interactive confirmation)', {
       code: ExitCodes.VALIDATION_ERROR,
     }));
@@ -394,7 +395,9 @@ async function handleScopedDelete(
 ): Promise<void> {
   const effectivePickerMode: PickerMode = jsonMode ? 'none' : pickerMode;
 
-  if (jsonMode && !options.force) {
+  const isDryRun = !!options.dryRun || !options.execute;
+
+  if (jsonMode && !options.force && !isDryRun) {
     printJson(jsonError('JSON mode requires --force flag (no interactive confirmation)', {
       code: ExitCodes.VALIDATION_ERROR,
     }));
@@ -486,8 +489,6 @@ async function handleScopedDelete(
     process.exitCode = ExitCodes.VALIDATION_ERROR;
     return;
   }
-
-  const isDryRun = !!options.dryRun || !options.execute;
 
   await deleteResolvedFile({
     file: resolution.file,
@@ -643,6 +644,7 @@ async function handleBulkDelete(
   for (const file of files) {
     try {
       await unlink(file.path);
+      await unregisterIssuedNotePath(vaultDir, file.relativePath);
       deleted.push(file.relativePath);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -802,6 +804,7 @@ async function deleteResolvedFile({
 
   // Delete the file
   await unlink(fullPath);
+  await unregisterIssuedNotePath(vaultDir, relativePath);
 
   // Success output
   if (jsonMode) {

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -57,36 +57,6 @@ function printEditSuccess(path: string, updatedFields: string[], jsonMode: boole
   printSuccess(`Updated: ${path}${updatedText}`);
 }
 
-function findExactNameMatches(index: { byPath: Map<string, ManagedFile>; byBasename: Map<string, ManagedFile[]> }, query: string): ManagedFile[] {
-  const cleanQuery = query.replace(/\.md$/, '');
-  const directPath = index.byPath.get(query) ?? index.byPath.get(`${cleanQuery}.md`);
-  if (directPath) {
-    return [directPath];
-  }
-
-  const exactBasename = index.byBasename.get(cleanQuery);
-  if (exactBasename && exactBasename.length > 0) {
-    return exactBasename;
-  }
-
-  const lowerQuery = cleanQuery.toLowerCase();
-  const matches: ManagedFile[] = [];
-  const seen = new Set<string>();
-
-  for (const [name, files] of index.byBasename.entries()) {
-    if (name.toLowerCase() === lowerQuery) {
-      for (const file of files) {
-        if (!seen.has(file.relativePath)) {
-          matches.push(file);
-          seen.add(file.relativePath);
-        }
-      }
-    }
-  }
-
-  return matches;
-}
-
 // ============================================================================
 // Command Definition
 // ============================================================================
@@ -253,33 +223,12 @@ Examples:
         filteredIndex.byBasename.set(fileBasename, existing);
       }
 
-      let result: Awaited<ReturnType<typeof resolveAndPick>>;
-      if (query && !options.type) {
-        const exactMatches = findExactNameMatches(filteredIndex, query);
-        if (exactMatches.length === 1) {
-          result = { ok: true, file: exactMatches[0]! };
-        } else if (exactMatches.length === 0) {
-          const error =
-            `No matching notes found for: ${query}\n` +
-            'Try:\n' +
-            `  bwrb edit --type <type> "${query}"\n` +
-            `  bwrb search "${query}" --output paths`;
-          exitWithResolutionError(error, undefined, jsonMode);
-        } else {
-          const error =
-            `Multiple notes named "${query}" found. ` +
-            'Use --type <type> or --path <glob> (or pass a full vault-relative path) to disambiguate.';
-          exitWithResolutionError(error, exactMatches, jsonMode);
-        }
-      } else {
-        // Resolve to a single file
-        result = await resolveAndPick(filteredIndex, query, {
-          pickerMode: effectivePickerMode,
-          prompt: 'Select note to edit',
-          preview: false,
-          vaultDir,
-        });
-      }
+      const result = await resolveAndPick(filteredIndex, query, {
+        pickerMode: effectivePickerMode,
+        prompt: 'Select note to edit',
+        preview: false,
+        vaultDir,
+      });
 
       if (!result.ok) {
         if (result.cancelled) {

--- a/src/commands/new/json-mode.ts
+++ b/src/commands/new/json-mode.ts
@@ -156,7 +156,7 @@ async function validateJsonFrontmatter(
   mergedInput: Record<string, unknown>,
   template?: Template | null
 ): Promise<void> {
-  const validation = validateFrontmatter(schema, typePath, mergedInput);
+  const validation = validateFrontmatter(schema, typePath, mergedInput, { strictFields: true });
   if (!validation.valid) {
     throwJsonError({
       success: false,

--- a/src/commands/schema/list.ts
+++ b/src/commands/schema/list.ts
@@ -140,12 +140,12 @@ listCommand
   .addOption(new Option('-t, --type <typePath>').hideHelp())
   .option('--output <format>', 'Output format: text (default) or json')
   .action(async (options: ListCommandOptions, cmd: Command) => {
-    const jsonMode = options.output === 'json';
+    const globalOpts = getGlobalOpts(cmd);
+    const jsonMode = options.output === 'json' || globalOpts.output === 'json';
 
     try {
       ensureNoTypeAliasConflict(cmd, 'bwrb schema list types');
 
-      const globalOpts = getGlobalOpts(cmd);
       const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
@@ -193,12 +193,12 @@ listCommand
   .addOption(new Option('-t, --type <typePath>').hideHelp())
   .option('--output <format>', 'Output format: text (default) or json')
   .action(async (options: ListCommandOptions, cmd: Command) => {
-    const jsonMode = options.output === 'json';
+    const globalOpts = getGlobalOpts(cmd);
+    const jsonMode = options.output === 'json' || globalOpts.output === 'json';
 
     try {
       ensureNoTypeAliasConflict(cmd, 'bwrb schema list fields');
 
-      const globalOpts = getGlobalOpts(cmd);
       const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -217,7 +217,6 @@ Examples:
   # Content search
   bwrb search "deploy" --body              # Search all notes for "deploy"
   bwrb search "deploy" -b -t task          # Search only in tasks
-  bwrb search "TODO" -b --status!=done     # Simple filter syntax
   bwrb search "TODO" -b --where "status != 'done'"  # Expression filter
   bwrb search "error.*log" -b --regex      # Regex search
   bwrb search "deploy" -b --output json    # JSON output with matches
@@ -225,6 +224,7 @@ Examples:
   
   # Piping
   bwrb search "bug" -t --output paths | xargs -I {} code {}`)
+  .allowExcessArguments(false)
   .action(async (query: string | undefined, options: SearchOptions, cmd: Command) => {
     // Resolve output format from deprecated flags and new --output option
     const outputFormat = resolveSearchOutputFormat(options);

--- a/src/lib/bulk/execute.ts
+++ b/src/lib/bulk/execute.ts
@@ -43,6 +43,8 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
 
   const result: BulkResult = {
     dryRun: !execute,
+    candidateFiles: 0,
+    matchedFiles: 0,
     totalFiles: 0,
     affectedFiles: 0,
     changes: [],
@@ -89,6 +91,7 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
     files = files.filter(file => textMatchingPaths!.has(file.path));
   }
 
+  result.candidateFiles = files.length;
   result.totalFiles = files.length;
 
   const parsedFiles: {
@@ -126,6 +129,8 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
     }
     filteredFiles = whereResult.files;
   }
+  result.matchedFiles = filteredFiles.length;
+  result.totalFiles = filteredFiles.length;
 
   // Filter and collect changes
   const filesToModify: typeof parsedFiles = [];
@@ -218,6 +223,8 @@ async function executeBulkWithMove(
 
   const result: BulkResult = {
     dryRun: !execute,
+    candidateFiles: 0,
+    matchedFiles: 0,
     totalFiles: 0,
     affectedFiles: 0,
     changes: [],
@@ -261,6 +268,7 @@ async function executeBulkWithMove(
     files = files.filter(file => textMatchingPaths!.has(file.path));
   }
 
+  result.candidateFiles = files.length;
   result.totalFiles = files.length;
 
   const parsedFiles: {
@@ -296,6 +304,8 @@ async function executeBulkWithMove(
     }
     filteredFiles = whereResult.files;
   }
+  result.matchedFiles = filteredFiles.length;
+  result.totalFiles = filteredFiles.length;
 
   const filesToMove = filteredFiles.map(file => file.path);
 

--- a/src/lib/bulk/types.ts
+++ b/src/lib/bulk/types.ts
@@ -47,6 +47,8 @@ export interface FileChange {
  */
 export interface BulkResult {
   dryRun: boolean;
+  candidateFiles: number;
+  matchedFiles: number;
   totalFiles: number;
   affectedFiles: number;
   changes: FileChange[];

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -179,6 +179,25 @@ export async function editNoteFromJson(
     throw new Error(error);
   }
 
+  const patchValidation = validateFrontmatter(schema, typePath, patchData, { strictFields: true });
+  const unknownPatchErrors = patchValidation.errors.filter(error => error.type === 'unknown_field');
+  if (unknownPatchErrors.length > 0) {
+    if (jsonMode) {
+      printJson({
+        success: false,
+        error: 'Validation failed',
+        errors: unknownPatchErrors.map(e => ({
+          field: e.field,
+          message: e.message,
+          ...(e.value !== undefined && { value: e.value }),
+          ...(e.suggestion !== undefined && { suggestion: e.suggestion }),
+        })),
+      });
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(`Validation failed: ${unknownPatchErrors.map(e => e.message).join(', ')}`);
+  }
+
   // Merge patch data into existing frontmatter
   const mergedFrontmatter = mergeFrontmatter(frontmatter, patchData);
   const updatedFields = Object.keys(patchData).filter(k => patchData[k] !== undefined);

--- a/src/lib/expression.ts
+++ b/src/lib/expression.ts
@@ -155,12 +155,16 @@ function evaluateBinary(expr: BinaryExpression, context: EvalContext): unknown {
     case '=~':
       return matchesRegex(left, right);
     case '<':
+      if (isEmptyComparisonOperand(left) || isEmptyComparisonOperand(right)) return false;
       return compareValues(left, right) < 0;
     case '>':
+      if (isEmptyComparisonOperand(left) || isEmptyComparisonOperand(right)) return false;
       return compareValues(left, right) > 0;
     case '<=':
+      if (isEmptyComparisonOperand(left) || isEmptyComparisonOperand(right)) return false;
       return compareValues(left, right) <= 0;
     case '>=':
+      if (isEmptyComparisonOperand(left) || isEmptyComparisonOperand(right)) return false;
       return compareValues(left, right) >= 0;
     case '&&':
       return Boolean(left) && Boolean(right);
@@ -447,6 +451,13 @@ function compareValues(a: unknown, b: unknown): number {
 
   // Regular string comparison
   return strA.localeCompare(strB);
+}
+
+function isEmptyComparisonOperand(value: unknown): boolean {
+  return value === null ||
+    value === undefined ||
+    value === '' ||
+    (Array.isArray(value) && value.length === 0);
 }
 
 function matchesRegex(value: unknown, pattern: unknown): boolean {

--- a/src/lib/note-id.ts
+++ b/src/lib/note-id.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { appendFile, mkdir, readFile } from 'fs/promises';
+import { appendFile, mkdir, readFile, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { dirname, join, relative } from 'path';
 
@@ -75,6 +75,34 @@ export async function registerIssuedNoteId(
   };
 
   await appendFile(registryPath, `${JSON.stringify(entry)}\n`, 'utf-8');
+}
+
+export async function unregisterIssuedNotePath(
+  vaultDir: string,
+  relativePath: string
+): Promise<void> {
+  const registryPath = getIdRegistryPath(vaultDir);
+  if (!existsSync(registryPath)) return;
+
+  const content = await readFile(registryPath, 'utf-8');
+  const retained: string[] = [];
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    try {
+      const parsed = JSON.parse(trimmed) as Partial<IdRegistryEntry>;
+      if (parsed.path === relativePath) continue;
+    } catch {
+      // Keep legacy/plain lines because they cannot be matched to a path.
+    }
+
+    retained.push(line);
+  }
+
+  const nextContent = retained.length > 0 ? `${retained.join('\n')}\n` : '';
+  await writeFile(registryPath, nextContent, 'utf-8');
 }
 
 export function ensureIdInFieldOrder(order: string[]): string[] {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -532,6 +532,14 @@ export function resolveTypeFromFrontmatter(
   
   // Check if the type exists in the schema
   if (schema.types.has(typeName)) {
+    const legacySubtype = frontmatter[`${typeName}-type`];
+    if (typeof legacySubtype === 'string') {
+      const subtype = schema.types.get(legacySubtype);
+      if (subtype?.parent === typeName) {
+        return legacySubtype;
+      }
+    }
+
     return typeName;
   }
   

--- a/tests/ts/commands/bulk.test.ts
+++ b/tests/ts/commands/bulk.test.ts
@@ -948,6 +948,24 @@ creation-date: 2024-01-15
       expect(json.data.filesModified).toBeGreaterThan(0);
     });
 
+    it('should distinguish candidate and matched files in JSON output', async () => {
+      const result = await runCLI([
+        'bulk',
+        '--type', 'idea',
+        '--where', "status == 'raw'",
+        '--set', 'status=settled',
+        '--output', 'json',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.candidateFiles).toBe(2);
+      expect(json.data.matchedFiles).toBe(1);
+      expect(json.data.totalFiles).toBe(1);
+      expect(json.data.filesModified).toBe(1);
+    });
+
     it('should show minimal output with --quiet', async () => {
       const result = await runCLI(['bulk', 'idea', '--all', '--set', 'status=settled', '--quiet'], vaultDir);
       

--- a/tests/ts/commands/delete.test.ts
+++ b/tests/ts/commands/delete.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { existsSync } from 'fs';
-import { writeFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join } from 'path';
 import { createTestVault, cleanupTestVault, runCLI, waitForFile } from '../fixtures/setup.js';
 
@@ -133,6 +133,18 @@ describe('delete command', () => {
       expect(json.error).toContain('--force');
     });
 
+    it('should not require --force for single-file JSON dry-runs', async () => {
+      const filePath = join(vaultDir, 'Ideas', 'Sample Idea.md');
+
+      const result = await runCLI(['delete', 'Sample Idea', '--dry-run', '--output', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.dryRun).toBe(true);
+      expect(existsSync(filePath)).toBe(true);
+    });
+
     it('should output JSON on success', async () => {
       const filePath = join(vaultDir, 'Ideas', 'Sample Idea.md');
       expect(existsSync(filePath)).toBe(true);
@@ -145,6 +157,22 @@ describe('delete command', () => {
       expect(json.path).toBe('Ideas/Sample Idea.md');
       expect(json.message).toContain('deleted');
       expect(existsSync(filePath)).toBe(false);
+    });
+
+    it('should remove deleted note paths from the id registry', async () => {
+      const createResult = await runCLI(
+        ['new', 'task', '--json', '{"name":"Registry Delete Smoke","status":"backlog"}'],
+        vaultDir
+      );
+      expect(createResult.exitCode).toBe(0);
+      const created = JSON.parse(createResult.stdout) as { path: string };
+
+      const registryPath = join(vaultDir, '.bwrb', 'ids.jsonl');
+      expect(await readFile(registryPath, 'utf-8')).toContain(created.path);
+
+      const deleteResult = await runCLI(['delete', created.path, '--force', '--output', 'json'], vaultDir);
+      expect(deleteResult.exitCode).toBe(0);
+      expect(await readFile(registryPath, 'utf-8')).not.toContain(created.path);
     });
 
     it('should output JSON error on no match', async () => {

--- a/tests/ts/commands/edit.test.ts
+++ b/tests/ts/commands/edit.test.ts
@@ -46,6 +46,19 @@ describe('edit command', () => {
       expect(content).toContain('status: backlog');
     });
 
+    it('should reject unknown JSON frontmatter fields', async () => {
+      const result = await runCLI(
+        ['edit', 'Ideas/Sample Idea.md', '--json', '{"totally-extra":"yep"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toBe('Validation failed');
+      expect(json.errors[0].field).toBe('totally-extra');
+    });
+
     it('should detect type from frontmatter type field', async () => {
       const result = await runCLI(
         ['edit', 'Ideas/Sample Idea.md', '--json', '{"status": "backlog"}'],
@@ -845,14 +858,13 @@ describe('edit command --open flag', () => {
       expect(result.exitCode).toBe(1);
       const json = JSON.parse(result.stdout);
       expect(json.success).toBe(false);
-      expect(json.error).toMatch(/multiple notes named/i);
-      expect(json.error).toMatch(/--type/);
+      expect(json.error).toMatch(/ambiguous query/i);
       const candidatePaths = json.errors?.map((e: { value: string }) => e.value) ?? [];
       expect(candidatePaths).toContain('Ideas/Sample Idea.md');
       expect(candidatePaths).toContain('Objectives/Tasks/Sample Idea.md');
     });
 
-    it('should include suggestions when no exact match', async () => {
+    it('should return no-match errors when search-like resolution finds no candidates', async () => {
       const result = await runCLI(
         ['edit', 'Missing Note Name', '--json', '{"status":"done"}'],
         vaultDir
@@ -861,9 +873,7 @@ describe('edit command --open flag', () => {
       expect(result.exitCode).toBe(1);
       const json = JSON.parse(result.stdout);
       expect(json.success).toBe(false);
-      expect(json.error).toMatch(/try:/i);
-      expect(json.error).toMatch(/--type <type>/i);
-      expect(json.error).toMatch(/bwrb search .*--output paths/i);
+      expect(json.error).toMatch(/no matching notes found/i);
     });
 
     it('should error with unknown type filter', async () => {

--- a/tests/ts/commands/json-io.test.ts
+++ b/tests/ts/commands/json-io.test.ts
@@ -15,6 +15,14 @@ describe('JSON I/O', () => {
     await cleanupTestVault(vaultDir);
   });
 
+  async function addIdeaTitleField(): Promise<void> {
+    const schemaPath = join(vaultDir, '.bwrb', 'schema.json');
+    const schema = JSON.parse(await readFile(schemaPath, 'utf-8'));
+    schema.types.idea.fields.title = { prompt: 'text' };
+    schema.types.idea.field_order = [...schema.types.idea.field_order, 'title'];
+    await writeFile(schemaPath, JSON.stringify(schema, null, 2), 'utf-8');
+  }
+
   describe('bwrb new --json', () => {
     it('should create a note with JSON frontmatter', async () => {
       const result = await runCLI(
@@ -650,6 +658,8 @@ defaults:
     });
 
     it('should use filename from pattern with frontmatter field', async () => {
+      await addIdeaTitleField();
+
       // Create template with filename pattern referencing a field
       await mkdir(join(vaultDir, '.bwrb/templates/idea'), { recursive: true });
       await writeFile(
@@ -676,6 +686,8 @@ defaults:
     });
 
     it('should report filename transformations from filename patterns', async () => {
+      await addIdeaTitleField();
+
       await mkdir(join(vaultDir, '.bwrb/templates/idea'), { recursive: true });
       await writeFile(
         join(vaultDir, '.bwrb/templates/idea', 'unsafe-title.md'),
@@ -706,6 +718,8 @@ defaults:
     });
 
     it('should use filename from combined pattern', async () => {
+      await addIdeaTitleField();
+
       // Create template with combined filename pattern
       await mkdir(join(vaultDir, '.bwrb/templates/idea'), { recursive: true });
       await writeFile(

--- a/tests/ts/commands/new.test.ts
+++ b/tests/ts/commands/new.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { readFile } from 'fs/promises';
+import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { createTestVault, cleanupTestVault, runCLI, waitForFile } from '../fixtures/setup.js';
 import { formatLocalDate } from '../../../src/lib/local-date.js';
@@ -149,6 +149,45 @@ describe('new command', () => {
       const id = extractIdFromFrontmatter(content);
       const registryIds = await readRegistryIds(vaultDir);
       expect(registryIds.has(id)).toBe(true);
+    });
+
+    it('should reject unknown JSON frontmatter fields', async () => {
+      const result = await runCLI(
+        ['new', 'task', '--json', '{"name":"Extra Field","status":"backlog","totally-extra":"yep"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(ExitCodes.VALIDATION_ERROR);
+      const output = JSON.parse(result.stdout);
+      expect(output.success).toBe(false);
+      expect(output.error).toBe('Validation failed');
+      expect(output.errors[0].field).toBe('totally-extra');
+    });
+
+    it('should reject templates whose defaults are invalid for the target type', async () => {
+      await writeFile(
+        join(vaultDir, '.bwrb', 'templates', 'task', 'invalid-default.md'),
+        `---
+type: template
+template-for: task
+description: Invalid default
+defaults:
+  totally-extra: yep
+---
+`,
+        'utf-8'
+      );
+
+      const result = await runCLI(
+        ['new', 'task', '--template', 'invalid-default', '--json', '{"name":"Invalid Template"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(ExitCodes.VALIDATION_ERROR);
+      const output = JSON.parse(result.stdout);
+      expect(output.success).toBe(false);
+      expect(output.error).toBe('Validation failed');
+      expect(output.errors[0].field).toBe('totally-extra');
     });
 
     it('should ignore slashes in JSON name when creating filename', async () => {

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -1048,6 +1048,24 @@ milestone: "[[Active Milestone]]"
       expect(result.stdout).toContain('idea');
     });
 
+    it('should output JSON for "schema list types --output json"', async () => {
+      const result = await runCLI(['schema', 'list', 'types', '--output', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.types).toContain('idea');
+    });
+
+    it('should output JSON for "schema list fields --output json"', async () => {
+      const result = await runCLI(['schema', 'list', 'fields', '--output', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.fields.some((field: { field: string }) => field.field === 'status')).toBe(true);
+    });
+
     it('should output JSON when --output json is specified', async () => {
       const result = await runCLI(['schema', 'list', '--output', 'json'], vaultDir);
 
@@ -1564,8 +1582,6 @@ milestone: "[[Active Milestone]]"
     });
 
     it('should pass --vault to schema list fields (3 levels deep)', async () => {
-      // Note: --output json has a pre-existing bug in schema list fields (not related to #134)
-      // so we test text output mode instead
       const result = await runCLI(['schema', 'list', 'fields'], vaultDir);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Fields:');

--- a/tests/ts/commands/search.test.ts
+++ b/tests/ts/commands/search.test.ts
@@ -356,6 +356,23 @@ Some content
       expect(result.stdout).toContain('--preview');
       expect(result.stdout).toContain('fzf picker');
     });
+
+    it('should not advertise unsupported simple filter options', async () => {
+      const result = await runCLI(['search', '--help'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain('--status!=done');
+      expect(result.stdout).toContain('--where "status !=');
+    });
+  });
+
+  describe('argument validation', () => {
+    it('should reject extra positional arguments', async () => {
+      const result = await runCLI(['search', 'TODO', '--body', 'status!=done', '--output', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/too many arguments/i);
+    });
   });
 
   describe('--preview flag', () => {

--- a/tests/ts/lib/expression.test.ts
+++ b/tests/ts/lib/expression.test.ts
@@ -74,6 +74,14 @@ describe('expression', () => {
       expect(matchesExpression("priority >= 2", ctx)).toBe(true);
       expect(matchesExpression("priority < 2", ctx)).toBe(false);
     });
+
+    it('should not match relational comparisons when a field is missing', () => {
+      const ctx = makeContext({});
+      expect(matchesExpression("deadline < today() + '7d'", ctx)).toBe(false);
+      expect(matchesExpression("deadline <= today() + '7d'", ctx)).toBe(false);
+      expect(matchesExpression("deadline > today() + '7d'", ctx)).toBe(false);
+      expect(matchesExpression("deadline >= today() + '7d'", ctx)).toBe(false);
+    });
   });
 
   describe('evaluateExpression - boolean logic', () => {


### PR DESCRIPTION
## Summary
- tighten new/edit JSON validation so unknown fields and invalid template defaults cannot create invalid notes
- fix delete dry-run/registry behavior, schema JSON subcommands, search arg handling, edit partial matching, bulk JSON counts, and missing-field comparisons
- update command docs and the bwrb agent skill for the changed automation contracts

## Issues
Closes #571
Closes #572
Closes #573
Closes #574
Closes #575
Closes #576
Closes #577
Closes #578
Closes #579

## Verification
- built CLI scratch-vault verification for #571-#579
- pnpm build
- pnpm verify:pack
- pnpm typecheck
- pnpm lint
- pnpm knip
- pnpm test -- --exclude='**/*.pty.test.ts' (ran full suite; 85 files, 1914 passed, 4 skipped)