### PR TITLE
Support raw _body strings in JSON note creation

### DIFF
--- a/docs-site/src/content/docs/reference/commands/new.md
+++ b/docs-site/src/content/docs/reference/commands/new.md
@@ -106,13 +106,16 @@ bwrb new task --json '{"name": "Bug"}' --template bug-report
 # With body sections
 bwrb new task --json '{"name": "Fix bug", "_body": {"Steps": ["Step 1", "Step 2"]}}'
 
+# With raw markdown body
+bwrb new task --json '{"name": "Quick capture", "_body": "## Notes\n\n- Captured from a script."}'
+
 # With instance scaffolding (JSON output includes instances)
 bwrb new project --json '{"name": "My Project"}' --template with-research
 ```
 
 `--json` mode validates the merged frontmatter before writing. Unknown fields in the JSON input or selected template defaults are rejected unless they are built-in bwrb fields such as `name`.
 
-The `_body` field accepts section names as keys, with string or string array values.
+The `_body` field accepts either a raw Markdown string or an object whose keys are schema body section names. Section-object values may be strings or string arrays. A raw string is written as the note body as-is and bypasses template/body-section generation.
 
 If the note name or resolved filename pattern contains characters that are not portable in filenames, `bwrb new` normalizes the filename by removing invalid characters, collapsing doubled whitespace, and trimming the result. Interactive creation prints a warning. JSON mode includes `nameTransformed` metadata:
 

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -163,6 +163,9 @@ bwrb new task --no-template --json '{"name": "Quick task"}'
 # Include body sections
 bwrb new task --json '{"name": "Task", "_body": {"Steps": ["Step 1", "Step 2"]}}'
 
+# Include a raw Markdown body
+bwrb new task --json '{"name": "Task", "_body": "## Notes\n\n- Captured from a script."}'
+
 # Skip instance scaffolding for templates that define instances
 bwrb new task --template epic --no-instances --json '{"name": "Ship feature"}'
 ```

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -65,7 +65,8 @@ Non-interactive (JSON) mode:
 
 Body sections (JSON mode):
   bwrb new task --json '{"name": "Fix bug", "_body": {"Steps": ["Step 1", "Step 2"]}}'
-  The _body field accepts section names as keys, with string or string[] values.
+  bwrb new task --json '{"name": "Quick capture", "_body": "## Notes\\n\\n- Captured from a script."}'
+  The _body field accepts a raw Markdown string or section names as keys, with string or string[] values.
 
 Template management:
   Templates are managed with 'bwrb template' - see 'bwrb template --help'.

--- a/src/commands/new/json-mode.ts
+++ b/src/commands/new/json-mode.ts
@@ -116,12 +116,15 @@ function parseJsonNoteInput(jsonInput: string): JsonNoteInputResult {
     );
   }
 
