### PR TITLE
chore: dedupe levenshteinDistance into a shared util

### DIFF
--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -32,7 +32,7 @@ import {
   isCanonicalIsoDate,
 } from './fix-policy.js';
 import { parseNote, writeNote } from '../frontmatter.js';
-import { levenshteinDistance } from '../discovery.js';
+import { levenshteinDistance } from '../levenshtein.js';
 import { promptSelection, promptConfirm, promptInput } from '../prompt.js';
 import type { LoadedSchema, Field } from '../../types/schema.js';
 import {

--- a/src/lib/audit/unknown-field.ts
+++ b/src/lib/audit/unknown-field.ts
@@ -1,5 +1,5 @@
 import { getFieldsForType, resolveTypeFromFrontmatter } from '../schema.js';
-import { levenshteinDistance } from '../discovery.js';
+import { levenshteinDistance } from '../levenshtein.js';
 import type { LoadedSchema, Field } from '../../types/schema.js';
 
 export type ValueShape = 'empty' | 'string' | 'number' | 'boolean' | 'array' | 'object' | 'unknown';

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -21,6 +21,7 @@ import {
 } from './schema.js';
 import { parseNote } from './frontmatter.js';
 import { getOwnedChildFolderFromOwnerDir } from './ownership-paths.js';
+import { levenshteinDistance } from './levenshtein.js';
 import type { LoadedSchema, OwnedFieldInfo } from '../types/schema.js';
 
 // ============================================================================
@@ -953,38 +954,3 @@ export function findSimilarFiles(target: string, allFiles: Set<string>, maxResul
   return results.slice(0, maxResults).map(r => r.file);
 }
 
-/**
- * Calculate Levenshtein distance between two strings.
- */
-export function levenshteinDistance(a: string, b: string): number {
-  const aLen = a.length;
-  const bLen = b.length;
-  
-  const matrix: number[][] = Array.from({ length: aLen + 1 }, () => 
-    Array.from({ length: bLen + 1 }, () => 0)
-  );
-
-  for (let i = 0; i <= aLen; i++) {
-    matrix[i]![0] = i;
-  }
-  
-  for (let j = 0; j <= bLen; j++) {
-    matrix[0]![j] = j;
-  }
-
-  for (let i = 1; i <= aLen; i++) {
-    for (let j = 1; j <= bLen; j++) {
-      if (a[i - 1] === b[j - 1]) {
-        matrix[i]![j] = matrix[i - 1]![j - 1]!;
-      } else {
-        matrix[i]![j] = Math.min(
-          matrix[i - 1]![j - 1]! + 1,
-          matrix[i]![j - 1]! + 1,
-          matrix[i - 1]![j]! + 1
-        );
-      }
-    }
-  }
-
-  return matrix[aLen]![bLen]!;
-}

--- a/src/lib/levenshtein.ts
+++ b/src/lib/levenshtein.ts
@@ -1,0 +1,46 @@
+/**
+ * Calculate the Levenshtein (edit) distance between two strings.
+ *
+ * The distance is the minimum number of single-character insertions,
+ * deletions, or substitutions required to transform `a` into `b`.
+ * Comparison is case-sensitive; callers that want case-insensitive
+ * matching should lowercase their inputs first.
+ *
+ * Used for fuzzy matching to suggest corrections for typos.
+ */
+export function levenshteinDistance(a: string, b: string): number {
+  const aLen = a.length;
+  const bLen = b.length;
+
+  // Create a 2D matrix with proper initialization
+  const matrix: number[][] = Array.from({ length: aLen + 1 }, () =>
+    Array.from({ length: bLen + 1 }, () => 0)
+  );
+
+  // Initialize first column
+  for (let i = 0; i <= aLen; i++) {
+    matrix[i]![0] = i;
+  }
+
+  // Initialize first row
+  for (let j = 0; j <= bLen; j++) {
+    matrix[0]![j] = j;
+  }
+
+  // Fill in the rest of the matrix
+  for (let i = 1; i <= aLen; i++) {
+    for (let j = 1; j <= bLen; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        matrix[i]![j] = matrix[i - 1]![j - 1]!;
+      } else {
+        matrix[i]![j] = Math.min(
+          matrix[i - 1]![j - 1]! + 1, // substitution
+          matrix[i]![j - 1]! + 1, // insertion
+          matrix[i - 1]![j]! + 1 // deletion
+        );
+      }
+    }
+  }
+
+  return matrix[aLen]![bLen]!;
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { existsSync } from 'fs';
 import { basename } from 'path';
 import { SCHEMA_RELATIVE_PATH } from './bwrb-paths.js';
+import { levenshteinDistance } from './levenshtein.js';
 import type { DatePrecision } from './local-date.js';
 import {
   BwrbSchema,
@@ -827,42 +828,6 @@ export function getOwnedFields(schema: LoadedSchema, ownerTypeName: string): Own
 export type SourceTypeResolution =
   | { success: true; typeName: string }
   | { success: false; error: string; suggestions?: string[] };
-
-/**
- * Calculate Levenshtein distance between two strings.
- * Used for fuzzy matching to suggest corrections for typos.
- */
-function levenshteinDistance(a: string, b: string): number {
-  // Create matrix with proper initialization
-  const matrix: number[][] = Array.from({ length: a.length + 1 }, () =>
-    Array.from({ length: b.length + 1 }, () => 0)
-  );
-
-  // Initialize first column
-  for (let i = 0; i <= a.length; i++) {
-    matrix[i]![0] = i;
-  }
-  // Initialize first row
-  for (let j = 0; j <= b.length; j++) {
-    matrix[0]![j] = j;
-  }
-
-  // Fill in the rest of the matrix
-  for (let i = 1; i <= a.length; i++) {
-    for (let j = 1; j <= b.length; j++) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      const row = matrix[i]!;
-      const prevRow = matrix[i - 1]!;
-      row[j] = Math.min(
-        prevRow[j]! + 1,        // deletion
-        row[j - 1]! + 1,        // insertion
-        prevRow[j - 1]! + cost  // substitution
-      );
-    }
-  }
-
-  return matrix[a.length]![b.length]!;
-}
 
 /**
  * Find close matches for a string within a list of candidates.

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -2,6 +2,7 @@ import { readdir } from 'fs/promises';
 import { join, basename, relative } from 'path';
 import { existsSync } from 'fs';
 import { parseNote, writeNote, generateBodySections } from './frontmatter.js';
+import { levenshteinDistance } from './levenshtein.js';
 import { TemplateFrontmatterSchema, type Template, type LoadedSchema, type Field, type Constraint, type InstanceScaffold, type ResolvedType } from '../types/schema.js';
 import { getType, getFieldsForType, getFieldOptions } from './schema.js';
 import { isBwrbBuiltinFrontmatterField } from './frontmatter/systemFields.js';
@@ -874,37 +875,6 @@ export interface TemplateValidationResult {
   valid: boolean;
   /** All validation issues found */
   issues: TemplateValidationIssue[];
-}
-
-/**
- * Calculate Levenshtein distance between two strings.
- * Used for typo suggestions.
- */
-function levenshteinDistance(a: string, b: string): number {
-  const matrix: number[][] = [];
-  
-  for (let i = 0; i <= b.length; i++) {
-    matrix[i] = [i];
-  }
-  for (let j = 0; j <= a.length; j++) {
-    matrix[0]![j] = j;
-  }
-  
-  for (let i = 1; i <= b.length; i++) {
-    for (let j = 1; j <= a.length; j++) {
-      if (b.charAt(i - 1) === a.charAt(j - 1)) {
-        matrix[i]![j] = matrix[i - 1]![j - 1]!;
-      } else {
-        matrix[i]![j] = Math.min(
-          matrix[i - 1]![j - 1]! + 1, // substitution
-          matrix[i]![j - 1]! + 1,     // insertion
-          matrix[i - 1]![j]! + 1      // deletion
-        );
-      }
-    }
-  }
-  
-  return matrix[b.length]![a.length]!;
 }
 
 /**

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -3,6 +3,7 @@ import { getFieldsForType, getDescendants, getType, getFieldOptions, resolveDate
 import { isBwrbBuiltinFrontmatterField } from './frontmatter/systemFields.js';
 import { queryByType } from './vault.js';
 import { extractWikilinkTarget } from './links.js';
+import { levenshteinDistance } from './levenshtein.js';
 import {
   expandStaticValue,
   parseDate,
@@ -392,46 +393,6 @@ function getFieldExpected(_schema: LoadedSchema, field: Field): string[] | undef
     return options;
   }
   return undefined;
-}
-
-/**
- * Calculate Levenshtein distance between two strings.
- */
-function levenshteinDistance(a: string, b: string): number {
-  const aLen = a.length;
-  const bLen = b.length;
-  
-  // Create a 2D array with proper initialization
-  const matrix: number[][] = Array.from({ length: aLen + 1 }, () => 
-    Array.from({ length: bLen + 1 }, () => 0)
-  );
-
-  // Initialize first column
-  for (let i = 0; i <= aLen; i++) {
-    matrix[i]![0] = i;
-  }
-  
-  // Initialize first row
-  for (let j = 0; j <= bLen; j++) {
-    matrix[0]![j] = j;
-  }
-
-  // Fill in the rest of the matrix
-  for (let i = 1; i <= aLen; i++) {
-    for (let j = 1; j <= bLen; j++) {
-      if (a[i - 1] === b[j - 1]) {
-        matrix[i]![j] = matrix[i - 1]![j - 1]!;
-      } else {
-        matrix[i]![j] = Math.min(
-          matrix[i - 1]![j - 1]! + 1, // substitution
-          matrix[i]![j - 1]! + 1,     // insertion
-          matrix[i - 1]![j]! + 1      // deletion
-        );
-      }
-    }
-  }
-
-  return matrix[aLen]![bLen]!;
 }
 
 export interface InvalidSelectOptionValue {

--- a/tests/ts/lib/discovery.test.ts
+++ b/tests/ts/lib/discovery.test.ts
@@ -19,7 +19,6 @@ import {
   collectFilesForType,
   collectPooledFiles,
   findSimilarFiles,
-  levenshteinDistance,
   getTypeOutputDirs,
   isInTypeOutputDir,
   discoverAllTypeFiles,
@@ -443,27 +442,6 @@ describe('Discovery', () => {
       // "Jailbirds" shares word "birds" - should match
       const birdsMatches = findSimilarFiles('Jailbirds', allFiles);
       expect(birdsMatches).toContain('birds whose bones are empty');
-    });
-  });
-
-  describe('levenshteinDistance', () => {
-    it('should return 0 for identical strings', () => {
-      expect(levenshteinDistance('test', 'test')).toBe(0);
-    });
-
-    it('should return string length for empty comparison', () => {
-      expect(levenshteinDistance('test', '')).toBe(4);
-      expect(levenshteinDistance('', 'test')).toBe(4);
-    });
-
-    it('should calculate single character changes', () => {
-      expect(levenshteinDistance('test', 'tast')).toBe(1); // substitution
-      expect(levenshteinDistance('test', 'tests')).toBe(1); // insertion
-      expect(levenshteinDistance('tests', 'test')).toBe(1); // deletion
-    });
-
-    it('should calculate multiple character changes', () => {
-      expect(levenshteinDistance('kitten', 'sitting')).toBe(3);
     });
   });
 

