### PR TITLE
feat(schema): self-documenting schema — descriptions on types, fields, and options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Self-documenting schema: `description` on types, fields, and select options**
+  - Add a `description` to any type or field, and to individual `select` options (via a `{ value, description }` form that coexists with bare-string options)
+  - `bwrb schema list` surfaces descriptions — a dim suffix in the overview tree, dedicated lines in `type <name>` detail, and a `description` key in `--output json` — so `bwrb schema list --output json` is a queryable source of what each type/field/option is for
+  - Descriptions are inherited like fields and can be overridden by a subtype
+  - Interactive `bwrb schema new/edit type` and `new/edit field` now prompt for descriptions; the `bwrb new` select picker shows option descriptions as hints
+  - `bwrb audit --check-schema-docs` (opt-in) reports types/fields with no description
+  - Description-only edits are treated as cosmetic: they never trigger a schema migration
+
 ## [0.1.8] - 2026-03-11
 
 Changes since `v0.1.7`.

--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -33,6 +33,7 @@ The target argument is auto-detected as type, path (contains `/`), or where expr
 | `--ignore <issue-type>` | Ignore specific issue type |
 | `--strict` | Treat unknown fields as errors instead of warnings |
 | `--allow-field <fields>` | Allow additional fields beyond schema (repeatable) |
+| `--check-schema-docs` | Also report schema types/fields that have no `description` |
 
 ### Repair
 

--- a/docs-site/src/content/docs/reference/commands/schema.md
+++ b/docs-site/src/content/docs/reference/commands/schema.md
@@ -46,6 +46,13 @@ bwrb schema migrate --execute
 
 List schema contents including types, fields, and detailed type information.
 
