### PR TITLE
docs(plans): product-direction review — kill LLM-in-bwrb, nvim, LSP; capture new direction

### DIFF
--- a/docs-site/src/content/docs/product/roadmap.md
+++ b/docs-site/src/content/docs/product/roadmap.md
@@ -25,8 +25,6 @@ description: Bowerbird development priorities
 
 ### Near Term
 
-- Neovim plugin (`bwrb.nvim`)
-- LSP for real-time validation
 - Schema discovery from existing files
 
 ### Future

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -89,15 +89,11 @@ Make the schema useful for knowledge work.
 
 | Feature | Issue | Description |
 |---------|-------|-------------|
-| Neovim plugin | `bwrb-tic` | Full CLI parity in Neovim |
-| LSP | `bwrb-0wp` | Real-time schema validation in editors |
 | Link validation | `bwrb-6f0` | Broken link detection in audit |
 | Command consolidation | `bwrb-fkd` | Merge list/search/open |
 
 ### v2.0 Exit Criteria
 
-- [ ] Neovim plugin with core functionality
-- [ ] LSP server for schema validation
 - [ ] Comprehensive link validation
 - [ ] Polished, consistent CLI surface
 

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -275,24 +275,6 @@ This ordering presents commands as a guided path: create notes → find notes �
 
 ---
 
-## Neovim Plugin
-
-`bwrb.nvim` brings full CLI functionality to Neovim.
-
-**Philosophy:**
-- Feature parity with CLI (for human-usable operations)
-- Lean on existing plugins (Telescope, nvim-cmp, Treesitter)
-- Minimal custom UI
-- CLI is source of truth (plugin wraps `--json` mode)
-
-**Future: LSP**
-- Real-time schema validation in editor
-- Wikilink completion
-- Frontmatter field suggestions
-- Diagnostic integration for type errors
-
----
-
 ## Roadmap Priorities
 
 ### V1.0 (Core)
@@ -302,11 +284,9 @@ This ordering presents commands as a guided path: create notes → find notes �
 3. **Core commands** — new, edit, list, search, audit, bulk, schema, template
 4. **JSON mode** — Every command scriptable
 5. **Migration tooling** — Rename fields, change enums, refactor types
-6. **Neovim plugin (basic)** — Search, create, edit via CLI wrapper
 
 ### Post-V1.0
 
-- LSP for real-time validation
 - AI ingest command
 - Schema discovery from existing files
 - Obsidian plugin

--- a/plans/archive/agentic-workflows.md
+++ b/plans/archive/agentic-workflows.md
@@ -1,3 +1,7 @@
+> **ARCHIVED — killed.** bwrb is a deterministic CLI, not an agent harness; this reinvents
+> the AI orchestration the agent (Claude Code, Codex, …) already provides. Kept for history.
+> See [`../features/ingest-safety-net.md`](../features/ingest-safety-net.md).
+
 # Agentic Workflows
 
 > AI-powered automation with vault-based prompt and workflow management

--- a/plans/archive/ai-ingest.md
+++ b/plans/archive/ai-ingest.md
@@ -1,3 +1,7 @@
+> **ARCHIVED — superseded by [`../features/ingest-safety-net.md`](../features/ingest-safety-net.md).**
+> bwrb will not embed an LLM caller. The deterministic kernel of this plan (entity matching,
+> processing-state, web integrity) migrated to the safety-net brief. Kept for history.
+
 # AI Ingest Command
 
 > AI-powered extraction of tasks, ideas, and entities from unstructured notes

--- a/plans/archive/neovim-plugin.md
+++ b/plans/archive/neovim-plugin.md
@@ -1,3 +1,7 @@
+> **ARCHIVED — killed.** bwrb is not pursuing editor-plugin or LSP surfaces; focus is honing
+> bwrb-the-system (CLI + schema). Any future "show violations to a human" surface is a thin
+> consumer of `bwrb audit --output json`, not a bundled plugin/LSP. Kept for history.
+
 # Neovim Plugin for Bowerbird
 
 > Native Neovim integration with full CLI feature parity