--- a/tests/ts/lib/levenshtein.test.ts
+++ b/tests/ts/lib/levenshtein.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { levenshteinDistance } from '../../../src/lib/levenshtein.js';
+
+describe('levenshteinDistance', () => {
+  it('returns 0 for identical strings', () => {
+    expect(levenshteinDistance('test', 'test')).toBe(0);
+  });
+
+  it('returns 0 for two empty strings', () => {
+    expect(levenshteinDistance('', '')).toBe(0);
+  });
+
+  it('returns string length when one side is empty', () => {
+    expect(levenshteinDistance('test', '')).toBe(4);
+    expect(levenshteinDistance('', 'test')).toBe(4);
+  });
+
+  it('counts a single edit', () => {
+    expect(levenshteinDistance('test', 'tast')).toBe(1); // substitution
+    expect(levenshteinDistance('test', 'tests')).toBe(1); // insertion
+    expect(levenshteinDistance('tests', 'test')).toBe(1); // deletion
+  });
+
+  it('counts a transposition as two edits', () => {
+    // Classic Levenshtein has no transposition op, so a swap costs 2.
+    expect(levenshteinDistance('ab', 'ba')).toBe(2);
+  });
+
+  it('handles multiple edits', () => {
+    expect(levenshteinDistance('kitten', 'sitting')).toBe(3);
+  });
+
+  it('is symmetric', () => {
+    expect(levenshteinDistance('kitten', 'sitting')).toBe(
+      levenshteinDistance('sitting', 'kitten')
+    );
+  });
+
+  it('is case-sensitive', () => {
+    expect(levenshteinDistance('Test', 'test')).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

`levenshteinDistance` was implemented **four** times across the codebase. The issue noted two (`src/lib/schema.ts`, `src/lib/validation.ts`); while working I also found copies in `src/lib/template.ts` and an exported one in `src/lib/discovery.ts` (consumed by `src/lib/audit/*`). This consolidates all four into a single shared util.

## Changes

- **New:** `src/lib/levenshtein.ts` — single exported `levenshteinDistance`.
- Updated call sites to import from it: `schema.ts`, `validation.ts`, `template.ts`, `discovery.ts`, `audit/unknown-field.ts`, `audit/fix.ts`.
- Moved the unit tests out of `discovery.test.ts` into a dedicated `tests/ts/lib/levenshtein.test.ts` and expanded coverage (identical/empty strings, single edits, transposition cost, symmetry, case sensitivity).

## Behavioral note

All four implementations were mathematically equivalent. `template.ts` indexed its matrix with the `a`/`b` axes swapped, but since Levenshtein distance is symmetric the result is identical. No user-facing behavior change.

## Quality gates

- `pnpm qa` — green (typecheck, lint, docs:lint, docs:doctor, build, 1995 tests pass).
- `pnpm knip` — green (no unused exports left behind).

Closes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)