### PR TITLE
fix(new): normalize date fields to canonical YYYY-MM-DD (#592)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`new` now normalizes date fields to canonical `YYYY-MM-DD`** (#592) — `bwrb new` previously stored date values verbatim (e.g. `12/25/2026`), so freshly created notes could fail `bwrb audit`. The create path now normalizes dates the same way `edit` does — accepting unambiguous `MM/DD/YYYY`/`DD/MM/YYYY` and interpolated defaults (`today()`), while preserving valid partial dates per the field's granularity. The normalization logic is shared with the audit/validation and `edit` layers.
+
 ## [0.1.9] - 2026-06-20
 
 Changes since `v0.1.8`.

--- a/src/commands/new/write-plan.ts
+++ b/src/commands/new/write-plan.ts
@@ -10,6 +10,7 @@ import {
 } from '../../lib/note-id.js';
 import { ensureOwnedOutputDir, formatValue } from '../../lib/vault.js';
 import { getTypeDefByPath } from '../../lib/schema.js';
+import { normalizeDateFields } from '../../lib/validation.js';
 import { ExitCodes, jsonError } from '../../lib/output.js';
 import { printWarning } from '../../lib/prompt.js';
 import type { NoteCreationResult, WritePlanArgs, FileExistsStrategy, OwnershipMode, CreationMode } from './types.js';
@@ -83,6 +84,19 @@ export async function writeNotePlan(
   if (existsSync(filePath)) {
     await fileExistsStrategy.onExists(filePath, args.vaultDir);
   }
+
+  // Normalize date fields to canonical YYYY-MM-DD before writing, using the
+  // same logic as the audit/validation and edit layers. This keeps freshly
+  // created notes passing `bwrb audit` regardless of the accepted input format
+  // (e.g. unambiguous MM/DD/YYYY) while preserving valid partial dates per the
+  // field's granularity. Applies to all create paths (json/interactive),
+  // covering user-supplied values, schema/template defaults, and interpolated
+  // date expressions (today(), @today, {date}).
+  args.content.frontmatter = normalizeDateFields(
+    args.schema,
+    args.typePath,
+    args.content.frontmatter
+  );
 
   const noteId = await generateUniqueNoteId(args.vaultDir);
   args.content.frontmatter.id = noteId;

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -11,7 +11,6 @@ import {
   resolveTypePathFromFrontmatter,
   getFieldsForType,
   getFrontmatterOrder,
-  resolveDateGranularity,
 } from './schema.js';
 import { parseNote, writeNote, generateBodySections } from './frontmatter.js';
 import { queryByType, formatValue } from './vault.js';
@@ -27,7 +26,7 @@ import {
 import {
   validateFrontmatter,
   validateContextFields,
-  normalizeToIsoDate,
+  normalizeDateFields,
 } from './validation.js';
 import { validateParentNoCycle } from './hierarchy.js';
 import {
@@ -38,57 +37,6 @@ import {
 import { type LoadedSchema, type Field, type BodySection, getOptionValues } from '../types/schema.js';
 import { UserCancelledError } from './errors.js';
 import { expandStaticValue } from './local-date.js';
-
-/**
- * Format a Date to YYYY-MM-DD using UTC components.
- * Used for YAML-parsed dates which are stored as midnight UTC.
- */
-function formatUtcDate(date: Date): string {
-  const year = date.getUTCFullYear();
-  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
-  const day = String(date.getUTCDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-/**
- * Normalize date fields to canonical YYYY-MM-DD strings.
- * Handles both string values (ISO datetimes) and any residual Date objects.
- * Note: frontmatter parsing already normalizes Date objects, but this provides
- * defense-in-depth for any edge cases.
- */
-function normalizeDateFields(
-  schema: LoadedSchema,
-  typePath: string,
-  frontmatter: Record<string, unknown>
-): Record<string, unknown> {
-  const fields = getFieldsForType(schema, typePath);
-  const normalized: Record<string, unknown> = { ...frontmatter };
-
-  for (const [fieldName, field] of Object.entries(fields)) {
-    if (field.prompt !== 'date') continue;
-    if (!(fieldName in normalized)) continue;
-
-    const value = normalized[fieldName];
-    if (value === undefined || value === null || value === '') continue;
-
-    // Handle any residual Date objects (defense-in-depth)
-    // Use UTC components since YAML dates are stored as midnight UTC
-    if (value instanceof Date) {
-      normalized[fieldName] = formatUtcDate(value);
-      continue;
-    }
-
-    if (typeof value === 'string') {
-      const granularity = resolveDateGranularity(field, schema.config);
-      const result = normalizeToIsoDate(value, granularity);
-      if (result.valid) {
-        normalized[fieldName] = result.value;
-      }
-    }
-  }
-
-  return normalized;
-}
 
 // ============================================================================
 // Types

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -36,7 +36,7 @@ function describeGranularityRequirement(granularity: DatePrecision): string {
  * field's `granularity` permits them, and are stored verbatim (ISO partials sort
  * lexically). `granularity` defaults to 'day' (full date required).
  */
-export function normalizeToIsoDate(
+function normalizeToIsoDate(
   value: string,
   granularity: DatePrecision = 'day'
 ): NormalizedDateResult {
@@ -88,6 +88,71 @@ export function normalizeToIsoDate(
   const month = String(parsed.date!.getMonth() + 1).padStart(2, '0');
   const day = String(parsed.date!.getDate()).padStart(2, '0');
   return { valid: true, value: `${year}-${month}-${day}` };
+}
+
+/**
+ * Format a Date to YYYY-MM-DD using UTC components.
+ * Used for YAML-parsed dates which are stored as midnight UTC.
+ */
+function formatUtcDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Normalize date fields in a frontmatter object to their canonical stored form.
+ *
+ * For each field whose schema `prompt` is `date`, the value is normalized via
+ * {@link normalizeToIsoDate} using the field's resolved granularity:
+ * - Unambiguous slash-format dates (e.g. `12/25/2026`) become `2026-12-25`.
+ * - ISO datetimes are truncated to their date part.
+ * - Valid partial dates (`2026`, `2026-05`) are preserved verbatim when the
+ *   field's granularity permits them.
+ * - Residual `Date` objects (from YAML parsing) are formatted from UTC.
+ *
+ * Values that fail normalization are left untouched so the validation layer can
+ * surface a clear error. This is the single source of truth for date
+ * normalization on write, shared by both the `new` and `edit` paths.
+ *
+ * @returns A shallow copy of `frontmatter` with date fields normalized.
+ */
+export function normalizeDateFields(
+  schema: LoadedSchema,
+  typePath: string,
+  frontmatter: Record<string, unknown>
+): Record<string, unknown> {
+  const fields = getFieldsForType(schema, typePath);
+  const normalized: Record<string, unknown> = { ...frontmatter };
+
+  for (const [fieldName, field] of Object.entries(fields)) {
+    if (field.prompt !== 'date') continue;
+    if (!(fieldName in normalized)) continue;
+
+    const value = normalized[fieldName];
+    if (value === undefined || value === null || value === '') continue;
+
+    // Handle any residual Date objects (defense-in-depth).
+    // Use UTC components since YAML dates are stored as midnight UTC.
+    if (value instanceof Date) {
+      normalized[fieldName] = formatUtcDate(value);
+      continue;
+    }
+
+    // A bare year (e.g. 2026) may arrive as a number from YAML/JSON; coerce so
+    // it can be normalized against the field's granularity.
+    const dateValue = typeof value === 'number' ? String(value) : value;
+    if (typeof dateValue !== 'string') continue;
+
+    const granularity = resolveDateGranularity(field, schema.config);
+    const result = normalizeToIsoDate(dateValue, granularity);
+    if (result.valid) {
+      normalized[fieldName] = result.value;
+    }
+  }
+
+  return normalized;
 }
 
 

--- a/tests/ts/commands/new.test.ts
+++ b/tests/ts/commands/new.test.ts
@@ -506,3 +506,101 @@ describe('new command - date expression evaluation', () => {
     expect(content).toContain('deadline: 2030-01-15');
   });
 });
+
+describe('new command - date normalization (issue #592)', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  it('normalizes unambiguous MM/DD/YYYY input to canonical YYYY-MM-DD', async () => {
+    const result = await runCLI(
+      ['new', 'task', '--json', '{"name": "Slash Date Task", "deadline": "12/25/2026"}', '--no-template'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(ExitCodes.SUCCESS);
+    const output = JSON.parse(result.stdout);
+    expect(output.success).toBe(true);
+
+    const content = await readFile(join(vaultDir, output.path), 'utf-8');
+    expect(content).toContain('deadline: 2026-12-25');
+    expect(content).not.toContain('12/25/2026');
+  });
+
+  it('produces a note that passes its own audit (the regression)', async () => {
+    const create = await runCLI(
+      ['new', 'task', '--json', '{"name": "Audit Clean Task", "deadline": "12/25/2026"}', '--no-template'],
+      vaultDir
+    );
+    expect(create.exitCode).toBe(ExitCodes.SUCCESS);
+
+    // Audit the newly created note; it must not report invalid-date errors.
+    const audit = await runCLI(['audit', 'task'], vaultDir);
+    expect(audit.stdout).not.toContain('Invalid date');
+    expect(audit.exitCode).toBe(ExitCodes.SUCCESS);
+  });
+
+  it('normalizes interpolated date defaults (today()) before storing', async () => {
+    // weekly-review template stores deadline via "today() + '7d'".
+    const create = await runCLI(
+      ['new', 'task', '--json', '{"name": "Interpolated Default"}', '--template', 'weekly-review'],
+      vaultDir
+    );
+    expect(create.exitCode).toBe(ExitCodes.SUCCESS);
+    const output = JSON.parse(create.stdout);
+
+    const content = await readFile(join(vaultDir, output.path), 'utf-8');
+    expect(content).toMatch(/deadline: \d{4}-\d{2}-\d{2}/);
+
+    const audit = await runCLI(['audit', 'task'], vaultDir);
+    expect(audit.stdout).not.toContain('Invalid date');
+    expect(audit.exitCode).toBe(ExitCodes.SUCCESS);
+  });
+
+  it('preserves valid partial dates per the field granularity', async () => {
+    // Install a schema with a month-granularity date field.
+    await writeFile(
+      join(vaultDir, '.bwrb', 'schema.json'),
+      JSON.stringify(
+        {
+          config: { link_format: 'wikilink', date_format: 'YYYY-MM-DD' },
+          types: {
+            release: {
+              output_dir: 'Ideas',
+              fields: {
+                type: { value: 'release' },
+                shipped: { prompt: 'date', granularity: 'month' },
+              },
+              field_order: ['type', 'shipped'],
+            },
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const create = await runCLI(
+      ['new', 'release', '--json', '{"name": "Partial Date Release", "shipped": "2026-05"}', '--no-template'],
+      vaultDir
+    );
+    expect(create.exitCode).toBe(ExitCodes.SUCCESS);
+    const output = JSON.parse(create.stdout);
+
+    const content = await readFile(join(vaultDir, output.path), 'utf-8');
+    // Month-precision partial preserved verbatim, not expanded to a full date.
+    expect(content).toContain('shipped: 2026-05');
+
+    // Scope the audit to the created note; the baseline test vault still
+    // contains sample notes for unrelated types.
+    const audit = await runCLI(['audit', '--path', output.path], vaultDir);
+    expect(audit.stdout).not.toContain('Invalid date');
+    expect(audit.exitCode).toBe(ExitCodes.SUCCESS);
+  });
+});


### PR DESCRIPTION
## Summary

`bwrb new` stored date field values verbatim (e.g. `12/25/2026`), so a freshly created note immediately **failed `bwrb audit`** — `new` and `audit` disagreed on the canonical date format. The `edit` command already normalized dates; `new` did not.

This shares the existing normalization logic across both paths and applies it in the common create write path.

## Repro (before)

```
$ bwrb new task --json '{"name":"X","deadline":"12/25/2026"}'
# stored: deadline: 12/25/2026   (verbatim)
$ bwrb audit task
#   ✗ Invalid date for deadline: must be YYYY-MM-DD   (exit 1)
```

## After

```
$ bwrb new task --json '{"name":"X","deadline":"12/25/2026"}'
# stored: deadline: 2026-12-25
$ bwrb audit task
# ✓ No issues found   (exit 0)
```

## Root cause

The `new` create paths (`json-mode.ts` via `applyDefaults`, `interactive.ts` via `buildNoteContent`) never normalized date values before writing. Date normalization lived as a **private** `normalizeDateFields` helper inside `src/lib/edit.ts`, used only by `edit`.

## Fix

- Promoted `normalizeDateFields` into `src/lib/validation.ts` (next to the `normalizeToIsoDate` + `resolveDateGranularity` logic the audit layer uses), making it the single source of truth.
- `src/lib/edit.ts` now imports the shared helper (removed its private copy + the now-unused `normalizeToIsoDate` export).
- Applied `normalizeDateFields` in `src/commands/new/write-plan.ts` — the shared write path for **all** create flows. This covers user-supplied values, schema/template defaults, and interpolated date expressions (`today()`/`@today`/`{date}`).
- Valid partial dates (e.g. `2026-05`) are preserved per the field's granularity.

## Files changed

- `src/lib/validation.ts` — new shared `normalizeDateFields`; `normalizeToIsoDate` made private.
- `src/lib/edit.ts` — use shared helper.
- `src/commands/new/write-plan.ts` — normalize before write.
- `tests/ts/commands/new.test.ts` — new "date normalization (#592)" suite.
- `CHANGELOG.md` — Unreleased > Fixed entry.

## Tests

New suite in `new.test.ts`: MM/DD/YYYY → ISO; created note passes its own audit; interpolated `today()` default normalized; month-granularity partial (`2026-05`) preserved + audits clean.

## Quality gates

- `pnpm qa` ✅ (typecheck, lint, docs:lint, docs:doctor, build, 1999 tests pass)
- `pnpm knip` ✅ (no unused exports)

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)