-  let bodyInput: Record<string, unknown> | undefined;
+  let bodyInput: string | Record<string, unknown> | undefined;
   if (rawBodyInput !== undefined && rawBodyInput !== null) {
-    if (typeof rawBodyInput !== 'object' || Array.isArray(rawBodyInput)) {
-      throwJsonError(jsonError('_body must be an object with section names as keys'), ExitCodes.VALIDATION_ERROR);
+    if (typeof rawBodyInput === 'string') {
+      bodyInput = rawBodyInput;
+    } else if (typeof rawBodyInput === 'object' && !Array.isArray(rawBodyInput)) {
+      bodyInput = rawBodyInput as Record<string, unknown>;
+    } else {
+      throwJsonError(jsonError('_body must be a string or an object with section names as keys'), ExitCodes.VALIDATION_ERROR);
     }
-    bodyInput = rawBodyInput as Record<string, unknown>;
   }
 
   if (bodyInput === undefined) {
@@ -269,9 +272,13 @@ function generateBodyForJson(
   typeDef: ResolvedType,
   frontmatter: Record<string, unknown>,
   template?: Template | null,
-  bodyInput?: Record<string, unknown>,
+  bodyInput?: string | Record<string, unknown>,
   dateFormat?: string
 ): string {
+  if (typeof bodyInput === 'string') {
+    return bodyInput;
+  }
+
   const sections = typeDef.bodySections ?? [];
 
   let sectionContent: Map<string, string[]> | undefined;

--- a/src/commands/new/types.ts
+++ b/src/commands/new/types.ts
@@ -56,7 +56,7 @@ export interface WritePlanArgs {
 
 export interface JsonNoteInputResult {
   frontmatter: Record<string, unknown>;
-  bodyInput?: Record<string, unknown>;
+  bodyInput?: string | Record<string, unknown>;
 }
 
 export interface FileExistsStrategy {

--- a/tests/ts/commands/json-io.test.ts
+++ b/tests/ts/commands/json-io.test.ts
@@ -255,6 +255,46 @@ describe('JSON I/O', () => {
         expect(content).toContain('Important notes here');
       });
 
+      it('should create note with raw markdown body from string _body', async () => {
+        const rawBody = '## Notes\n\n- Captured from a script.\n- No section schema needed.\n';
+        const result = await runCLI(
+          ['new', 'task', '--json', JSON.stringify({
+            'name': 'Raw Body Task',
+            _body: rawBody,
+          })],
+          vaultDir
+        );
+
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.success).toBe(true);
+
+        const filePath = join(vaultDir, json.path);
+        const content = await readFile(filePath, 'utf-8');
+        expect(content).toContain(`---\n${rawBody}`);
+        expect(content).not.toContain('## Steps');
+      });
+
+      it('should let raw string _body override template body', async () => {
+        const rawBody = '## Custom\n\nRaw body wins over template body.\n';
+        const result = await runCLI(
+          ['new', 'task', '--template', 'bug-report', '--json', JSON.stringify({
+            'name': 'Raw Body Template Task',
+            _body: rawBody,
+          })],
+          vaultDir
+        );
+
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.success).toBe(true);
+
+        const filePath = join(vaultDir, json.path);
+        const content = await readFile(filePath, 'utf-8');
+        expect(content).toContain(`---\n${rawBody}`);
+        expect(content).not.toContain('Steps to Reproduce');
+      });
+
       it('should error on unknown body section', async () => {
         const result = await runCLI(
           ['new', 'task', '--json', JSON.stringify({
@@ -273,11 +313,11 @@ describe('JSON I/O', () => {
         expect(json.error).toContain('UnknownSection');
       });
 
-      it('should error when _body is not an object', async () => {
+      it('should error when _body is neither a string nor an object', async () => {
         const result = await runCLI(
           ['new', 'task', '--json', JSON.stringify({
             'name': 'Bad Body Task',
-            _body: 'not an object',
+            _body: 123,
           })],
           vaultDir
         );
@@ -285,7 +325,7 @@ describe('JSON I/O', () => {
         expect(result.exitCode).toBe(1);
         const json = JSON.parse(result.stdout);
         expect(json.success).toBe(false);
-        expect(json.error).toContain('_body must be an object');
+        expect(json.error).toContain('_body must be a string or an object');
       });
 
       it('should error when _body is an array', async () => {
@@ -300,7 +340,7 @@ describe('JSON I/O', () => {
         expect(result.exitCode).toBe(1);
         const json = JSON.parse(result.stdout);
         expect(json.success).toBe(false);
-        expect(json.error).toContain('_body must be an object');
+        expect(json.error).toContain('_body must be a string or an object');
       });
 
       it('should handle empty _body object', async () => {


### PR DESCRIPTION
## Summary
- allow `bwrb new --json` `_body` to be either raw Markdown or schema-section objects
- document raw Markdown bodies in command help, docs-site, and the bwrb automation skill
- add JSON I/O coverage for raw bodies and template override behavior

Closes #581

## Verification
- `pnpm test -- tests/ts/commands/json-io.test.ts tests/ts/commands/new.test.ts`
- `pnpm build`
- `pnpm verify:pack`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm test -- --exclude='**/*.pty.test.ts'`