### PR TITLE
Add list limit and count

### DIFF
--- a/docs-site/src/content/docs/reference/commands/dashboard.md
+++ b/docs-site/src/content/docs/reference/commands/dashboard.md
@@ -44,7 +44,11 @@ Save any list query as a dashboard:
 ```bash
 bwrb list task --where "status='active'" --save-as "active-tasks"
 bwrb list task --output tree --save-as "task-tree" --force
+bwrb list task --count --save-as "task-count"
 ```
+
+Dashboards saved from `bwrb list` preserve filters, default output settings,
+selected fields, `--limit`, and `--count`.
 
 ### With `dashboard new`
 
@@ -79,4 +83,3 @@ bwrb dashboard edit my-tasks
 - [CLI Safety and Flags](/concepts/cli-safety-and-flags/) — `--execute` vs `--force` semantics
 - [bwrb list](/reference/commands/list/) — List and filter notes
 - [Targeting Model](/reference/targeting/) — Selector reference
-

--- a/docs-site/src/content/docs/reference/commands/list.md
+++ b/docs-site/src/content/docs/reference/commands/list.md
@@ -30,6 +30,8 @@ The positional argument is auto-detected as type, path (contains `/`), or where 
 |--------|-------------|
 | `--output <format>` | Output format: `text`, `paths`, `tree`, `link`, `json` |
 | `--fields <fields>` | Show frontmatter fields in a table (comma-separated) |
+| `--limit <n>` | Show only the first `n` matching notes |
+| `--count` | Print only the number of matching notes |
 | `-L, --depth <n>` | Limit tree depth |
 
 ### Actions
