### PR TITLE
docs(product): reconcile vision + roadmap with product-direction review

### DIFF
--- a/docs-site/src/content/docs/product/roadmap.md
+++ b/docs-site/src/content/docs/product/roadmap.md
@@ -11,7 +11,7 @@ description: Bowerbird development priorities
 - **Inheritance model** — Full, consistent type inheritance
 - **Core commands** — new, edit, list, search, audit, bulk, schema, template
 - **JSON mode** — Every command scriptable
-- **Migration tooling** — Rename fields, change enums, refactor types
+- **Migration tooling** — Rename fields, change select options, refactor types
 
 ### Exit Criteria
 
@@ -23,15 +23,23 @@ description: Bowerbird development priorities
 
 ## Post-V1.0
 
-### Near Term
+### Near Term — Schema Expressiveness
 
-- Schema discovery from existing files
+A richer schema so the AI agent uses it correctly:
 
-### Future
+- Aliases — first-class alias field role
+- Traits — composition alongside inheritance
+- Hierarchical scope — contexts as real notes + `under` join
 
-- AI ingest command
-- Obsidian plugin
-- Cost tracking for AI operations
+### Future — AI Safety Net
+
+bwrb is the deterministic safety net *under* the AI agent, never an LLM caller:
+
+- `search --fuzzy` — scored candidate lookup before writing
+- `audit: unlinked-mention` — flag known entities mentioned but not linked
+- Daily-note sweep — coverage bookkeeping
+- `schema discover` — deterministic field-usage facts over a folder
+- Task recurrence — event-driven spawn + offset templating
 
 ---
 

--- a/docs-site/src/content/docs/product/vision.md
+++ b/docs-site/src/content/docs/product/vision.md
@@ -17,7 +17,7 @@ Bowerbird's functionality exists in concentric layers:
 
 1. **Schema** (core) — Type enforcement, validation, migration
 2. **PKM** (middle) — Queries, organization, knowledge discovery
-3. **AI** (outer) — Optional automation, never required
+3. **AI safety net** (outer) — Deterministic guarantees *under* the AI agent, never an LLM caller
 
 If the schema layer doesn't work, nothing works.
 
@@ -29,7 +29,7 @@ The schema is the source of truth. Notes must conform.
 
 ### Composable, Not Monolithic
 
-Bowerbird does one thing well. Use Git for version control, ripgrep for search, Neovim for editing.
+Bowerbird does one thing well. Use Git for version control, ripgrep for search, AI agents for authoring.
 
 ### Portable and Offline
 
@@ -49,6 +49,7 @@ Small command surface. Consistent flags. JSON mode everywhere.
 - Not a database
 - Not a sync service
 - Not a web app
+- Not an LLM caller — the AI agent drives bwrb, not the other way around
 
 ## Success Criteria
 

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -7,8 +7,8 @@
 ## Version Philosophy
 
 **v1: Schema + Dashboards** — Rock-solid schema enforcement, inheritance model, type safety, and saved queries
-**v2: PKM** — Plugins, ecosystem, visibility into your knowledge
-**v3: AI** — Built-in AI features, ingest, automation
+**v2: Schema expressiveness + PKM** — A richer schema (aliases, traits, hierarchical scope) so the AI agent uses it correctly, plus deeper queries and visibility
+**v3: AI safety net** — Deterministic primitives *under* the AI agent (no LLM in bwrb): `search --fuzzy`, `audit: unlinked-mention`, daily-note sweep, `schema discover`, event-driven task recurrence
 
 ---
 
@@ -81,43 +81,51 @@ Dashboards are saved `bwrb list` queries that can be recalled by name. This mini
 
 ---
 
-## v2.0: PKM (Future)
+## v2.0: Schema Expressiveness + PKM (Future)
 
-Make the schema useful for knowledge work.
+Make the schema richer so the AI agent uses it correctly, and make queries deeper. The schema is the shared language between the human and the agent; investing here pays off everywhere. See `plans/features/schema-expressiveness.md`.
 
 ### Planned Features
 
 | Feature | Issue | Description |
 |---------|-------|-------------|
