### PR TITLE
feat(search): --fuzzy scored entity/note lookup

### DIFF
--- a/docs-site/src/content/docs/reference/commands/search.md
+++ b/docs-site/src/content/docs/reference/commands/search.md
@@ -13,9 +13,10 @@ bwrb search [options] [query]
 
 ## Modes
 
-Search operates in two modes:
+Search operates in three modes:
 
 - **Name search** (default): Searches by note name, basename, or path
+- **Fuzzy search** (`--fuzzy`): Ranked approximate matching over note names and aliases, with scores
 - **Content search** (`--body`): Full-text search across note contents using ripgrep
 
 ## Options
@@ -45,6 +46,15 @@ Search operates in two modes:
 | `-p, --path <pattern>` | Filter by file path glob pattern |
 | `-w, --where <expr>` | Filter results by frontmatter expression (repeatable) |
 | `-b, --body` | Enable content search mode |
+| `--fuzzy` | Enable fuzzy ranked matching over names and aliases |
+
+### Fuzzy Search Options
+
+| Option | Description |
+|--------|-------------|
+| `--fuzzy` | Enable fuzzy ranked matching |
+| `--threshold <0-1>` | Minimum similarity score to include a match (default: `0.5`) |
+| `-l, --limit <count>` | Maximum ranked results (default: `10`) |
 
 ### Content Search Options
 