--- a/plans/features/ingest-safety-net.md
+++ b/plans/features/ingest-safety-net.md
@@ -1,0 +1,105 @@
+# Ingest as a Deterministic Safety Net
+
+> bwrb is the deterministic safety net *under* the AI agent, not a parallel agent.
+>
+> Supersedes `ai-ingest.md` and `agentic-workflows.md` (both to be archived).
+
+---
+
+## Context: why the old plans are dead
+
+`ai-ingest.md` and `agentic-workflows.md` were both designed in a **pre-agentic world**, where bwrb itself had to become the LLM caller (embed an OpenRouter client, a model-pricing table, prompt/workflow storage, cost tracking, confidence scoring).
+
+That assumption is now invalid. In daily use, bwrb is driven *through* an AI harness (Claude Code, Codex, etc.) that already does extraction, multi-step orchestration, and cost accounting better than a baked-in Haiku call ever would.
+
+- **`agentic-workflows.md` → killed outright.** It reinvents the agent harness. No payoff.
+- **`ai-ingest.md` → killed as an LLM command, but its *kernel* survives** as the deterministic primitives below.
+
+The LLM-calling, confidence-UI, and approval-flow parts are redundant. What's *not* redundant is everything bwrb can guarantee **deterministically**, so the human doesn't have to trust that the AI didn't miss something.
+
+---
+
+## The actual end goal
+
+Ramble daily notes — journal, write, whatever — every day, and **know nothing gets swept under the rug**. Two guarantees underneath that:
+
+1. **Coverage** — everything I rambled actually got looked at.
+2. **Web integrity** — every mention of a known name links to the right entity; the vault stays a connected graph, not islands.
+
+Extraction is just the means, and extraction is the part the harness already does well.
+
+---
+
+## The organizing reframe: closed-world vs open-world
+
+| | Who | How |
+|---|---|---|
+| **Open-world discovery** — "is there a new task/idea/person buried in this ramble?" Unbounded, needs judgment. | **The agent**, via prompting | fuzzy, LLM |
+| **Closed-world verification** — "of the entities I *already know*, are they all linked everywhere they're mentioned?" Bounded, no false positives. | **bwrb** | deterministic |
+
+bwrb's job is the closed-world half (plus a cheap heuristic nudge toward the open-world half). The agent's loop becomes:
+
+```
+ramble → agent extracts → agent asks bwrb "does this exist?" (search --fuzzy)
+       → agent writes conformant notes → bwrb audit proves nothing is orphaned
+```
+
+This also leans on the **schema-as-shared-language** insight: schema *descriptions* (shipped v0.1.9) already make the agent use types correctly. The highest-ROI investment is making the schema more expressive, not AI plumbing — every bit of schema richness improves the agent's extraction for free, and the deterministic audit enforces it.
+
+---
+
+## The pieces (all deterministic, all AI-agnostic)
+
+| Piece | Type | Trust model |
+|---|---|---|
+| Entity `aliases` field | schema (net-new) | substrate — makes the rest trustworthy |
+| `search --fuzzy` | new search flag | agent/human decides; reuses existing Levenshtein |
+| `audit: unlinked-mention` | new audit detection | **exact/alias → `--fix --auto`; fuzzy → flag only** |
+| `audit: frequent-unlinked-term` | new audit detection | flag only, thresholded, advisory |
+| daily-note sweep field | schema convention | coverage bookkeeping |
+
+### 1. Entity `aliases` — net-new substrate
+There is **no alias concept in bwrb today.** Every `alias` reference in `src/` is wikilink *display* aliases (`[[Target|Alias]]`), command aliases, or doc comments. Nothing in `schema.schema.json` defines it. Aliases are load-bearing for everything else ("Steve" / "Steve Yegge" / "stevey" → one entity). Relates to dormant issue #266 (Obsidian aliases validation).
+
+### 2. `search --fuzzy` — the lookup primitive
+Returns scored candidates so the agent can check "does X already exist?" before writing. **Low effort:** `levenshteinDistance` already exists in the codebase — implemented *twice* (`src/lib/schema.ts:835`, `src/lib/validation.ts:400`). Incidental cleanup: extract into one shared util.
+
+### 3. `audit: unlinked-mention` — the web-integrity guarantee (centerpiece)
+bwrb knows every note and (with #1) every alias. It scans note bodies for the literal name of a known entity that appears as plain text but isn't wikilinked, and flags it. Two tiers:
+- **Exact name or registered alias** present, not linked → trusted, auto-fixable.
+- **Fuzzy near-match** ("Steve Yeg" ≈ `[[Steve Yegge]]`) → review item with "did you mean?", **never auto-linked.**
+
+Ambiguity ("Mercury" = planet/element/Freddie) is never auto-resolved — it becomes a visible review item, which *is* the "nothing swept under the rug" behavior.
+
+### 4. `audit: frequent-unlinked-term` — open-world nudge
+Attacks the real failure mode: *the AI forgets to link because it doesn't know the entity exists.* Surfaces things mentioned a lot that have no note yet ("you might want notes for these 6 things"). **Honest caveat:** discovering an unknown "thing" in prose without an LLM is inherently heuristic (repeated capitalized n-grams, proper-noun-ish phrases, threshold e.g. ≥4 mentions across ≥2 notes). That's noisy — *fine here* because it's advisory-only and never acts. Gate behind a threshold; iterate on the heuristic over time.
+
+### 5. daily-note sweep field — coverage
+Almost no new code: a frontmatter convention on the existing `daily-note` type (e.g. `reviewed` / `ai-process-stage`) plus a `list --where` query / saved dashboard. The risk (agent forgetting to stamp it) is prompting discipline, not a bwrb feature.
+
+---
+
+## How the pieces compose
+1. `search --fuzzy` → prevents the miss (agent checks before writing).
+2. `unlinked-mention` → backstop for entities that exist but got missed (closed-world).
+3. `frequent-unlinked-term` → surfaces entities that should exist but don't yet (open-world).
+
+(3) creates the entity that should exist → (2) keeps it wired up forever after. Complete deterministic safety net, zero LLM calls.
+
+---
+
+## Trust line (decided)
+Trust **exact matches** for auto-action; **flag fuzziness** for review. Never auto-resolve ambiguity.
+
+---
+
+## Follow-up actions (not yet done)
+- [ ] Archive `plans/features/agentic-workflows.md` (killed).
+- [ ] Archive / supersede `plans/features/ai-ingest.md` (kernel migrated here).
+- [ ] Reframe the open "Phase 6 ingest" issues rather than blank-closing them:
+  - #93 (entity matching) → becomes `search --fuzzy` + `unlinked-mention`.
+  - #96 (AI extraction via OpenRouter/Anthropic), #94 (ingest skeleton), #91 (approval flow), #81 (`--auto`/thresholds), #89 (Phase 6 umbrella) → close as superseded (LLM-in-bwrb is dead).
+  - #87 (`ai-process-stage` field) → shrinks to the daily-note sweep convention (#5).
+  - #103 (schema migration hooks for re-indexing) → re-evaluate; only relevant if re-sweeping is needed.
+  - New issues: entity `aliases` field, `search --fuzzy`, `audit: unlinked-mention`, `audit: frequent-unlinked-term`.
+  - Incidental: dedupe `levenshteinDistance` into a shared util.

--- a/plans/features/schema-expressiveness.md
+++ b/plans/features/schema-expressiveness.md
@@ -1,0 +1,101 @@
+# Schema Expressiveness
+
+> Make the schema richer so the agent uses it correctly and the vault stays a web.
+> The schema is the shared language; investing here pays off everywhere.
+
+---
+
+## Why this cluster
+
+The AI brainstorm (see `ingest-safety-net.md`) concluded that **schema-as-language** is the real multiplier: schema *descriptions* (shipped v0.1.9) already make an AI agent use types correctly with no extra plumbing. So the highest-ROI investment isn't AI features — it's making the schema more expressive. Every bit of richness improves the agent's extraction for free, and deterministic audit enforces it.
+
+Four threads, in build order.
+
+---
+
+## 1. Aliases — first-class field *role* (from #266)
+
+**Status today:** no alias concept exists. Every `alias` reference in `src/` is wikilink *display* aliases (`[[Target|Alias]]`), command aliases, or doc comments. Nothing in `schema.schema.json`.
+
+**Decision:** aliases are a **recognized field role** bwrb understands (like `owned` is today) — *not* a loose convention — so linking, `search --fuzzy`, and `audit: unlinked-mention` all consult them uniformly. Conventions drift and break the deterministic guarantee.
+
+Two parts:
+1. The alias **role** — the load-bearing new thing; unblocks the entire ingest safety net.
+2. Obsidian-format **validation** (array, no dupes, no empty strings) — the original #266 ask; comes nearly free once aliases are modeled.
+
+**Priority: #1** — it's a dependency of the AI safety-net work.
+
+---
+
+## 2. Traits — composition alongside inheritance (#442)
+
+`extends` is *is-a* (inheritance); **traits** are *also-has* (composition). Recurring field bundles — status, due/review dates, scope, rating — are exactly the cross-cutting pattern inheritance models badly.
+
+```json
+{
+  "traits": {
+    "actionable": { "fields": { "status": {…}, "due": {…} } }
+  },
+  "types": { "task": { "extends": "objective", "traits": ["actionable"] } }
+}
+```
+
+- High value, moderate effort, low conceptual risk.
+- Hard parts (named in #442): collision/precedence rules must be deterministic and documented; resolved-schema must be visible. **Reuse `schema list`** — it already renders *inherited* fields; extend it to render *trait-composed* fields.
+- Purest expression of schema-as-language: define a pattern once, the agent applies it consistently.
+
+**Priority: #2.**
+
+---
+
+## 3. Hierarchical scope — contexts as real notes + `under` join (#554)
+
+**Keep this one.** (Tagged `ralph:intent:brainstorm`; this is the brainstorm outcome.)
+
+### The problem it solves
+Notes today carry two redundant fields — a `scope` select (life domain) and a `context` relation (project) — where the domain is derivable from the context. The redundancy is a double-entry maintenance problem: move PKM from software-dev to personal and you fix the PKM entity *and* bulk-update every note. There are also no transitive queries ("everything in the career domain") without keeping the redundant field or OR-ing every leaf.
+
+### Correction to an earlier claim
+`isDescendantOf` does **not** already solve this. It walks the *filtered note's own* `parent` chain (e.g. task → milestone → objective). The context lives in a *field*, not the note's structural parent, so the existing functions can't reach it. The transitive-query pain is genuinely unsolved.
+
+### The design (decided)
+Contexts/domains are **real entity notes** in a `parent` hierarchy. A "domain" (career) is just a root node; a project (Builder) is a child.
+
+```yaml
+# contexts/career.md        →  parent: null
+# contexts/Builder.md       →  parent: "[[career]]"
+# a task                    →  context: "[[Builder]]"   (only the leaf; domain derivable)
+```
+
+Query at any altitude:
+- `context = [[Builder]]` — exact
+- `context under [[career]]` — Builder, Vercel, Job Search, anything deeper
+
+### The one new primitive
+A `under` operator that **dereferences a relation field, then walks the *target's* ancestor chain** — distinct from `isDescendantOf` (which walks the current note's own chain). Generalizes to *any* relation field, not just context.
+
+### The bonus
+This **collapses scope + context into one concept**: a single tree of context notes, queried at any level. Two fields → one field → zero redundancy — without inventing a new "tree" field type (just `parent`, which entities already have, plus `under`). Because contexts are real notes, they also get aliases, `unlinked-mention` coverage, and existing relation-source audit validation. Everything reinforces.
+
+**Why entities not labels:** contexts are mixed — some are rich (Betson, Builder: own content, backlinks, graph presence), some are basically labels (PKM, Job Search). Modeling them all as notes keeps the rich ones first-class and the labels cost almost nothing.
+
+**Priority: #3** — design is settled; build after aliases + traits.
+
+---
+
+## 4. `schema discover` — deterministic field-usage facts (reframe of #97)
+
+Same move as ingest: "AI suggests a schema" is redundant (the agent does that well). The deterministic kernel survives: bwrb reports **frontmatter facts** over a folder — every field that appears, frequency, value-type consistency, which files diverge.
+
+**Works in two roles:**
+- **Before a schema exists** → onboarding: raw material for designing types.
+- **After a schema exists** → drift detection: fields used but undefined, defined-but-unused, values diverging from declared options.
+
+**Clean line vs `audit`:** discover is **descriptive** (facts, no judgment, never passes/fails); audit is **prescriptive** (what's wrong vs the schema). Safe to run anytime. Could be its own mode or fold into #188 (`bwrb init`).
+
+**Priority: #4** — cheap, useful for onboarding, lower urgency than the rest.
+
+---
+
+## Build order
+aliases → traits → hierarchical scope → `schema discover`.

--- a/plans/features/task-system.md
+++ b/plans/features/task-system.md
@@ -1,0 +1,84 @@
+# Task System: Recurrence + Templating
+
+> Recurrence and templating together make a real, *declarative* task system —
+> no daemon, no cron, no LLM. The schema is the system.
+>
+> Reframes issue #107 (was "cron recurrence", now "event-driven spawn + offset templating").
+> Recurrence config rides on a trait — see `schema-expressiveness.md` (#442).
+
+---
+
+## Two mechanisms
+
+### A. Recurrence = spawn-on-transition (event-driven)
+
+The trigger is a **field transition, not a clock.** Declaratively: "when `status` enters `done`, spawn a successor from a template, with the successor's date field offset from a predecessor date field."
+
+#### Two-path execution (the reliability model)
+Same pattern as `audit: unlinked-mention` in `ingest-safety-net.md`:
+
+- **Fast path** — completing via `bwrb edit` / `bulk --set status=done` spawns the successor immediately, as a deterministic side-effect of the write.
+- **Backstop** — completing *in Obsidian* (bwrb never saw it) is caught on the next `bwrb audit`: "`status = done` AND `next` empty AND type has the `recurring` trait" → spawn the missing successor.
+
+So recurrence integrity holds **regardless of how the task was completed**. The task system inherits the "nothing swept under the rug" guarantee.
+
+> **Cross-repo dependency:** the **teenylilthoughts** `AGENTS.md` must instruct the agent to **always edit note fields via bwrb**, never directly. This feeds the fast path and dogfoods bwrb (surfacing issues naturally). (This is a vault-side directive — NOT for bwrb's own repo AGENTS.md, which is dev-focused.)
+
+#### Date rule: field-offset ONLY (decided)
+```
+successor.<dateField> = <predecessor date field> + <offset>     e.g. deadline + 7d
+```
+- The referenced base **must be a date field.**
+- **Transition-time offset (`completed + 7d`) was rejected.** It's only exact on the fast path; the Obsidian backstop can't know *when* the change happened (mtime is fuzzy), so it would be inconsistent. Field-offset is computed identically in both paths → fully robust. Robustness wins over the slightly nicer "a week after I actually finished" semantics.
+- "next Monday" / calendar-anchored bases: **deferred.** Add later only if missed.
+
+#### Config (rides on the `recurring` trait)
+```yaml
+traits:
+  recurring:
+    fields:
+      next: { prompt: relation }          # see "one field, three jobs" below
+    recurrence:
+      on: "status = done"                  # trigger transition
+      template: <name>                     # default: the type's own default template
+      set:
+        deadline: "deadline + 7d"          # field-offset; base must be a date field
+```
+- Template **defaults to the completed note's type default template** (a task begets a task); name one to spawn something different (finish "draft" → spawn "review").
+- **Audit validates the referenced template exists** — a rule pointing at a deleted template is a deterministic error. Config gets the same safety net as data.
+
+#### One field, three jobs
+A single `next` (and/or `prev`) relation field collapses three requirements into one mechanism:
+1. **Graph chain / history** — the linked thread of recurring instances, for free.
+2. **Idempotency** — spawn only if `next` is empty; re-completing a task that already has a `next` is a no-op.
+3. **Audit backstop check** — the "missing successor" detection is literally "done + `next` empty + `recurring` trait".
+
+### B. Template multi-spawn with offset deadlines
+
+The "write-an-article spawns its 10 predictable tasks, deadlines staggered from today" workflow.
+
+- **`InstanceScaffold` already exists** (`src/types/schema.ts:393`): a parent template can spawn multiple related files on creation, each with its own template + defaults.
+- **The gap is date-offset expressions in template values.** Today template interpolation is basic (`{date}`, `{date:FORMAT}`, `{title}`, `@today` in meta defaults — `src/lib/template.ts:643`). There's a `date-expression.ts` engine (used for constraints/queries) **not yet wired into template value generation.**
+
+```yaml
+# .bwrb/templates/project/write-an-article.md
+instances:
+  - { template: task, defaults: { title: "Outline", deadline: "@today+1d" } }
+  - { template: task, defaults: { title: "Draft",   deadline: "@today+3d" } }
+  - { template: task, defaults: { title: "Edit",    deadline: "@today+5d" } }
+  - { template: task, defaults: { title: "Publish", deadline: "@today+7d" } }
+```
+`bwrb new project --template write-an-article` → ten staggered tasks. The only real work: teach template values to evaluate date expressions via the existing engine.
+
+---
+
+## Synthesis
+- **Templates** define what work *looks like* (the staggered plan).
+- **Recurrence rules** define when work *regenerates* (on completion).
+- bwrb executes deterministically (fast path) and audit backstops it.
+- The whole system is declared in schema + templates, so the agent operates it natively (schema-as-language). No daemon, no cron, no LLM.
+
+## Build dependencies
+- Recurrence config needs **traits** (#442) and a **date-expression-in-values** capability.
+- Multi-spawn needs the same **date-expression-in-values** capability (shared with recurrence) on top of existing `instances`.
+- Backstop needs a new **audit detection** (missing-successor), sibling to `unlinked-mention`.


### PR DESCRIPTION
Outcome of a theme-by-theme review of all open issues and plan docs.

## Direction
bwrb stays a **deterministic CLI + schema system** — a safety net *under* the AI harness, not a parallel agent. Not pursuing AI-in-bwrb, Neovim, or LSP surfaces; any future "show violations to a human" surface is a thin consumer of `bwrb audit --output json`.

## Changes
- **New briefs:** `ingest-safety-net.md` (deterministic entity primitives + `unlinked-mention` audit), `schema-expressiveness.md` (aliases role, traits, `under`-join, `schema discover`), `task-system.md` (event-driven recurrence + offset templating).
- **Archived (superseded/killed):** `agentic-workflows.md`, `ai-ingest.md`, `neovim-plugin.md`.
- **Pruned roadmap/vision** of the killed Neovim-plugin + LSP entries.

## Tracker (already applied)
16 issues closed, 8 reframed, new feature issues filed (#599–#605). Remaining vision/roadmap reconciliation tracked in #605.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)