### PR TITLE
refactor(format): consolidate frontmatter display-value formatters

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -23,6 +23,7 @@ import {
 import { UserCancelledError } from '../lib/errors.js';
 import { openNote, resolveAppMode } from './open.js';
 import { pickFile, parsePickerMode } from '../lib/picker.js';
+import { formatDisplayValue } from '../lib/value-format.js';
 import type { LoadedSchema, DashboardDefinition } from '../types/schema.js';
 import {
   resolveTargets,
@@ -684,7 +685,7 @@ function printTable(
         : field === '_path'
           ? relative(vaultDir, path)
           : frontmatter[field];
-      row[field] = formatValue(value);
+      row[field] = formatDisplayValue(value, { empty: '—' });
     }
 
     rows.push(row);
@@ -694,19 +695,6 @@ function printTable(
   for (const line of lines) {
     console.log(line);
   }
-}
-
-/**
- * Format a frontmatter value for display.
- */
-function formatValue(value: unknown): string {
-  if (value === undefined || value === null) {
-    return '—';
-  }
-  if (Array.isArray(value)) {
-    return value.join(', ');
-  }
-  return String(value);
 }
 
 // ============================================================================

--- a/src/lib/bulk/operations.ts
+++ b/src/lib/bulk/operations.ts
@@ -2,6 +2,7 @@
  * Bulk operation logic for modifying frontmatter.
  */
 
+import { formatDisplayValue } from '../value-format.js';
 import type { BulkOperation, FieldChange, OperationType } from './types.js';
 
 /**
@@ -210,16 +211,7 @@ export function applyOperations(
  * Format a value for display.
  */
 function formatValue(value: unknown): string {
-  if (value === undefined || value === null) {
-    return '(empty)';
-  }
-  if (Array.isArray(value)) {
-    if (value.length === 0) {
-      return '[]';
-    }
-    return `[${value.join(', ')}]`;
-  }
-  return String(value);
+  return formatDisplayValue(value, { empty: '(empty)', arrayStyle: 'bracketed' });
 }
 
 /**

--- a/src/lib/migration/execute.ts
+++ b/src/lib/migration/execute.ts
@@ -7,6 +7,7 @@ import { discoverManagedFiles } from '../discovery.js';
 import { createBackup } from '../bulk/backup.js';
 import { getFieldsForType, resolveTypeFromFrontmatter } from '../schema.js';
 import { toWikilink, toMarkdownLink, isWikilink, isMarkdownLink } from '../links.js';
+import { formatDisplayValue } from '../value-format.js';
 import type { LoadedSchema } from '../../types/schema.js';
 import type {
   MigrationPlan,
@@ -413,11 +414,8 @@ export function formatMigrationResult(result: MigrationResult): string {
  * Format a single applied change for display.
  */
 function formatAppliedChange(change: AppliedChange): string {
-  const formatValue = (v: unknown): string => {
-    if (v === undefined) return '(empty)';
-    if (Array.isArray(v)) return `[${v.join(', ')}]`;
-    return String(v);
-  };
+  const formatValue = (v: unknown): string =>
+    formatDisplayValue(v, { empty: '(empty)', arrayStyle: 'bracketed', nullIsEmpty: false });
 
   switch (change.kind) {
     case 'set':

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -8,6 +8,7 @@ import { isBwrbBuiltinFrontmatterField } from './frontmatter/systemFields.js';
 import { matchesExpression, parseExpression, type EvalContext } from './expression.js';
 import { applyDefaults } from './validation.js';
 import { evaluateTemplateDefault, validateDateExpression, isDateExpression } from './date-expression.js';
+import { formatDisplayValue } from './value-format.js';
 import { formatDateWithPattern, DEFAULT_DATE_FORMAT } from './local-date.js';
 import { sanitizeFilenameBase, type FilenameTransformation } from './filename.js';
 import {
@@ -687,13 +688,7 @@ export function processTemplateBody(
  * Format a frontmatter value for body substitution.
  */
 function formatValueForBody(value: unknown): string {
-  if (value === null || value === undefined) {
-    return '';
-  }
-  if (Array.isArray(value)) {
-    return value.join(', ');
-  }
-  return String(value);
+  return formatDisplayValue(value);
 }
 
 /**

--- a/src/lib/value-format.ts
+++ b/src/lib/value-format.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared formatting for frontmatter values rendered as human-readable display
+ * strings.
+ *
+ * Several call sites (list output, bulk change previews, migration change
+ * previews, template body substitution) historically each carried their own
+ * near-identical `formatValue` helper. They differed only in two dimensions:
+ * the placeholder shown for empty values, and whether arrays are wrapped in
+ * brackets. This module unifies them behind a single parameterized helper so
+ * the rendering rules live in one tested place.
+ *
+ * Note: this is distinct from `formatValue` in `vault.ts`, which formats a
+ * single string into a YAML-safe wikilink/markdown link. That helper serves a
+ * different purpose and is intentionally left separate.
+ */
+
+export interface DisplayValueOptions {
+  /**
+   * Placeholder returned for empty values (`undefined`, and `null` unless
+   * `nullIsEmpty` is false). Defaults to an empty string.
+   */
+  empty?: string;
+  /**
+   * How arrays are rendered:
+   * - `'plain'` (default): `"a, b"`, and `""` for an empty array.
+   * - `'bracketed'`: `"[a, b]"`, and `"[]"` for an empty array.
+   */
+  arrayStyle?: 'plain' | 'bracketed';
+  /**
+   * Whether `null` is treated as empty (returns the `empty` placeholder).
+   * Defaults to `true`. When `false`, `null` is stringified to `"null"`.
+   */
+  nullIsEmpty?: boolean;
+}
+
+/**
+ * Render a frontmatter value as a human-readable display string.
+ */
+export function formatDisplayValue(
+  value: unknown,
+  options: DisplayValueOptions = {}
+): string {
+  const { empty = '', arrayStyle = 'plain', nullIsEmpty = true } = options;
+
+  if (value === undefined || (nullIsEmpty && value === null)) {
+    return empty;
+  }
+
+  if (Array.isArray(value)) {
+    if (arrayStyle === 'bracketed') {
+      return value.length === 0 ? '[]' : `[${value.join(', ')}]`;
+    }
+    return value.join(', ');
+  }
+
+  return String(value);
+}

--- a/tests/ts/lib/value-format.test.ts
+++ b/tests/ts/lib/value-format.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { formatDisplayValue } from '../../../src/lib/value-format.js';
+
+describe('formatDisplayValue', () => {
+  describe('defaults', () => {
+    it('renders undefined as empty string', () => {
+      expect(formatDisplayValue(undefined)).toBe('');
+    });
+
+    it('renders null as empty string', () => {
+      expect(formatDisplayValue(null)).toBe('');
+    });
+
+    it('joins arrays with ", "', () => {
+      expect(formatDisplayValue(['a', 'b', 'c'])).toBe('a, b, c');
+    });
+
+    it('renders an empty array as empty string', () => {
+      expect(formatDisplayValue([])).toBe('');
+    });
+
+    it('stringifies scalars', () => {
+      expect(formatDisplayValue('hello')).toBe('hello');
+      expect(formatDisplayValue(42)).toBe('42');
+      expect(formatDisplayValue(0)).toBe('0');
+      expect(formatDisplayValue(true)).toBe('true');
+      expect(formatDisplayValue(false)).toBe('false');
+    });
+  });
+
+  describe('custom empty placeholder', () => {
+    it('uses the provided placeholder for undefined and null', () => {
+      expect(formatDisplayValue(undefined, { empty: '(empty)' })).toBe('(empty)');
+      expect(formatDisplayValue(null, { empty: '(empty)' })).toBe('(empty)');
+    });
+  });
+
+  describe('bracketed array style', () => {
+    it('wraps non-empty arrays in brackets', () => {
+      expect(formatDisplayValue(['a', 'b'], { arrayStyle: 'bracketed' })).toBe('[a, b]');
+    });
+
+    it('renders an empty array as "[]"', () => {
+      expect(formatDisplayValue([], { arrayStyle: 'bracketed' })).toBe('[]');
+    });
+  });
+
+  describe('nullIsEmpty: false', () => {
+    it('stringifies null instead of using the placeholder', () => {
+      expect(formatDisplayValue(null, { empty: '(empty)', nullIsEmpty: false })).toBe('null');
+    });
+
+    it('still treats undefined as empty', () => {
+      expect(formatDisplayValue(undefined, { empty: '(empty)', nullIsEmpty: false })).toBe('(empty)');
+    });
+  });
+
+  // The following groups lock in the exact behavior of the four call sites this
+  // helper replaced, so any future change to the shared helper that would alter
+  // one of those outputs fails loudly.
+
+  describe('parity: list output formatter (empty: "—", plain arrays)', () => {
+    const fmt = (v: unknown) => formatDisplayValue(v, { empty: '—' });
+    it('matches legacy behavior', () => {
+      expect(fmt(undefined)).toBe('—');
+      expect(fmt(null)).toBe('—');
+      expect(fmt(['a', 'b'])).toBe('a, b');
+      expect(fmt([])).toBe('');
+      expect(fmt('x')).toBe('x');
+      expect(fmt(5)).toBe('5');
+    });
+  });
+
+  describe('parity: bulk change formatter (empty: "(empty)", bracketed arrays)', () => {
+    const fmt = (v: unknown) => formatDisplayValue(v, { empty: '(empty)', arrayStyle: 'bracketed' });
+    it('matches legacy behavior', () => {
+      expect(fmt(undefined)).toBe('(empty)');
+      expect(fmt(null)).toBe('(empty)');
+      expect(fmt([])).toBe('[]');
+      expect(fmt(['a', 'b'])).toBe('[a, b]');
+      expect(fmt('x')).toBe('x');
+    });
+  });
+
+  describe('parity: migration change formatter (empty: "(empty)", bracketed, null stringified)', () => {
+    const fmt = (v: unknown) =>
+      formatDisplayValue(v, { empty: '(empty)', arrayStyle: 'bracketed', nullIsEmpty: false });
+    it('matches legacy behavior', () => {
+      expect(fmt(undefined)).toBe('(empty)');
+      expect(fmt(null)).toBe('null');
+      expect(fmt([])).toBe('[]');
+      expect(fmt(['a', 'b'])).toBe('[a, b]');
+      expect(fmt('x')).toBe('x');
+    });
+  });
+
+  describe('parity: template body formatter (empty: "", plain arrays)', () => {
+    const fmt = (v: unknown) => formatDisplayValue(v);
+    it('matches legacy behavior', () => {
+      expect(fmt(null)).toBe('');
+      expect(fmt(undefined)).toBe('');
+      expect(fmt(['a', 'b'])).toBe('a, b');
+      expect(fmt('x')).toBe('x');
+    });
+  });
+});


### PR DESCRIPTION
## What

Four separate call sites each carried their own near-identical private helper for rendering a frontmatter value as a human-readable display string:

- `src/commands/list.ts` — `formatValue` (empty → `—`, plain arrays)
- `src/lib/bulk/operations.ts` — `formatValue` (empty → `(empty)`, bracketed arrays)
- `src/lib/migration/execute.ts` — inline `formatValue` closure (empty → `(empty)`, bracketed, `null` stringified)
- `src/lib/template.ts` — `formatValueForBody` (empty → `""`, plain arrays)

They differed only in two dimensions: the placeholder shown for empty values, and whether arrays are wrapped in brackets.

This PR extracts a single parameterized `formatDisplayValue(value, options)` into `src/lib/value-format.ts` and routes all four sites through it. Each site's exact prior behavior is preserved via the `empty`, `arrayStyle`, and `nullIsEmpty` options.

> Note: this is intentionally distinct from `vault.ts`'s `formatValue`, which builds YAML-safe wikilink/markdown links — a different concern, left untouched.

## Why

DRY win on pure functions with no behavior change. Rendering rules for display values now live in one tested place instead of four drifting copies (the migration variant, for instance, already diverged on `null` handling). Net **-36 / +172** lines including new tests.

## Testing

- New `tests/ts/lib/value-format.test.ts` (14 cases): full input matrix for the helper, plus explicit **parity** cases pinning each of the four call sites' previous output.
- Full local CI parity green: `build`, `verify:pack`, `typecheck`, `lint`, `knip`, and the non-PTY suite (**87 files / 1965 tests**).
- Ran the affected PTY suites (`bulk.pty`, `template.pty`) locally — 23/23 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)