+| Aliases | #266 | First-class alias field role; substrate for the ingest safety net |
+| Traits | #442 | Composition (`also-has`) alongside inheritance (`is-a`) |
+| Hierarchical scope | #554 | Contexts as real notes + `under` join; collapses scope + context |
 | Link validation | `bwrb-6f0` | Broken link detection in audit |
 | Command consolidation | `bwrb-fkd` | Merge list/search/open |
 
 ### v2.0 Exit Criteria
 
+- [ ] Alias field role and Obsidian-format validation
+- [ ] Trait composition with deterministic precedence rules
+- [ ] Hierarchical scope with `under` operator
 - [ ] Comprehensive link validation
 - [ ] Polished, consistent CLI surface
 
 ---
 
-## v3.0: AI (Future)
+## v3.0: AI Safety Net (Future)
 
-Optional AI-powered features for automation.
+bwrb is the **deterministic safety net under the AI agent, not an LLM caller.** The AI agent (Claude Code, Codex, etc.) does open-world extraction; bwrb provides closed-world verification — deterministic primitives that guarantee nothing gets swept under the rug. No LLM, no OpenRouter client, no cost tracking in bwrb. See `plans/features/ingest-safety-net.md` and `plans/features/task-system.md`.
 
 ### Planned Features
 
 | Feature | Issue | Description |
 |---------|-------|-------------|
-| AI Ingest | `bwrb-acd` | Extract tasks/ideas/entities from notes |
-| Entity matching | `bwrb-h9o` | Link mentions to existing notes |
-| Agentic workflows | — | Run AI workflows from vault |
-| Cost tracking | — | Monitor AI spend |
+| `search --fuzzy` | #93 | Scored candidate lookup so the agent checks "does X exist?" before writing |
+| `audit: unlinked-mention` | #93 | Flag known-entity names in prose that aren't wikilinked (exact/alias auto-fixable; fuzzy flag-only) |
+| `audit: frequent-unlinked-term` | — | Advisory nudge toward entities mentioned often but with no note yet |
+| Daily-note sweep | #87 | Frontmatter convention + saved query proving every ramble was looked at |
+| Task recurrence | #107 | Event-driven spawn-on-transition + offset templating (no daemon, no cron) |
 
 ### v3.0 Exit Criteria
 
-- [ ] `bwrb ingest` command working
-- [ ] Interactive approval flow for AI suggestions
-- [ ] Entity matching and auto-linking
-- [ ] Optional—works without AI keys
+- [ ] `search --fuzzy` returns scored candidates
+- [ ] `unlinked-mention` audit with exact/alias auto-fix and fuzzy review
+- [ ] Daily-note sweep coverage query
+- [ ] Event-driven recurrence with audit backstop
+- [ ] Zero LLM calls — works entirely offline, no AI keys
 
 ---
 
@@ -125,9 +133,7 @@ Optional AI-powered features for automation.
 
 | Feature | Issue | Notes |
 |---------|-------|-------|
-| Recurrence | `bwrb-yuq` | Recurring task creation |
-| Schema discovery | `bwrb-onp` | Suggest schema from existing files |
-| Obsidian plugin | — | If there's demand |
+| `schema discover` | #97 | Deterministic field-usage facts over a folder (not AI schema generation) |
 
 ---
 

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -34,9 +34,10 @@ Bowerbird's functionality exists in concentric layers of priority:
 │   │   knowledge discovery           │   │
 │   │                                 │   │
 │   └─────────────────────────────────┘   │
