### PR TITLE
Add list sort option

### DIFF
--- a/docs-site/src/content/docs/reference/commands/dashboard.md
+++ b/docs-site/src/content/docs/reference/commands/dashboard.md
@@ -48,7 +48,7 @@ bwrb list task --count --save-as "task-count"
 ```
 
 Dashboards saved from `bwrb list` preserve filters, default output settings,
-selected fields, `--limit`, and `--count`.
+selected fields, `--sort`, `--desc`, `--limit`, and `--count`.
 
 ### With `dashboard new`
 

--- a/docs-site/src/content/docs/reference/commands/list.md
+++ b/docs-site/src/content/docs/reference/commands/list.md
@@ -30,6 +30,8 @@ The positional argument is auto-detected as type, path (contains `/`), or where 
 |--------|-------------|
 | `--output <format>` | Output format: `text`, `paths`, `tree`, `link`, `json` |
 | `--fields <fields>` | Show frontmatter fields in a table (comma-separated) |
+| `--sort <field>` | Sort by a frontmatter field, `name`, `_name`, or `_path` |
+| `--desc` | Sort descending (requires `--sort`) |
 | `--limit <n>` | Show only the first `n` matching notes |
 | `--count` | Print only the number of matching notes |
 | `-L, --depth <n>` | Limit tree depth |
@@ -110,6 +112,11 @@ bwrb list --type task --output tree      # Hierarchical display
 ### Limiting and Counting
 
 ```bash
+# Sort by frontmatter or display fields
+bwrb list --type task --sort deadline
+bwrb list --type task --sort priority --desc
+bwrb list --sort name
+
 # Show the first five matches after filtering
 bwrb list --type task --where "status == 'in-progress'" --limit 5
 
