### PR TITLE
release: v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,35 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-06-20
+
+Changes since `v0.1.8`.
+
 ### Added
 
-- **Self-documenting schema: `description` on types, fields, and select options**
+- **Self-documenting schema: `description` on types, fields, and select options** (#588)
   - Add a `description` to any type or field, and to individual `select` options (via a `{ value, description }` form that coexists with bare-string options)
   - `bwrb schema list` surfaces descriptions — a dim suffix in the overview tree, dedicated lines in `type <name>` detail, and a `description` key in `--output json` — so `bwrb schema list --output json` is a queryable source of what each type/field/option is for
   - Descriptions are inherited like fields and can be overridden by a subtype
   - Interactive `bwrb schema new/edit type` and `new/edit field` now prompt for descriptions; the `bwrb new` select picker shows option descriptions as hints
   - `bwrb audit --check-schema-docs` (opt-in) reports types/fields with no description
   - Description-only edits are treated as cosmetic: they never trigger a schema migration
+
+- **`list --sort`** — sort results by a frontmatter field (#587)
+- **`list --limit` and `list --count`** — cap result rows or print just the match count (#586)
+- **Schema discovery aliases** — shorthand forms for navigating types in `schema list` (#583)
+- **Raw `_body` strings in JSON note creation** — supply a note body directly when creating notes via JSON (#584)
+
+### Changed
+
+- **Actionable template validation** — `template` surfaces concrete, fixable health warnings (#585)
+
+### Fixed
+
+- **Warn on unsafe note filenames** before they create problematic files (#570)
+- **`edit --json` honors the `--output` flag** in JSON mode (#567, #569)
+- **`list` tree output hierarchy** fixed for non-recursive results (#568, issue #524)
+- **May 21 CLI bug batch** (#580, closes #571–#579) — tighter `new`/`edit` JSON validation so unknown fields and invalid template defaults can't create invalid notes, plus fixes to delete dry-run/registry behavior, schema JSON subcommands, search arg handling, edit partial matching, and bulk JSON counts
 
 ## [0.1.8] - 2026-03-11
 

--- a/docs-site/src/content/docs/changelog.md
+++ b/docs-site/src/content/docs/changelog.md
@@ -9,7 +9,16 @@ For the complete changelog with all details, see [CHANGELOG.md](https://github.c
 
 ## Recent Highlights
 
-### Unreleased
+### 0.1.9
+
+- **Self-documenting schema** — Add a `description` to any type, field, or `select` option; `bwrb schema list` (and its `--output json`) surfaces them, so the schema itself documents what each type/field/option is for
+- **`list --sort`, `--limit`, `--count`** — Sort by a frontmatter field, cap rows, or print just the match count
+- **Schema discovery aliases** — Shorthand forms for navigating types in `schema list`
+- **Raw `_body` in JSON note creation** — Supply a note body directly when creating notes via JSON
+- **Actionable template validation** — `template` surfaces concrete, fixable health warnings
+- Fixes: unsafe-filename warnings, `edit --json` output handling, `list` tree hierarchy, and a batch of `new`/`edit`/`delete`/`search`/`bulk` JSON-mode correctness fixes
+
+### Earlier highlights
 
 - **Dashboard queries** — Save and run queries with `--save-as` and `bwrb dashboard`
 - **Unified opener** — Consistent `--app` modes across commands

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bwrb",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Schema-driven note management for markdown vaults",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release. Version bump + changelog for everything shipped since `v0.1.8`.

## Included since v0.1.8

**Added**
- Self-documenting schema — `description` on types, fields, and select options ([#588](https://github.com/3mdistal/bwrb/pull/588))
- `list --sort` ([#587](https://github.com/3mdistal/bwrb/pull/587)); `list --limit` / `--count` ([#586](https://github.com/3mdistal/bwrb/pull/586))
- Schema discovery aliases ([#583](https://github.com/3mdistal/bwrb/pull/583))
- Raw `_body` strings in JSON note creation ([#584](https://github.com/3mdistal/bwrb/pull/584))

**Changed**
- Actionable template validation ([#585](https://github.com/3mdistal/bwrb/pull/585))

**Fixed**
- Unsafe-filename warnings ([#570](https://github.com/3mdistal/bwrb/pull/570)); `edit --json` output handling ([#567](https://github.com/3mdistal/bwrb/pull/567), [#569](https://github.com/3mdistal/bwrb/pull/569)); `list` tree hierarchy ([#568](https://github.com/3mdistal/bwrb/pull/568)); May 21 CLI bug batch ([#580](https://github.com/3mdistal/bwrb/pull/580), closes #571–#579)

## Release steps
- [x] `package.json` → `0.1.9`
- [x] `CHANGELOG.md` updated
- [x] bwrb.dev changelog highlights refreshed
- [ ] Merge, then tag `v0.1.9` + GitHub release
- [ ] `npm publish` (run by maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)