-│                  AI                     │
-│   Optional automation, ingest,          │
-│   processing helpers                    │
+│              AI SAFETY NET               │
+│   Deterministic primitives the AI        │
+│   agent relies on (search --fuzzy,       │
+│   unlinked-mention audit)                │
 │                                         │
 └─────────────────────────────────────────┘
 ```
@@ -44,7 +45,7 @@ Bowerbird's functionality exists in concentric layers of priority:
 **Priority order:**
 1. **Schema** (core) — If this doesn't work, nothing works
 2. **PKM** (middle) — Makes the schema useful for knowledge work
-3. **AI** (outer) — Nice-to-have automation, never required
+3. **AI safety net** (outer) — Deterministic guarantees *under* the AI agent, never an LLM caller
 
 ---
 
@@ -54,7 +55,7 @@ Bowerbird's functionality exists in concentric layers of priority:
 
 - Power user, developer, creative
 - Writes in Markdown, lives in the terminal
-- Uses Neovim (or similar) as primary editor
+- Authors and edits notes through AI agents (Claude Code, Codex, etc.)
 - Wants to publish writing to the web
 - Tired of migrating between PKM tools
 - Needs strict organization without manual discipline
@@ -62,9 +63,8 @@ Bowerbird's functionality exists in concentric layers of priority:
 If Bowerbird works for this user, it will work for others. But it must work for this user first.
 
 **Secondary audiences (stretch goals):**
-- Neovim enthusiasts who want Obsidian-like PKM
 - Developers who want schema-enforced Markdown as CMS
-- Obsidian users who want CLI automation
+- Anyone driving a Markdown vault through an AI agent who wants deterministic guardrails
 
 ---
 
@@ -87,7 +87,7 @@ Bowerbird does one thing well: schema enforcement. It uses the existing ecosyste
 - **Git** for version control (Bowerbird doesn't manage commits)
 - **yq/yaql** for raw YAML queries (Bowerbird provides schema-aware queries)
 - **ripgrep** for content search (Bowerbird wraps it with type awareness)
-- **Neovim** for editing (Bowerbird provides a plugin, not an editor)
+- **AI agents** for authoring and editing (Bowerbird enforces the schema, doesn't write prose)
 - **GitHub Actions** for automation (Bowerbird is scriptable, not a scheduler)
 
 ### 3. Portable and Offline
@@ -134,11 +134,12 @@ The CLI should be predictable and learnable.
 - A query engine for typed notes
 - A validator and auditor for note hygiene
 - A migration tool for schema evolution
-- A Neovim plugin for in-editor PKM (secondary)
+- A deterministic safety net under the AI agents that author your notes
 
 ## What Bowerbird Is NOT
 
-- **Not a note-taking app** — Use Neovim, Obsidian, whatever you want
+- **Not a note-taking app** — Author your notes however you like; bwrb enforces the schema
+- **Not an LLM caller** — bwrb runs no model and ships no AI keys; the AI agent drives bwrb, not the other way around
 - **Not a database** — Markdown files are the source of truth
 - **Not a sync service** — Use Git, iCloud, Syncthing
 - **Not version control** — Use Git
@@ -216,7 +217,7 @@ Target: <15 top-level commands that cover all use cases.
 - `bwrb edit` — Modify existing note frontmatter
 - `bwrb list` — Query notes by type and fields
 - `bwrb search` — Find notes by name or content
-- `bwrb open` — Open notes in editor/Obsidian
+- `bwrb open` — Open notes in your configured handler
 - `bwrb delete` — Remove notes with backlink warnings
 - `bwrb audit` — Validate notes against schema
 - `bwrb bulk` — Batch frontmatter operations
@@ -229,10 +230,10 @@ The same verbs that work on notes also work on schema and templates, reducing le
 
 ```bash
 # Schema management
-bwrb schema new [type|field|enum]    # Create (prompts if noun omitted)
-bwrb schema edit [type|field|enum]   # Edit with picker
-bwrb schema delete [type|field|enum] # Delete (dry-run default)
-bwrb schema list [types|fields|enums] # List/show
+bwrb schema new [type|field]    # Create (prompts if noun omitted)
+bwrb schema edit [type|field]   # Edit with picker
+bwrb schema delete [type|field] # Delete (dry-run default)
+bwrb schema list [types|fields] # List/show
 
 # Template management (uses two separate args like schema commands)
 bwrb template new [type]           # Create template (prompts for type if omitted)
