### PR TITLE
feat(date): support partial dates (YYYY, YYYY-MM) via granularity

### DIFF
--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -67,6 +67,22 @@
         "default_dashboard": {
           "type": "string",
           "description": "Default dashboard to run when `bwrb dashboard` is called without arguments"
+        },
+        "excluded_directories": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Vault-root-relative directory prefixes excluded from all discovery/targeting"
+        },
+        "date_format": {
+          "type": "string",
+          "default": "YYYY-MM-DD",
+          "description": "Display/parse format for date fields (YYYY, MM, DD tokens), e.g. MM/DD/YYYY"
+        },
+        "date_granularity": {
+          "type": "string",
+          "enum": ["day", "month", "year"],
+          "default": "day",
+          "description": "Default coarsest date precision for all date fields; per-field `granularity` overrides it"
         }
       }
     },
@@ -142,6 +158,11 @@
           "type": "string",
           "enum": ["text", "select", "list", "date", "relation", "boolean", "number"],
           "description": "Prompt type (how the field is collected)"
+        },
+        "granularity": {
+          "type": "string",
+          "enum": ["day", "month", "year"],
+          "description": "Coarsest date precision allowed for date fields (day=full YYYY-MM-DD, month=YYYY-MM, year=YYYY); overrides config.date_granularity"
         },
         "value": {
           "type": "string",

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -214,7 +214,7 @@ Stored as `true` or `false` (YAML booleans).
 
 ### date
 
-Date input with YYYY-MM-DD format.
+Date input. By default a full `YYYY-MM-DD` is required.
 
 ```json
 {
@@ -224,6 +224,31 @@ Date input with YYYY-MM-DD format.
   }
 }
 ```
+
+#### Partial dates and granularity
+
+Many dates are legitimately approximate — you remember the month or year, not the
+day. Set `granularity` on a date field to allow partial ISO dates. `granularity`
+is the *coarsest* precision allowed; finer values are always accepted:
+
+| `granularity` | Accepts |
+| --- | --- |
+| `day` (default) | `2026-05-12` |
+| `month` | `2026-05`, `2026-05-12` |
+| `year` | `2026`, `2026-05`, `2026-05-12` |
+
+```json
+{
+  "last-contact": {
+    "prompt": "date",
+    "granularity": "month"
+  }
+}
+```
+
+Partial dates are stored verbatim (ISO partials still sort lexically). To relax
+the default for *all* date fields at once, set [`date_granularity`](#config) in
+config; a field's own `granularity` overrides that default.
 
 ### select
 
@@ -385,6 +410,7 @@ Complete list of field properties:
 | `description` | string | any | What this field is for and when to use it. Surfaced by `bwrb schema list`; distinct from `label` |
 | `required` | boolean | prompted | Whether field must have a value (default: `false`) |
 | `default` | string | prompted | Default value if user skips prompt |
+| `granularity` | string | `date` | Coarsest precision allowed: `day` (default), `month`, or `year`. Overrides `date_granularity` |
 | `options` | array | `select` | Allowed values: bare strings or `{ value, description }` objects |
 | `multiple` | boolean | `select`, `relation` | Allow multiple values (default: `false`) |
 | `source` | string | `relation` | Type name to filter picker, or `"any"` |
@@ -461,6 +487,8 @@ Vault-wide settings:
 | `editor` | string | `$EDITOR` | Terminal editor command |
 | `visual` | string | `$VISUAL` | GUI editor command |
 | `obsidian_vault` | string | auto | Obsidian vault name for URI scheme |
+| `date_format` | string | `"YYYY-MM-DD"` | Display/parse format for date fields (`YYYY`, `MM`, `DD` tokens) |
+| `date_granularity` | string | `"day"` | Default coarsest date precision for all date fields: `day`, `month`, or `year`. Per-field [`granularity`](#partial-dates-and-granularity) overrides it |
 
 ---
 

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -113,7 +113,7 @@ Issue Types:
   ambiguous-link-target Relation target matches multiple files
   invalid-list-element  List field contains non-string values
   wrong-scalar-type     Scalar value has wrong type for schema
-  invalid-date-format   Date value is not in YYYY-MM-DD format
+  invalid-date-format   Date value too imprecise or malformed for field granularity
   format-violation      Field value doesn't match expected format (wikilink, etc.)
   stale-reference       Wikilink points to non-existent file
   frontmatter-not-at-top Frontmatter block is not at top

--- a/src/commands/schema/helpers/output.ts
+++ b/src/commands/schema/helpers/output.ts
@@ -173,6 +173,7 @@ function formatFieldForJson(field: Field): Record<string, unknown> {
   if (field.label) result.label = field.label;
   if (field.source) result.source = field.source;
   if (field.list_format) result.list_format = field.list_format;
+  if (field.granularity) result.granularity = field.granularity;
 
   return result;
 }
@@ -404,6 +405,10 @@ function printFieldDetails(
 
   if (field.required) {
     details.push('required');
+  }
+
+  if (field.granularity) {
+    details.push(`granularity=${field.granularity}`);
   }
 
   const prefix = `${indent}${chalk.yellow(name)}: ${type}`;

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -434,7 +434,13 @@ export async function auditFile(
           expected: 'boolean',
           autoFixable: booleanCoercion.ok,
         });
-      } else if (expectedScalarType === 'string' && (valueShape === 'number' || valueShape === 'boolean')) {
+      } else if (
+        expectedScalarType === 'string' &&
+        (valueShape === 'number' || valueShape === 'boolean') &&
+        // Date fields handle numeric values themselves (a bare year like 2026
+        // is a partial date, not just a mis-typed string) — see date block below.
+        field.prompt !== 'date'
+      ) {
         issues.push({
           severity: 'error',
           code: 'wrong-scalar-type',
@@ -457,10 +463,13 @@ export async function auditFile(
       }
     }
 
-    if (field.prompt === 'date' && typeof value === 'string') {
+    if (field.prompt === 'date' && (typeof value === 'string' || typeof value === 'number')) {
+      // A bare year (e.g. 2026) is parsed as a number by YAML; treat it as a
+      // partial date string for validation.
+      const dateStr = String(value);
       const granularity = resolveDateGranularity(field, schema.config);
-      if (!isAcceptableDate(value, granularity)) {
-        const normalization = getUnambiguousDateNormalization(value);
+      if (!isAcceptableDate(dateStr, granularity)) {
+        const normalization = getUnambiguousDateNormalization(dateStr);
         const expected =
           granularity === 'day'
             ? 'YYYY-MM-DD'
@@ -477,6 +486,17 @@ export async function auditFile(
           ...(normalization && { suggestion: `Suggested: ${normalization.normalized}` }),
           ...(normalization && { meta: { normalized: normalization.normalized, normalizationKind: normalization.kind } }),
           autoFixable: Boolean(normalization),
+        });
+      } else if (typeof value === 'number') {
+        // Valid date but stored as a YAML number — should be quoted as a string.
+        issues.push({
+          severity: 'error',
+          code: 'wrong-scalar-type',
+          message: `Non-string value for ${fieldName} should be a string`,
+          field: fieldName,
+          value,
+          expected: 'string',
+          autoFixable: true,
         });
       }
     }

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -14,6 +14,7 @@ import {
   getOutputDir,
   getTypeFamilies,
   getDescendants,
+  resolveDateGranularity,
 } from '../schema.js';
 import { readStructuralFrontmatter } from './structural.js';
 import {
@@ -29,7 +30,7 @@ import {
   getScalarToList,
   getUnambiguousDateNormalization,
   getValueShape,
-  isCanonicalIsoDate,
+  isAcceptableDate,
 } from './fix-policy.js';
 import { extractYamlNodeValue, isEffectivelyEmpty } from './value-utils.js';
 import { isMap } from 'yaml';
@@ -457,15 +458,22 @@ export async function auditFile(
     }
 
     if (field.prompt === 'date' && typeof value === 'string') {
-      if (!isCanonicalIsoDate(value)) {
+      const granularity = resolveDateGranularity(field, schema.config);
+      if (!isAcceptableDate(value, granularity)) {
         const normalization = getUnambiguousDateNormalization(value);
+        const expected =
+          granularity === 'day'
+            ? 'YYYY-MM-DD'
+            : granularity === 'month'
+              ? 'YYYY-MM-DD or YYYY-MM'
+              : 'YYYY-MM-DD, YYYY-MM, or YYYY';
         issues.push({
           severity: 'error',
           code: 'invalid-date-format',
-          message: `Invalid date for ${fieldName}: must be YYYY-MM-DD`,
+          message: `Invalid date for ${fieldName}: must be ${expected}`,
           field: fieldName,
           value,
-          expected: 'YYYY-MM-DD',
+          expected,
           ...(normalization && { suggestion: `Suggested: ${normalization.normalized}` }),
           ...(normalization && { meta: { normalized: normalization.normalized, normalizationKind: normalization.kind } }),
           autoFixable: Boolean(normalization),

--- a/src/lib/audit/fix-policy.ts
+++ b/src/lib/audit/fix-policy.ts
@@ -98,10 +98,10 @@ export function isCanonicalIsoDate(raw: string): boolean {
  * (YYYY, YYYY-MM) are acceptable only when granularity permits that precision.
  */
 export function isAcceptableDate(raw: string, granularity: DatePrecision = 'day'): boolean {
-  const trimmed = raw.trim();
-  if (CANONICAL_DATE.test(trimmed)) return true;
-  if (granularity === 'day') return false;
-  const partial = parsePartialIsoDate(trimmed);
+  // parsePartialIsoDate calendar-validates both full (YYYY-MM-DD) and partial
+  // ISO dates, so e.g. 2026-13-01 / 2025-02-29 are rejected consistently with
+  // their partial counterparts.
+  const partial = parsePartialIsoDate(raw.trim());
   return partial.valid && isPrecisionAllowed(partial.precision, granularity);
 }
 

--- a/src/lib/audit/fix-policy.ts
+++ b/src/lib/audit/fix-policy.ts
@@ -4,6 +4,7 @@
 
 import type { Field } from '../../types/schema.js';
 import { coerceBooleanFromString, coerceNumberFromString } from './coercion.js';
+import { parsePartialIsoDate, isPrecisionAllowed, type DatePrecision } from '../local-date.js';
 
 export type ScalarType = 'string' | 'number' | 'boolean';
 export type ValueShape = 'empty' | 'string' | 'number' | 'boolean' | 'list' | 'object' | 'unknown';
@@ -89,6 +90,19 @@ export function getScalarToList(value: unknown): { ok: true; value: unknown[] } 
 
 export function isCanonicalIsoDate(raw: string): boolean {
   return CANONICAL_DATE.test(raw.trim());
+}
+
+/**
+ * Whether a stored date value is acceptable for a field with the given
+ * granularity. Full canonical dates are always acceptable; partial ISO dates
+ * (YYYY, YYYY-MM) are acceptable only when granularity permits that precision.
+ */
+export function isAcceptableDate(raw: string, granularity: DatePrecision = 'day'): boolean {
+  const trimmed = raw.trim();
+  if (CANONICAL_DATE.test(trimmed)) return true;
+  if (granularity === 'day') return false;
+  const partial = parsePartialIsoDate(trimmed);
+  return partial.valid && isPrecisionAllowed(partial.precision, granularity);
 }
 
 function isValidDateParts(year: number, month: number, day: number): boolean {

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -11,6 +11,7 @@ import {
   resolveTypePathFromFrontmatter,
   getFieldsForType,
   getFrontmatterOrder,
+  resolveDateGranularity,
 } from './schema.js';
 import { parseNote, writeNote, generateBodySections } from './frontmatter.js';
 import { queryByType, formatValue } from './vault.js';
@@ -78,7 +79,8 @@ function normalizeDateFields(
     }
 
     if (typeof value === 'string') {
-      const result = normalizeToIsoDate(value);
+      const granularity = resolveDateGranularity(field, schema.config);
+      const result = normalizeToIsoDate(value, granularity);
       if (result.valid) {
         normalized[fieldName] = result.value;
       }

--- a/src/lib/local-date.ts
+++ b/src/lib/local-date.ts
@@ -66,6 +66,81 @@ export function formatDateWithPattern(date: Date = new Date(), format: string = 
 }
 
 /**
+ * Coarsest date precision allowed for a date field.
+ * Ordered from finest to coarsest: day < month < year.
+ */
+export type DatePrecision = 'day' | 'month' | 'year';
+
+/** Numeric rank for comparing precisions (lower = finer). */
+const PRECISION_RANK: Record<DatePrecision, number> = { day: 0, month: 1, year: 2 };
+
+/**
+ * Result of parsing a partial-or-full ISO date.
+ */
+export type PartialDateResult =
+  | { valid: true; value: string; precision: DatePrecision }
+  | { valid: false; error: string };
+
+/**
+ * Parse a partial or full ISO date (YYYY, YYYY-MM, or YYYY-MM-DD).
+ *
+ * Validates component ranges (month 1-12, day valid for the month) and reports
+ * the precision of the supplied value. Does NOT accept non-ISO partial formats
+ * (e.g. "05/2026") — partial dates must be ISO so they remain lexically sortable.
+ *
+ * @example
+ * parsePartialIsoDate('2026')        // { valid: true, value: '2026', precision: 'year' }
+ * parsePartialIsoDate('2026-05')     // { valid: true, value: '2026-05', precision: 'month' }
+ * parsePartialIsoDate('2026-05-12')  // { valid: true, value: '2026-05-12', precision: 'day' }
+ * parsePartialIsoDate('2026-13')     // { valid: false, ... }
+ */
+export function parsePartialIsoDate(value: string): PartialDateResult {
+  const trimmed = value.trim();
+
+  // Year only: YYYY
+  const yearMatch = trimmed.match(/^(\d{4})$/);
+  if (yearMatch) {
+    const error = validateDateComponents(parseInt(yearMatch[1]!, 10), 1, 1);
+    return error ? { valid: false, error } : { valid: true, value: trimmed, precision: 'year' };
+  }
+
+  // Year + month: YYYY-MM
+  const monthMatch = trimmed.match(/^(\d{4})-(\d{2})$/);
+  if (monthMatch) {
+    const error = validateDateComponents(
+      parseInt(monthMatch[1]!, 10),
+      parseInt(monthMatch[2]!, 10),
+      1
+    );
+    return error ? { valid: false, error } : { valid: true, value: trimmed, precision: 'month' };
+  }
+
+  // Full date: YYYY-MM-DD
+  const dayMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (dayMatch) {
+    const error = validateDateComponents(
+      parseInt(dayMatch[1]!, 10),
+      parseInt(dayMatch[2]!, 10),
+      parseInt(dayMatch[3]!, 10)
+    );
+    return error ? { valid: false, error } : { valid: true, value: trimmed, precision: 'day' };
+  }
+
+  return {
+    valid: false,
+    error: `Unrecognized partial date: "${value}". Use YYYY, YYYY-MM, or YYYY-MM-DD`,
+  };
+}
+
+/**
+ * Whether a precision is allowed under a granularity setting.
+ * granularity = coarsest precision allowed; anything finer is always allowed.
+ */
+export function isPrecisionAllowed(precision: DatePrecision, granularity: DatePrecision): boolean {
+  return PRECISION_RANK[precision] <= PRECISION_RANK[granularity];
+}
+
+/**
  * Result of parsing a date string.
  */
 export interface ParsedDate {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { existsSync } from 'fs';
 import { basename } from 'path';
 import { SCHEMA_RELATIVE_PATH } from './bwrb-paths.js';
+import type { DatePrecision } from './local-date.js';
 import {
   BwrbSchema,
   type Schema,
@@ -413,6 +414,7 @@ function resolveConfig(config: Schema['config']): ResolvedConfig {
     obsidianVault: config?.obsidian_vault,
     defaultDashboard: config?.default_dashboard,
     dateFormat: config?.date_format ?? 'YYYY-MM-DD',
+    dateGranularity: config?.date_granularity ?? 'day',
   };
 }
 
@@ -517,6 +519,18 @@ export function getDescendants(schema: LoadedSchema, typeName: string): string[]
  */
 export function getFieldOptions(field: Field): string[] {
   return getOptionValues(field.options);
+}
+
+/**
+ * Resolve the effective date granularity for a field.
+ * A field's own `granularity` overrides the global `config.date_granularity`,
+ * which defaults to 'day' (strict full YYYY-MM-DD).
+ */
+export function resolveDateGranularity(
+  field: Field,
+  config: ResolvedConfig
+): DatePrecision {
+  return field.granularity ?? config.dateGranularity;
 }
 
 /**

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -284,6 +284,11 @@ function computeEffectiveFields(
         if (fieldDef.description !== undefined) {
           fields[fieldName] = { ...fields[fieldName], description: fieldDef.description };
         }
+        // Allow 'granularity' override - a subtype can loosen or tighten the
+        // precision required for an inherited date field.
+        if (fieldDef.granularity !== undefined) {
+          fields[fieldName] = { ...fields[fieldName], granularity: fieldDef.granularity };
+        }
       } else {
         // New field
         fields[fieldName] = { ...fieldDef };

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,16 +1,61 @@
 import type { LoadedSchema, Field } from '../types/schema.js';
-import { getFieldsForType, getDescendants, getType, getFieldOptions } from './schema.js';
+import { getFieldsForType, getDescendants, getType, getFieldOptions, resolveDateGranularity } from './schema.js';
 import { isBwrbBuiltinFrontmatterField } from './frontmatter/systemFields.js';
 import { queryByType } from './vault.js';
 import { extractWikilinkTarget } from './links.js';
-import { expandStaticValue, parseDate } from './local-date.js';
+import {
+  expandStaticValue,
+  parseDate,
+  parsePartialIsoDate,
+  isPrecisionAllowed,
+  type DatePrecision,
+} from './local-date.js';
 
 export type NormalizedDateResult =
   | { valid: true; value: string }
   | { valid: false; error: string };
 
-export function normalizeToIsoDate(value: string): NormalizedDateResult {
+/** Human-readable description of the minimum precision a granularity requires. */
+function describeGranularityRequirement(granularity: DatePrecision): string {
+  switch (granularity) {
+    case 'day':
+      return 'a full date (YYYY-MM-DD)';
+    case 'month':
+      return 'at least month precision (YYYY-MM)';
+    case 'year':
+      return 'at least year precision (YYYY)';
+  }
+}
+
+/**
+ * Normalize a user-supplied date value to its canonical stored form.
+ *
+ * Full dates accept ISO, ISO datetime, and unambiguous US/EU formats and are
+ * stored as YYYY-MM-DD. Partial dates (YYYY, YYYY-MM) are accepted only when the
+ * field's `granularity` permits them, and are stored verbatim (ISO partials sort
+ * lexically). `granularity` defaults to 'day' (full date required).
+ */
+export function normalizeToIsoDate(
+  value: string,
+  granularity: DatePrecision = 'day'
+): NormalizedDateResult {
   const trimmed = value.trim();
+
+  // Partial ISO dates (YYYY or YYYY-MM). Full YYYY-MM-DD is handled by the
+  // canonical/format-agnostic paths below.
+  if (/^\d{4}(-\d{2})?$/.test(trimmed)) {
+    const partial = parsePartialIsoDate(trimmed);
+    if (!partial.valid) {
+      return { valid: false, error: partial.error };
+    }
+    if (!isPrecisionAllowed(partial.precision, granularity)) {
+      return {
+        valid: false,
+        error: `"${trimmed}" is too coarse: this field requires ${describeGranularityRequirement(granularity)}`,
+      };
+    }
+    return { valid: true, value: partial.value };
+  }
 
   // Already ISO date
   if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
@@ -158,7 +203,8 @@ export function validateFrontmatter(
 
     // Type checking
     if (hasValue) {
-      const typeError = validateFieldType(fieldName, value, field);
+      const granularity = resolveDateGranularity(field, schema.config);
+      const typeError = validateFieldType(fieldName, value, field, granularity);
       if (typeError) {
         errors.push(typeError);
       }
@@ -233,7 +279,8 @@ export function applyDefaults(
 function validateFieldType(
   fieldName: string,
   value: unknown,
-  field: Field
+  field: Field,
+  granularity: DatePrecision = 'day'
 ): ValidationError | null {
   // Handle list fields (multi-value arrays or comma-separated strings)
   if (field.prompt === 'list' || field.list_format) {
@@ -257,7 +304,11 @@ function validateFieldType(
       return null;
     }
 
-    if (typeof value !== 'string') {
+    // A bare year (e.g. 2026) is parsed as a number by YAML; coerce so it can
+    // be validated against the field's granularity.
+    const dateValue = typeof value === 'number' ? String(value) : value;
+
+    if (typeof dateValue !== 'string') {
       return {
         type: 'invalid_type',
         field: fieldName,
@@ -267,7 +318,7 @@ function validateFieldType(
       };
     }
 
-    const normalized = normalizeToIsoDate(value);
+    const normalized = normalizeToIsoDate(dateValue, granularity);
     if (!normalized.valid) {
       return {
         type: 'invalid_date',

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -34,6 +34,12 @@ export const FieldOptionSchema = z.union([
 export const FieldSchema = z.object({
   // Prompt type (how the field is collected)
   prompt: z.enum(['text', 'select', 'list', 'date', 'relation', 'boolean', 'number']).optional(),
+  // Coarsest date precision allowed for `date` fields (finer is always allowed).
+  // - day (default): full YYYY-MM-DD only
+  // - month: YYYY-MM or YYYY-MM-DD (e.g. last-contact known to the month)
+  // - year: YYYY, YYYY-MM, or YYYY-MM-DD (e.g. "around 2021")
+  // Overrides the global config.date_granularity for this field.
+  granularity: z.enum(['day', 'month', 'year']).optional(),
   // Static value (no prompting)
   value: z.string().optional(),
   // Human-readable description of what this field is for and when to use it.
@@ -160,6 +166,12 @@ export const ConfigSchema = z.object({
   // DD-MM-YYYY: EU format with dashes
   // Custom patterns using YYYY, MM, DD tokens are also supported
   date_format: z.string().optional(),
+  // Default coarsest date precision allowed for all `date` fields.
+  // - day (default): full YYYY-MM-DD only
+  // - month: YYYY-MM or finer
+  // - year: YYYY or finer
+  // Per-field `granularity` overrides this default.
+  date_granularity: z.enum(['day', 'month', 'year']).optional(),
 });
 
 // ============================================================================
@@ -297,6 +309,8 @@ export interface ResolvedConfig {
   defaultDashboard: string | undefined;
   /** Date format for date fields (defaults to 'YYYY-MM-DD') */
   dateFormat: string;
+  /** Default coarsest date precision allowed for date fields (defaults to 'day') */
+  dateGranularity: 'day' | 'month' | 'year';
 }
 
 /**

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -3454,6 +3454,49 @@ effort: "3"
       );
       expect(issues).toHaveLength(1);
     });
+
+    it('flags calendar-invalid full dates (consistent with partials)', async () => {
+      const badMonth = await auditPerson(
+        'Bjarne.md',
+        `---\ntype: person\ndeadline: 2026-13-01\n---\n`
+      );
+      expect(badMonth).toHaveLength(1);
+
+      const badLeap = await auditPerson(
+        'Ken.md',
+        `---\ntype: person\ndeadline: 2025-02-29\n---\n`
+      );
+      expect(badLeap).toHaveLength(1);
+    });
+
+    it('treats a YAML-numeric bare year as a date, not a generic scalar', async () => {
+      // first-met has year granularity: a numeric 2021 is a valid year, so the
+      // only issue is that it should be quoted as a string (not invalid-date-format).
+      await writeFile(
+        join(tempVaultDir, 'People', 'Rob.md'),
+        `---\ntype: person\nfirst-met: 2021\n---\n`
+      );
+      const result = await runCLI(['audit', 'person', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(result.stdout);
+      const file = output.files.find((f: { path: string }) => f.path.includes('Rob.md'));
+      const codes: string[] = (file?.issues ?? []).map((i: { code: string }) => i.code);
+      expect(codes).toContain('wrong-scalar-type');
+      expect(codes).not.toContain('invalid-date-format');
+
+      // last-contact has month granularity: numeric 2026 is too coarse → date error,
+      // not a generic "should be a string" scalar error.
+      await writeFile(
+        join(tempVaultDir, 'People', 'James.md'),
+        `---\ntype: person\nlast-contact: 2026\n---\n`
+      );
+      const result2 = await runCLI(['audit', 'person', '--output', 'json'], tempVaultDir);
+      const output2 = JSON.parse(result2.stdout);
+      const file2 = output2.files.find((f: { path: string }) => f.path.includes('James.md'));
+      const issues2: { code: string; field?: string }[] = file2?.issues ?? [];
+      const lastContact = issues2.filter((i) => i.field === 'last-contact');
+      expect(lastContact).toHaveLength(1);
+      expect(lastContact[0].code).toBe('invalid-date-format');
+    });
   });
 
   describe('unknown-enum-casing detection and fix', () => {

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -3370,6 +3370,92 @@ effort: "3"
     });
   });
 
+  describe('partial date granularity', () => {
+    let tempVaultDir: string;
+
+    const GRANULAR_SCHEMA = {
+      version: 2,
+      config: { date_granularity: 'day' as const },
+      types: {
+        person: {
+          output_dir: 'People',
+          fields: {
+            type: { value: 'person' },
+            'last-contact': { prompt: 'date' as const, granularity: 'month' as const },
+            'first-met': { prompt: 'date' as const, granularity: 'year' as const },
+            deadline: { prompt: 'date' as const },
+          },
+        },
+      },
+    };
+
+    beforeEach(async () => {
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-audit-granularity-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify(GRANULAR_SCHEMA, null, 2)
+      );
+      await mkdir(join(tempVaultDir, 'People'), { recursive: true });
+    });
+
+    afterEach(async () => {
+      await rm(tempVaultDir, { recursive: true, force: true });
+    });
+
+    async function auditPerson(filename: string, body: string) {
+      await writeFile(join(tempVaultDir, 'People', filename), body);
+      const result = await runCLI(['audit', 'person', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(result.stdout);
+      // Files with no issues may be omitted from the report entirely.
+      const file = output.files.find((f: { path: string }) => f.path.includes(filename));
+      const issues: { code: string; field?: string }[] = file?.issues ?? [];
+      return issues.filter((i) => i.code === 'invalid-date-format');
+    }
+
+    it('accepts YYYY-MM in a month-granularity field', async () => {
+      const issues = await auditPerson(
+        'Ada.md',
+        `---\ntype: person\nlast-contact: 2026-05\n---\n`
+      );
+      expect(issues).toHaveLength(0);
+    });
+
+    it('accepts a bare year in a year-granularity field', async () => {
+      const issues = await auditPerson(
+        'Grace.md',
+        `---\ntype: person\nfirst-met: "2021"\n---\n`
+      );
+      expect(issues).toHaveLength(0);
+    });
+
+    it('flags a YYYY-MM value in a strict (default) date field', async () => {
+      const issues = await auditPerson(
+        'Linus.md',
+        `---\ntype: person\ndeadline: 2026-05\n---\n`
+      );
+      expect(issues).toHaveLength(1);
+      expect(issues[0].field).toBe('deadline');
+    });
+
+    it('flags a bare year in a month-granularity field (too coarse)', async () => {
+      const issues = await auditPerson(
+        'Edsger.md',
+        `---\ntype: person\nlast-contact: "2026"\n---\n`
+      );
+      expect(issues).toHaveLength(1);
+      expect(issues[0].field).toBe('last-contact');
+    });
+
+    it('still flags malformed dates in a relaxed field', async () => {
+      const issues = await auditPerson(
+        'Donald.md',
+        `---\ntype: person\nfirst-met: 2026-13\n---\n`
+      );
+      expect(issues).toHaveLength(1);
+    });
+  });
+
   describe('unknown-enum-casing detection and fix', () => {
     let tempVaultDir: string;
 

--- a/tests/ts/lib/local-date.test.ts
+++ b/tests/ts/lib/local-date.test.ts
@@ -6,6 +6,8 @@ import {
   formatDateWithPattern,
   parseDate,
   isValidDate,
+  parsePartialIsoDate,
+  isPrecisionAllowed,
   DEFAULT_DATE_FORMAT,
 } from '../../../src/lib/local-date.js';
 
@@ -319,6 +321,65 @@ describe('local-date', () => {
   describe('DEFAULT_DATE_FORMAT', () => {
     it('should be ISO format', () => {
       expect(DEFAULT_DATE_FORMAT).toBe('YYYY-MM-DD');
+    });
+  });
+
+  describe('parsePartialIsoDate', () => {
+    it('parses a year-only date', () => {
+      const result = parsePartialIsoDate('2026');
+      expect(result).toEqual({ valid: true, value: '2026', precision: 'year' });
+    });
+
+    it('parses a year-month date', () => {
+      const result = parsePartialIsoDate('2026-05');
+      expect(result).toEqual({ valid: true, value: '2026-05', precision: 'month' });
+    });
+
+    it('parses a full date', () => {
+      const result = parsePartialIsoDate('2026-05-12');
+      expect(result).toEqual({ valid: true, value: '2026-05-12', precision: 'day' });
+    });
+
+    it('trims surrounding whitespace but stores the trimmed value', () => {
+      expect(parsePartialIsoDate('  2026-05  ')).toEqual({
+        valid: true,
+        value: '2026-05',
+        precision: 'month',
+      });
+    });
+
+    it('rejects an out-of-range month', () => {
+      expect(parsePartialIsoDate('2026-13').valid).toBe(false);
+    });
+
+    it('rejects an impossible day', () => {
+      expect(parsePartialIsoDate('2026-02-30').valid).toBe(false);
+    });
+
+    it('rejects non-ISO partial formats', () => {
+      expect(parsePartialIsoDate('05/2026').valid).toBe(false);
+      expect(parsePartialIsoDate('May 2026').valid).toBe(false);
+      expect(parsePartialIsoDate('2026-5').valid).toBe(false); // unpadded month
+    });
+  });
+
+  describe('isPrecisionAllowed', () => {
+    it('day granularity allows only day precision', () => {
+      expect(isPrecisionAllowed('day', 'day')).toBe(true);
+      expect(isPrecisionAllowed('month', 'day')).toBe(false);
+      expect(isPrecisionAllowed('year', 'day')).toBe(false);
+    });
+
+    it('month granularity allows day and month, not year', () => {
+      expect(isPrecisionAllowed('day', 'month')).toBe(true);
+      expect(isPrecisionAllowed('month', 'month')).toBe(true);
+      expect(isPrecisionAllowed('year', 'month')).toBe(false);
+    });
+
+    it('year granularity allows all precisions', () => {
+      expect(isPrecisionAllowed('day', 'year')).toBe(true);
+      expect(isPrecisionAllowed('month', 'year')).toBe(true);
+      expect(isPrecisionAllowed('year', 'year')).toBe(true);
     });
   });
 });

--- a/tests/ts/lib/validation.test.ts
+++ b/tests/ts/lib/validation.test.ts
@@ -297,6 +297,39 @@ describe('validation', () => {
       expect(validateFrontmatter(s, 'note', { type: 'note', when: '2026-13' }).valid).toBe(false);
       expect(validateFrontmatter(s, 'note', { type: 'note', when: '05/2026' }).valid).toBe(false);
     });
+
+    it('calendar-validates full dates consistently with partials', () => {
+      const s = buildSchema({ fieldGranularity: 'year' });
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '2026-13-01' }).valid).toBe(false);
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '2025-02-29' }).valid).toBe(false);
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '2024-02-29' }).valid).toBe(true);
+    });
+
+    it('lets a child type override an inherited date field granularity', () => {
+      const s = resolveSchema({
+        version: 1,
+        types: {
+          base: {
+            fields: {
+              type: { value: 'base' },
+              when: { prompt: 'date', granularity: 'day' },
+            },
+          },
+          child: {
+            extends: 'base',
+            fields: {
+              type: { value: 'child' },
+              when: { prompt: 'date', granularity: 'year' },
+            },
+          },
+        },
+      } as never);
+
+      // Child relaxed to year — accepts a bare year.
+      expect(validateFrontmatter(s, 'child', { type: 'child', when: '2026' }).valid).toBe(true);
+      // Parent stays strict — rejects it.
+      expect(validateFrontmatter(s, 'base', { type: 'base', when: '2026' }).valid).toBe(false);
+    });
   });
 
   describe('applyDefaults', () => {

--- a/tests/ts/lib/validation.test.ts
+++ b/tests/ts/lib/validation.test.ts
@@ -8,7 +8,7 @@ import {
   suggestFieldName,
   formatValidationErrors,
 } from '../../../src/lib/validation.js';
-import { loadSchema } from '../../../src/lib/schema.js';
+import { loadSchema, resolveSchema } from '../../../src/lib/schema.js';
 import type { LoadedSchema } from '../../../src/types/schema.js';
 import { createTestVault, cleanupTestVault } from '../fixtures/setup.js';
 
@@ -209,6 +209,93 @@ describe('validation', () => {
       });
 
       expect(result.valid).toBe(true);
+    });
+
+    it('should reject partial dates under default (day) granularity', () => {
+      const monthResult = validateFrontmatter(schema, 'task', {
+        type: 'objective',
+        'objective-type': 'task',
+        status: 'raw',
+        deadline: '2024-01',
+      });
+      expect(monthResult.valid).toBe(false);
+      expect(monthResult.errors[0].type).toBe('invalid_date');
+
+      const yearResult = validateFrontmatter(schema, 'task', {
+        type: 'objective',
+        'objective-type': 'task',
+        status: 'raw',
+        deadline: '2024',
+      });
+      expect(yearResult.valid).toBe(false);
+      expect(yearResult.errors[0].type).toBe('invalid_date');
+    });
+  });
+
+  describe('partial date granularity', () => {
+    // Build a focused schema with two date fields: a strict default field and
+    // a per-field-relaxed field, plus an optional global default.
+    function buildSchema(opts: {
+      fieldGranularity?: 'day' | 'month' | 'year';
+      configGranularity?: 'day' | 'month' | 'year';
+    }) {
+      return resolveSchema({
+        version: 1,
+        ...(opts.configGranularity && {
+          config: { date_granularity: opts.configGranularity },
+        }),
+        types: {
+          note: {
+            fields: {
+              type: { value: 'note' },
+              when: {
+                prompt: 'date',
+                ...(opts.fieldGranularity && { granularity: opts.fieldGranularity }),
+              },
+            },
+          },
+        },
+      } as never);
+    }
+
+    it('accepts YYYY-MM when field granularity is month, rejects bare year', () => {
+      const s = buildSchema({ fieldGranularity: 'month' });
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '2026-05' }).valid).toBe(true);
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '2026-05-12' }).valid).toBe(true);
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '2026' }).valid).toBe(false);
+    });
+
+    it('accepts bare year when field granularity is year', () => {
+      const s = buildSchema({ fieldGranularity: 'year' });
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '2026' }).valid).toBe(true);
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '2026-05' }).valid).toBe(true);
+    });
+
+    it('uses the global config default when no field granularity is set', () => {
+      const s = buildSchema({ configGranularity: 'month' });
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '2026-05' }).valid).toBe(true);
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '2026' }).valid).toBe(false);
+    });
+
+    it('per-field granularity overrides the global default', () => {
+      // Global says month, but the field tightens to day.
+      const s = buildSchema({ fieldGranularity: 'day', configGranularity: 'month' });
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '2026-05' }).valid).toBe(false);
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '2026-05-12' }).valid).toBe(true);
+    });
+
+    it('coerces a YAML-numeric bare year and validates it against granularity', () => {
+      const yearSchema = buildSchema({ fieldGranularity: 'year' });
+      expect(validateFrontmatter(yearSchema, 'note', { type: 'note', when: 2026 }).valid).toBe(true);
+
+      const daySchema = buildSchema({ fieldGranularity: 'day' });
+      expect(validateFrontmatter(daySchema, 'note', { type: 'note', when: 2026 }).valid).toBe(false);
+    });
+
+    it('still rejects malformed partial values regardless of granularity', () => {
+      const s = buildSchema({ fieldGranularity: 'year' });
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '2026-13' }).valid).toBe(false);
+      expect(validateFrontmatter(s, 'note', { type: 'note', when: '05/2026' }).valid).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #590. `date`-type fields can now accept partial ISO dates (`YYYY` and `YYYY-MM`), gated by a `granularity` setting so strictness stays opt-in.

- **Per-field** `granularity: day | month | year` on a date field.
- **Global** `config.date_granularity` sets the default; a field's own `granularity` overrides it. Default is `day` (strict full `YYYY-MM-DD`, unchanged behavior).
- Semantics: `granularity` is the **coarsest** precision allowed; finer is always accepted.

| `granularity` | accepts |
| --- | --- |
| `day` (default) | `2026-05-12` |
| `month` | `2026-05`, `2026-05-12` |
| `year` | `2026`, `2026-05`, `2026-05-12` |

Partial dates are stored verbatim — ISO partials still sort lexically, so sortability is preserved. Non-ISO partials (e.g. `05/2026`) are not accepted.

```jsonc
// schema.json
"last-contact": { "prompt": "date", "granularity": "month" }, // "talked to them in May" → 2026-05
"deadline":     { "prompt": "date" }                          // still requires 2026-05-12
```

## Implementation

- **schema**: new field `granularity` and config `date_granularity` (+ `ResolvedConfig.dateGranularity`, `resolveDateGranularity` helper). Child types may override an inherited date field's granularity.
- **local-date**: `parsePartialIsoDate` / `isPrecisionAllowed` helpers + `DatePrecision` type.
- **validation**: granularity-aware `normalizeToIsoDate` / `validateFieldType`; coerces YAML-numeric bare years.
- **audit**: `isAcceptableDate`; detection reports granularity-aware expected formats. Full ISO dates are now calendar-validated consistently with partials (`2026-13-01`, `2025-02-29` are rejected). Numeric date values are treated as partial dates rather than generic scalar-type errors.
- **edit**: normalizes date fields against the resolved granularity.
- **schema list**: surfaces `granularity` in text and JSON output.
- **docs**: schema reference + public JSON schema (also backfills the previously-undocumented `date_format` and `excluded_directories`).

## Testing

- Unit + CLI tests: `local-date` (partial parsing, precision), `validation` (per-field/global/override resolution, calendar consistency, inheritance, numeric coercion), and `audit` (granularity acceptance, calendar-invalid full dates, numeric handling). Full suite: **1977 passing**.
- Stress-tested end-to-end via the built CLI by three sub-agents (audit/fix path, create/edit/sort path, schema/config/inheritance path). Findings in-scope were fixed (calendar consistency, inheritance override, numeric handling, `schema list` visibility). Two pre-existing, out-of-scope bugs they surfaced — `bwrb new` not normalizing dates, and list/`multiple` date fields skipping per-element validation — are tracked separately rather than expanding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