+When a type, field, or select option has a [`description`](/reference/schema/#field-properties-reference),
+`schema list` surfaces it — as a dim suffix in the overview tree, on its own line
+in `type <name>` detail view, and as a `description` key in `--output json`. This
+makes the schema self-documenting: agents and humans can run
+`bwrb schema list --output json` to learn what each type and field is for instead
+of relying on out-of-band notes.
+
 ### Synopsis
 
 ```bash

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -67,6 +67,7 @@ Types define categories of notes. Each type has a name (the object key) and a de
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `extends` | string | `"meta"` | Parent type name |
+| `description` | string | — | What this type is for and when to use it. Surfaced by `bwrb schema list` |
 | `fields` | object | `{}` | Field definitions |
 | `field_order` | array | — | Order of fields in frontmatter |
 | `body_sections` | array | — | Body structure after frontmatter |
@@ -239,6 +240,26 @@ Choose from predefined options.
 }
 ```
 
+#### Documenting options
+
+Any option can be written as a `{ value, description }` object instead of a bare
+string. The description explains what the value means; it shows up as a hint in
+the `bwrb new` picker and in `bwrb schema list` / its JSON output. Bare strings
+and objects can be mixed freely in the same list:
+
+```json
+{
+  "status": {
+    "prompt": "select",
+    "options": [
+      { "value": "active", "description": "currently being worked on" },
+      { "value": "waiting", "description": "blocked; trigger noted in the body" },
+      "backlog"
+    ]
+  }
+}
+```
+
 For multi-select (array output):
 
 ```json
@@ -269,6 +290,11 @@ Link to other notes in the vault. Shows a picker filtered by type.
 - Specific type: `"source": "milestone"` — only milestones
 - Type branch: `"source": "objective"` — objectives and all descendants (task, milestone, project, etc.)
 - Any note: `"source": "any"` — entire vault
+
+**Name collisions:** when two notes share a name, a relation value is stored in
+its shortest unambiguous form — path-qualified (e.g. `[[contexts/Betson]]`) so it
+resolves to the right note. See the [`search` command](/reference/commands/search/)
+for the full link-resolution rule.
 
 **Filtering results:**
 
@@ -355,10 +381,11 @@ Complete list of field properties:
 |----------|------|------------|-------------|
 | `value` | string | static | Fixed value (mutually exclusive with `prompt`) |
 | `prompt` | string | prompted | Prompt type: `text`, `number`, `boolean`, `date`, `select`, `relation`, `list` |
-| `label` | string | prompted | Custom label shown during prompting |
+| `label` | string | prompted | Custom label shown during prompting (the imperative prompt text) |
+| `description` | string | any | What this field is for and when to use it. Surfaced by `bwrb schema list`; distinct from `label` |
 | `required` | boolean | prompted | Whether field must have a value (default: `false`) |
 | `default` | string | prompted | Default value if user skips prompt |
-| `options` | array | `select` | Allowed values for selection |
+| `options` | array | `select` | Allowed values: bare strings or `{ value, description }` objects |
 | `multiple` | boolean | `select`, `relation` | Allow multiple values (default: `false`) |
 | `source` | string | `relation` | Type name to filter picker, or `"any"` |
 | `filter` | object | `relation` | Filter conditions for source query |

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -163,6 +163,10 @@
           }
         },
         "field_order": { "type": "array", "items": { "type": "string" }, "description": "Field ordering (v2 model)" },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this type is for and when to use it. Surfaced by `bwrb schema list`."
+        },
         "recursive": { "type": "boolean", "description": "Whether this type can contain instances of itself" }
       },
       "anyOf": [
@@ -187,15 +191,32 @@
         },
         "label": {
           "type": "string",
-          "description": "Label shown to user for input prompts"
+          "description": "Label shown to user for input prompts (the imperative prompt text, e.g. \"Select status\"). Distinct from `description`, which explains what the field is for."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this field is for and when to use it. Surfaced by `bwrb schema list`; distinct from `label`."
         },
         "options": {
           "type": "array",
-          "items": { "type": "string" },
-          "description": "Allowed values for select fields (inline options)"
+          "items": {
+            "anyOf": [
+              { "type": "string" },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["value"],
+                "properties": {
+                  "value": { "type": "string", "description": "The option value stored in frontmatter" },
+                  "description": { "type": "string", "description": "What this option means / when to choose it" }
+                }
+              }
+            ]
+          },
+          "description": "Allowed values for select fields (inline options). Each entry is a bare value or a { value, description } pair that documents what the option means."
         },
         "source": {
-          "description": "Type name(s) for relation prompts",
+          "description": "Type name(s) for relation prompts. When a relation's value is ambiguous because two notes share a name, path-qualify the link (e.g. `[[contexts/Betson]]`); see the search command docs for the shortest-unambiguous-form rule.",
           "anyOf": [
             { "type": "string" },
             { "type": "array", "items": { "type": "string" } }

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -50,6 +50,11 @@ import {
   outputFixResults,
   showAvailableTypes,
 } from '../lib/audit/output.js';
+import {
+  findUndocumentedSchemaEntries,
+  type UndocumentedSchemaEntries,
+} from '../lib/audit/schema-docs.js';
+import chalk from 'chalk';
 
 const FIX_TARGETING_ERROR_SUMMARY =
   'No files selected. Use --type, --path, --where, --body, or --all.';
@@ -62,6 +67,30 @@ const FIX_TARGETING_ERROR_MESSAGE = [
   '  bwrb audit --all --fix',
   '  bwrb audit --path "Ideas/**" --fix --dry-run --auto',
 ].join('\n');
+
+/**
+ * Print the schema documentation coverage report (opt-in --check-schema-docs).
+ */
+function printSchemaDocsCoverage(undocumented: UndocumentedSchemaEntries): void {
+  const { types, fields } = undocumented;
+  console.log('');
+  if (types.length === 0 && fields.length === 0) {
+    console.log(chalk.green('Schema docs: every type and field has a description.'));
+    return;
+  }
+  console.log(chalk.bold('Schema documentation coverage'));
+  if (types.length > 0) {
+    console.log(chalk.yellow(`  ${types.length} type(s) missing a description:`));
+    console.log(chalk.gray(`    ${types.join(', ')}`));
+  }
+  if (fields.length > 0) {
+    console.log(chalk.yellow(`  ${fields.length} field(s) missing a description:`));
+    for (const { type, field } of fields) {
+      console.log(chalk.gray(`    ${type}.${field}`));
+    }
+  }
+  console.log(chalk.dim('  Add one with `bwrb schema edit field` / `bwrb schema edit type`.'));
+}
 
 // ============================================================================
 // Command Definition
@@ -145,11 +174,13 @@ Examples:
   .option('--dry-run', 'With --fix: preview fixes without writing')
   .option('--execute', 'With --fix --auto: apply fixes (omit to preview)')
   .option('--allow-field <fields...>', 'Allow additional fields beyond schema (repeatable)')
+  .option('--check-schema-docs', 'Also report schema types/fields that have no description')
   .action(async (target: string | undefined, options: AuditOptions & {
     type?: string;
     where?: string[];
     body?: string;
     text?: string; // deprecated
+    checkSchemaDocs?: boolean;
   }, cmd: Command) => {
     const jsonMode = options.output === 'json';
     const fixMode = options.fix ?? false;
@@ -342,10 +373,24 @@ Examples:
       // Output results (report mode)
       const summary = calculateSummary(results);
 
+      // Optional schema documentation coverage check (opt-in).
+      const undocumented = options.checkSchemaDocs
+        ? findUndocumentedSchemaEntries(schema)
+        : undefined;
+
       if (jsonMode) {
-        outputJsonResults(results, summary);
+        outputJsonResults(
+          results,
+          summary,
+          undocumented
+            ? { schemaDocs: { types: undocumented.types, fields: undocumented.fields } }
+            : undefined
+        );
       } else {
         outputTextResults(results, summary, vaultDir);
+        if (undocumented) {
+          printSchemaDocsCoverage(undocumented);
+        }
       }
 
       // Exit code based on errors

--- a/src/commands/new/prompting.ts
+++ b/src/commands/new/prompting.ts
@@ -12,7 +12,7 @@ import { queryByType, formatValue } from '../../lib/vault.js';
 import { expandStaticValue } from '../../lib/local-date.js';
 import { extractSectionItems } from '../../lib/frontmatter.js';
 import { UserCancelledError } from '../../lib/errors.js';
-import type { BodySection, Field, LoadedSchema } from '../../types/schema.js';
+import { type BodySection, type Field, type LoadedSchema, getOptionValues, getOptionDescription } from '../../types/schema.js';
 
 export async function promptField(
   schema: LoadedSchema,
@@ -27,7 +27,8 @@ export async function promptField(
   switch (field.prompt) {
     case 'select': {
       if (!field.options || field.options.length === 0) return field.default;
-      const selectOptions = field.options;
+      const selectOptions = getOptionValues(field.options);
+      const optionDescriptions = field.options;
 
       if (field.multiple) {
         const selected = await promptMultiSelect(`Select ${fieldName}:`, selectOptions);
@@ -38,16 +39,22 @@ export async function promptField(
       }
 
       let options: string[];
+      let hints: string[];
       let skipLabel: string | undefined;
+      const valueHints = selectOptions.map(
+        (value) => getOptionDescription(optionDescriptions, value) ?? ''
+      );
       if (!field.required) {
         const defaultStr = field.default !== undefined ? String(field.default) : undefined;
         skipLabel = defaultStr ? `(skip) [${defaultStr}]` : '(skip)';
         options = [skipLabel, ...selectOptions];
+        hints = ['', ...valueHints];
       } else {
         options = selectOptions;
+        hints = valueHints;
       }
 
-      const selected = await promptSelection(`Select ${fieldName}:`, options);
+      const selected = await promptSelection(`Select ${fieldName}:`, options, hints);
       if (selected === null) {
         throw new UserCancelledError();
       }

--- a/src/commands/schema/field.ts
+++ b/src/commands/schema/field.ts
@@ -219,8 +219,8 @@ export function registerEditFieldCommand(editCommand: Command): void {
         if (currentDef.required) console.log(`Required: yes`);
         if (currentDef.default !== undefined) console.log(`Default: ${currentDef.default}`);
 
-        const editOptions = ['Change prompt type', 'Toggle required', 'Set default', 'Done'];
-        
+        const editOptions = ['Edit description', 'Change prompt type', 'Toggle required', 'Set default', 'Done'];
+
         while (true) {
           const choice = await promptSelection('What would you like to edit?', editOptions);
           if (choice === null || choice === 'Done') {
@@ -234,7 +234,22 @@ export function registerEditFieldCommand(editCommand: Command): void {
             process.exit(1);
           }
 
-          if (choice === 'Change prompt type') {
+          if (choice === 'Edit description') {
+            const fieldEntry = rawTypeEntry.fields?.[fieldName];
+            if (fieldEntry) {
+              const newDesc = await promptInput('Description (blank to clear)', fieldEntry.description ?? '');
+              if (newDesc !== null) {
+                const trimmed = newDesc.trim();
+                if (trimmed) {
+                  fieldEntry.description = trimmed;
+                } else {
+                  delete fieldEntry.description;
+                }
+                await writeSchema(vaultDir, rawSchema);
+                printSuccess('Description updated');
+              }
+            }
+          } else if (choice === 'Change prompt type') {
             const promptOptions = ['text', 'select', 'list', 'date', 'relation', 'boolean', 'number'];
             const newPrompt = await promptSelection('Prompt type', promptOptions);
             const fieldEntry = rawTypeEntry.fields?.[fieldName];

--- a/src/commands/schema/helpers/output.ts
+++ b/src/commands/schema/helpers/output.ts
@@ -20,7 +20,7 @@ import {
 } from '../../../lib/schema.js';
 import { printError } from '../../../lib/prompt.js';
 import { printJson, jsonError, ExitCodes } from '../../../lib/output.js';
-import type { LoadedSchema, Field, BodySection, ResolvedType } from '../../../types/schema.js';
+import { type LoadedSchema, type Field, type BodySection, type ResolvedType, getOptionValues } from '../../../types/schema.js';
 import { getTtyContext, type TtyContext } from '../../../lib/tty/context.js';
 import { truncateAnsi, visibleWidth, wrapAnsi } from '../../../lib/tty/layout.js';
 import { renderTable } from '../../../lib/tty/table.js';
@@ -75,6 +75,7 @@ export function outputTypeDetailsJson(schema: LoadedSchema, typePath: string): v
 
   const output: Record<string, unknown> = {
     type_path: typePath,
+    description: typeDef.description,
     extends: typeDef.parent,
     output_dir: getOutputDir(schema, typePath),
     filename: typeDef.filename,
@@ -122,6 +123,8 @@ function formatTypeForJson(
     output_dir: getOutputDir(schema, typePath),
   };
 
+  if (typeDef.description) result.description = typeDef.description;
+
   // Add subtypes if present (children in new model)
   if (hasSubtypes(typeDef)) {
     result.subtypes = Object.fromEntries(
@@ -155,7 +158,11 @@ function formatFieldForJson(field: Field): Record<string, unknown> {
     result.type = 'auto';
   }
 
-  // Add options if applicable
+  // Description (what the field is for); distinct from label
+  if (field.description) result.description = field.description;
+
+  // Add options if applicable. Options retain their { value, description }
+  // shape when annotated, so per-option descriptions flow into JSON verbatim.
   if (field.options && field.options.length > 0) {
     result.options = field.options;
   }
@@ -233,6 +240,9 @@ function printTypeTree(
   // Build type label - always show directory since getOutputDir always returns a value
   let label = chalk.green(typeName);
   label += chalk.gray(` -> ${outputDir}`);
+  if (typeDef.description) {
+    label += chalk.dim(`  — ${typeDef.description}`);
+  }
 
   printTreeLine(indent, label, context);
 
@@ -286,6 +296,11 @@ export function showTypeDetails(schema: LoadedSchema, typePath: string): void {
   }
 
   console.log(chalk.bold(`\nType: ${typePath}\n`));
+
+  // Description (what this type is for), when documented
+  if (typeDef.description) {
+    printLabelValue('Description', typeDef.description, context);
+  }
 
   // Basic info - always show output dir since getOutputDir always returns a value
   const outputDir = getOutputDir(schema, typePath);
@@ -365,10 +380,11 @@ function printFieldDetails(
   const details: string[] = [];
 
   if (field.options && field.options.length > 0) {
+    const optionValues = getOptionValues(field.options);
     if (context.isTTY) {
-      details.push(`options=[${field.options.slice(0, 5).join(', ')}${field.options.length > 5 ? '...' : ''}]`);
+      details.push(`options=[${optionValues.slice(0, 5).join(', ')}${optionValues.length > 5 ? '...' : ''}]`);
     } else {
-      details.push(`options=[${field.options.join(', ')}]`);
+      details.push(`options=[${optionValues.join(', ')}]`);
     }
   }
 
@@ -393,20 +409,54 @@ function printFieldDetails(
   const prefix = `${indent}${chalk.yellow(name)}: ${type}`;
   const suffix = details.length > 0 ? ` ${chalk.gray(details.join(' '))}` : '';
 
+  const content = details.join(' ');
   if (!context.isTTY || !context.width) {
     console.log(prefix + suffix);
-    return;
-  }
-
-  const content = details.join(' ');
-  if (!content) {
+  } else if (!content) {
     console.log(prefix);
-    return;
+  } else {
+    const wrapped = wrapAnsi(content, context.width, {
+      indent: `${prefix} `,
+      hangingIndent: ' '.repeat(visibleWidth(prefix) + 1),
+    });
+    for (const line of wrapped) {
+      console.log(line);
+    }
   }
 
-  const wrapped = wrapAnsi(content, context.width, {
-    indent: `${prefix} `,
-    hangingIndent: ' '.repeat(visibleWidth(prefix) + 1),
+  // Field description on its own dim line, then any per-option descriptions.
+  printFieldDescription(field, indent, context);
+}
+
+/**
+ * Print a field's description and any per-option descriptions as dim, indented
+ * lines beneath the field's main line.
+ */
+function printFieldDescription(field: Field, indent: string, context: TtyContext): void {
+  const descIndent = `${indent}  `;
+  if (field.description) {
+    printDimWrapped(field.description, descIndent, context);
+  }
+  if (field.options) {
+    for (const option of field.options) {
+      if (typeof option !== 'string' && option.description) {
+        printDimWrapped(`${option.value} — ${option.description}`, `${descIndent}  `, context);
+      }
+    }
+  }
+}
+
+/**
+ * Print dim text, wrapped to terminal width when interactive.
+ */
+function printDimWrapped(text: string, indent: string, context: TtyContext): void {
+  if (!context.isTTY || !context.width) {
+    console.log(`${indent}${chalk.dim(text)}`);
+    return;
+  }
+  const wrapped = wrapAnsi(chalk.dim(text), context.width, {
+    indent,
+    hangingIndent: indent,
   });
   for (const line of wrapped) {
     console.log(line);
@@ -480,6 +530,9 @@ function printTypeTreeVerbose(
   }
   const effectiveOutputDir = getOutputDir(schema, typePath);
   header += chalk.gray(` -> ${effectiveOutputDir}`);
+  if (typeDef.description) {
+    header += chalk.dim(`  — ${typeDef.description}`);
+  }
 
   printTreeLine(indent, header, context);
 
@@ -647,6 +700,8 @@ export function outputSchemaVerboseJson(schema: LoadedSchema): void {
     const typeOutput: Record<string, unknown> = {
       name: typeName,
     };
+
+    if (typeDef.description) typeOutput.description = typeDef.description;
 
     // Add extends if present (hide implicit 'meta' parent for cleaner output)
     if (typeDef.parent && typeDef.parent !== 'meta') {

--- a/src/commands/schema/helpers/prompts.ts
+++ b/src/commands/schema/helpers/prompts.ts
@@ -11,7 +11,33 @@ import {
 } from '../../../lib/prompt.js';
 import { getTypeNames } from '../../../lib/schema.js';
 import { validateFieldName } from './validation.js';
-import type { LoadedSchema, Field } from '../../../types/schema.js';
+import type { LoadedSchema, Field, FieldOption } from '../../../types/schema.js';
+
+/**
+ * Prompt for an optional field description.
+ * Returns the trimmed description, '' if skipped, or null if the user cancels.
+ */
+async function promptFieldDescription(): Promise<string | null> {
+  const result = await promptInput('Description (what is this field for? blank to skip)');
+  if (result === null) return null;
+  return result.trim();
+}
+
+/**
+ * Given the raw option values, prompt for an optional description per option.
+ * Returns options as bare strings (when skipped) or { value, description }
+ * objects (when described), or null if the user cancels.
+ */
+async function promptOptionDescriptions(values: string[]): Promise<FieldOption[] | null> {
+  const options: FieldOption[] = [];
+  for (const value of values) {
+    const desc = await promptInput(`Description for option "${value}" (blank to skip)`);
+    if (desc === null) return null;
+    const trimmed = desc.trim();
+    options.push(trimmed ? { value, description: trimmed } : value);
+  }
+  return options;
+}
 
 /**
  * Prompt for field definition interactively.
@@ -79,7 +105,9 @@ export async function promptFieldDefinition(
         printError('Select fields require at least one option');
         return promptFieldDefinition(schema);
       }
-      field.options = optionsResult;
+      const annotated = await promptOptionDescriptions(optionsResult);
+      if (annotated === null) return null;
+      field.options = annotated;
     }
     
     // For dynamic, get source type
@@ -109,7 +137,11 @@ export async function promptFieldDefinition(
       }
     }
   }
-  
+
+  const description = await promptFieldDescription();
+  if (description === null) return null;
+  if (description) field.description = description;
+
   return { name, field };
 }
 
@@ -186,7 +218,9 @@ export async function promptSingleFieldDefinition(
       if (optionsResult.length === 0) {
         throw new Error('Select fields require at least one option');
       }
-      field.options = optionsResult;
+      const annotated = await promptOptionDescriptions(optionsResult);
+      if (annotated === null) return null;
+      field.options = annotated;
     }
     
     // For relation, get source type
@@ -215,6 +249,10 @@ export async function promptSingleFieldDefinition(
       }
     }
   }
-  
+
+  const description = await promptFieldDescription();
+  if (description === null) return null;
+  if (description) field.description = description;
+
   return { name, field };
 }

--- a/src/commands/schema/list.ts
+++ b/src/commands/schema/list.ts
@@ -23,7 +23,7 @@ import {
   getFieldType,
   renderSchemaFieldsTable,
 } from './helpers/output.js';
-import type { Field, LoadedSchema } from '../../types/schema.js';
+import { type Field, type LoadedSchema, getOptionValues } from '../../types/schema.js';
 
 interface ListCommandOptions {
   output?: string;
@@ -229,11 +229,22 @@ listCommand
           allFields.map(({ type, field, definition }) => {
             const details: string[] = [];
             if (definition.options?.length) {
+              const optionValues = getOptionValues(definition.options);
               if (context.isTTY) {
-                details.push(`options=[${definition.options.slice(0, 3).join(', ')}${definition.options.length > 3 ? '...' : ''}]`);
+                details.push(`options=[${optionValues.slice(0, 3).join(', ')}${optionValues.length > 3 ? '...' : ''}]`);
               } else {
-                details.push(`options=[${definition.options.join(', ')}]`);
+                details.push(`options=[${optionValues.join(', ')}]`);
               }
+            }
+            if (definition.description) {
+              // Show a short, unquoted snippet — the full text lives in the
+              // type detail view and JSON. Quotes-in-description must not create
+              // an ambiguous `desc="..."` token, and a long description must not
+              // blow out the table column.
+              const snippet = definition.description.length > 60
+                ? `${definition.description.slice(0, 59)}…`
+                : definition.description;
+              details.push(`desc: ${snippet}`);
             }
             if (definition.required) {
               details.push('required');

--- a/src/commands/schema/type.ts
+++ b/src/commands/schema/type.ts
@@ -37,6 +37,7 @@ interface NewTypeOptions {
   fields?: string;
   directory?: string;
   inherits?: string;
+  description?: string;
 }
 
 interface EditTypeOptions {
@@ -60,6 +61,7 @@ export function registerNewTypeCommand(newCommand: Command): void {
     .option('--fields <fields>', 'Comma-separated field definitions (name:type)')
     .option('--directory <dir>', 'Output directory for notes of this type')
     .option('--inherits <type>', 'Parent type to inherit from')
+    .option('--description <text>', 'Human-readable description of what this type is for')
     .action(async (name: string | undefined, options: NewTypeOptions, cmd: Command) => {
       const jsonMode = options.output === 'json';
 
@@ -157,8 +159,21 @@ export function registerNewTypeCommand(newCommand: Command): void {
           }
         }
 
+        // Description - from option or interactive prompt
+        let description = options.description?.trim();
+        if (description === undefined && !jsonMode) {
+          const descResult = await promptInput('Description (what is this type for? blank to skip)');
+          if (descResult === null) {
+            process.exit(0);
+          }
+          description = descResult.trim() || undefined;
+        }
+
         // Build the type object
         const newType: Type = {};
+        if (description) {
+          newType.description = description;
+        }
         if (inherits) {
           newType.extends = inherits;
         }
@@ -251,8 +266,8 @@ export function registerEditTypeCommand(editCommand: Command): void {
 
         console.log(chalk.bold(`\nEditing type: ${typeName}\n`));
         
-        const editOptions = ['Edit output directory', 'Edit inheritance', 'Add field', 'Done'];
-        
+        const editOptions = ['Edit description', 'Edit output directory', 'Edit inheritance', 'Add field', 'Done'];
+
         while (true) {
           const choice = await promptSelection('What would you like to edit?', editOptions);
           if (choice === null || choice === 'Done') {
@@ -261,7 +276,21 @@ export function registerEditTypeCommand(editCommand: Command): void {
 
           const rawSchema = await loadRawSchemaJson(vaultDir);
 
-          if (choice === 'Edit output directory') {
+          if (choice === 'Edit description') {
+            const resolvedType = schema.types.get(typeName);
+            const currentDesc = resolvedType?.description ?? '';
+            const newDesc = await promptInput('Description (blank to clear)', currentDesc);
+            if (newDesc !== null) {
+              const trimmed = newDesc.trim();
+              if (trimmed) {
+                rawSchema.types[typeName]!.description = trimmed;
+              } else {
+                delete rawSchema.types[typeName]!.description;
+              }
+              await writeSchema(vaultDir, rawSchema);
+              printSuccess('Description updated');
+            }
+          } else if (choice === 'Edit output directory') {
             const resolvedType = schema.types.get(typeName);
             const currentDir = resolvedType?.outputDir || computeDefaultOutputDir(schema, typeName);
             const newDir = await promptInput('Output directory', currentDir);

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -39,7 +39,7 @@ import {
   jsonError,
   ExitCodes,
 } from '../lib/output.js';
-import type { LoadedSchema, Field, Template } from '../types/schema.js';
+import { type LoadedSchema, type Field, type Template, getOptionValues } from '../types/schema.js';
 import { UserCancelledError } from '../lib/errors.js';
 import { getTtyContext } from '../lib/tty/context.js';
 import { renderTable } from '../lib/tty/table.js';
@@ -944,7 +944,7 @@ async function promptFieldDefault(
   switch (field.prompt) {
     case 'select': {
       if (!field.options || field.options.length === 0) return undefined;
-      const selectOptions = field.options;
+      const selectOptions = getOptionValues(field.options);
       const options = ['(skip)', ...selectOptions];
       
       const selected = await promptSelection(`Default ${label}:`, options);
@@ -1410,7 +1410,7 @@ async function promptFieldDefaultEdit(
   switch (field.prompt) {
     case 'select': {
       if (!field.options || field.options.length === 0) return currentValue;
-      const selectOptions = field.options;
+      const selectOptions = getOptionValues(field.options);
       const options = ['(keep)', '(clear)', ...selectOptions];
       
       const selected = await promptSelection(`New ${label}:`, options);

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -38,7 +38,7 @@ import { isDeepStrictEqual } from 'node:util';
 import { suggestOptionValue, suggestFieldName } from '../validation.js';
 import { searchContent } from '../content-search.js';
 import { applyWhereExpressions } from '../where-targeting.js';
-import type { LoadedSchema, Field } from '../../types/schema.js';
+import { type LoadedSchema, type Field, getOptionValues } from '../../types/schema.js';
 import {
   type AuditIssue,
   type FileAuditResult,
@@ -475,7 +475,7 @@ export async function auditFile(
 
     // Check select field options
     if (field.options && field.options.length > 0) {
-      const validOptions = field.options;
+      const validOptions = getOptionValues(field.options);
       if (Array.isArray(value)) {
         value.forEach((item, index) => {
           if (typeof item !== 'string') return;
@@ -1565,7 +1565,7 @@ function checkHygieneIssues(
     
     // Check enum casing for select fields
     if (field?.options && field.options.length > 0) {
-      const enumIssue = checkUnknownEnumCasing(fieldName, value, field.options);
+      const enumIssue = checkUnknownEnumCasing(fieldName, value, getOptionValues(field.options));
       if (enumIssue) {
         issues.push(enumIssue);
       }

--- a/src/lib/audit/output.ts
+++ b/src/lib/audit/output.ts
@@ -55,7 +55,11 @@ export function calculateSummary(results: FileAuditResult[]): AuditSummary {
 /**
  * Output results as JSON.
  */
-export function outputJsonResults(results: FileAuditResult[], summary: AuditSummary): void {
+export function outputJsonResults(
+  results: FileAuditResult[],
+  summary: AuditSummary,
+  extra?: Record<string, unknown>
+): void {
   const output = {
     ...jsonSuccess(),
     files: results.map(r => ({
@@ -98,6 +102,7 @@ export function outputJsonResults(results: FileAuditResult[], summary: AuditSumm
       })),
     })),
     summary,
+    ...(extra ?? {}),
   };
 
   printJson(output);

--- a/src/lib/audit/schema-docs.ts
+++ b/src/lib/audit/schema-docs.ts
@@ -1,0 +1,54 @@
+/**
+ * Schema documentation coverage check.
+ *
+ * Unlike the rest of the audit subsystem (which validates notes against the
+ * schema), this is a schema-quality check: it reports types and fields that
+ * lack a `description`. It keeps a self-documenting schema honest over time —
+ * the same way a lint rule nudges for missing docstrings.
+ *
+ * This is surfaced via the opt-in `bwrb audit --check-schema-docs` flag so it
+ * never changes the default per-note audit contract.
+ */
+
+import type { LoadedSchema } from '../../types/schema.js';
+import { getTypeNames, getFieldsByOrigin } from '../schema.js';
+
+export interface UndocumentedSchemaEntries {
+  /** Type names with no `description`. */
+  types: string[];
+  /** Fields (by owning type) with no `description`. */
+  fields: Array<{ type: string; field: string }>;
+}
+
+/**
+ * Find types and fields that have no description.
+ *
+ * Only a type's *own* fields are checked — an inherited field is documented at
+ * the ancestor that defines it, so reporting it on every descendant would be
+ * noise. Static identity fields (a fixed `value`, e.g. the `type` discriminator)
+ * are skipped because their meaning is self-evident.
+ */
+export function findUndocumentedSchemaEntries(schema: LoadedSchema): UndocumentedSchemaEntries {
+  const types: string[] = [];
+  const fields: Array<{ type: string; field: string }> = [];
+
+  for (const typeName of getTypeNames(schema)) {
+    if (typeName === 'meta') continue;
+    const resolved = schema.types.get(typeName);
+    if (!resolved) continue;
+
+    if (!resolved.description) {
+      types.push(typeName);
+    }
+
+    const { ownFields } = getFieldsByOrigin(schema, typeName);
+    for (const [fieldName, field] of Object.entries(ownFields)) {
+      if (field.value !== undefined) continue; // static identity field
+      if (!field.description) {
+        fields.push({ type: typeName, field: fieldName });
+      }
+    }
+  }
+
+  return { types, fields };
+}

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -34,7 +34,7 @@ import {
   jsonError,
   ExitCodes,
 } from './output.js';
-import type { LoadedSchema, Field, BodySection } from '../types/schema.js';
+import { type LoadedSchema, type Field, type BodySection, getOptionValues } from '../types/schema.js';
 import { UserCancelledError } from './errors.js';
 import { expandStaticValue } from './local-date.js';
 
@@ -399,7 +399,7 @@ async function promptFieldEdit(
   switch (field.prompt) {
     case 'select': {
       if (!field.options || field.options.length === 0) return currentValue;
-      const selectOptions = field.options;
+      const selectOptions = getOptionValues(field.options);
       
       // Multi-select mode
       if (field.multiple) {

--- a/src/lib/migration/diff.ts
+++ b/src/lib/migration/diff.ts
@@ -3,7 +3,7 @@
  * Compares two schemas and generates a migration plan.
  */
 
-import { Schema, Field } from '../../types/schema.js';
+import { Schema, Field, getOptionValues } from '../../types/schema.js';
 import {
   MigrationPlan,
   MigrationOp,
@@ -199,16 +199,27 @@ function detectFieldChanges(
  */
 function detectFieldPropertyChanges(oldField: Field, newField: Field): string[] {
   const changes: string[] = [];
-  
-  // Properties that matter for migration
-  const props: (keyof Field)[] = ['options', 'source', 'required', 'multiple'];
-  
+
+  // Compare option *values* only. Per-option descriptions are cosmetic metadata
+  // (they document what a value means, not what values are allowed), so adding
+  // or editing a description must not register as a migration-relevant change.
+  if (
+    JSON.stringify(getOptionValues(oldField.options)) !==
+    JSON.stringify(getOptionValues(newField.options))
+  ) {
+    changes.push('options');
+  }
+
+  // Other properties that matter for migration. Note: `description` and `label`
+  // are intentionally excluded — they are documentation, never data shape.
+  const props: (keyof Field)[] = ['source', 'required', 'multiple'];
+
   for (const prop of props) {
     if (JSON.stringify(oldField[prop]) !== JSON.stringify(newField[prop])) {
       changes.push(prop);
     }
   }
-  
+
   return changes;
 }
 

--- a/src/lib/migration/status.ts
+++ b/src/lib/migration/status.ts
@@ -1,15 +1,12 @@
 import type { Schema } from '../../types/schema.js';
 import type { SchemaSnapshot } from '../../types/migration.js';
+import { diffSchemas } from './diff.js';
 
 export interface MigrationStatus {
   hasSnapshot: boolean;
   pending: boolean;
   fromVersion?: string;
   toVersion?: string;
-}
-
-function schemaToComparableJson(schema: Schema): string {
-  return JSON.stringify(schema);
 }
 
 export function getMigrationStatus(
@@ -31,7 +28,17 @@ export function getMigrationStatus(
     return status;
   }
 
-  const pending = schemaToComparableJson(currentSchema) !== schemaToComparableJson(snapshot.schema);
+  // `pending` means there are *migration-relevant* differences — not merely any
+  // textual difference. Cosmetic edits (type/field/option descriptions, field
+  // labels, key reordering) produce no migration ops, so they must not nag the
+  // user to run a migration that `schema migrate` would itself report as empty.
+  const plan = diffSchemas(
+    snapshot.schema,
+    currentSchema,
+    snapshot.schemaVersion ?? '0.0.0',
+    toVersion ?? '0.0.0'
+  );
+  const pending = plan.hasChanges;
 
   const status: MigrationStatus = {
     hasSnapshot: true,

--- a/src/lib/numberedSelect.ts
+++ b/src/lib/numberedSelect.ts
@@ -7,6 +7,12 @@ import chalk from 'chalk';
 export interface NumberedSelectOptions {
   message: string;
   choices: string[];
+  /**
+   * Optional dim hint text rendered after each choice, aligned by index with
+   * `choices`. An empty string means no hint for that choice. Hints are
+   * cosmetic and never affect the returned value.
+   */
+  hints?: string[];
   /** Initial selected index (default: 0) */
   initial?: number;
 }
@@ -50,6 +56,7 @@ function parseNumberKey(char: string): number {
 export class NumberedSelectPrompt {
   private message: string;
   private choices: string[];
+  private hints: string[];
   private cursor: number;
   private currentPage: number;
   private totalPages: number;
@@ -61,6 +68,7 @@ export class NumberedSelectPrompt {
   constructor(options: NumberedSelectOptions) {
     this.message = options.message;
     this.choices = options.choices;
+    this.hints = options.hints ?? [];
     this.cursor = options.initial ?? 0;
     this.totalPages = Math.ceil(this.choices.length / ITEMS_PER_PAGE);
     this.currentPage = Math.floor(this.cursor / ITEMS_PER_PAGE);
@@ -303,11 +311,13 @@ export class NumberedSelectPrompt {
     const keyLabel = getDisplayKey(indexInPage);
     const choice = this.choices[absoluteIndex];
     const isSelected = absoluteIndex === this.cursor;
+    const hint = this.hints[absoluteIndex];
+    const hintSuffix = hint ? `  ${chalk.dim('— ' + hint)}` : '';
 
     if (isSelected) {
-      return `${chalk.cyan('❯')} ${chalk.dim(keyLabel)}  ${chalk.cyan.underline(choice)}`;
+      return `${chalk.cyan('❯')} ${chalk.dim(keyLabel)}  ${chalk.cyan.underline(choice)}${hintSuffix}`;
     } else {
-      return `  ${chalk.dim(keyLabel)}  ${choice}`;
+      return `  ${chalk.dim(keyLabel)}  ${choice}${hintSuffix}`;
     }
   }
 
@@ -375,20 +385,9 @@ export class NumberedSelectPrompt {
     const pageStart = this.currentPage * ITEMS_PER_PAGE;
     const pageEnd = Math.min(pageStart + ITEMS_PER_PAGE, this.choices.length);
 
-    // Render choices
+    // Render choices (single source of truth shared with differential updates)
     for (let i = pageStart; i < pageEnd; i++) {
-      const indexInPage = i - pageStart;
-      const keyLabel = getDisplayKey(indexInPage);
-      const choice = this.choices[i];
-      const isSelected = i === this.cursor;
-
-      let line: string;
-      if (isSelected) {
-        line = `${chalk.cyan('❯')} ${chalk.dim(keyLabel)}  ${chalk.cyan.underline(choice)}`;
-      } else {
-        line = `  ${chalk.dim(keyLabel)}  ${choice}`;
-      }
-      lines.push(line);
+      lines.push(this.renderChoiceLine(i));
     }
 
     // Hint line
@@ -414,9 +413,12 @@ export class NumberedSelectPrompt {
  */
 export async function numberedSelect(
   message: string,
-  choices: string[]
+  choices: string[],
+  hints?: string[]
 ): Promise<string | null> {
-  const prompt = new NumberedSelectPrompt({ message, choices });
+  const options: NumberedSelectOptions = { message, choices };
+  if (hints) options.hints = hints;
+  const prompt = new NumberedSelectPrompt(options);
   const result = await prompt.run();
   if (result.aborted) {
     return null; // User cancelled - signal quit

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -121,12 +121,13 @@ async function readLineFromStdin(timeoutMs: number): Promise<string | null> {
  */
 export async function promptSelection(
   message: string,
-  options: string[]
+  options: string[],
+  hints?: string[]
 ): Promise<PromptResult<string>> {
   if (!isInteractive()) {
     throw nonInteractivePromptError('interactive prompts are disabled. Re-run in a TTY or use non-interactive flags.');
   }
-  return numberedSelect(message, options);
+  return numberedSelect(message, options, hints);
 }
 
 /**

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -13,6 +13,7 @@ import {
   type OwnershipMap,
   type OwnedFieldInfo,
   type OwnerInfo,
+  getOptionValues,
 } from '../types/schema.js';
 
 const META_TYPE = 'meta';
@@ -98,6 +99,7 @@ export function resolveSchema(schema: Schema): LoadedSchema {
   for (const [name, typeDef] of Object.entries(schema.types)) {
     types.set(name, {
       name,
+      description: typeDef.description,
       parent: typeDef.extends ?? (name === META_TYPE ? undefined : META_TYPE),
       children: [],
       fields: { ...typeDef.fields },
@@ -173,6 +175,7 @@ export function resolveSchema(schema: Schema): LoadedSchema {
 function createImplicitMeta(): ResolvedType {
   return {
     name: META_TYPE,
+    description: undefined,
     parent: undefined,
     children: [],
     fields: {},
@@ -274,6 +277,11 @@ function computeEffectiveFields(
         // where each type has its own fixed value (e.g., type: task vs type: objective)
         if (fieldDef.value !== undefined) {
           fields[fieldName] = { ...fields[fieldName], value: fieldDef.value };
+        }
+        // Allow 'description' override - a subtype can document an inherited
+        // field with meaning specific to its context.
+        if (fieldDef.description !== undefined) {
+          fields[fieldName] = { ...fields[fieldName], description: fieldDef.description };
         }
       } else {
         // New field
@@ -508,7 +516,7 @@ export function getDescendants(schema: LoadedSchema, typeName: string): string[]
  * Options are defined inline on the field.
  */
 export function getFieldOptions(field: Field): string[] {
-  return field.options ?? [];
+  return getOptionValues(field.options);
 }
 
 /**
@@ -579,7 +587,7 @@ export function getOptionsForField(
   if (!type) return [];
   
   const field = type.fields[fieldName];
-  return field?.options ?? [];
+  return getOptionValues(field?.options);
 }
 
 /**

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -13,6 +13,21 @@ export const FilterConditionSchema = z.object({
 });
 
 /**
+ * A single select option.
+ * Either a bare value ("active") or an object that pairs the value with a
+ * description ({ value: "active", description: "currently being worked on" }).
+ * The object form lets the schema document what each option means; the bare
+ * string form is preserved so existing schemas stay valid untouched.
+ */
+export const FieldOptionSchema = z.union([
+  z.string(),
+  z.object({
+    value: z.string(),
+    description: z.string().optional(),
+  }),
+]);
+
+/**
  * Field definition for type frontmatter.
  * Fields can be static values, prompted inputs, or relation queries.
  */
@@ -21,8 +36,13 @@ export const FieldSchema = z.object({
   prompt: z.enum(['text', 'select', 'list', 'date', 'relation', 'boolean', 'number']).optional(),
   // Static value (no prompting)
   value: z.string().optional(),
-  // Inline options for select prompts (replaces global enums)
-  options: z.array(z.string()).optional(),
+  // Human-readable description of what this field is for and when to use it.
+  // Surfaced by `bwrb schema list` (text + JSON); distinct from `label`, which
+  // is the imperative prompt shown during input.
+  description: z.string().optional(),
+  // Inline options for select prompts (replaces global enums).
+  // Each option is a bare value or a { value, description } pair.
+  options: z.array(FieldOptionSchema).optional(),
   // Type name(s) for relation prompts (e.g., "milestone", "objective")
   // When specified, queryByType() fetches notes of this type (and descendants)
   // Can be an array to allow multiple valid types (e.g., for recursive types with extends)
@@ -74,6 +94,9 @@ export const BodySectionSchema: z.ZodType<BodySection, z.ZodTypeDef, BodySection
 export const TypeSchema = z.object({
   // Parent type name (implicit 'meta' if not specified)
   extends: z.string().optional(),
+  // Human-readable description of what this type is for and when to use it.
+  // Surfaced by `bwrb schema list` (text + JSON).
+  description: z.string().optional(),
   // Field definitions (merged with ancestors at load time)
   fields: z.record(FieldSchema).optional(),
   // Explicit field ordering (optional - defaults to definition order)
@@ -173,6 +196,33 @@ export const BwrbSchema = z.object({
 // ============================================================================
 
 export type Field = z.infer<typeof FieldSchema>;
+export type FieldOption = z.infer<typeof FieldOptionSchema>;
+
+/**
+ * Extract the bare value strings from a field's options, regardless of whether
+ * each option is a plain string or a { value, description } object.
+ */
+export function getOptionValues(options: FieldOption[] | undefined): string[] {
+  if (!options) return [];
+  return options.map((option) => (typeof option === 'string' ? option : option.value));
+}
+
+/**
+ * Look up the description for a specific option value, if one was provided.
+ * Returns undefined for bare-string options or unknown values.
+ */
+export function getOptionDescription(
+  options: FieldOption[] | undefined,
+  value: string
+): string | undefined {
+  if (!options) return undefined;
+  for (const option of options) {
+    if (typeof option !== 'string' && option.value === value) {
+      return option.description;
+    }
+  }
+  return undefined;
+}
 export type BodySection = {
   title: string;
   level?: number | undefined;
@@ -205,6 +255,8 @@ export type Schema = z.infer<typeof BwrbSchema>;
 export interface ResolvedType {
   /** Type name (unique identifier) */
   name: string;
+  /** Human-readable description of what this type is for, if declared */
+  description: string | undefined;
   /** Parent type name (undefined only for 'meta') */
   parent: string | undefined;
   /** Direct child type names */

--- a/tests/ts/commands/new.pty.test.ts
+++ b/tests/ts/commands/new.pty.test.ts
@@ -789,4 +789,45 @@ defaults:
       );
     }, 30000);
   });
+
+  describe('select option descriptions', () => {
+    const SCHEMA_WITH_OPTION_DESCRIPTIONS = {
+      version: 2,
+      types: {
+        chore: {
+          output_dir: 'Chores',
+          fields: {
+            type: { value: 'chore' },
+            status: {
+              prompt: 'select',
+              options: [
+                { value: 'active', description: 'currently being worked on' },
+                'backlog',
+              ],
+            },
+          },
+          field_order: ['type', 'status'],
+        },
+      },
+    };
+
+    it('renders a select option description as a picker hint', async () => {
+      await withTempVault(
+        ['new', 'chore'],
+        async (proc) => {
+          await proc.waitFor('Name', 10000);
+          await proc.typeAndEnter('Hint Test');
+
+          // The select picker should render the option's description as a hint
+          await proc.waitFor('status', 10000);
+          await proc.waitFor('currently being worked on', 5000);
+
+          // Choose an option to finish (1 = skip for optional field)
+          proc.write('1');
+          await proc.waitForStable(200);
+        },
+        { schema: SCHEMA_WITH_OPTION_DESCRIPTIONS }
+      );
+    }, 30000);
+  });
 });

--- a/tests/ts/commands/schema.pty.test.ts
+++ b/tests/ts/commands/schema.pty.test.ts
@@ -32,6 +32,10 @@ describePty('schema new type PTY tests', () => {
           await proc.waitFor('Add fields', 5000);
           proc.write('n');
 
+          // Skip the optional type description prompt
+          await proc.waitFor('Description', 5000);
+          proc.write('\r');
+
           // Wait for creation
           await proc.waitFor('created', 5000);
 
@@ -62,6 +66,10 @@ describePty('schema new type PTY tests', () => {
           await proc.waitFor('Add fields', 5000);
           proc.write('n');
 
+          // Skip the optional type description prompt
+          await proc.waitFor('Description', 5000);
+          proc.write('\r');
+
           // Wait for creation
           await proc.waitFor('created', 5000);
 
@@ -84,6 +92,10 @@ describePty('schema new type PTY tests', () => {
           // Should NOT prompt for parent type, go straight to fields
           await proc.waitFor('Add fields', 10000);
           proc.write('n');
+
+          // Skip the optional type description prompt
+          await proc.waitFor('Description', 5000);
+          proc.write('\r');
 
           // Wait for creation
           await proc.waitFor('created', 5000);

--- a/tests/ts/lib/schema-descriptions.test.ts
+++ b/tests/ts/lib/schema-descriptions.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BwrbSchema,
+  getOptionValues,
+  getOptionDescription,
+} from '../../../src/types/schema.js';
+import { resolveSchema, getFieldsForType } from '../../../src/lib/schema.js';
+import { diffSchemas } from '../../../src/lib/migration/diff.js';
+import { getMigrationStatus } from '../../../src/lib/migration/status.js';
+import { findUndocumentedSchemaEntries } from '../../../src/lib/audit/schema-docs.js';
+import type { z } from 'zod';
+
+type BwrbSchemaType = z.infer<typeof BwrbSchema>;
+
+describe('option helpers', () => {
+  it('getOptionValues handles bare strings and {value,description} objects', () => {
+    expect(getOptionValues(['a', 'b'])).toEqual(['a', 'b']);
+    expect(
+      getOptionValues(['a', { value: 'b', description: 'the b option' }])
+    ).toEqual(['a', 'b']);
+    expect(getOptionValues(undefined)).toEqual([]);
+  });
+
+  it('getOptionDescription returns the description only for documented object options', () => {
+    const options = ['a', { value: 'b', description: 'the b option' }];
+    expect(getOptionDescription(options, 'b')).toBe('the b option');
+    expect(getOptionDescription(options, 'a')).toBeUndefined();
+    expect(getOptionDescription(options, 'missing')).toBeUndefined();
+    expect(getOptionDescription(undefined, 'b')).toBeUndefined();
+  });
+});
+
+describe('schema parsing with descriptions', () => {
+  it('accepts description on types and fields and the option union', () => {
+    const parsed = BwrbSchema.parse({
+      version: 2,
+      types: {
+        task: {
+          description: 'a concrete next action',
+          output_dir: 'Tasks',
+          fields: {
+            status: {
+              prompt: 'select',
+              description: 'workflow state',
+              options: [
+                { value: 'active', description: 'being worked on' },
+                'backlog',
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const taskFields = parsed.types.task.fields!;
+    expect(parsed.types.task.description).toBe('a concrete next action');
+    expect(taskFields.status!.description).toBe('workflow state');
+    expect(taskFields.status!.options).toEqual([
+      { value: 'active', description: 'being worked on' },
+      'backlog',
+    ]);
+  });
+
+  it('strips unknown keys rather than persisting them', () => {
+    const parsed = BwrbSchema.parse({
+      version: 2,
+      types: { task: { output_dir: 'Tasks', fields: {}, bogusKey: true } },
+    });
+    expect('bogusKey' in parsed.types.task).toBe(false);
+  });
+});
+
+describe('description inheritance', () => {
+  const raw: BwrbSchemaType = {
+    version: 2,
+    types: {
+      objective: {
+        output_dir: 'Objectives',
+        fields: {
+          context: { prompt: 'relation', source: 'context', description: 'the area this belongs to' },
+        },
+      },
+      task: {
+        extends: 'objective',
+        output_dir: 'Tasks',
+        fields: {},
+      },
+      milestone: {
+        extends: 'objective',
+        output_dir: 'Milestones',
+        fields: {
+          context: { description: 'the milestone-specific area' },
+        },
+      },
+    },
+  };
+
+  it('inherits a field description from an ancestor', () => {
+    const schema = resolveSchema(raw);
+    const fields = getFieldsForType(schema, 'task');
+    expect(fields.context!.description).toBe('the area this belongs to');
+  });
+
+  it('lets a subtype override an inherited field description', () => {
+    const schema = resolveSchema(raw);
+    const fields = getFieldsForType(schema, 'milestone');
+    expect(fields.context!.description).toBe('the milestone-specific area');
+  });
+});
+
+describe('migration treats descriptions as cosmetic', () => {
+  const base: BwrbSchemaType = {
+    version: 2,
+    schemaVersion: '1.0.0',
+    types: {
+      task: {
+        output_dir: 'Tasks',
+        fields: {
+          status: { prompt: 'select', options: ['active', 'done'] },
+        },
+      },
+    },
+  };
+
+  it('adding a type description produces no migration', () => {
+    const next: BwrbSchemaType = {
+      ...base,
+      types: { task: { ...base.types.task, description: 'a next action' } },
+    };
+    const plan = diffSchemas(base, next, '1.0.0', '1.0.0');
+    expect(plan.hasChanges).toBe(false);
+  });
+
+  it('adding a field description produces no migration', () => {
+    const next: BwrbSchemaType = {
+      ...base,
+      types: {
+        task: {
+          ...base.types.task,
+          fields: {
+            status: { prompt: 'select', options: ['active', 'done'], description: 'state' },
+          },
+        },
+      },
+    };
+    const plan = diffSchemas(base, next, '1.0.0', '1.0.0');
+    expect(plan.hasChanges).toBe(false);
+  });
+
+  it('annotating an option (value unchanged) produces no migration', () => {
+    const next: BwrbSchemaType = {
+      ...base,
+      types: {
+        task: {
+          ...base.types.task,
+          fields: {
+            status: {
+              prompt: 'select',
+              options: [{ value: 'active', description: 'being worked on' }, 'done'],
+            },
+          },
+        },
+      },
+    };
+    const plan = diffSchemas(base, next, '1.0.0', '1.0.0');
+    expect(plan.hasChanges).toBe(false);
+  });
+
+  it('getMigrationStatus reports a description-only edit as not pending', () => {
+    const next: BwrbSchemaType = {
+      ...base,
+      types: { task: { ...base.types.task, description: 'a next action' } },
+    };
+    const status = getMigrationStatus(next, {
+      schema: base,
+      schemaVersion: '1.0.0',
+    } as Parameters<typeof getMigrationStatus>[1]);
+    expect(status.pending).toBe(false);
+  });
+
+  it('getMigrationStatus still reports a real structural change as pending', () => {
+    const next: BwrbSchemaType = {
+      ...base,
+      types: {
+        task: {
+          ...base.types.task,
+          fields: {
+            status: { prompt: 'select', options: ['active', 'done'] },
+            owner: { prompt: 'text' }, // genuinely new field
+          },
+        },
+      },
+    };
+    const status = getMigrationStatus(next, {
+      schema: base,
+      schemaVersion: '1.0.0',
+    } as Parameters<typeof getMigrationStatus>[1]);
+    expect(status.pending).toBe(true);
+  });
+});
+
+describe('findUndocumentedSchemaEntries', () => {
+  it('reports types and own fields lacking a description, skipping static identity fields', () => {
+    const raw: BwrbSchemaType = {
+      version: 2,
+      types: {
+        task: {
+          output_dir: 'Tasks',
+          fields: {
+            type: { value: 'task' }, // static identity — skipped
+            status: { prompt: 'select', options: ['a'], description: 'state' }, // documented
+            owner: { prompt: 'text' }, // undocumented
+          },
+        },
+        note: {
+          description: 'a note',
+          output_dir: 'Notes',
+          fields: {},
+        },
+      },
+    };
+    const schema = resolveSchema(raw);
+    const result = findUndocumentedSchemaEntries(schema);
+
+    expect(result.types).toContain('task');
+    expect(result.types).not.toContain('note');
+    expect(result.fields).toContainEqual({ type: 'task', field: 'owner' });
+    expect(result.fields).not.toContainEqual({ type: 'task', field: 'status' });
+    expect(result.fields).not.toContainEqual({ type: 'task', field: 'type' });
+  });
+});


### PR DESCRIPTION
## What

Makes the bwrb schema self-documenting: an optional `description` on **types**, **fields**, and **individual select options**, surfaced through the existing `schema list` command (no new verb). `bwrb schema list --output json` becomes a queryable source of what each type/field/option is *for* — replacing out-of-band notes (like a hand-maintained AGENTS.md "Schema Legend") with annotations co-located with the schema.

The guiding idea: bwrb already documents its *own* schema format with `description` keys in `schema.schema.json`. This extends the same convention inward to user schemas.

## How it surfaces

- **Tree** (`schema list`): description as a dim suffix
- **Detail** (`schema list type <name>`): a `Description:` line for the type, a line under each field, and indented per-option lines
- **JSON** (`--output json`): `description` keys on types, fields, and options (options keep their `{ value, description }` shape)

## Behavior

- **Non-breaking option union.** `options` accepts bare strings *or* `{ value, description }` objects; existing schemas are untouched. A `getOptionValues()`/`getOptionDescription()` helper pair keeps all existing option consumers working.
- **Inheritance.** Field descriptions inherit across `extends` and can be overridden by a subtype (added to the allowed-override set). Type descriptions are intrinsic (not inherited).
- **Cosmetic, never migrates.** `getMigrationStatus` now derives `pending` from the migration *diff* rather than a raw JSON compare, so description-only edits (type/field/option) don't nag to migrate — and `schema list` / `schema migrate` agree. The diff also compares option *values* (not full objects), so annotating an option isn't seen as a value change.
- **Authoring.** Interactive `schema new/edit type` and `new/edit field` prompt for descriptions (and per-option descriptions); `schema new type` gains a headless `--description`. The `bwrb new` select picker shows option descriptions as dim hints.
- **Audit (opt-in).** `audit --check-schema-docs` reports undocumented types/fields, skipping static identity fields and inherited fields. Default audit output and JSON contract are unchanged.

## Docs

Schema reference (type/field tables, option object form, relation name-collision note co-located with the relation field), `schema`/`audit` command pages, the `schema.schema.json` meta-schema, and CHANGELOG — all updated in lockstep.

## Testing

- New unit suite (`schema-descriptions.test.ts`): option helpers, parsing, inheritance + override, migration-is-cosmetic vs real-change-still-pending, and doc-coverage.
- Updated the `schema new type` PTY scripts for the new description prompt; added a PTY smoke test asserting the picker renders an option-description hint.
- Manually verified end-to-end by driving the built CLI across surfacing/JSON edge cases (special chars, unicode, quotes), three-level inheritance, migration cosmetic-vs-real, and audit coverage.
- Local: typecheck, lint, knip, build, verify:pack, full non-PTY suite (1915 passed), picker/schema PTY tests, and docs build/doctor/lint all green.

## Notes / out of scope

- **Option-*value* changes (rename/add/remove) don't trigger a migration** — this is pre-existing behavior (`field-changed` is informational in the diff classifier), independent of this feature. Flagged here because it's adjacent; not changed in this PR to avoid expanding into migration semantics.
- `--output json` is silently ignored on the `schema list types` / `schema list fields` *subcommands* (pre-existing; the primary `schema list` and `schema list type` JSON paths work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)