@@ -245,7 +246,7 @@ bwrb template list [type] [name]   # List all, or show details if both provided
 - `open` is an alias for `search --open`
 - `edit` is an alias for `search --edit`
 - `list` remains separate (structured query output vs search/action)
-- AI commands deferred to post-V1.0
+- The AI safety-net primitives (`search --fuzzy`, `audit: unlinked-mention`) are deferred to post-V1.0
 
 ### Design Principles
 
@@ -283,14 +284,14 @@ This ordering presents commands as a guided path: create notes → find notes �
 2. **Inheritance model** — Full, consistent type inheritance
 3. **Core commands** — new, edit, list, search, audit, bulk, schema, template
 4. **JSON mode** — Every command scriptable
-5. **Migration tooling** — Rename fields, change enums, refactor types
+5. **Migration tooling** — Rename fields, change select options, refactor types
 
 ### Post-V1.0
 
-- AI ingest command
-- Schema discovery from existing files
-- Obsidian plugin
-- Cost tracking for AI operations
+- Schema expressiveness — aliases, traits, hierarchical scope
+- Ingest safety net — `search --fuzzy`, `audit: unlinked-mention` / `frequent-unlinked-term`, daily-note sweep
+- `schema discover` — deterministic field-usage facts over a folder
+- Task system — event-driven recurrence + offset templating
 
 ---
 
@@ -299,7 +300,6 @@ This ordering presents commands as a guided path: create notes → find notes �
 - **CLI command:** `bwrb`
 - **Product name:** Bowerbird
 - **Config directory:** `.bwrb/`
-- **Neovim plugin:** `bwrb.nvim`
 - **Schema file:** `.bwrb/schema.json`
 
 ---


### PR DESCRIPTION
## Summary

Reconciles `docs/product/vision.md`, `docs/product/roadmap.md`, and the docs-site mirror (`docs-site/src/content/docs/product/{vision,roadmap}.md`) with the decided product direction in:

- `plans/features/ingest-safety-net.md`
- `plans/features/schema-expressiveness.md`
- `plans/features/task-system.md`

(The prior pass already killed the LSP/nvim-plugin roadmap *items*; this is the remaining editorial reconciliation.)

## What changed

- **AI reframe** — The outer "AI" circle is now an **AI safety net**: deterministic primitives *under* the AI agent (search --fuzzy, audit unlinked-mention), explicitly **not an LLM caller** (no OpenRouter client, no cost tracking in bwrb). Replaced the AI-ingest / agentic-workflow / cost-tracking roadmap entries with the safety-net primitives + event-driven task recurrence.
- **Schema discovery** — `schema discover` reframed to deterministic field-usage facts, not AI schema generation; moved to Deferred per the brief's build order.
- **Schema expressiveness** — Added a v2 lane (aliases #266, traits #442, hierarchical scope #554).
- **Nvim / Obsidian** — Dropped Neovim as a product surface and Obsidian-first / Obsidian-plugin framing; primary user now authors via AI agents. Removed the `bwrb.nvim` naming entry. (Left the legit `config.open_with` / `BWRB_DEFAULT_APP` obsidian *example*, and the Obsidian-aliases-format validation reference per brief #266, intact.)
- **Stale terminology** — `enums` → current `select` / options; schema CLI nouns `[type|field|enum]` → `[type|field]`.

## Already reconciled / left alone

- The killed LSP/nvim-plugin roadmap **items** were already gone (prior pass) — no leftovers found.
- `docs-site/.../reference/schema.md` generic `nvim-lspconfig` / `jsonls` references (editing `schema.json` with a JSON LSP) — legit, untouched.

## Quality gates

- `pnpm qa` — pass (1995 tests passed, 4 skipped; typecheck/lint/docs:lint/docs:doctor/build/test all green)
- `pnpm knip` — clean
- `pnpm docs:build` — success (35 pages built)
- `pnpm docs:lint` — clean

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)