### PR TITLE
Add schema discovery aliases

### DIFF
--- a/docs-site/src/content/docs/reference/commands/schema.md
+++ b/docs-site/src/content/docs/reference/commands/schema.md
@@ -15,6 +15,8 @@ bwrb schema <subcommand>
 
 | Subcommand | Description |
 |------------|-------------|
+| [types](#types-alias) | Alias for `schema list` |
+| [fields](#fields-alias) | Alias for `schema list <typePath>` |
 | [list](#list) | List schema contents |
 | [validate](#validate) | Validate schema structure |
 | [diff](#diff) | Show pending schema changes |
@@ -26,9 +28,11 @@ bwrb schema <subcommand>
 ```bash
 # List all types
 bwrb schema list
+bwrb schema types
 
 # Show specific type details
 bwrb schema list type task
+bwrb schema fields task
 
 # Validate schema structure
 bwrb schema validate
@@ -107,6 +111,59 @@ bwrb schema list types --output json
 bwrb schema list fields --output json
 bwrb schema list type task --output json
 bwrb schema list -t task --output json
+```
+
+---
+
+## types alias
+
+`schema types` is a discovery-friendly alias for `schema list`.
+
+### Synopsis
+
+```bash
+bwrb schema types [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--output <format>` | Output format: `text`, `json` |
+| `--verbose` | Show all types with fields inline |
+
+### Examples
+
+```bash
+bwrb schema types
+bwrb schema types --verbose
+bwrb schema types --output json
+```
+
+---
+
+## fields alias
+
+`schema fields <typePath>` is a discovery-friendly alias for `schema list <typePath>`.
+Use `schema list fields` when you want the all-fields overview across every type.
+
+### Synopsis
+
+```bash
+bwrb schema fields <typePath> [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--output <format>` | Output format: `text`, `json` |
+
+### Examples
+
+```bash
+bwrb schema fields task
+bwrb schema fields objective/milestone --output json
 ```
 
 ---

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -57,15 +57,19 @@ Before creating or querying notes, understand the vault's schema:
 ```bash
 # List all types and their structure
 bwrb schema list
+bwrb schema types
 
 # Show all types with fields inline (full overview)
 bwrb schema list --verbose
+bwrb schema types --verbose
 
 # Show specific type definition with fields
 bwrb schema list type task
+bwrb schema fields task
 
 # Get JSON output for parsing
 bwrb schema list type task --output json
+bwrb schema fields task --output json
 bwrb schema list --verbose --output json  # All types with fields as JSON
 ```
 

--- a/src/commands/schema/index.ts
+++ b/src/commands/schema/index.ts
@@ -12,7 +12,7 @@ import { getGlobalOpts } from '../../lib/command.js';
 import { UserCancelledError } from '../../lib/errors.js';
 
 // Subcommand modules
-import { listCommand } from './list.js';
+import { listCommand, runSchemaListOverview, runSchemaListTypeDetails } from './list.js';
 import { registerNewTypeCommand, registerEditTypeCommand, registerDeleteTypeCommand } from './type.js';
 import { registerNewFieldCommand, registerEditFieldCommand, registerDeleteFieldCommand } from './field.js';
 import { registerMigrationCommands } from './migrate.js';
@@ -28,10 +28,80 @@ export const schemaCommand = new Command('schema')
   .addHelpText('after', `
 Examples:
   bwrb schema list              # List all types
+  bwrb schema types             # Alias for schema list
+  bwrb schema fields task       # Alias for schema list task
   bwrb schema list type objective  # Show objective type details (canonical)
   bwrb schema list objective/task  # Alias for schema list type objective/task
   bwrb schema list -t task --output json  # Type details as JSON for AI/scripting
   bwrb schema validate          # Validate schema structure`);
+
+interface SchemaTypesAliasOptions {
+  output?: string;
+  verbose?: boolean;
+}
+
+interface SchemaFieldsAliasOptions {
+  output?: string;
+}
+
+schemaCommand
+  .command('types')
+  .description('Alias for "schema list"')
+  .option('--output <format>', 'Output format: text (default) or json')
+  .option('--verbose', 'Show all types with their fields inline')
+  .action(async (options: SchemaTypesAliasOptions, cmd: Command) => {
+    const globalOpts = getGlobalOpts(cmd);
+    const jsonMode = options.output === 'json' || globalOpts.output === 'json';
+
+    try {
+      await runSchemaListOverview(options, cmd);
+    } catch (err) {
+      if (err instanceof UserCancelledError) {
+        if (jsonMode) {
+          printJson(jsonError('Cancelled', { code: ExitCodes.VALIDATION_ERROR }));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        console.log('Cancelled.');
+        process.exit(1);
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      if (jsonMode) {
+        printJson(jsonError(message));
+        process.exit(ExitCodes.SCHEMA_ERROR);
+      }
+      printError(message);
+      process.exit(1);
+    }
+  });
+
+schemaCommand
+  .command('fields <typePath>')
+  .description('Alias for "schema list <typePath>"')
+  .option('--output <format>', 'Output format: text (default) or json')
+  .action(async (typePath: string, options: SchemaFieldsAliasOptions, cmd: Command) => {
+    const globalOpts = getGlobalOpts(cmd);
+    const jsonMode = options.output === 'json' || globalOpts.output === 'json';
+
+    try {
+      await runSchemaListTypeDetails(typePath, options, cmd);
+    } catch (err) {
+      if (err instanceof UserCancelledError) {
+        if (jsonMode) {
+          printJson(jsonError('Cancelled', { code: ExitCodes.VALIDATION_ERROR }));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        console.log('Cancelled.');
+        process.exit(1);
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      if (jsonMode) {
+        printJson(jsonError(message));
+        process.exit(ExitCodes.SCHEMA_ERROR);
+      }
+      printError(message);
+      process.exit(1);
+    }
+  });
 
 // ============================================================================
 // Validate Command

--- a/src/commands/schema/list.ts
+++ b/src/commands/schema/list.ts
@@ -31,6 +31,15 @@ interface ListCommandOptions {
   type?: string;
 }
 
+export interface SchemaListOverviewOptions {
+  output?: string;
+  verbose?: boolean;
+}
+
+export interface SchemaListTypeOptions {
+  output?: string;
+}
+
 function getReservedListNouns(): Set<string> {
   return new Set(listCommand.commands.map((command) => command.name()));
 }
@@ -43,6 +52,51 @@ function ensureNoTypeAliasConflict(cmd: Command, usage: string): void {
     `Cannot use --type with '${usage}'. ` +
     `Use either '${usage}' or 'bwrb schema list --type <typePath>'.`
   );
+}
+
+export async function runSchemaListOverview(
+  options: SchemaListOverviewOptions,
+  cmd: Command
+): Promise<void> {
+  const globalOpts = getGlobalOpts(cmd);
+  const jsonMode = options.output === 'json' || globalOpts.output === 'json';
+  const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
+  if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
+  const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
+  const schema = await loadCurrentSchema(vaultDir);
+  await warnIfPendingMigration(vaultDir, schema, jsonMode);
+
+  if (jsonMode) {
+    if (options.verbose) {
+      outputSchemaVerboseJson(schema);
+    } else {
+      outputSchemaJson(schema);
+    }
+  } else if (options.verbose) {
+    showSchemaTreeVerbose(schema);
+  } else {
+    showSchemaTree(schema);
+  }
+}
+
+export async function runSchemaListTypeDetails(
+  typePath: string,
+  options: SchemaListTypeOptions,
+  cmd: Command
+): Promise<void> {
+  const globalOpts = getGlobalOpts(cmd);
+  const jsonMode = options.output === 'json' || globalOpts.output === 'json';
+  const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
+  if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
+  const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
+  const schema = await loadCurrentSchema(vaultDir);
+  await warnIfPendingMigration(vaultDir, schema, jsonMode);
+
+  if (jsonMode) {
+    outputTypeDetailsJson(schema, typePath);
+  } else {
+    showTypeDetails(schema, typePath);
+  }
 }
 
 export const listCommand = new Command('list')
@@ -86,34 +140,12 @@ listCommand
         );
       }
 
-      const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
-      if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
-      const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
-      const schema = await loadCurrentSchema(vaultDir);
-      await warnIfPendingMigration(vaultDir, schema, jsonMode);
-
       if (targetType) {
-        if (jsonMode) {
-          outputTypeDetailsJson(schema, targetType);
-        } else {
-          showTypeDetails(schema, targetType);
-        }
+        await runSchemaListTypeDetails(targetType, options, cmd);
         return;
       }
 
-      if (jsonMode) {
-        if (options.verbose) {
-          outputSchemaVerboseJson(schema);
-        } else {
-          outputSchemaJson(schema);
-        }
-      } else {
-        if (options.verbose) {
-          showSchemaTreeVerbose(schema);
-        } else {
-          showSchemaTree(schema);
-        }
-      }
+      await runSchemaListOverview(options, cmd);
     } catch (err) {
       if (err instanceof UserCancelledError) {
         if (jsonMode) {
@@ -295,17 +327,7 @@ listCommand
         );
       }
 
-      const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
-      if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
-      const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
-      const schema = await loadCurrentSchema(vaultDir);
-      await warnIfPendingMigration(vaultDir, schema, jsonMode);
-
-      if (jsonMode) {
-        outputTypeDetailsJson(schema, name);
-      } else {
-        showTypeDetails(schema, name);
-      }
+      await runSchemaListTypeDetails(name, options, cmd);
     } catch (err) {
       if (err instanceof UserCancelledError) {
         if (jsonMode) {

--- a/tests/ts/commands/help.contract.test.ts
+++ b/tests/ts/commands/help.contract.test.ts
@@ -69,6 +69,8 @@ describe('help output contract snapshots', () => {
     expect(normalized).toContain('Schema introspection commands');
     expect(normalized).toContain('Commands:');
     expect(commandNames).toEqual([
+      'types',
+      'fields',
       'validate',
       'new',
       'edit',
@@ -79,6 +81,8 @@ describe('help output contract snapshots', () => {
       'history',
       'help',
     ]);
+    expect(normalized).toContain('bwrb schema types');
+    expect(normalized).toContain('bwrb schema fields task');
     expect(normalized).toContain('bwrb schema list objective/task');
     expect(normalized).toContain('bwrb schema list -t task --output json');
   });

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -624,6 +624,42 @@ milestone: "[[Active Milestone]]"
   });
 
   describe('schema list shorthand targeting', () => {
+    it('should support schema types as an alias for schema list', async () => {
+      const result = await runCLI(['schema', 'types'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Schema Types');
+      expect(result.stdout).toContain('objective');
+      expect(result.stdout).toContain('idea');
+    });
+
+    it('should support schema types in JSON mode', async () => {
+      const result = await runCLI(['schema', 'types', '--output', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.types.objective).toBeDefined();
+      expect(json.types.idea).toBeDefined();
+    });
+
+    it('should support schema fields <type> as an alias for schema list <type>', async () => {
+      const result = await runCLI(['schema', 'fields', 'task'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Type: task');
+      expect(result.stdout).toContain('Own fields:');
+      expect(result.stdout).toContain('status');
+    });
+
+    it('should support schema fields <type> in JSON mode', async () => {
+      const result = await runCLI(['schema', 'fields', 'task', '--output', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.type_path).toBe('task');
+      expect(json.fields.status).toBeDefined();
+    });
+
     it('should treat positional typePath as alias for "schema list type <name>"', async () => {
       const result = await runCLI(['schema', 'list', 'idea'], vaultDir);
 
@@ -1357,6 +1393,8 @@ milestone: "[[Active Milestone]]"
       expect(commands).not.toContain('edit-type');
       expect(commands).not.toContain('edit-field');
       // Modern commands should appear
+      expect(commands).toContain('types');
+      expect(commands).toContain('fields');
       expect(commands).toContain('new');
       expect(commands).toContain('edit');
       expect(commands).toContain('delete');


### PR DESCRIPTION
## Summary

Adds the two schema discovery aliases from #517:

- `bwrb schema types` as a thin alias for `bwrb schema list`
- `bwrb schema fields <typePath>` as a thin alias for `bwrb schema list <typePath>`

The product choice here is intentionally conservative: the existing `schema list` grammar remains canonical, while the aliases make the first guesses people naturally try land on the same behavior.

Closes #517

## Validation

- `pnpm build`
- `pnpm test tests/ts/commands/schema.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- Built CLI smoke test against `dist/index.js` for `schema types --output json` and `schema fields task --output json`
