### PR TITLE
Surface actionable template validation

### DIFF
--- a/docs-site/src/content/docs/reference/commands/template.md
+++ b/docs-site/src/content/docs/reference/commands/template.md
@@ -50,6 +50,12 @@ Templates are stored in `.bwrb/templates/{type}/{subtype}/{name}.md`.
 
 List templates in your vault, optionally filtered by type.
 
+Text output includes a `STATUS` column:
+
+- `valid`: template can be used as-is
+- `warning`: template can be used, but has references worth reviewing
+- `invalid`: template has schema errors and should be fixed before use
+
 ### Synopsis
 
 ```bash
@@ -85,6 +91,8 @@ bwrb template list task bug-report
 # JSON output
 bwrb template list --output json
 ```
+
+JSON output includes `valid`, `status`, and `issues` for each template so scripts can fail early on invalid template configuration.
 
 ---
 
@@ -265,6 +273,16 @@ Checks templates for:
 - Prompt-fields reference existing fields
 - No references to removed schema fields
 
+Validation output includes the template path, target type, issue location, and suggested repair. For example:
+
+```text
+.bwrb/templates/daily-note/default.md
+  Type: daily-note
+  ✗ Invalid
+  ✗ Unknown field 'status' in defaults
+    Remove 'status' from defaults, or add 'status' to the 'daily-note' schema if this template should set it.
+```
+
 ### Examples
 
 ```bash
@@ -294,4 +312,3 @@ bwrb template validate --output json
 - [Templates Overview](/templates/overview/) — Template concepts
 - [Creating Templates](/templates/creating-templates/) — Template authoring guide
 - [bwrb schema validate](/reference/commands/schema/#validate) — Validate schema
-

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -176,6 +176,15 @@ When `bwrb new --json` runs instance scaffolding, the response includes an `inst
 
 When `bwrb new --json` normalizes a filename (for example removing `/`, `?`, or other non-portable characters), the JSON response includes `nameTransformed` with `original`, `sanitized`, and `filename`. Long relative paths over 200 characters include `pathLengthWarning`; paths over 260 characters are rejected.
 