@@ -118,6 +125,7 @@ bwrb list --type task --count
 bwrb list --type task --count --output json  # {"count": 12}
 ```
 
+Missing sort values are always placed at the end, including with `--desc`.
 `--count` reports the total number of matching notes before any `--limit` is applied.
 
 ### Open from Results

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -144,6 +144,10 @@ bwrb list task --where "priority == 'high' && status != 'done'" --output json
 # Include specific fields in output
 bwrb list task --fields status,priority --output json
 
+# Sort matches before reading or limiting output
+bwrb list task --sort deadline --output json
+bwrb list task --sort priority --desc --output json
+
 # Limit or count matches
 bwrb list task --limit 5 --output json
 bwrb list task --count --output json

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -159,6 +159,8 @@ async function runDashboard(
       fields: dashboard.fields,
       limit: dashboard.limit,
       count: dashboard.count,
+      sortField: dashboard.sort,
+      sortDesc: dashboard.desc,
     };
 
     await listObjects(schema, vaultDir, targeting.type, targetResult.files, listOpts);

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -99,6 +99,8 @@ interface ListCommandOptions {
   id?: string;
   limit?: string;
   count?: boolean;
+  sort?: string;
+  desc?: boolean;
   output?: string;
   json?: boolean; // deprecated
   // Open options
@@ -126,6 +128,8 @@ Targeting Selectors (compose via AND):
   --where <expr>       Filter by frontmatter expression (can repeat)
   --id <uuid>          Filter by stable note id
   --body <query>       Filter by body content (uses ripgrep)
+  --sort <field>       Sort by frontmatter field, name, _name, or _path
+  --desc               Sort descending (requires --sort)
   --limit <n>          Show only the first n matching notes
   --count              Print only the number of matching notes
 
@@ -143,6 +147,8 @@ Examples:
   bwrb list --type idea
   bwrb list --type task --where "status == 'done'"
   bwrb list --path "Projects/**" --body "TODO"
+  bwrb list --type task --sort deadline
+  bwrb list --type task --sort priority --desc
   bwrb list --type task --limit 5
   bwrb list --type task --count
   bwrb list --type task --output json
@@ -182,6 +188,8 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
   .option('--fields <fields>', 'Show frontmatter fields in a table (comma-separated)')
   .option('-w, --where <expression...>', 'Filter with expression (multiple are ANDed)')
   .option('--id <uuid>', 'Filter by stable note id')
+  .option('--sort <field>', 'Sort by frontmatter field, name, _name, or _path')
+  .option('--desc', 'Sort descending (requires --sort)')
   .option('--limit <n>', 'Limit output to the first n matching notes')
   .option('--count', 'Print only the number of matching notes')
   .option('--output <format>', 'Output format: text (default), paths, tree, link, json')
@@ -284,10 +292,25 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
       const depth = options.depth ? parseInt(options.depth, 10) : undefined;
       const limit = parseListLimit(options.limit, jsonMode);
 
-      // Validate --fields when --type is specified (strict mode)
-      if (targeting.type && fields && fields.length > 0) {
+      if (options.desc && !options.sort) {
+        const error = 'Cannot use --desc without --sort';
+        if (jsonMode) {
+          printJson(jsonError(error));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(error);
+        process.exit(1);
+      }
+
+      // Validate display/sort fields when --type is specified (strict mode)
+      if (targeting.type && ((fields && fields.length > 0) || options.sort)) {
         const allFieldNames = getAllFieldsForType(schema, targeting.type);
-        for (const field of fields) {
+        const fieldNamesToValidate = [
+          ...(fields ?? []),
+          ...(options.sort ? [options.sort] : []),
+        ];
+
+        for (const field of fieldNamesToValidate) {
           if (!allFieldNames.has(field) && !RESERVED_DISPLAY_FIELDS.has(field)) {
             const fieldList = Array.from(allFieldNames);
             const suggestion = suggestFieldName(field, fieldList);
@@ -329,6 +352,8 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
         descendantsOf: options.descendantsOf,
         depth,
         count: options.count,
+        sortField: options.sort,
+        sortDesc: options.desc,
         ...(limit !== undefined && { limit }),
       });
 
@@ -345,6 +370,8 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
         if (fields?.length) definition.fields = fields;
         if (limit !== undefined) definition.limit = limit;
         if (options.count) definition.count = true;
+        if (options.sort) definition.sort = options.sort;
+        if (options.desc) definition.desc = true;
 
         try {
           if (options.force) {
@@ -396,6 +423,8 @@ export interface ListOptions {
   fields?: string[] | undefined;
   limit?: number | undefined;
   count?: boolean | undefined;
+  sortField?: string | undefined;
+  sortDesc?: boolean | undefined;
   // Open options
   open?: boolean | undefined;
   app?: string | undefined;
@@ -469,12 +498,8 @@ export async function listObjects(
     }
   }
 
-  // Sort by name
-  filteredFiles.sort((a, b) => {
-    const nameA = basename(a.path, '.md');
-    const nameB = basename(b.path, '.md');
-    return nameA.localeCompare(nameB);
-  });
+  const fileComparator = createFileComparator(vaultDir, options.sortField, options.sortDesc);
+  filteredFiles.sort(fileComparator);
 
   const matchCount = filteredFiles.length;
 
@@ -574,14 +599,14 @@ export async function listObjects(
     case 'tree': {
       if (isRecursive) {
         const parentMap = buildParentMap(filteredFiles);
-        const tree = buildTree(filteredFiles, parentMap, options.depth);
+        const tree = buildTree(filteredFiles, parentMap, options.depth, fileComparator);
         if (treeHasNestedNotes(tree)) {
           printTree(tree, vaultDir, showPaths);
           return;
         }
       }
 
-      const directoryTree = buildDirectoryTree(filteredFiles, vaultDir, options.depth);
+      const directoryTree = buildDirectoryTree(filteredFiles, vaultDir, options.depth, fileComparator);
       printDirectoryTree(directoryTree, showPaths);
       return;
     }
@@ -689,6 +714,85 @@ function formatValue(value: unknown): string {
 // ============================================================================
 
 type FileWithFrontmatter = { path: string; frontmatter: Record<string, unknown> };
+type FileComparator = (a: FileWithFrontmatter, b: FileWithFrontmatter) => number;
+
+function compareByName(a: FileWithFrontmatter, b: FileWithFrontmatter): number {
+  return basename(a.path, '.md').localeCompare(basename(b.path, '.md'));
+}
+
+function getSortValue(file: FileWithFrontmatter, vaultDir: string, field: string): unknown {
+  if (field === 'name' || field === '_name') {
+    return basename(file.path, '.md');
+  }
+  if (field === '_path') {
+    return relative(vaultDir, file.path);
+  }
+  return file.frontmatter[field];
+}
+
+function isMissingSortValue(value: unknown): boolean {
+  return value === undefined ||
+    value === null ||
+    value === '' ||
+    (Array.isArray(value) && value.length === 0);
+}
+
+function normalizeSortValue(value: unknown): string | number | boolean {
+  if (Array.isArray(value)) {
+    return value.map(item => String(item)).join(', ');
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  return String(value);
+}
+
+function compareSortValues(a: unknown, b: unknown): number {
+  const normalizedA = normalizeSortValue(a);
+  const normalizedB = normalizeSortValue(b);
+
+  if (typeof normalizedA === 'number' && typeof normalizedB === 'number') {
+    return normalizedA - normalizedB;
+  }
+
+  if (typeof normalizedA === 'boolean' && typeof normalizedB === 'boolean') {
+    return Number(normalizedA) - Number(normalizedB);
+  }
+
+  return String(normalizedA).localeCompare(String(normalizedB), undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
+}
+
+function createFileComparator(
+  vaultDir: string,
+  sortField: string | undefined,
+  descending: boolean | undefined
+): FileComparator {
+  if (!sortField) {
+    return compareByName;
+  }
+
+  return (a, b) => {
+    const valueA = getSortValue(a, vaultDir, sortField);
+    const valueB = getSortValue(b, vaultDir, sortField);
+    const missingA = isMissingSortValue(valueA);
+    const missingB = isMissingSortValue(valueB);
+
+    if (missingA && missingB) {
+      return compareByName(a, b);
+    }
+    if (missingA) return 1;
+    if (missingB) return -1;
+
+    const comparison = compareSortValues(valueA, valueB);
+    if (comparison !== 0) {
+      return descending ? -comparison : comparison;
+    }
+    return compareByName(a, b);
+  };
+}
 
 /**
  * Build a map from note name -> parent note name from frontmatter.
@@ -797,7 +901,8 @@ interface DirectoryTreeNode {
 function buildTree(
   files: FileWithFrontmatter[],
   parentMap: Map<string, string>,
-  maxDepth?: number | undefined
+  maxDepth?: number | undefined,
+  fileComparator: FileComparator = compareByName
 ): TreeNode[] {
   // Create nodes for all files
   const nodeMap = new Map<string, TreeNode>();
@@ -827,7 +932,7 @@ function buildTree(
   // Compute depths and sort children
   function computeDepth(node: TreeNode, depth: number): void {
     node.depth = depth;
-    node.children.sort((a, b) => a.name.localeCompare(b.name));
+    node.children.sort((a, b) => fileComparator(a, b));
     for (const child of node.children) {
       computeDepth(child, depth + 1);
     }
@@ -837,7 +942,7 @@ function buildTree(
     computeDepth(root, 0);
   }
   
-  roots.sort((a, b) => a.name.localeCompare(b.name));
+  roots.sort((a, b) => fileComparator(a, b));
   
   // Filter by max depth if specified
   if (maxDepth !== undefined) {
@@ -889,7 +994,8 @@ function treeHasNestedNotes(nodes: TreeNode[]): boolean {
 function buildDirectoryTree(
   files: FileWithFrontmatter[],
   vaultDir: string,
-  maxDepth?: number | undefined
+  maxDepth?: number | undefined,
+  fileComparator: FileComparator = compareByName
 ): DirectoryTreeNode[] {
   const root: DirectoryTreeNode = {
     name: '',
@@ -941,7 +1047,7 @@ function buildDirectoryTree(
 
   const sortNode = (node: DirectoryTreeNode): void => {
     node.directories.sort((a, b) => a.name.localeCompare(b.name));
-    node.notes.sort((a, b) => basename(a.path, '.md').localeCompare(basename(b.path, '.md')));
+    node.notes.sort(fileComparator);
     for (const directory of node.directories) {
       sortNode(directory);
     }

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -268,7 +268,7 @@ async function resolveVaultDirForCompletion(options: { vault?: string }): Promis
 const COMMAND_OPTIONS: Record<string, string[]> = {
   new: ['--type', '-t', '--vault', '--non-interactive', '--template', '--json', '--help'],
   edit: ['--type', '-t', '--path', '-p', '--where', '-w', '--id', '--body', '-b', '--picker', '--json', '--output', '--open', '--app', '--vault', '--non-interactive', '--help'],
-  list: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--text', '--id', '--fields', '--limit', '--count', '--output', '-o', '--vault', '--non-interactive', '--json', '--help'],
+  list: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--text', '--id', '--fields', '--sort', '--desc', '--limit', '--count', '--output', '-o', '--vault', '--non-interactive', '--json', '--help'],
   open: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--app', '--vault', '--non-interactive', '--help'],
   search: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--wikilink', '--vault', '--non-interactive', '--help'],
   audit: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--text', '--all', '-a', '--strict', '--only', '--ignore', '--output', '--fix', '--auto', '--dry-run', '--execute', '--allow-field', '--vault', '--non-interactive', '--help'],

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -410,6 +410,10 @@ export const DashboardDefinitionSchema = z.object({
   limit: z.number().int().positive().optional(),
   /** Print only the number of matching notes */
   count: z.boolean().optional(),
+  /** Sort output by a frontmatter/display field */
+  sort: z.string().optional(),
+  /** Sort descending when sort is present */
+  desc: z.boolean().optional(),
 });
 
 export type DashboardDefinition = z.infer<typeof DashboardDefinitionSchema>;

--- a/tests/ts/commands/list.test.ts
+++ b/tests/ts/commands/list.test.ts
@@ -468,6 +468,127 @@ describe('list command', () => {
     });
   });
 
+  describe('--sort', () => {
+    it('should sort by a frontmatter field in ascending order', async () => {
+      await writeFile(
+        join(vaultDir, 'Ideas', 'Low Effort Idea.md'),
+        [
+          '---',
+          'type: idea',
+          'status: raw',
+          'priority: low',
+          'effort: 1',
+          '---',
+          '',
+        ].join('\n')
+      );
+
+      const result = await runCLI(['list', 'idea', '--sort', 'effort', '--output', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.map((note: { _name: string }) => note._name)).toEqual([
+        'Low Effort Idea',
+        'Sample Idea',
+        'Another Idea',
+      ]);
+    });
+
+    it('should sort descending and keep missing values at the end', async () => {
+      await writeFile(
+        join(vaultDir, 'Ideas', 'Low Effort Idea.md'),
+        [
+          '---',
+          'type: idea',
+          'status: raw',
+          'priority: low',
+          'effort: 1',
+          '---',
+          '',
+        ].join('\n')
+      );
+
+      const result = await runCLI(['list', 'idea', '--sort', 'effort', '--desc', '--output', 'json'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.map((note: { _name: string }) => note._name)).toEqual([
+        'Sample Idea',
+        'Low Effort Idea',
+        'Another Idea',
+      ]);
+    });
+
+    it('should compose sort with limit', async () => {
+      await writeFile(
+        join(vaultDir, 'Ideas', 'Low Effort Idea.md'),
+        [
+          '---',
+          'type: idea',
+          'status: raw',
+          'priority: low',
+          'effort: 1',
+          '---',
+          '',
+        ].join('\n')
+      );
+
+      const result = await runCLI(['list', 'idea', '--sort', 'effort', '--desc', '--limit', '1'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('Sample Idea');
+    });
+
+    it('should sort by display fields', async () => {
+      const result = await runCLI(['list', 'idea', '--sort', '_path', '--desc', '--output', 'paths'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim().split('\n')).toEqual([
+        'Ideas/Sample Idea.md',
+        'Ideas/Low Effort Idea.md',
+        'Ideas/Another Idea.md',
+      ]);
+    });
+
+    it('should apply sort order within tree output', async () => {
+      await writeFile(
+        join(vaultDir, 'Objectives', 'Tasks', 'Later Task.md'),
+        [
+          '---',
+          'type: task',
+          'status: backlog',
+          'deadline: "2025-01-01"',
+          '---',
+          '',
+        ].join('\n')
+      );
+
+      const result = await runCLI(['list', 'task', '--sort', 'deadline', '--output', 'tree'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const sampleIndex = result.stdout.indexOf('Sample Task');
+      const laterIndex = result.stdout.indexOf('Later Task');
+      expect(sampleIndex).toBeGreaterThanOrEqual(0);
+      expect(laterIndex).toBeGreaterThanOrEqual(0);
+      expect(sampleIndex).toBeLessThan(laterIndex);
+    });
+
+    it('should reject unknown sort fields when type is specified', async () => {
+      const result = await runCLI(['list', 'idea', '--sort', 'statsu'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Unknown field 'statsu'");
+      expect(result.stderr).toContain("Did you mean 'status'?");
+    });
+
+    it('should reject --desc without --sort', async () => {
+      const result = await runCLI(['list', 'idea', '--desc'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Cannot use --desc without --sort');
+    });
+  });
+
   describe('error handling', () => {
     it('should error on unknown type', async () => {
       const result = await runCLI(['list', '--type', 'nonexistent'], vaultDir);
@@ -964,6 +1085,27 @@ status: done
         type: 'task',
         limit: 1,
         count: true,
+      });
+    });
+
+    it('should save query with sort options', async () => {
+      const { join } = await import('path');
+
+      const result = await runCLI(
+        ['list', '--type', 'task', '--sort', 'status', '--desc', '--save-as', 'sorted-tasks'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain('Dashboard "sorted-tasks" saved');
+
+      const dashboardsPath = join(tempVaultDir, '.bwrb', 'dashboards.json');
+      const content = await import('fs/promises').then(fs => fs.readFile(dashboardsPath, 'utf-8'));
+      const dashboards = JSON.parse(content);
+      expect(dashboards.dashboards['sorted-tasks']).toEqual({
+        type: 'task',
+        sort: 'status',
+        desc: true,
       });
     });
 


### PR DESCRIPTION
## Summary
- add `bwrb list --sort <field>` with optional `--desc` for frontmatter and display-field ordering
- keep missing sort values at the end, including descending sorts, with name tie-breakers for stable output
- preserve sort options in saved dashboards and completions
- document sorting in the CLI docs and bwrb automation skill

## Product direction
This keeps ordering as a small read/query affordance on `list` instead of creating a broader query language change. `--sort <field>` mirrors `--fields` validation when a type is known, while untyped queries remain permissive because they may span mixed note types. `--desc` is intentionally separate so ascending remains the default and dashboards can store the direction explicitly.

Closes #523

## Verification
- `pnpm build`
- `pnpm test tests/ts/commands/dashboard.test.ts -t "should clear default when deleting default dashboard"`
- `pnpm test tests/ts/commands/list.test.ts tests/ts/commands/dashboard.test.ts tests/ts/commands/completion.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `node dist/index.js list idea --sort status --output json` from `tests/fixtures/vault`
- `node dist/index.js list idea --sort status --desc --limit 1` from `tests/fixtures/vault`
- `node dist/index.js list idea --sort typo` from `tests/fixtures/vault`
- `node dist/index.js list task --desc` from `tests/fixtures/vault`