@@ -104,6 +106,19 @@ bwrb list --type task --output paths
 bwrb list --type task --output link      # [[Task 1]], [[Task 2]], ...
 bwrb list --type task --output tree      # Hierarchical display
 ```
+
+### Limiting and Counting
+
+```bash
+# Show the first five matches after filtering
+bwrb list --type task --where "status == 'in-progress'" --limit 5
+
+# Print only the number of matches
+bwrb list --type task --count
+bwrb list --type task --count --output json  # {"count": 12}
+```
+
+`--count` reports the total number of matching notes before any `--limit` is applied.
 
 ### Open from Results
 

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -144,6 +144,10 @@ bwrb list task --where "priority == 'high' && status != 'done'" --output json
 # Include specific fields in output
 bwrb list task --fields status,priority --output json
 
+# Limit or count matches
+bwrb list task --limit 5 --output json
+bwrb list task --count --output json
+
 # Target by stable id
 bwrb list --id "<uuid>" --output json
 

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -157,6 +157,8 @@ async function runDashboard(
     const listOpts: ListOptions = {
       outputFormat: effectiveFormat,
       fields: dashboard.fields,
+      limit: dashboard.limit,
+      count: dashboard.count,
     };
 
     await listObjects(schema, vaultDir, targeting.type, targetResult.files, listOpts);

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -71,6 +71,23 @@ function resolveListOutputFormat(options: ListCommandOptions): ListOutputFormat 
   return 'default';
 }
 
+function parseListLimit(value: string | undefined, jsonMode: boolean): number | undefined {
+  if (value === undefined) return undefined;
+
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit <= 0) {
+    const error = 'Invalid --limit value: must be a positive integer';
+    if (jsonMode) {
+      printJson(jsonError(error));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    printError(error);
+    process.exit(1);
+  }
+
+  return limit;
+}
+
 interface ListCommandOptions {
   type?: string;
   path?: string;
@@ -80,6 +97,8 @@ interface ListCommandOptions {
   fields?: string;
   where?: string[];
   id?: string;
+  limit?: string;
+  count?: boolean;
   output?: string;
   json?: boolean; // deprecated
   // Open options
@@ -107,6 +126,8 @@ Targeting Selectors (compose via AND):
   --where <expr>       Filter by frontmatter expression (can repeat)
   --id <uuid>          Filter by stable note id
   --body <query>       Filter by body content (uses ripgrep)
+  --limit <n>          Show only the first n matching notes
+  --count              Print only the number of matching notes
 
 Expression Filters (--where):
   bwrb list --type task --where "status == 'in-progress'"
@@ -122,6 +143,8 @@ Examples:
   bwrb list --type idea
   bwrb list --type task --where "status == 'done'"
   bwrb list --path "Projects/**" --body "TODO"
+  bwrb list --type task --limit 5
+  bwrb list --type task --count
   bwrb list --type task --output json
   bwrb list --type task --open                    # Pick from tasks and open
   bwrb list --type task --where "status=inbox" --open
@@ -159,6 +182,8 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
   .option('--fields <fields>', 'Show frontmatter fields in a table (comma-separated)')
   .option('-w, --where <expression...>', 'Filter with expression (multiple are ANDed)')
   .option('--id <uuid>', 'Filter by stable note id')
+  .option('--limit <n>', 'Limit output to the first n matching notes')
+  .option('--count', 'Print only the number of matching notes')
   .option('--output <format>', 'Output format: text (default), paths, tree, link, json')
   // Open options
   .option('-o, --open', 'Open the first result (or pick from results interactively)')
@@ -257,6 +282,7 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
 
       const fields = options.fields?.split(',').map(f => f.trim());
       const depth = options.depth ? parseInt(options.depth, 10) : undefined;
+      const limit = parseListLimit(options.limit, jsonMode);
 
       // Validate --fields when --type is specified (strict mode)
       if (targeting.type && fields && fields.length > 0) {
@@ -302,6 +328,8 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
         childrenOf: options.childrenOf,
         descendantsOf: options.descendantsOf,
         depth,
+        count: options.count,
+        ...(limit !== undefined && { limit }),
       });
 
       // Save as dashboard if --save-as was provided
@@ -315,6 +343,8 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
         if (targeting.body) definition.body = targeting.body;
         if (outputFormat !== 'default') definition.output = outputFormat;
         if (fields?.length) definition.fields = fields;
+        if (limit !== undefined) definition.limit = limit;
+        if (options.count) definition.count = true;
 
         try {
           if (options.force) {
@@ -364,6 +394,8 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
 export interface ListOptions {
   outputFormat: ListOutputFormat;
   fields?: string[] | undefined;
+  limit?: number | undefined;
+  count?: boolean | undefined;
   // Open options
   open?: boolean | undefined;
   app?: string | undefined;
@@ -443,6 +475,21 @@ export async function listObjects(
     const nameB = basename(b.path, '.md');
     return nameA.localeCompare(nameB);
   });
+
+  const matchCount = filteredFiles.length;
+
+  if (options.count) {
+    if (jsonMode) {
+      console.log(JSON.stringify({ count: matchCount }, null, 2));
+    } else {
+      console.log(String(matchCount));
+    }
+    return;
+  }
+
+  if (options.limit !== undefined) {
+    filteredFiles = filteredFiles.slice(0, options.limit);
+  }
 
   // Handle no results
   if (filteredFiles.length === 0) {

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -268,7 +268,7 @@ async function resolveVaultDirForCompletion(options: { vault?: string }): Promis
 const COMMAND_OPTIONS: Record<string, string[]> = {
   new: ['--type', '-t', '--vault', '--non-interactive', '--template', '--json', '--help'],
   edit: ['--type', '-t', '--path', '-p', '--where', '-w', '--id', '--body', '-b', '--picker', '--json', '--output', '--open', '--app', '--vault', '--non-interactive', '--help'],
-  list: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--output', '-o', '--vault', '--non-interactive', '--json', '--help'],
+  list: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--text', '--id', '--fields', '--limit', '--count', '--output', '-o', '--vault', '--non-interactive', '--json', '--help'],
   open: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--app', '--vault', '--non-interactive', '--help'],
   search: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--wikilink', '--vault', '--non-interactive', '--help'],
   audit: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--text', '--all', '-a', '--strict', '--only', '--ignore', '--output', '--fix', '--auto', '--dry-run', '--execute', '--allow-field', '--vault', '--non-interactive', '--help'],

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -406,6 +406,10 @@ export const DashboardDefinitionSchema = z.object({
   output: z.enum(['default', 'text', 'paths', 'tree', 'link', 'json']).optional(),
   /** Fields to display in table output */
   fields: z.array(z.string()).optional(),
+  /** Limit output to the first n matching notes */
+  limit: z.number().int().positive().optional(),
+  /** Print only the number of matching notes */
+  count: z.boolean().optional(),
 });
 
 export type DashboardDefinition = z.infer<typeof DashboardDefinitionSchema>;

--- a/tests/ts/commands/list.test.ts
+++ b/tests/ts/commands/list.test.ts
@@ -402,6 +402,72 @@ describe('list command', () => {
     });
   });
 
+  describe('--limit and --count', () => {
+    it('should limit text output to the first matching notes', async () => {
+      const result = await runCLI(['list', 'idea', '--limit', '1'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Another Idea');
+      expect(result.stdout).not.toContain('Sample Idea');
+    });
+
+    it('should limit JSON output', async () => {
+      const result = await runCLI(['list', 'idea', '--limit', '1', '--output', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json).toHaveLength(1);
+      expect(json[0]._name).toBe('Another Idea');
+    });
+
+    it('should limit link and path output formats', async () => {
+      const linkResult = await runCLI(['list', 'idea', '--limit', '1', '--output', 'link'], vaultDir);
+      const pathResult = await runCLI(['list', 'idea', '--limit', '1', '--output', 'paths'], vaultDir);
+
+      expect(linkResult.exitCode).toBe(0);
+      expect(linkResult.stdout.trim()).toBe('[[Another Idea]]');
+      expect(pathResult.exitCode).toBe(0);
+      expect(pathResult.stdout.trim()).toBe('Ideas/Another Idea.md');
+    });
+
+    it('should print only the matching count in text mode', async () => {
+      const result = await runCLI(['list', 'idea', '--count'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('2');
+    });
+
+    it('should print only the matching count in JSON mode', async () => {
+      const result = await runCLI(['list', 'idea', '--count', '--output', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({ count: 2 });
+    });
+
+    it('should count matches before applying --limit', async () => {
+      const result = await runCLI(['list', 'idea', '--limit', '1', '--count'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('2');
+    });
+
+    it('should reject invalid limit values', async () => {
+      const result = await runCLI(['list', 'idea', '--limit', '0'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Invalid --limit value');
+    });
+
+    it('should return JSON errors for invalid limit values in JSON mode', async () => {
+      const result = await runCLI(['list', 'idea', '--limit', 'abc', '--output', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('Invalid --limit value');
+    });
+  });
+
   describe('error handling', () => {
     it('should error on unknown type', async () => {
       const result = await runCLI(['list', '--type', 'nonexistent'], vaultDir);
@@ -876,6 +942,28 @@ status: done
       expect(dashboards.dashboards['task-table']).toEqual({
         type: 'task',
         fields: ['status'],
+      });
+    });
+
+    it('should save query with limit and count options', async () => {
+      const { join } = await import('path');
+
+      const result = await runCLI(
+        ['list', '--type', 'task', '--limit', '1', '--count', '--save-as', 'counted-tasks'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('2');
+      expect(result.stderr).toContain('Dashboard "counted-tasks" saved');
+
+      const dashboardsPath = join(tempVaultDir, '.bwrb', 'dashboards.json');
+      const content = await import('fs/promises').then(fs => fs.readFile(dashboardsPath, 'utf-8'));
+      const dashboards = JSON.parse(content);
+      expect(dashboards.dashboards['counted-tasks']).toEqual({
+        type: 'task',
+        limit: 1,
+        count: true,
       });
     });
 


### PR DESCRIPTION
## Summary

Adds `bwrb list --limit <n>` and `bwrb list --count` for bounded result display and script-friendly match counts.

Product choices:

- `--count` reports the total number of matching notes before `--limit`, so it answers “how many match this query?” rather than “how many did I display?”
- `--limit` applies after targeting, hierarchy filters, and the existing default name ordering, so all output formats see the same window of results.
- Dashboards saved from `bwrb list --save-as` preserve `limit` and `count`, since those options materially change the saved query’s presentation.

Closes #520

## Validation

- `pnpm build`
- `pnpm test tests/ts/commands/list.test.ts tests/ts/commands/dashboard.test.ts tests/ts/commands/completion.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- Built CLI smoke test against `dist/index.js` for `list --limit`, `list --count`, and `list --count --output json`