+Before relying on templates in automation, check template health:
+
+```bash
+bwrb template list --output json
+bwrb template validate --output json
+```
+
+`template list --output json` includes `valid`, `status`, and `issues` per template. `template validate` exits non-zero when any template is invalid and includes suggested repairs for unknown fields, invalid defaults, filename-pattern references, body placeholders, constraints, and instance defaults.
+
 ```json
 {
   "path": "Projects/Ship feature.md",

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -17,6 +17,7 @@ import {
   parseTemplate,
   getInheritedTemplates,
   type TemplateWithSource,
+  type TemplateValidationResult,
 } from '../lib/template.js';
 import { queryByType, formatValue } from '../lib/vault.js';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
@@ -61,6 +62,8 @@ interface TemplateNewOptions {
 interface TemplateEditOptions {
   json?: string;
 }
+
+type TemplateHealthStatus = 'valid' | 'warning' | 'invalid';
 
 export const templateCommand = new Command('template')
   .description('Template management commands')
@@ -125,6 +128,64 @@ async function promptTemplatePicker(
   return templates[index] ?? null;
 }
 
+async function validateTemplatesForDisplay(
+  vaultDir: string,
+  schema: LoadedSchema,
+  templates: Template[]
+): Promise<Map<string, TemplateValidationResult>> {
+  const entries = await Promise.all(
+    templates.map(async (template) => [template.path, await validateTemplate(vaultDir, template, schema)] as const)
+  );
+
+  return new Map(entries);
+}
+
+function getTemplateHealthStatus(validation: TemplateValidationResult): TemplateHealthStatus {
+  if (!validation.valid) return 'invalid';
+  return validation.issues.length > 0 ? 'warning' : 'valid';
+}
+
+function formatTemplateHealthStatus(validation: TemplateValidationResult): string {
+  return getTemplateHealthStatus(validation);
+}
+
+function serializeTemplateForList(
+  vaultDir: string,
+  template: Template,
+  validation: TemplateValidationResult,
+  inherited: boolean,
+  inheritedFrom?: string
+): Record<string, unknown> {
+  return {
+    type: template.templateFor,
+    name: template.name,
+    description: template.description,
+    path: relative(vaultDir, template.path),
+    hasDefaults: Boolean(template.defaults && Object.keys(template.defaults).length > 0),
+    promptFields: template.promptFields,
+    filenamePattern: template.filenamePattern,
+    inherited,
+    ...(inheritedFrom ? { inheritedFrom } : {}),
+    valid: validation.valid,
+    status: getTemplateHealthStatus(validation),
+    issues: validation.issues,
+  };
+}
+
+function printValidationIssues(
+  issues: TemplateValidationResult['issues'],
+  indent = '  '
+): void {
+  for (const issue of issues) {
+    const icon = issue.severity === 'error' ? '✗' : '⚠';
+    const color = issue.severity === 'error' ? chalk.red : chalk.yellow;
+    console.log(color(`${indent}${icon} ${issue.message}`));
+    if (issue.suggestion) {
+      console.log(chalk.gray(`${indent}  ${issue.suggestion}`));
+    }
+  }
+}
+
 // ============================================================================
 // template list [type] [name]
 // ============================================================================
@@ -165,7 +226,7 @@ templateCommand
 
       // If both type and name provided, show template details
       if (typePath && templateName) {
-        await showTemplateDetails(vaultDir, typePath, templateName, jsonMode);
+        await showTemplateDetails(vaultDir, schema, typePath, templateName, jsonMode);
         return;
       }
 
@@ -181,33 +242,37 @@ templateCommand
       }
 
       if (jsonMode) {
+        const validationByPath = await validateTemplatesForDisplay(
+          vaultDir,
+          schema,
+          [...ownTemplates, ...inheritedTemplates]
+        );
+
         printJson(jsonSuccess({
           data: {
-            templates: ownTemplates.map(t => ({
-              type: t.templateFor,
-              name: t.name,
-              description: t.description,
-              path: relative(vaultDir, t.path),
-              hasDefaults: Boolean(t.defaults && Object.keys(t.defaults).length > 0),
-              promptFields: t.promptFields,
-              filenamePattern: t.filenamePattern,
-              inherited: false,
-            })),
-            inherited: inheritedTemplates.map(t => ({
-              type: t.templateFor,
-              name: t.name,
-              description: t.description,
-              path: relative(vaultDir, t.path),
-              hasDefaults: Boolean(t.defaults && Object.keys(t.defaults).length > 0),
-              promptFields: t.promptFields,
-              filenamePattern: t.filenamePattern,
-              inherited: true,
-              inheritedFrom: t.inheritedFrom,
-            })),
+            templates: ownTemplates.map((t) => serializeTemplateForList(
+              vaultDir,
+              t,
+              validationByPath.get(t.path)!,
+              false
+            )),
+            inherited: inheritedTemplates.map((t) => serializeTemplateForList(
+              vaultDir,
+              t,
+              validationByPath.get(t.path)!,
+              true,
+              t.inheritedFrom
+            )),
           },
         }));
         return;
       }
+
+      const validationByPath = await validateTemplatesForDisplay(
+        vaultDir,
+        schema,
+        [...ownTemplates, ...inheritedTemplates]
+      );
 
       // Text output
       if (ownTemplates.length === 0 && inheritedTemplates.length === 0) {
@@ -231,6 +296,7 @@ templateCommand
         } else {
           const ownRows = ownTemplates.map((template) => ({
             name: template.name,
+            status: formatTemplateHealthStatus(validationByPath.get(template.path)!),
             description: template.description ?? '(no description)',
           }));
           const ownLines = renderTable({
@@ -242,6 +308,15 @@ templateCommand
                 minWidth: 10,
                 weight: 2,
                 priority: 0,
+                canDrop: false,
+                ...(headerStyle ? { style: headerStyle } : {}),
+              },
+              {
+                key: 'status',
+                title: 'STATUS',
+                minWidth: 7,
+                weight: 1,
+                priority: 1,
                 canDrop: false,
                 ...(headerStyle ? { style: headerStyle } : {}),
               },
@@ -270,6 +345,7 @@ templateCommand
 
           const inheritedRows = inheritedTemplates.map((template) => ({
             name: template.name,
+            status: formatTemplateHealthStatus(validationByPath.get(template.path)!),
             source: `from ${template.inheritedFrom}`,
             description: template.description ?? '',
           }));
@@ -282,6 +358,15 @@ templateCommand
                 minWidth: 10,
                 weight: 2,
                 priority: 0,
+                canDrop: false,
+                ...(headerStyle ? { style: headerStyle } : {}),
+              },
+              {
+                key: 'status',
+                title: 'STATUS',
+                minWidth: 7,
+                weight: 1,
+                priority: 1,
                 canDrop: false,
                 ...(headerStyle ? { style: headerStyle } : {}),
               },
@@ -324,6 +409,7 @@ templateCommand
         const rows = ownTemplates.map(template => ({
           type: template.templateFor,
           name: template.name,
+          status: formatTemplateHealthStatus(validationByPath.get(template.path)!),
           description: template.description ?? '(no description)',
         }));
         const lines = renderTable({
@@ -344,6 +430,15 @@ templateCommand
               minWidth: 10,
               weight: 2,
               priority: 1,
+              canDrop: false,
+              ...(headerStyle ? { style: headerStyle } : {}),
+            },
+            {
+              key: 'status',
+              title: 'STATUS',
+              minWidth: 7,
+              weight: 1,
+              priority: 2,
               canDrop: false,
               ...(headerStyle ? { style: headerStyle } : {}),
             },
@@ -381,6 +476,7 @@ templateCommand
  */
 async function showTemplateDetails(
   vaultDir: string,
+  schema: LoadedSchema,
   typePath: string,
   templateName: string,
   jsonMode: boolean
@@ -397,6 +493,8 @@ async function showTemplateDetails(
     process.exit(1);
   }
 
+  const validation = await validateTemplate(vaultDir, template, schema);
+
   if (jsonMode) {
     printJson(jsonSuccess({
       data: {
@@ -408,6 +506,9 @@ async function showTemplateDetails(
         promptFields: template.promptFields,
         filenamePattern: template.filenamePattern,
         body: template.body,
+        valid: validation.valid,
+        status: getTemplateHealthStatus(validation),
+        issues: validation.issues,
       },
     }));
     return;
@@ -417,9 +518,15 @@ async function showTemplateDetails(
   console.log(chalk.bold(`\nTemplate: ${template.name}\n`));
   console.log(`  ${chalk.cyan('Type:')} ${template.templateFor}`);
   console.log(`  ${chalk.cyan('Path:')} ${relative(vaultDir, template.path)}`);
+  console.log(`  ${chalk.cyan('Status:')} ${formatTemplateHealthStatus(validation)}`);
   
   if (template.description) {
     console.log(`  ${chalk.cyan('Description:')} ${template.description}`);
+  }
+
+  if (validation.issues.length > 0) {
+    console.log(`\n  ${chalk.cyan('Issues:')}`);
+    printValidationIssues(validation.issues, '    ');
   }
 
   if (template.defaults && Object.keys(template.defaults).length > 0) {
@@ -532,30 +639,17 @@ templateCommand
 
       for (const result of results) {
         console.log(result.relativePath);
+        console.log(chalk.gray(`  Type: ${result.templateFor}`));
         
         if (result.valid && result.issues.length === 0) {
           console.log(chalk.green('  ✓ Valid\n'));
         } else if (result.valid) {
           console.log(chalk.green('  ✓ Valid (with warnings)'));
-          for (const issue of result.issues) {
-            if (issue.severity === 'warning') {
-              console.log(chalk.yellow(`  ⚠ ${issue.message}`));
-              if (issue.suggestion) {
-                console.log(chalk.gray(`    ${issue.suggestion}`));
-              }
-            }
-          }
+          printValidationIssues(result.issues.filter(issue => issue.severity === 'warning'));
           console.log('');
         } else {
           console.log(chalk.red('  ✗ Invalid'));
-          for (const issue of result.issues) {
-            const icon = issue.severity === 'error' ? '✗' : '⚠';
-            const color = issue.severity === 'error' ? chalk.red : chalk.yellow;
-            console.log(color(`  ${icon} ${issue.message}`));
-            if (issue.suggestion) {
-              console.log(chalk.gray(`    ${issue.suggestion}`));
-            }
-          }
+          printValidationIssues(result.issues);
           console.log('');
         }
       }

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -931,13 +931,49 @@ function findClosestMatch(target: string, options: string[]): string | undefined
   return closest;
 }
 
+function buildUnknownFieldSuggestion(
+  fieldName: string,
+  location: string,
+  templateFor: string,
+  validFieldNames: string[]
+): string {
+  const suggestion = findClosestMatch(fieldName, validFieldNames);
+  const repair = `Remove '${fieldName}' from ${location}, or add '${fieldName}' to the '${templateFor}' schema if this template should set it.`;
+
+  if (suggestion) {
+    return `Did you mean '${suggestion}'? ${repair}`;
+  }
+
+  const validFields = validFieldNames.length > 0
+    ? ` Valid fields for '${templateFor}': ${validFieldNames.join(', ')}.`
+    : '';
+
+  return `${repair}${validFields}`;
+}
+
+function buildInvalidValueSuggestion(
+  fieldName: string,
+  templateFor: string,
+  fieldOptions: string[],
+  valueSuggestion?: string
+): string {
+  const repair = `Update '${fieldName}' in defaults for '${templateFor}' to an allowed value.`;
+
+  if (valueSuggestion) {
+    return `Did you mean '${valueSuggestion}'? ${repair}`;
+  }
+
+  return `Expected one of: ${fieldOptions.join(', ')}. ${repair}`;
+}
+
 /**
  * Validate field value against its field definition.
  */
 function validateFieldValue(
   fieldName: string,
   field: Field,
-  value: unknown
+  value: unknown,
+  templateFor: string
 ): TemplateValidationIssue[] {
   const issues: TemplateValidationIssue[] = [];
   
@@ -958,9 +994,7 @@ function validateFieldValue(
             severity: 'error',
             message: `Invalid value '${v}' for field '${fieldName}'`,
             field: fieldName,
-            suggestion: suggestion 
-              ? `Did you mean '${suggestion}'?`
-              : `Expected one of: ${fieldOptions.join(', ')}`,
+            suggestion: buildInvalidValueSuggestion(fieldName, templateFor, fieldOptions, suggestion),
           });
         }
       }
@@ -971,9 +1005,7 @@ function validateFieldValue(
           severity: 'error',
           message: `Invalid value '${value}' for field '${fieldName}'`,
           field: fieldName,
-          suggestion: suggestion 
-            ? `Did you mean '${suggestion}'?`
-            : `Expected one of: ${fieldOptions.join(', ')}`,
+          suggestion: buildInvalidValueSuggestion(fieldName, templateFor, fieldOptions, suggestion),
         });
       }
     }
@@ -985,6 +1017,7 @@ function validateFieldValue(
       severity: 'warning',
       message: `Field '${fieldName}' expects an array but got ${typeof value}`,
       field: fieldName,
+      suggestion: `Use a YAML list for '${fieldName}' in defaults for '${templateFor}', or change the schema field if a scalar is intended.`,
     });
   }
   
@@ -1016,7 +1049,7 @@ export async function validateTemplate(
     issues.push({
       severity: 'error',
       message: `Type '${template.templateFor}' not found in schema`,
-      suggestion: 'Check the template-for field matches a valid type name',
+      suggestion: `Set template-for to a valid schema type, or add '${template.templateFor}' to the schema before using this template.`,
     });
     
     // Can't do further validation without a valid type
@@ -1041,16 +1074,12 @@ export async function validateTemplate(
     for (const [fieldName, value] of Object.entries(template.defaults)) {
       // Check field exists
       if (!isKnownField(fieldName)) {
-        const suggestion = findClosestMatch(fieldName, validFieldNames);
-        const issue: TemplateValidationIssue = {
+        issues.push({
           severity: 'error',
           message: `Unknown field '${fieldName}' in defaults`,
           field: fieldName,
-        };
-        if (suggestion) {
-          issue.suggestion = `Did you mean '${suggestion}'?`;
-        }
-        issues.push(issue);
+          suggestion: buildUnknownFieldSuggestion(fieldName, 'defaults', template.templateFor, validFieldNames),
+        });
         continue;
       }
       
@@ -1062,6 +1091,7 @@ export async function validateTemplate(
             severity: 'error',
             message: dateExprError,
             field: fieldName,
+            suggestion: `Fix the date expression for '${fieldName}' in defaults for '${template.templateFor}', or replace it with a literal date.`,
           });
           continue;
         }
@@ -1070,7 +1100,7 @@ export async function validateTemplate(
       // Validate value against field definition (skip for date expressions)
       const field = fields[fieldName];
       if (field && !(typeof value === 'string' && isDateExpression(value))) {
-        const valueIssues = validateFieldValue(fieldName, field, value);
+        const valueIssues = validateFieldValue(fieldName, field, value, template.templateFor);
         issues.push(...valueIssues);
       }
     }
@@ -1080,16 +1110,12 @@ export async function validateTemplate(
   if (template.promptFields) {
     for (const fieldName of template.promptFields) {
       if (!isKnownField(fieldName)) {
-        const suggestion = findClosestMatch(fieldName, validFieldNames);
-        const issue: TemplateValidationIssue = {
+        issues.push({
           severity: 'error',
           message: `Unknown field '${fieldName}' in prompt-fields`,
           field: fieldName,
-        };
-        if (suggestion) {
-          issue.suggestion = `Did you mean '${suggestion}'?`;
-        }
-        issues.push(issue);
+          suggestion: buildUnknownFieldSuggestion(fieldName, 'prompt-fields', template.templateFor, validFieldNames),
+        });
       }
     }
   }
@@ -1108,16 +1134,12 @@ export async function validateTemplate(
         if (fieldName === 'date' || fieldName === 'title') continue;
         
         if (fieldName && !isKnownField(fieldName)) {
-          const suggestion = findClosestMatch(fieldName, validFieldNames);
-          const issue: TemplateValidationIssue = {
+          issues.push({
             severity: 'warning',
             message: `Unknown field '${fieldName}' referenced in filename-pattern`,
             field: fieldName,
-          };
-          if (suggestion) {
-            issue.suggestion = `Did you mean '${suggestion}'?`;
-          }
-          issues.push(issue);
+            suggestion: buildUnknownFieldSuggestion(fieldName, 'filename-pattern', template.templateFor, validFieldNames),
+          });
         }
       }
     }
@@ -1134,16 +1156,12 @@ export async function validateTemplate(
       if (fieldName === 'date' || fieldName === 'title') continue;
       
       if (fieldName && !isKnownField(fieldName)) {
-        const suggestion = findClosestMatch(fieldName, validFieldNames);
-        const issue: TemplateValidationIssue = {
+        issues.push({
           severity: 'warning',
           message: `Unknown field '${fieldName}' referenced in body`,
           field: fieldName,
-        };
-        if (suggestion) {
-          issue.suggestion = `Did you mean '${suggestion}'?`;
-        }
-        issues.push(issue);
+          suggestion: buildUnknownFieldSuggestion(fieldName, 'the template body', template.templateFor, validFieldNames),
+        });
       }
     }
   }
@@ -1153,16 +1171,12 @@ export async function validateTemplate(
     for (const [fieldName, constraint] of Object.entries(template.constraints)) {
       // Check field exists
       if (!isKnownField(fieldName)) {
-        const suggestion = findClosestMatch(fieldName, validFieldNames);
-        const issue: TemplateValidationIssue = {
+        issues.push({
           severity: 'error',
           message: `Unknown field '${fieldName}' in constraints`,
           field: fieldName,
-        };
-        if (suggestion) {
-          issue.suggestion = `Did you mean '${suggestion}'?`;
-        }
-        issues.push(issue);
+          suggestion: buildUnknownFieldSuggestion(fieldName, 'constraints', template.templateFor, validFieldNames),
+        });
         continue;
       }
       
@@ -1175,6 +1189,7 @@ export async function validateTemplate(
             severity: 'error',
             message: `Invalid constraint expression for '${fieldName}': ${(e as Error).message}`,
             field: fieldName,
+            suggestion: `Fix the constraint expression for '${fieldName}' in '${template.templateFor}', or remove that constraint.`,
           });
         }
       }
@@ -1198,9 +1213,9 @@ export async function validateTemplate(
         if (suggestion) {
           issue.suggestion = `Did you mean '${suggestion}'?`;
         } else if (validChildTypes.length > 0) {
-          issue.suggestion = `Valid child types: ${validChildTypes.join(', ')}`;
+          issue.suggestion = `Use one of the valid child types for '${template.templateFor}': ${validChildTypes.join(', ')}.`;
         } else {
-          issue.suggestion = `Type '${template.templateFor}' has no child types`;
+          issue.suggestion = `Type '${template.templateFor}' has no child types; remove this instance scaffold or add a child type to the schema.`;
         }
         issues.push(issue);
         continue;
@@ -1223,16 +1238,12 @@ export async function validateTemplate(
         
         for (const fieldName of Object.keys(instance.defaults)) {
           if (!isKnownInstanceField(fieldName)) {
-            const suggestion = findClosestMatch(fieldName, instanceFieldNames);
-            const issue: TemplateValidationIssue = {
+            issues.push({
               severity: 'warning',
               message: `Unknown field '${fieldName}' in instance defaults for '${instance.type}'`,
               field: fieldName,
-            };
-            if (suggestion) {
-              issue.suggestion = `Did you mean '${suggestion}'?`;
-            }
-            issues.push(issue);
+              suggestion: buildUnknownFieldSuggestion(fieldName, `instance defaults for '${instance.type}'`, instance.type, instanceFieldNames),
+            });
           }
         }
       }

--- a/tests/ts/commands/template.test.ts
+++ b/tests/ts/commands/template.test.ts
@@ -47,6 +47,29 @@ describe('template command', () => {
       expect(json.data.templates.length).toBeGreaterThan(0);
       expect(json.data.templates[0]).toHaveProperty('type');
       expect(json.data.templates[0]).toHaveProperty('name');
+      expect(json.data.templates[0]).toHaveProperty('status');
+      expect(json.data.templates[0]).toHaveProperty('valid');
+      expect(json.data.templates[0]).toHaveProperty('issues');
+    });
+
+    it('should mark invalid templates with status', async () => {
+      await writeFile(
+        join(vaultDir, '.bwrb/templates/idea', 'bad-default.md'),
+        `---
+type: template
+template-for: idea
+defaults:
+  unknown-field: yep
+---
+Body
+`
+      );
+
+      const result = await runCLI(['template', 'list'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('STATUS');
+      expect(result.stdout).toMatch(/idea\s+bad-default\s+invalid/);
     });
 
     it('should error on unknown type', async () => {
@@ -90,6 +113,8 @@ describe('template command', () => {
       expect(json.data.type).toBe('idea');
       expect(json.data.description).toBe('Default idea template');
       expect(json.data.defaults).toHaveProperty('status');
+      expect(json.data.valid).toBe(true);
+      expect(json.data.status).toBe('valid');
     });
 
     it('should error on unknown template', async () => {
@@ -164,9 +189,10 @@ Body
       expect(result.stdout).toContain('Invalid');
       expect(result.stdout).toContain("Invalid value 'invalid-status'");
       expect(result.stdout).toContain("Invalid value 'super-high'");
+      expect(result.stdout).toContain("Update 'status' in defaults for 'idea' to an allowed value");
     });
 
-    it('should suggest typo corrections', async () => {
+    it('should suggest actionable typo corrections', async () => {
       // Create a template with typo in field name
       await writeFile(
         join(vaultDir, '.bwrb/templates/idea', 'typo.md'),
@@ -184,8 +210,11 @@ Body
       const result = await runCLI(['template', 'validate'], vaultDir);
 
       expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain('Type: idea');
       expect(result.stdout).toContain("Unknown field 'staus'");
       expect(result.stdout).toContain("Did you mean 'status'");
+      expect(result.stdout).toContain("Remove 'staus' from defaults");
+      expect(result.stdout).toContain("add 'staus' to the 'idea' schema");
     });
 
     it('should accept valid date expressions in defaults', async () => {


### PR DESCRIPTION
## Summary
- add template health (`valid`, `warning`, `invalid`) to `template list` text and JSON output
- show validation status/issues in template details and target type in `template validate`
- expand validation suggestions with concrete repairs for unknown fields, invalid defaults, date expressions, constraints, and instance defaults
- document the new template health/status behavior for users and automation

Closes #582

## Verification
- `pnpm typecheck`
- `pnpm test -- tests/ts/commands/template.test.ts`
- `pnpm dev -- --vault /Users/alicemoore/Developer/teenylilthoughts template validate daily-note` (expected exit 1; confirmed actionable daily-note diagnostics)
- `pnpm build`
- `pnpm verify:pack`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm test -- --exclude='**/*.pty.test.ts'`