@@ -90,6 +100,62 @@ bwrb search "My Note" --edit
 # Non-interactive edit
 bwrb search "My Note" --edit --json '{"status":"settled"}'
 ```
+
+### Fuzzy Search
+
+Fuzzy search answers "does an entity like X already exist?" before you (or an
+AI agent) create a new note. It returns **ranked** candidates with a visible
+similarity score (`1.0` = exact match), matching against each note's name and
+its declared aliases.
+
+```bash
+# Ranked near-matches by name or alias
+bwrb search "Stephen Yeg" --fuzzy
+
+# Tighten the match cutoff (default threshold is 0.5)
+bwrb search "Steve" --fuzzy --threshold 0.7
+
+# Cap the number of ranked results (default 10)
+bwrb search "Steve" --fuzzy --limit 3
+
+# JSON output with scores for an agent to consume
+bwrb search "Steve" --fuzzy --output json
+```
+
+#### What participates in matching
+
+- The note **name** (file basename, without `.md`) — always.
+- Every declared **alias** (the field carrying the `alias` role) — for
+  schema-typed entities. A note like `Steve Yegge` with aliases `Stevey` /
+  `Steve Y` is matchable by any of those strings.
+
+Each note contributes its single best-scoring field. An exact name match always
+scores `1.0` and ranks first; results below the threshold are dropped, and the
+remainder are returned best-first up to the limit.
+
+#### JSON output shape
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "name": "Steve Yegge",
+      "score": 0.8333,
+      "matchedField": "alias",
+      "matchedValue": "Stevey",
+      "aliases": ["Stevey", "Steve Y"],
+      "wikilink": "[[Steve Yegge]]",
+      "path": "People/Steve Yegge.md",
+      "absolutePath": "/vault/People/Steve Yegge.md"
+    }
+  ]
+}
+```
+
+`matchedField` is `"name"` or `"alias"`; `matchedValue` is the specific string
+that produced the score. An empty `data` array means no candidate met the
+threshold.
 
 ### Content Search
 

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -577,6 +577,34 @@ async function filterByFrontmatter(
 // ============================================================================
 
 /**
+ * Strictly parse a finite decimal number from a raw flag string.
+ *
+ * Unlike `Number.parseFloat`, this rejects trailing garbage ("0.5abc"),
+ * exponent notation ("1e1"), and other non-decimal forms, returning `null`
+ * for anything that is not a plain finite number.
+ */
+function parseStrictNumber(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!/^[+-]?(\d+\.?\d*|\.\d+)$/.test(trimmed)) return null;
+  const value = Number(trimmed);
+  return Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Strictly parse an integer from a raw flag string.
+ *
+ * Unlike `Number.parseInt`, this rejects non-integer values ("2.7"), trailing
+ * garbage ("3abc"), and exponent notation ("1e1"), returning `null` for
+ * anything that is not a plain integer.
+ */
+function parseStrictInteger(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!/^[+-]?\d+$/.test(trimmed)) return null;
+  const value = Number(trimmed);
+  return Number.isInteger(value) ? value : null;
+}
+
+/**
  * Fuzzy search: ranked approximate matching over note names and aliases.
  *
  * Returns scored candidates (best first) so an agent or human can decide
@@ -602,11 +630,13 @@ async function handleFuzzySearch(
     process.exit(1);
   }
 
-  // Parse and validate threshold / limit.
+  // Parse and validate threshold / limit. Use strict format checks so that
+  // malformed values (e.g. "0.5abc", "2.7", "1e1") error cleanly rather than
+  // being silently coerced by parseFloat/parseInt's lenient parsing.
   const threshold = options.threshold !== undefined
-    ? Number.parseFloat(options.threshold)
+    ? parseStrictNumber(options.threshold)
     : DEFAULT_FUZZY_THRESHOLD;
-  if (Number.isNaN(threshold) || threshold < 0 || threshold > 1) {
+  if (threshold === null || threshold < 0 || threshold > 1) {
     const error = `Invalid --threshold "${options.threshold}": must be a number between 0 and 1`;
     if (jsonMode) {
       printJson(jsonError(error));
@@ -617,9 +647,9 @@ async function handleFuzzySearch(
   }
 
   const limit = options.limit !== undefined
-    ? Number.parseInt(options.limit, 10)
+    ? parseStrictInteger(options.limit)
     : DEFAULT_FUZZY_LIMIT;
-  if (Number.isNaN(limit) || limit < 1) {
+  if (limit === null || limit < 1) {
     const error = `Invalid --limit "${options.limit}": must be a positive integer`;
     if (jsonMode) {
       printJson(jsonError(error));

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -29,6 +29,12 @@ import {
   formatResultsJson,
   type ContentMatch,
 } from '../lib/content-search.js';
+import {
+  fuzzySearch,
+  DEFAULT_FUZZY_LIMIT,
+  DEFAULT_FUZZY_THRESHOLD,
+  type FuzzyMatch,
+} from '../lib/fuzzy-search.js';
 import { parseNote } from '../lib/frontmatter.js';
 import { applyWhereExpressions } from '../lib/where-targeting.js';
 import { minimatch } from 'minimatch';
@@ -66,6 +72,9 @@ interface SearchOptions {
   caseSensitive?: boolean;
   regex?: boolean;
   limit?: string;
+  // Fuzzy search options
+  fuzzy?: boolean;
+  threshold?: string;
 }
 
 interface SearchResultData {
@@ -153,6 +162,9 @@ export const searchCommand = new Command('search')
   .option('-S, --case-sensitive', 'Case-sensitive search (default: case-insensitive)')
   .option('-E, --regex', 'Treat pattern as regex (default: literal)')
   .option('-l, --limit <count>', 'Maximum files to return (default: 100)')
+  // Fuzzy search options
+  .option('--fuzzy', 'Fuzzy name/alias search: ranked approximate matches with scores')
+  .option('--threshold <score>', 'Minimum similarity 0-1 for --fuzzy (default: 0.5)')
   .addHelpText('after', `
 Name Search (default):
   Searches by note name, basename, or path.
@@ -169,6 +181,18 @@ Name Search (default):
     fzf         Force fzf (error if unavailable)
     numbered    Force numbered select
     none        Error on ambiguity (for non-interactive use)
+
+Fuzzy Search (--fuzzy):
+  Ranked approximate matching over note names and aliases. Use this to ask
+  "does an entity like X already exist?" before creating a new note.
+
+  Options:
+    --fuzzy              Enable fuzzy ranked matching
+    --threshold <0-1>    Minimum similarity score (default: 0.5)
+    -l, --limit <n>      Max ranked results (default: 10)
+
+  Each result carries a similarity score (1.0 = exact). Use --output json to
+  consume scores programmatically.
 
 Content Search (--body):
   Full-text search across note contents using ripgrep.
@@ -221,7 +245,12 @@ Examples:
   bwrb search "error.*log" -b --regex      # Regex search
   bwrb search "deploy" -b --output json    # JSON output with matches
   bwrb search "deploy" -b --open           # Search and open first match
-  
+
+  # Fuzzy search (ranked candidates with scores)
+  bwrb search "Stephen Yeg" --fuzzy        # Ranked near-matches by name/alias
+  bwrb search "Steve" --fuzzy --output json  # Scores for an agent to consume
+  bwrb search "Steve" --fuzzy --threshold 0.7  # Tighter match cutoff
+
   # Piping
   bwrb search "bug" -t --output paths | xargs -I {} code {}`)
   .allowExcessArguments(false)
@@ -286,7 +315,9 @@ Examples:
       };
 
       // Dispatch to appropriate search mode
-      if (effectiveOptions.body) {
+      if (effectiveOptions.fuzzy) {
+        await handleFuzzySearch(query, effectiveOptions, vaultDir, schema, jsonMode, outputFormat);
+      } else if (effectiveOptions.body) {
         await handleContentSearch(query, effectiveOptions, vaultDir, schema, jsonMode, outputFormat);
       } else {
         await handleNameSearch(query, effectiveOptions, vaultDir, schema, jsonMode, outputFormat);
@@ -539,6 +570,122 @@ async function filterByFrontmatter(
 
   // Return the original ContentMatch objects
   return filtered.files.map(f => f.original);
+}
+
+// ============================================================================
+// Fuzzy Search Handler
+// ============================================================================
+
+/**
+ * Fuzzy search: ranked approximate matching over note names and aliases.
+ *
+ * Returns scored candidates (best first) so an agent or human can decide
+ * whether an entity like the query already exists before creating a note.
+ * Always non-interactive; honors the existing --output json contract by
+ * exposing the score on each result.
+ */
+async function handleFuzzySearch(
+  query: string | undefined,
+  options: SearchOptions,
+  vaultDir: string,
+  schema: import('../types/schema.js').LoadedSchema,
+  jsonMode: boolean,
+  outputFormat: SearchOutputFormat
+): Promise<void> {
+  if (!query) {
+    const error = 'Search query is required for fuzzy search (--fuzzy)';
+    if (jsonMode) {
+      printJson(jsonError(error));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    printError(error);
+    process.exit(1);
+  }
+
+  // Parse and validate threshold / limit.
+  const threshold = options.threshold !== undefined
+    ? Number.parseFloat(options.threshold)
+    : DEFAULT_FUZZY_THRESHOLD;
+  if (Number.isNaN(threshold) || threshold < 0 || threshold > 1) {
+    const error = `Invalid --threshold "${options.threshold}": must be a number between 0 and 1`;
+    if (jsonMode) {
+      printJson(jsonError(error));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    printError(error);
+    process.exit(1);
+  }
+
+  const limit = options.limit !== undefined
+    ? Number.parseInt(options.limit, 10)
+    : DEFAULT_FUZZY_LIMIT;
+  if (Number.isNaN(limit) || limit < 1) {
+    const error = `Invalid --limit "${options.limit}": must be a positive integer`;
+    if (jsonMode) {
+      printJson(jsonError(error));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    printError(error);
+    process.exit(1);
+  }
+
+  const index = await buildNoteIndex(schema, vaultDir);
+  const matches = await fuzzySearch(index, query, schema, vaultDir, { threshold, limit });
+
+  if (jsonMode) {
+    printJson(jsonSuccess({
+      data: matches.map(m => ({
+        name: m.name,
+        score: Number(m.score.toFixed(4)),
+        matchedField: m.matchedField,
+        matchedValue: m.matchedValue,
+        aliases: m.aliases,
+        wikilink: generateWikilink(index, m.file),
+        path: m.file.relativePath,
+        absolutePath: m.file.path,
+      })),
+    }));
+    return;
+  }
+
+  if (matches.length === 0) {
+    // Silent for no matches (consistent with content search / grep behavior).
+    return;
+  }
+
+  for (const match of matches) {
+    outputFuzzyResult(index, match, outputFormat);
+  }
+}
+
+/**
+ * Output a single fuzzy match in the requested text format.
+ *
+ * The default format shows the score so ranking is visible; pipe-friendly
+ * formats (paths, link) stay clean for scripting.
+ */
+function outputFuzzyResult(
+  index: NoteIndex,
+  match: FuzzyMatch,
+  format: SearchOutputFormat
+): void {
+  switch (format) {
+    case 'paths':
+      console.log(match.file.relativePath);
+      break;
+    case 'link':
+      console.log(generateWikilink(index, match.file));
+      break;
+    case 'default':
+    default: {
+      const score = match.score.toFixed(2);
+      const via = match.matchedField === 'alias'
+        ? ` (alias: ${match.matchedValue})`
+        : '';
+      console.log(`${score}  ${match.name}${via}`);
+      break;
+    }
+  }
 }
 
 // ============================================================================

--- a/src/lib/fuzzy-search.ts
+++ b/src/lib/fuzzy-search.ts
@@ -1,0 +1,177 @@
+/**
+ * Fuzzy entity/note lookup for `search --fuzzy`.
+ *
+ * Returns scored candidate matches so an AI agent (or human) can ask
+ * "does an entity like X already exist?" before creating a new note.
+ *
+ * Unlike the default name search (exact/substring resolution), this returns a
+ * ranked list of approximate matches with a visible score, consulting both the
+ * note name (basename) and any declared aliases (the `alias` field role).
+ *
+ * Scoring is deterministic and AI-agnostic: it reuses the shared
+ * {@link levenshteinDistance} util and normalizes edit distance into a 0..1
+ * similarity. Substring containment is given a floor so that a query which is
+ * fully contained in a candidate (or vice versa) still scores as a usable hint
+ * even when the length difference would otherwise sink the Levenshtein ratio.
+ */
+
+import { basename } from 'path';
+import type { LoadedSchema } from '../types/schema.js';
+import type { ManagedFile, NoteIndex } from './navigation.js';
+import { buildVaultNoteSnapshot } from './discovery.js';
+import { getEntityAliases } from './schema.js';
+import { levenshteinDistance } from './levenshtein.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Default minimum similarity (0..1) for a candidate to be returned. */
+export const DEFAULT_FUZZY_THRESHOLD = 0.5;
+
+/** Default maximum number of ranked results returned. */
+export const DEFAULT_FUZZY_LIMIT = 10;
+
+/**
+ * Similarity floor applied when the query is a substring of a candidate (or
+ * vice versa). Substring containment is a strong "might be the same entity"
+ * signal that raw edit-distance ratios undervalue for short queries against
+ * long names, so we never let a containment match score below this.
+ */
+const SUBSTRING_SCORE_FLOOR = 0.6;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Which field on the note produced the winning score. */
+export type FuzzyMatchField = 'name' | 'alias';
+
+export interface FuzzyMatch {
+  /** Note basename (no extension). */
+  name: string;
+  /** Wikilink-friendly shortest target / `[[name]]` is built by the caller. */
+  file: ManagedFile;
+  /** Best similarity score in 0..1 (1 = exact, higher is better). */
+  score: number;
+  /** Whether the best score came from the name or one of the aliases. */
+  matchedField: FuzzyMatchField;
+  /** The actual string (name or specific alias) that produced the best score. */
+  matchedValue: string;
+  /** All aliases declared on the note (for agent context). */
+  aliases: string[];
+}
+
+export interface FuzzySearchOptions {
+  /** Minimum similarity (0..1). Defaults to {@link DEFAULT_FUZZY_THRESHOLD}. */
+  threshold?: number;
+  /** Max results. Defaults to {@link DEFAULT_FUZZY_LIMIT}. */
+  limit?: number;
+}
+
+// ============================================================================
+// Scoring
+// ============================================================================
+
+/**
+ * Similarity between two strings in 0..1 (1 = identical), case-insensitive.
+ *
+ * Combines a normalized Levenshtein ratio with a substring-containment floor.
+ */
+export function similarityScore(query: string, candidate: string): number {
+  const a = query.trim().toLowerCase();
+  const b = candidate.trim().toLowerCase();
+
+  if (a === '' || b === '') return 0;
+  if (a === b) return 1;
+
+  const dist = levenshteinDistance(a, b);
+  const maxLen = Math.max(a.length, b.length);
+  const levRatio = maxLen === 0 ? 0 : 1 - dist / maxLen;
+
+  // Substring containment is a strong signal; floor it so short-vs-long pairs
+  // (e.g. "Steve" inside "Steve Yegge") still surface as candidates.
+  if (b.includes(a) || a.includes(b)) {
+    return Math.max(levRatio, SUBSTRING_SCORE_FLOOR);
+  }
+
+  return levRatio;
+}
+
+// ============================================================================
+// Search
+// ============================================================================
+
+/**
+ * Run a fuzzy search over the vault, returning ranked candidate matches.
+ *
+ * Fields that participate in matching:
+ *  - the note name (file basename, sans `.md`) — always
+ *  - every declared alias (via {@link getEntityAliases}) — for schema-typed
+ *    entities that have an `alias`-role field
+ *
+ * Each note contributes its single best-scoring field. Results at or above the
+ * threshold are returned best-first, then capped to `limit`.
+ */
+export async function fuzzySearch(
+  index: NoteIndex,
+  query: string,
+  schema: LoadedSchema,
+  vaultDir: string,
+  options: FuzzySearchOptions = {}
+): Promise<FuzzyMatch[]> {
+  const threshold = options.threshold ?? DEFAULT_FUZZY_THRESHOLD;
+  const limit = options.limit ?? DEFAULT_FUZZY_LIMIT;
+
+  const cleanQuery = query.replace(/\.md$/, '').trim();
+  if (cleanQuery === '') return [];
+
+  // Build a single map of relativePath -> aliases from one parse pass.
+  const aliasesByPath = new Map<string, string[]>();
+  const snapshot = await buildVaultNoteSnapshot(schema, vaultDir);
+  for (const note of snapshot.notes) {
+    if (!note.resolvedType || !note.frontmatter) continue;
+    const aliases = getEntityAliases(schema, note.resolvedType, note.frontmatter);
+    if (aliases.length > 0) {
+      aliasesByPath.set(note.relativePath, aliases);
+    }
+  }
+
+  const matches: FuzzyMatch[] = [];
+
+  for (const file of index.allFiles) {
+    const name = basename(file.relativePath, '.md');
+    const aliases = aliasesByPath.get(file.relativePath) ?? [];
+
+    // Score the name first; aliases only win on a strictly higher score so an
+    // exact name match always beats an aliased near-match.
+    let bestScore = similarityScore(cleanQuery, name);
+    let bestField: FuzzyMatchField = 'name';
+    let bestValue = name;
+
+    for (const alias of aliases) {
+      const aliasScore = similarityScore(cleanQuery, alias);
+      if (aliasScore > bestScore) {
+        bestScore = aliasScore;
+        bestField = 'alias';
+        bestValue = alias;
+      }
+    }
+
+    if (bestScore >= threshold) {
+      matches.push({
+        name,
+        file,
+        score: bestScore,
+        matchedField: bestField,
+        matchedValue: bestValue,
+        aliases,
+      });
+    }
+  }
+
+  // Best score first; tie-break by name for deterministic ordering.
+  matches.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name, 'en'));
+
+  return matches.slice(0, limit);
+}

--- a/src/lib/fuzzy-search.ts
+++ b/src/lib/fuzzy-search.ts
@@ -98,6 +98,14 @@ export function similarityScore(query: string, candidate: string): number {
   return levRatio;
 }
 
+/**
+ * Sort weight for a matched field: a real name match (0) ranks ahead of an
+ * alias match (1) when scores are tied, so an exact name beats an exact alias.
+ */
+function fieldRank(field: FuzzyMatchField): number {
+  return field === 'name' ? 0 : 1;
+}
+
 // ============================================================================
 // Search
 // ============================================================================
@@ -170,8 +178,15 @@ export async function fuzzySearch(
     }
   }
 
-  // Best score first; tie-break by name for deterministic ordering.
-  matches.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name, 'en'));
+  // Best score first; on a score tie prefer a real name match over an alias
+  // match (the "exact match ranks first" contract), then fall back to
+  // alphabetical order for deterministic ordering.
+  matches.sort(
+    (a, b) =>
+      b.score - a.score ||
+      fieldRank(a.matchedField) - fieldRank(b.matchedField) ||
+      a.name.localeCompare(b.name, 'en')
+  );
 
   return matches.slice(0, limit);
 }

--- a/tests/ts/commands/search-fuzzy.test.ts
+++ b/tests/ts/commands/search-fuzzy.test.ts
@@ -68,6 +68,25 @@ type: idea
 `
   );
 
+  // Tie-break subjects: a real note named "Zed" and a different note whose
+  // alias is "Zed". Both score 1.0 for the query "Zed"; the name match must win.
+  await writeFile(
+    join(vaultDir, 'People', 'Zed.md'),
+    `---
+type: person
+---
+`
+  );
+  await writeFile(
+    join(vaultDir, 'People', 'Zachary.md'),
+    `---
+type: person
+aliases:
+  - Zed
+---
+`
+  );
+
   return vaultDir;
 }
 
@@ -198,6 +217,34 @@ describe('search --fuzzy', () => {
     expect(result.stdout.split('\n')[0]).toBe('[[Steve Yegge]]');
   });
 
+  it('ranks an exact name match above an exact alias match at equal score', async () => {
+    // "Zed" is both the name of one note and the alias of another; both score
+    // 1.0. The documented "exact match ranks first" contract means the real
+    // name match (Zed) must rank above the aliased match (Zachary).
+    const result = await runCLI(
+      ['search', 'Zed', '--fuzzy', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+
+    const zed = json.data.find((d: { name: string }) => d.name === 'Zed');
+    const zachary = json.data.find((d: { name: string }) => d.name === 'Zachary');
+    expect(zed).toBeDefined();
+    expect(zachary).toBeDefined();
+    expect(zed.score).toBe(1);
+    expect(zed.matchedField).toBe('name');
+    expect(zachary.score).toBe(1);
+    expect(zachary.matchedField).toBe('alias');
+
+    // Name match must come first overall, and specifically before the alias match.
+    expect(json.data[0].name).toBe('Zed');
+    const zedIdx = json.data.indexOf(zed);
+    const zacharyIdx = json.data.indexOf(zachary);
+    expect(zedIdx).toBeLessThan(zacharyIdx);
+  });
+
   it('rejects an out-of-range threshold', async () => {
     const result = await runCLI(
       ['search', 'Steve', '--fuzzy', '--threshold', '5', '--output', 'json'],
@@ -208,6 +255,62 @@ describe('search --fuzzy', () => {
     const json = JSON.parse(result.stdout);
     expect(json.success).toBe(false);
     expect(json.error).toContain('threshold');
+  });
+
+  it('rejects a malformed --threshold with trailing garbage (json mode)', async () => {
+    const result = await runCLI(
+      ['search', 'Steve', '--fuzzy', '--threshold', '0.5abc', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(false);
+    expect(json.error).toContain('threshold');
+  });
+
+  it('rejects a malformed --threshold in text mode', async () => {
+    const result = await runCLI(
+      ['search', 'Steve', '--fuzzy', '--threshold', '0.5abc'],
+      vaultDir
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr + result.stdout).toContain('threshold');
+  });
+
+  it('rejects a non-integer --limit (2.7)', async () => {
+    const result = await runCLI(
+      ['search', 'Steve', '--fuzzy', '--limit', '2.7', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(false);
+    expect(json.error).toContain('limit');
+  });
+
+  it('rejects an exponent-notation --limit (1e1)', async () => {
+    const result = await runCLI(
+      ['search', 'Steve', '--fuzzy', '--limit', '1e1', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(false);
+    expect(json.error).toContain('limit');
+  });
+
+  it('rejects a malformed --limit with trailing garbage in text mode', async () => {
+    const result = await runCLI(
+      ['search', 'Steve', '--fuzzy', '--limit', '3abc'],
+      vaultDir
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr + result.stdout).toContain('limit');
   });
 
   it('requires a query', async () => {

--- a/tests/ts/commands/search-fuzzy.test.ts
+++ b/tests/ts/commands/search-fuzzy.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runCLI } from '../fixtures/setup.js';
+
+/**
+ * Schema with a `person` entity type whose `aliases` field carries the alias
+ * role. Lets us exercise alias-aware fuzzy matching.
+ */
+const FUZZY_SCHEMA = {
+  version: 2,
+  types: {
+    person: {
+      output_dir: 'People',
+      fields: {
+        type: { value: 'person' },
+        aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
+      },
+      field_order: ['type', 'aliases'],
+    },
+    idea: {
+      output_dir: 'Ideas',
+      fields: { type: { value: 'idea' } },
+      field_order: ['type'],
+    },
+  },
+};
+
+async function createFuzzyVault(): Promise<string> {
+  const vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-fuzzy-'));
+  await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+  await writeFile(
+    join(vaultDir, '.bwrb', 'schema.json'),
+    JSON.stringify(FUZZY_SCHEMA, null, 2)
+  );
+
+  await mkdir(join(vaultDir, 'People'), { recursive: true });
+  await mkdir(join(vaultDir, 'Ideas'), { recursive: true });
+
+  // Person with aliases (the alias-matching subject).
+  await writeFile(
+    join(vaultDir, 'People', 'Steve Yegge.md'),
+    `---
+type: person
+aliases:
+  - Stevey
+  - "Steve Y"
+---
+`
+  );
+
+  // A clearly different person, far from the queries below.
+  await writeFile(
+    join(vaultDir, 'People', 'Margaret Hamilton.md'),
+    `---
+type: person
+---
+`
+  );
+
+  // A near-typo target for name-based fuzzy ranking.
+  await writeFile(
+    join(vaultDir, 'Ideas', 'Deterministic Safety Net.md'),
+    `---
+type: idea
+---
+`
+  );
+
+  return vaultDir;
+}
+
+describe('search --fuzzy', () => {
+  let vaultDir: string;
+
+  beforeAll(async () => {
+    vaultDir = await createFuzzyVault();
+  });
+
+  afterAll(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('ranks the closest name match first', async () => {
+    const result = await runCLI(
+      ['search', 'Detrministic Safety Net', '--fuzzy', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(true);
+    expect(json.data.length).toBeGreaterThan(0);
+    expect(json.data[0].name).toBe('Deterministic Safety Net');
+  });
+
+  it('exact name match scores highest (1.0)', async () => {
+    const result = await runCLI(
+      ['search', 'Steve Yegge', '--fuzzy', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.data[0].name).toBe('Steve Yegge');
+    expect(json.data[0].score).toBe(1);
+    expect(json.data[0].matchedField).toBe('name');
+  });
+
+  it('matches a note by its alias', async () => {
+    const result = await runCLI(
+      ['search', 'Stevey', '--fuzzy', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.data[0].name).toBe('Steve Yegge');
+    expect(json.data[0].matchedField).toBe('alias');
+    expect(json.data[0].matchedValue).toBe('Stevey');
+    expect(json.data[0].score).toBe(1);
+  });
+
+  it('surfaces an alias near-match (typo)', async () => {
+    const result = await runCLI(
+      ['search', 'Stevy', '--fuzzy', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    const top = json.data[0];
+    expect(top.name).toBe('Steve Yegge');
+    expect(top.matchedField).toBe('alias');
+    expect(top.score).toBeGreaterThan(0.5);
+    expect(top.score).toBeLessThan(1);
+  });
+
+  it('threshold excludes far matches', async () => {
+    // High threshold should reject everything for an unrelated query.
+    const result = await runCLI(
+      ['search', 'Quetzalcoatl', '--fuzzy', '--threshold', '0.9', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(true);
+    expect(json.data).toEqual([]);
+  });
+
+  it('JSON output includes scores and aliases', async () => {
+    const result = await runCLI(
+      ['search', 'Steve', '--fuzzy', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    const top = json.data[0];
+    expect(top.name).toBe('Steve Yegge');
+    expect(typeof top.score).toBe('number');
+    expect(top).toHaveProperty('wikilink');
+    expect(top).toHaveProperty('path');
+    expect(top.aliases).toEqual(expect.arrayContaining(['Stevey', 'Steve Y']));
+  });
+
+  it('empty/no-match returns empty data in JSON mode', async () => {
+    const result = await runCLI(
+      ['search', 'zzzzzzzzzzxxxxxxx', '--fuzzy', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(true);
+    expect(json.data).toEqual([]);
+  });
+
+  it('default text output shows the score and ranks best first', async () => {
+    const result = await runCLI(['search', 'Steve', '--fuzzy'], vaultDir);
+
+    expect(result.exitCode).toBe(0);
+    const lines = result.stdout.split('\n').filter(Boolean);
+    expect(lines[0]).toContain('Steve Yegge');
+    // Default format prefixes a two-decimal score.
+    expect(lines[0]).toMatch(/^\d\.\d{2}\s+Steve Yegge/);
+  });
+
+  it('--output link emits a clean wikilink for the top match', async () => {
+    const result = await runCLI(
+      ['search', 'Steve Yegge', '--fuzzy', '--output', 'link'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.split('\n')[0]).toBe('[[Steve Yegge]]');
+  });
+
+  it('rejects an out-of-range threshold', async () => {
+    const result = await runCLI(
+      ['search', 'Steve', '--fuzzy', '--threshold', '5', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(false);
+    expect(json.error).toContain('threshold');
+  });
+
+  it('requires a query', async () => {
+    const result = await runCLI(['search', '--fuzzy', '--output', 'json'], vaultDir);
+
+    expect(result.exitCode).not.toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(false);
+  });
+});

--- a/tests/ts/lib/fuzzy-search.test.ts
+++ b/tests/ts/lib/fuzzy-search.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { similarityScore } from '../../../src/lib/fuzzy-search.js';
+
+describe('similarityScore', () => {
+  it('scores identical strings as 1', () => {
+    expect(similarityScore('Steve Yegge', 'Steve Yegge')).toBe(1);
+  });
+
+  it('is case-insensitive', () => {
+    expect(similarityScore('steve yegge', 'Steve Yegge')).toBe(1);
+  });
+
+  it('returns 0 for empty input', () => {
+    expect(similarityScore('', 'Steve')).toBe(0);
+    expect(similarityScore('Steve', '')).toBe(0);
+  });
+
+  it('scores a one-char typo highly but below exact', () => {
+    const score = similarityScore('Stevey', 'Stevy');
+    expect(score).toBeGreaterThan(0.5);
+    expect(score).toBeLessThan(1);
+  });
+
+  it('floors substring containment to a usable score', () => {
+    // "Steve" is far from "Steve Yegge" by raw edit distance ratio, but
+    // containment should keep it above the 0.5 default threshold.
+    expect(similarityScore('Steve', 'Steve Yegge')).toBeGreaterThanOrEqual(0.6);
+  });
+
+  it('scores unrelated strings low', () => {
+    expect(similarityScore('Quetzalcoatl', 'Steve')).toBeLessThan(0.3);
+  });
+
+  it('ranks a closer candidate above a farther one', () => {
+    const close = similarityScore('Detrministic', 'Deterministic');
+    const far = similarityScore('Detrministic', 'Margaret');
+    expect(close).toBeGreaterThan(far);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `--fuzzy` mode to `bwrb search` that returns **ranked, scored candidate matches** over note names and aliases. This is the lookup primitive from the ingest safety-net plan: an AI agent (or human) can ask "does an entity like X already exist?" before creating a new note, instead of relying on today's exact/substring resolution.

Closes #93

## Matching algorithm

- **Fields that participate:** the note **name** (file basename) always, plus every declared **alias** (the `alias` field role from #266), read via the existing `getEntityAliases(schema, type, frontmatter)` accessor. Each note contributes its single best-scoring field; an alias only wins on a strictly higher score, so an exact name match always ranks first at `1.0`.
- **Scoring:** deterministic similarity in `0..1` built on the shared `levenshteinDistance` (`src/lib/levenshtein.ts` — no copy reintroduced). Score = `1 - dist/maxLen`, with a substring-containment floor (`0.6`) so a short query fully contained in a longer name (e.g. `Steve` in `Steve Yegge`) still surfaces.
- **Threshold / cap:** default threshold `0.5` (`--threshold <0-1>`), default cap `10` (existing `-l/--limit`). Results below threshold are dropped; the rest are returned best-first, then capped.

## JSON output shape

```json
{
  "success": true,
  "data": [
    {
      "name": "Steve Yegge",
      "score": 0.8333,
      "matchedField": "alias",
      "matchedValue": "Stevey",
      "aliases": ["Stevey", "Steve Y"],
      "wikilink": "[[Steve Yegge]]",
      "path": "People/Steve Yegge.md",
      "absolutePath": "/vault/People/Steve Yegge.md"
    }
  ]
}
```

Default text output shows the score for ranking visibility (`0.83  Steve Yegge (alias: Stevey)`); `--output paths`/`link` stay pipe-clean.

## Tests

`tests/ts/commands/search-fuzzy.test.ts` (closest-first ranking, exact-best `1.0`, alias exact + typo matches, threshold cutoff, JSON scores/aliases, empty/no-match, validation) and `tests/ts/lib/fuzzy-search.test.ts` (unit coverage of the scorer).

## Quality gates

- `pnpm qa` — pass (2036 tests, 91 files)
- `pnpm knip` — pass
- `pnpm docs:build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)