### PR TITLE
feat(audit): add unlinked-mention detection (ingest safety net)

### DIFF
--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -76,6 +76,7 @@ Delete semantics in repair mode:
 | `trailing-whitespace` | Trailing spaces/tabs on raw frontmatter `key: value` lines (warning; auto-fixable) |
 | `wrong-scalar-type` | Scalar value has wrong type for schema |
 | `illegal-aliases` | An [`alias`-role field](/reference/schema/#alias) has empty or non-string entries (the Obsidian aliases format requires non-empty, unique strings) |
+| `unlinked-mention` | A known entity's name or [registered alias](/reference/schema/#alias) appears in body prose as plain text but is not wikilinked (warning; exact/alias matches auto-fixable, fuzzy/ambiguous matches flag-only — see below) |
 
 Note: built-in fields written by `bwrb new` (currently `id` and `name`) are always allowed and do not produce `unknown-field` issues.
 Invalid option values inside list fields are reported as `invalid-option` with `listIndex` metadata, not a separate issue code.
@@ -183,6 +184,51 @@ after:  status: "raw"
 ```
 
 `bwrb audit --fix` refuses to run without a TTY when interactive fixes are needed (use `--fix --auto` for non-interactive previews, and add `--execute` for execute-gated auto-fixes like `trailing-whitespace`).
+
+### Unlinked-mention semantics (web integrity)
+
+`unlinked-mention` is the closed-world web-integrity check: bwrb knows every note (by name) and, via the [`alias`-role field](/reference/schema/#alias), every registered alias. It scans note **bodies** for any known name or alias that appears as plain text but is **not** wikilinked, so the vault stays a connected graph instead of islands.
+
+It enforces a strict **trust line** — only matches bwrb can be certain about are auto-linked; everything uncertain becomes a visible review item that is never silently resolved:
+
+| Tier | What it matches | Behavior |
+|------|-----------------|----------|
+| **Exact / alias** | The literal note name, or a registered alias, present as unlinked plain text and resolving to exactly **one** entity | **Trusted → auto-fixable.** `--fix --auto --execute` converts it to a wikilink (`--fix --auto` alone previews). |
+| **Fuzzy** | A capitalized phrase that is a near (small Levenshtein distance) match to a known name, e.g. `Steve Yeg` ≈ `Steve Yegge` | **Review item ("did you mean?") — never auto-linked.** |
+| **Ambiguous** | A surface that matches **multiple** distinct entities/aliases, e.g. `Mercury` | **Never auto-resolved.** Listed as a review item with all candidates. |
+
+Auto-fix output format:
+
+- When the surface text equals the canonical note name, the fix uses a plain wikilink: `[[Steve Yegge]]`.
+- When the surface differs from the canonical name (an alias, or different casing), the fix preserves the author's text via the Obsidian display-alias form: `[[Entity|surface]]`.
+
+```text
+# Exact name mention
+before: I spoke with Steve Yegge today.
+after:  I spoke with [[Steve Yegge]] today.
+
+# Alias mention (display form preserves the surface)
+before: Notes from Stevey.
+after:  Notes from [[Steve Yegge|Stevey]].
+```
+
+False-positive guards (none of these are scanned or rewritten):
+
+- Text already inside `[[wikilinks]]`, markdown links/images, fenced code blocks, inline code spans, and bare URLs.
+- A note never flags a mention of **its own** name or alias.
+- Matching is word-boundary aware (`Ada` does not match inside `Adafruit` or `Canada`) and case-insensitive, but the original surface casing is preserved in the fix.
+
+Only frontmatter is exempt from scanning — this detection looks at body prose only. Surfaces shorter than three characters are ignored to avoid noise. The entity index is built once per run and each body is scanned in a single pass, so cost scales with body size rather than notes × entities.
+
+```bash
+# Report unlinked mentions only
+bwrb audit --only unlinked-mention
+
+# Auto-link trusted (exact/alias) mentions across the Notes directory
+bwrb audit --path "Notes/**" --fix --auto --execute
+```
+
+Fuzzy and ambiguous mentions are reported with a suggestion but are **never** modified by `--fix --auto`; resolve them with interactive `--fix` (which will skip them with the suggestion) or by editing manually.
 
 ### Non-interactive mode
 

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -119,6 +119,8 @@ Issue Types:
   frontmatter-not-at-top Frontmatter block is not at top
   duplicate-frontmatter-keys Duplicate YAML keys in frontmatter
   malformed-wikilink    Near-wikilink bracket typo (frontmatter only)
+  unlinked-mention      Known entity name/alias in body prose, not wikilinked
+                        (exact/alias auto-fixable; fuzzy/ambiguous flag-only)
 
 Type Resolution:
   Audit resolves each file's type from its frontmatter 'type' field.

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -71,6 +71,14 @@ import {
   type OwnershipIndex,
 } from '../ownership.js';
 
+// Import unlinked-mention detection (ingest safety net, #600)
+import {
+  buildEntityMentionIndex,
+  detectUnlinkedMentions,
+  type EntityMentionIndex,
+} from './unlinked-mention.js';
+import { parseNote } from '../frontmatter.js';
+
 // ============================================================================
 // Main Audit Runner
 // ============================================================================
@@ -161,11 +169,16 @@ export async function runAudit(
   // Build parent map for cycle detection on recursive types
   const parentMap = await buildParentMap(schema, filteredFiles, noteIndex);
 
+  // Build the entity-mention index once for the whole run (#600). The full
+  // vault snapshot (not just the filtered set) is the source of known names so
+  // that, e.g., auditing one daily note still detects mentions of every entity.
+  const entityMentionIndex = buildEntityMentionIndex(noteIndex.snapshot, schema);
+
   // Audit each file
   const results: FileAuditResult[] = [];
 
   for (const file of filteredFiles) {
-    const issues = await auditFile(schema, vaultDir, file, options, noteIndex, ownershipIndex, parentMap);
+    const issues = await auditFile(schema, vaultDir, file, options, noteIndex, ownershipIndex, parentMap, entityMentionIndex);
 
     // Apply issue filters
     let filteredIssues = issues;
@@ -203,6 +216,7 @@ export async function auditFile(
   noteIndex?: import('../discovery.js').VaultNoteIndex,
   ownershipIndex?: OwnershipIndex,
   parentMap?: Map<string, string>,
+  entityMentionIndex?: EntityMentionIndex,
 ): Promise<AuditIssue[]> {
   const issues: AuditIssue[] = [];
 
@@ -601,6 +615,27 @@ export async function auditFile(
 
   // Note: Body stale-reference detection is deferred to v2.0
   // Per product scope, v1.0 only validates frontmatter relation fields
+
+  // Unlinked-mention detection (#600): scan body prose for known entity
+  // names/aliases that are not wikilinked. Skipped entirely when the caller
+  // filtered this issue out, to avoid the extra body read.
+  if (
+    entityMentionIndex &&
+    entityMentionIndex.surfacePattern &&
+    options.ignoreIssue !== 'unlinked-mention' &&
+    (options.onlyIssue === undefined || options.onlyIssue === 'unlinked-mention')
+  ) {
+    try {
+      const { body } = await parseNote(file.path);
+      if (body && body.trim().length > 0) {
+        issues.push(
+          ...detectUnlinkedMentions(body, file.relativePath, entityMentionIndex)
+        );
+      }
+    } catch {
+      // If the body can't be parsed, skip mention detection for this file.
+    }
+  }
 
   // Check for ownership violations
   if (ownershipIndex && noteIndex?.notePathMap) {

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -55,6 +55,7 @@ import {
   type FixContext,
 } from './types.js';
 import { toMarkdownLink, toWikilink } from '../links.js';
+import { maskNonProse } from './unlinked-mention.js';
 import {
   readStructuralFrontmatterFromRaw,
   movePrimaryBlockToTop,
@@ -120,6 +121,62 @@ function registerManualReview(
   list.push({ file, issue });
 }
 
+
+/**
+ * Apply an `unlinked-mention` auto-fix: rewrite the first unlinked, word-bounded
+ * occurrence of the mention surface in the body to a wikilink.
+ *
+ * The fix re-derives the target position from the live body (rather than a
+ * stored offset) so it stays correct when multiple mentions in the same file are
+ * fixed sequentially — each call re-reads and converges on the next occurrence.
+ * Only exact/alias (auto-fixable) mentions reach here; fuzzy/ambiguous mentions
+ * are flag-only and never dispatched to a fix.
+ */
+async function applyUnlinkedMentionFix(
+  schema: LoadedSchema,
+  filePath: string,
+  issue: AuditIssue
+): Promise<FixResult> {
+  const surface = (issue.meta?.['surface'] as string | undefined) ?? (typeof issue.value === 'string' ? issue.value : undefined);
+  const replacement = issue.meta?.['replacement'] as string | undefined;
+  if (!surface || !replacement) {
+    return { file: filePath, issue, action: 'failed', message: 'Missing mention surface/replacement' };
+  }
+
+  const parsed = await parseNote(filePath);
+  const body = parsed.body;
+
+  // Mask non-prose regions so we never relink inside code/links/existing
+  // wikilinks, then find the first word-bounded occurrence of the surface.
+  const masked = maskNonProse(body);
+  const re = new RegExp(`(?<![\\w'])${escapeRegExp(surface)}(?![\\w'])`, 'g');
+  let match: RegExpExecArray | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(masked)) !== null) {
+    // Confirm the original (unmasked) text at this position is the exact surface.
+    if (body.slice(m.index, m.index + surface.length) === surface) {
+      match = m;
+      break;
+    }
+  }
+
+  if (!match) {
+    return { file: filePath, issue, action: 'skipped', message: `Mention '${surface}' no longer present as plain text` };
+  }
+
+  const newBody =
+    body.slice(0, match.index) + replacement + body.slice(match.index + surface.length);
+
+  const typePath = resolveTypePathFromFrontmatter(schema, parsed.frontmatter);
+  const typeDef = typePath ? getTypeDefByPath(schema, typePath) : undefined;
+  const order = typeDef?.fieldOrder;
+
+  if (!isDryRunEnabled()) {
+    await writeNote(filePath, parsed.frontmatter, newBody, order);
+  }
+
+  return { file: filePath, issue, action: 'fixed' };
+}
 
 async function applyTrailingWhitespaceFix(filePath: string, issue: AuditIssue): Promise<FixResult> {
   const lineNumber = issue.lineNumber;
@@ -307,6 +364,10 @@ async function applyFix(
 
     if (issue.code === 'trailing-whitespace') {
       return await applyTrailingWhitespaceFix(filePath, issue);
+    }
+
+    if (issue.code === 'unlinked-mention') {
+      return await applyUnlinkedMentionFix(schema, filePath, issue);
     }
 
     if (issue.code === 'frontmatter-key-casing') {
@@ -1331,6 +1392,25 @@ export async function runAutoFix(
           console.log(chalk.red(`    ✗ Failed to dedupe ${issue.field}: ${fixResult.message}`));
           failed++;
         }
+      } else if (issue.code === 'unlinked-mention') {
+        // Only exact/alias mentions are auto-fixable (fuzzy/ambiguous are
+        // flag-only and never reach here, since autoFixable is false on them).
+        const fixResult = await applyFix(schema, result.path, issue);
+        if (fixResult.action === 'fixed') {
+          const replacement = (issue.meta?.['replacement'] as string | undefined) ?? '';
+          console.log(chalk.cyan(`  ${result.relativePath}`));
+          console.log(chalk.green(`    ✓ Linked '${String(issue.value)}' → ${replacement}`));
+          fixed++;
+        } else if (fixResult.action === 'skipped') {
+          console.log(chalk.cyan(`  ${result.relativePath}`));
+          console.log(chalk.yellow(`    ⚠ ${fixResult.message}`));
+          skipped++;
+          registerManualReview(manualReviewNeeded, result.relativePath, issue);
+        } else {
+          console.log(chalk.cyan(`  ${result.relativePath}`));
+          console.log(chalk.red(`    ✗ Failed to link mention: ${fixResult.message}`));
+          failed++;
+        }
       } else if ((issue.code === 'frontmatter-key-casing' || issue.code === 'singular-plural-mismatch') && issue.field && issue.canonicalKey) {
         // Auto-fix key casing/singular-plural mismatch
         const fixResult = await applyFix(schema, result.path, issue);
@@ -1532,6 +1612,8 @@ async function handleInteractiveFix(
     case 'frontmatter-key-casing':
     case 'singular-plural-mismatch':
       return handleKeyCasingFix(schema, result, issue);
+    case 'unlinked-mention':
+      return handleUnlinkedMentionFix(schema, result, issue);
     default:
       // Truly non-fixable issues
       if (issue.suggestion) {
@@ -3051,6 +3133,50 @@ async function handleTrailingWhitespaceFix(
     return 'fixed';
   } else if (fixResult.action === 'skipped') {
     console.log(chalk.dim('    → Skipped'));
+    return 'skipped';
+  } else {
+    console.log(chalk.red(`    ✗ Failed: ${fixResult.message}`));
+    return 'failed';
+  }
+}
+
+/**
+ * Handle an unlinked-mention fix interactively.
+ *
+ * Exact/alias mentions (autoFixable) offer to convert the plain-text mention to
+ * a wikilink. Fuzzy/ambiguous mentions are flag-only: we surface the suggestion
+ * and skip, honoring the trust line (never auto-resolve fuzziness/ambiguity).
+ */
+async function handleUnlinkedMentionFix(
+  schema: LoadedSchema,
+  result: FileAuditResult,
+  issue: AuditIssue
+): Promise<'fixed' | 'skipped' | 'failed' | 'quit'> {
+  if (!issue.autoFixable) {
+    // Fuzzy / ambiguous — review only.
+    if (issue.suggestion) {
+      console.log(chalk.dim(`    ${issue.suggestion}`));
+    }
+    console.log(chalk.dim('    (Review item — not auto-linked)'));
+    return 'skipped';
+  }
+
+  const replacement = (issue.meta?.['replacement'] as string | undefined) ?? '';
+  const confirm = await promptConfirm(
+    `    → Link '${String(issue.value)}' to ${replacement}?`
+  );
+  if (confirm === null) return 'quit';
+  if (!confirm) {
+    console.log(chalk.dim('    → Skipped'));
+    return 'skipped';
+  }
+
+  const fixResult = await applyFix(schema, result.path, issue);
+  if (fixResult.action === 'fixed') {
+    console.log(chalk.green(`    ✓ Linked '${String(issue.value)}' → ${replacement}`));
+    return 'fixed';
+  } else if (fixResult.action === 'skipped') {
+    console.log(chalk.dim(`    → Skipped: ${fixResult.message}`));
     return 'skipped';
   } else {
     console.log(chalk.red(`    ✗ Failed: ${fixResult.message}`));

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -50,7 +50,10 @@ export type IssueCode =
   // Phase 4: Structural integrity fixes
   | 'frontmatter-not-at-top'
   | 'duplicate-frontmatter-keys'
-  | 'malformed-wikilink';
+  | 'malformed-wikilink'
+  // Ingest safety net (#600): a known entity name/alias mentioned in body prose
+  // but not wikilinked. Exact/alias → auto-fixable; fuzzy/ambiguous → flag-only.
+  | 'unlinked-mention';
 
 /**
  * A single audit issue.

--- a/src/lib/audit/unlinked-mention.ts
+++ b/src/lib/audit/unlinked-mention.ts
@@ -1,0 +1,501 @@
+/**
+ * `unlinked-mention` audit detection — the web-integrity safety net.
+ *
+ * bwrb knows every note (by basename) and, via the alias field role (#266),
+ * every declared alias. This detection scans note **bodies** for the literal
+ * name or a registered alias of a known entity appearing as plain text but
+ * **not** wikilinked, and flags it.
+ *
+ * The trust line (decided design, see plans/features/ingest-safety-net.md §3):
+ *  - **Exact name or registered alias**, present as unlinked plain text, that
+ *    resolves to exactly one entity → TRUSTED → auto-fixable. `--fix --auto`
+ *    rewrites it to a wikilink, preserving the surface text via the alias
+ *    display form (`[[Entity|surface]]`) when the surface differs from the
+ *    canonical note name.
+ *  - **Fuzzy near-match** (Levenshtein) → REVIEW ITEM ("did you mean?"),
+ *    **never** auto-linked.
+ *  - **Ambiguity** (a surface that matches multiple entities/aliases) → never
+ *    auto-resolved → visible review item. Nothing is swept under the rug.
+ *
+ * False-positive guards: text already inside `[[...]]`, markdown links, fenced
+ * code blocks, inline code, and bare URLs is masked before scanning. Matching
+ * is word-boundary aware and case-insensitive, but the original surface casing
+ * is preserved in the fix. A note never flags a mention of its own name/alias.
+ *
+ * Performance: the entity index is built once per audit run (not per file), and
+ * each body is scanned with a single combined alternation regex over all known
+ * surfaces rather than one pass per entity — keeping cost ~O(body length) per
+ * note instead of O(notes × entities). See #500.
+ */
+
+import { basename } from 'path';
+import type { LoadedSchema } from '../../types/schema.js';
+import type { VaultNoteSnapshot } from '../discovery.js';
+import { getEntityAliases } from '../schema.js';
+import { levenshteinDistance } from '../levenshtein.js';
+import type { AuditIssue } from './types.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Minimum surface length (in characters) to consider for matching. Single- and
+ * two-character names are too noisy to flag safely in prose.
+ */
+const MIN_SURFACE_LENGTH = 3;
+
+/**
+ * Fuzzy tier: maximum Levenshtein distance (case-insensitive) between an
+ * unmatched candidate phrase and a known entity surface for it to be offered as
+ * a "did you mean?" review item. Kept small so only genuine near-misses surface.
+ */
+const FUZZY_MAX_DISTANCE = 2;
+
+/**
+ * Fuzzy tier: a candidate must be at least this long to be eligible, so short
+ * words don't fuzzy-match unrelated entities by coincidence.
+ */
+const FUZZY_MIN_CANDIDATE_LENGTH = 4;
+
+/** Cap on how many distinct fuzzy "did you mean?" suggestions to list. */
+const FUZZY_MAX_SUGGESTIONS = 3;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** How a known surface relates to its entity. */
+export type SurfaceKind = 'name' | 'alias';
+
+/** A single known surface string that can be mentioned in prose. */
+interface EntitySurface {
+  /** The matchable surface text (canonical note name or a declared alias). */
+  surface: string;
+  /** The canonical note name (basename, no extension) to link to. */
+  canonicalName: string;
+  /** Vault-relative path of the source note (used to skip self-mentions). */
+  sourcePath: string;
+  /** Whether this surface is the note name or one of its aliases. */
+  kind: SurfaceKind;
+}
+
+/**
+ * Precomputed index of every linkable surface in the vault, plus a single
+ * combined matcher. Built once per audit run.
+ */
+export interface EntityMentionIndex {
+  /** lowercased surface -> all entities that expose it. */
+  bySurface: Map<string, EntitySurface[]>;
+  /** All distinct entity names (for the fuzzy "did you mean?" tier). */
+  allNames: string[];
+  /**
+   * Combined word-boundary alternation regex over all known surfaces, or null
+   * when the vault exposes no surfaces. Created fresh per scan by the caller via
+   * {@link matchSurfaces} (regex carries `lastIndex` state, so it is not reused).
+   */
+  readonly surfacePattern: string | null;
+}
+
+// ============================================================================
+// Index construction
+// ============================================================================
+
+/**
+ * Build the vault-wide entity-mention index from a note snapshot.
+ *
+ * Registers each note's basename as a `name` surface and every declared alias
+ * (via {@link getEntityAliases}) as an `alias` surface. Surfaces shorter than
+ * {@link MIN_SURFACE_LENGTH} are skipped to avoid noise.
+ */
+export function buildEntityMentionIndex(
+  snapshot: VaultNoteSnapshot,
+  schema: LoadedSchema
+): EntityMentionIndex {
+  const bySurface = new Map<string, EntitySurface[]>();
+  const allNames: string[] = [];
+  const surfaceSet = new Set<string>();
+
+  const register = (surface: EntitySurface): void => {
+    const trimmed = surface.surface.trim();
+    if (trimmed.length < MIN_SURFACE_LENGTH) return;
+    const key = trimmed.toLowerCase();
+    const existing = bySurface.get(key);
+    const entry: EntitySurface = { ...surface, surface: trimmed };
+    if (existing) {
+      // De-dup identical (surface, canonicalName, kind) pairs from the same note.
+      if (
+        !existing.some(
+          (e) =>
+            e.canonicalName === entry.canonicalName &&
+            e.sourcePath === entry.sourcePath &&
+            e.kind === entry.kind
+        )
+      ) {
+        existing.push(entry);
+      }
+    } else {
+      bySurface.set(key, [entry]);
+    }
+    surfaceSet.add(trimmed);
+  };
+
+  for (const note of snapshot.notes) {
+    const name = basename(note.relativePath, '.md');
+    if (name) {
+      allNames.push(name);
+      register({
+        surface: name,
+        canonicalName: name,
+        sourcePath: note.relativePath,
+        kind: 'name',
+      });
+    }
+
+    if (note.resolvedType && note.frontmatter) {
+      const aliases = getEntityAliases(schema, note.resolvedType, note.frontmatter);
+      for (const alias of aliases) {
+        register({
+          surface: alias,
+          canonicalName: name,
+          sourcePath: note.relativePath,
+          kind: 'alias',
+        });
+      }
+    }
+  }
+
+  // Sort surfaces longest-first so the combined alternation prefers the longest
+  // match (e.g. "Steve Yegge" wins over "Steve" at the same position).
+  const surfaces = Array.from(surfaceSet).sort((a, b) => b.length - a.length);
+  const surfacePattern =
+    surfaces.length > 0
+      ? surfaces.map((s) => escapeRegExp(s)).join('|')
+      : null;
+
+  return { bySurface, allNames, surfacePattern };
+}
+
+// ============================================================================
+// Body masking (false-positive guards)
+// ============================================================================
+
+/**
+ * Replace a matched region with same-length spaces, preserving newlines so line
+ * numbers stay accurate. Masking (rather than deleting) keeps every character
+ * offset stable for later word-boundary matching.
+ */
+function blankOut(text: string): string {
+  return text.replace(/[^\n]/g, ' ');
+}
+
+/**
+ * Mask regions of the body where a literal name match must NOT be flagged:
+ * fenced code blocks, inline code, existing wikilinks, markdown links, and bare
+ * URLs. Returns a string of identical length/line structure with those regions
+ * blanked to spaces.
+ */
+export function maskNonProse(body: string): string {
+  let masked = body;
+
+  const maskPattern = (pattern: RegExp): void => {
+    masked = masked.replace(pattern, (m) => blankOut(m));
+  };
+
+  // Fenced code blocks (``` or ~~~), including the fences and content.
+  maskPattern(/^[ \t]*(```|~~~)[^\n]*\n[\s\S]*?^[ \t]*\1[^\n]*$/gm);
+  // Unterminated fence to end of document.
+  maskPattern(/^[ \t]*(```|~~~)[\s\S]*$/gm);
+  // Inline code spans.
+  maskPattern(/`[^`\n]+`/g);
+  // Existing wikilinks (including display-aliased form).
+  maskPattern(/\[\[[^\]]*\]\]/g);
+  // Markdown links/images: keep the visible text out of scope entirely so we
+  // don't link inside an existing link or its URL.
+  maskPattern(/!?\[[^\]]*\]\([^)]*\)/g);
+  // Bare URLs.
+  maskPattern(/\bhttps?:\/\/\S+/gi);
+  maskPattern(/\bwww\.\S+/gi);
+
+  return masked;
+}
+
+// ============================================================================
+// Surface matching
+// ============================================================================
+
+/** A located surface occurrence in the masked body. */
+interface SurfaceHit {
+  surface: string;
+  start: number;
+  end: number;
+}
+
+/**
+ * Find all word-boundary, case-insensitive occurrences of any known surface in
+ * the masked body using a single combined regex pass.
+ */
+function matchSurfaces(maskedBody: string, surfacePattern: string): SurfaceHit[] {
+  const hits: SurfaceHit[] = [];
+  // Word boundaries on both sides so we don't match inside larger words.
+  // `\b` is unreliable for surfaces with leading/trailing non-word chars, so we
+  // use explicit non-word lookarounds that also accept string edges.
+  const re = new RegExp(`(?<![\\w'])(?:${surfacePattern})(?![\\w'])`, 'gi');
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(maskedBody)) !== null) {
+    if (m[0].length === 0) {
+      re.lastIndex++;
+      continue;
+    }
+    hits.push({ surface: m[0], start: m.index, end: m.index + m[0].length });
+  }
+  return hits;
+}
+
+/** Compute 1-based line number for a character offset. */
+function lineNumberAt(text: string, offset: number): number {
+  let line = 1;
+  for (let i = 0; i < offset && i < text.length; i++) {
+    if (text[i] === '\n') line++;
+  }
+  return line;
+}
+
+// ============================================================================
+// Detection
+// ============================================================================
+
+/**
+ * Scan a single note body for unlinked mentions of known entities.
+ *
+ * `selfPath` is the vault-relative path of the note being scanned, used to
+ * suppress self-mentions (a note never flags references to its own name/alias).
+ */
+export function detectUnlinkedMentions(
+  body: string,
+  selfPath: string,
+  index: EntityMentionIndex
+): AuditIssue[] {
+  const issues: AuditIssue[] = [];
+  if (!index.surfacePattern) return issues;
+
+  const masked = maskNonProse(body);
+
+  // --- Exact / alias / ambiguous tiers ----------------------------------
+  const hits = matchSurfaces(masked, index.surfacePattern);
+  // Track positions consumed by exact matches so fuzzy doesn't double-flag them.
+  const consumed: Array<[number, number]> = [];
+
+  for (const hit of hits) {
+    const entities = index.bySurface.get(hit.surface.toLowerCase());
+    if (!entities || entities.length === 0) continue;
+
+    // A note never flags a mention that points back to itself.
+    const others = entities.filter((e) => e.sourcePath !== selfPath);
+    if (others.length === 0) continue;
+
+    consumed.push([hit.start, hit.end]);
+
+    const line = lineNumberAt(body, hit.start);
+    const distinctTargets = new Set(others.map((e) => e.canonicalName));
+
+    if (distinctTargets.size > 1) {
+      // Ambiguous: matches multiple distinct entities. Never auto-resolve.
+      const candidates = Array.from(distinctTargets).sort((a, b) =>
+        a.localeCompare(b, 'en')
+      );
+      issues.push({
+        severity: 'warning',
+        code: 'unlinked-mention',
+        message: `Ambiguous unlinked mention on line ${line}: '${hit.surface}' could link to ${candidates.length} entities`,
+        value: hit.surface,
+        autoFixable: false,
+        inBody: true,
+        lineNumber: line,
+        candidates,
+        suggestion: `Ambiguous — link manually to one of: ${candidates
+          .map((c) => `[[${c}]]`)
+          .join(', ')}`,
+        meta: {
+          tier: 'ambiguous',
+          surface: hit.surface,
+          offset: hit.start,
+        },
+      });
+      continue;
+    }
+
+    // Unambiguous: exactly one entity. Trusted → auto-fixable.
+    const entity = others[0]!;
+    const canonical = entity.canonicalName;
+    // Preserve surface casing/text via display alias when it differs from the
+    // canonical note name (case-insensitive comparison: same text, different
+    // case still uses the display form to preserve the author's casing).
+    const useDisplayForm = hit.surface !== canonical;
+    const replacement = useDisplayForm
+      ? `[[${canonical}|${hit.surface}]]`
+      : `[[${canonical}]]`;
+
+    issues.push({
+      severity: 'warning',
+      code: 'unlinked-mention',
+      message: `Unlinked mention on line ${line}: '${hit.surface}' is ${
+        entity.kind === 'alias' ? `an alias of '${canonical}'` : `the note '${canonical}'`
+      } but not wikilinked`,
+      value: hit.surface,
+      autoFixable: true,
+      inBody: true,
+      lineNumber: line,
+      targetName: canonical,
+      suggestion: `Link to ${replacement}`,
+      meta: {
+        tier: 'exact',
+        surface: hit.surface,
+        offset: hit.start,
+        matchedKind: entity.kind,
+        replacement,
+      },
+    });
+  }
+
+  // --- Fuzzy tier ("did you mean?") -------------------------------------
+  // Only run on prose not already consumed by an exact match. Tokenize
+  // capitalized words/phrases and offer near-miss entity names. Flag-only.
+  for (const fuzzy of detectFuzzyCandidates(masked, body, selfPath, index, consumed)) {
+    issues.push(fuzzy);
+  }
+
+  return issues;
+}
+
+/**
+ * Find capitalized prose phrases that are a near (Levenshtein) match to a known
+ * entity name but not an exact match, and emit flag-only "did you mean?" items.
+ */
+function detectFuzzyCandidates(
+  masked: string,
+  body: string,
+  selfPath: string,
+  index: EntityMentionIndex,
+  consumed: Array<[number, number]>
+): AuditIssue[] {
+  const issues: AuditIssue[] = [];
+
+  const isConsumed = (start: number, end: number): boolean =>
+    consumed.some(([s, e]) => start < e && end > s);
+
+  // Candidate phrases: runs of capitalized words (proper-noun-ish), e.g.
+  // "Steve Yeg", "Mercry". Conservative to keep the fuzzy tier low-noise.
+  const phraseRe = /\b[A-Z][\w'-]*(?:\s+[A-Z][\w'-]*)*/g;
+  // Known surfaces (lowercased) for exact-membership checks.
+  const knownSurfaces = index.bySurface;
+
+  // Expand a maximal capitalized run into candidate sub-phrases: the full run
+  // plus each suffix beginning at a later word, with absolute offsets. This lets
+  // a near-match survive a leading common-but-capitalized word ("Also Steve
+  // Yeg" → "Steve Yeg"). Suffixes only (not arbitrary infixes) to stay cheap.
+  const expandCandidates = (
+    phrase: string,
+    phraseStart: number
+  ): Array<{ text: string; start: number }> => {
+    const out: Array<{ text: string; start: number }> = [{ text: phrase, start: phraseStart }];
+    const wordRe = /\S+/g;
+    const offsets: number[] = [];
+    let w: RegExpExecArray | null;
+    while ((w = wordRe.exec(phrase)) !== null) offsets.push(w.index);
+    for (let i = 1; i < offsets.length; i++) {
+      out.push({ text: phrase.slice(offsets[i]!), start: phraseStart + offsets[i]! });
+    }
+    return out;
+  };
+
+  const seen = new Set<string>();
+  let m: RegExpExecArray | null;
+  while ((m = phraseRe.exec(masked)) !== null) {
+    const fullPhrase = m[0];
+    if (fullPhrase.length < FUZZY_MIN_CANDIDATE_LENGTH) continue;
+
+    // Pick the best-scoring candidate sub-phrase for this run.
+    let best:
+      | { phrase: string; start: number; suggestions: Array<{ name: string; distance: number }> }
+      | null = null;
+
+    for (const cand of expandCandidates(fullPhrase, m.index)) {
+      const phrase = cand.text;
+      if (phrase.length < FUZZY_MIN_CANDIDATE_LENGTH) continue;
+      const start = cand.start;
+      const end = start + phrase.length;
+      if (isConsumed(start, end)) continue;
+
+      const lower = phrase.toLowerCase();
+      // Skip exact known surfaces (handled by the exact tier).
+      if (knownSurfaces.has(lower)) continue;
+
+      const suggestions: Array<{ name: string; distance: number }> = [];
+      for (const name of index.allNames) {
+        if (name.length < FUZZY_MIN_CANDIDATE_LENGTH) continue;
+        const dist = levenshteinDistance(lower, name.toLowerCase());
+        if (dist === 0) continue;
+        if (dist <= FUZZY_MAX_DISTANCE) {
+          suggestions.push({ name, distance: dist });
+        }
+      }
+      if (suggestions.length === 0) continue;
+
+      const bestDist = Math.min(...suggestions.map((s) => s.distance));
+      const incumbentDist = best ? Math.min(...best.suggestions.map((s) => s.distance)) : Infinity;
+      if (bestDist < incumbentDist) {
+        best = { phrase, start, suggestions };
+      }
+    }
+
+    if (!best) continue;
+    const { phrase, start } = best;
+    const suggestions = best.suggestions;
+
+    // Don't suggest linking a note to itself.
+    const selfName = basename(selfPath, '.md');
+    const filtered = suggestions.filter((s) => s.name !== selfName);
+    if (filtered.length === 0) continue;
+
+    filtered.sort(
+      (a, b) => a.distance - b.distance || a.name.localeCompare(b.name, 'en')
+    );
+    const top = filtered.slice(0, FUZZY_MAX_SUGGESTIONS);
+
+    const dedupeKey = `${start}:${phrase}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    const line = lineNumberAt(body, start);
+    const names = top.map((s) => s.name);
+    issues.push({
+      severity: 'warning',
+      code: 'unlinked-mention',
+      message: `Possible unlinked mention on line ${line}: '${phrase}' looks like ${names
+        .map((n) => `'${n}'`)
+        .join(' or ')}`,
+      value: phrase,
+      autoFixable: false,
+      inBody: true,
+      lineNumber: line,
+      similarFiles: names,
+      suggestion: `Did you mean ${names.map((n) => `[[${n}]]`).join(' or ')}? (not auto-linked)`,
+      meta: {
+        tier: 'fuzzy',
+        surface: phrase,
+        offset: start,
+      },
+    });
+  }
+
+  return issues;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/ts/lib/audit-unlinked-mention.test.ts
+++ b/tests/ts/lib/audit-unlinked-mention.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, writeFile, rm, readFile } from 'fs/promises';
+import { mkdtemp } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadSchema } from '../../../src/lib/schema.js';
+import { runAudit } from '../../../src/lib/audit/detection.js';
+import { runAutoFix } from '../../../src/lib/audit/fix.js';
+import {
+  buildEntityMentionIndex,
+  detectUnlinkedMentions,
+  maskNonProse,
+} from '../../../src/lib/audit/unlinked-mention.js';
+import { buildVaultNoteSnapshot } from '../../../src/lib/discovery.js';
+import type { Schema } from '../../../src/types/schema.js';
+import { resolveSchema } from '../../../src/lib/schema.js';
+
+const SCHEMA: Schema = {
+  version: 2,
+  types: {
+    meta: { fields: {} },
+    person: {
+      extends: 'meta',
+      output_dir: 'People',
+      fields: {
+        type: { value: 'person' },
+        aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
+      },
+      field_order: ['type', 'aliases'],
+    },
+    note: {
+      extends: 'meta',
+      output_dir: 'Notes',
+      fields: { type: { value: 'note' } },
+      field_order: ['type'],
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Unit tests on the detection module (no filesystem)
+// ---------------------------------------------------------------------------
+
+describe('unlinked-mention: maskNonProse', () => {
+  it('masks fenced code blocks while preserving line count', () => {
+    const body = 'Steve Yegge here.\n```\nSteve Yegge in code\n```\nSteve again.';
+    const masked = maskNonProse(body);
+    expect(masked.split('\n')).toHaveLength(body.split('\n').length);
+    // The code-fence "Steve Yegge in code" line should be blanked.
+    expect(masked).not.toContain('Steve Yegge in code');
+    // Prose mentions remain.
+    expect(masked).toContain('Steve Yegge here.');
+  });
+
+  it('masks inline code, wikilinks, markdown links, and URLs', () => {
+    const body =
+      'Plain Mercury. `Mercury code`. [[Mercury]]. [Mercury](Mercury.md). https://mercury.example/Mercury';
+    const masked = maskNonProse(body);
+    // Exactly one un-masked "Mercury" should survive: the plain-text one.
+    const count = (masked.match(/Mercury/g) ?? []).length;
+    expect(count).toBe(1);
+  });
+});
+
+describe('unlinked-mention: detectUnlinkedMentions', () => {
+  const schema = resolveSchema(SCHEMA);
+
+  function indexFor(notes: Array<{ relativePath: string; frontmatter?: Record<string, unknown>; resolvedType?: string }>) {
+    return buildEntityMentionIndex(
+      { notes: notes.map((n) => ({ path: n.relativePath, relativePath: n.relativePath, ...(n.frontmatter ? { frontmatter: n.frontmatter } : {}), ...(n.resolvedType ? { resolvedType: n.resolvedType } : {}) })) },
+      schema
+    );
+  }
+
+  const personNotes = [
+    { relativePath: 'People/Steve Yegge.md', resolvedType: 'person', frontmatter: { type: 'person', aliases: ['Stevey'] } },
+    { relativePath: 'People/Margaret Hamilton.md', resolvedType: 'person', frontmatter: { type: 'person' } },
+  ];
+
+  it('flags an exact name mention as auto-fixable with a plain wikilink', () => {
+    const index = indexFor(personNotes);
+    const issues = detectUnlinkedMentions('I talked to Steve Yegge today.', 'Notes/Daily.md', index);
+    expect(issues).toHaveLength(1);
+    const issue = issues[0]!;
+    expect(issue.code).toBe('unlinked-mention');
+    expect(issue.autoFixable).toBe(true);
+    expect(issue.meta?.['tier']).toBe('exact');
+    expect(issue.meta?.['replacement']).toBe('[[Steve Yegge]]');
+  });
+
+  it('flags an alias mention as auto-fixable using the display form', () => {
+    const index = indexFor(personNotes);
+    const issues = detectUnlinkedMentions('Notes from Stevey.', 'Notes/Daily.md', index);
+    expect(issues).toHaveLength(1);
+    const issue = issues[0]!;
+    expect(issue.autoFixable).toBe(true);
+    expect(issue.meta?.['matchedKind']).toBe('alias');
+    expect(issue.meta?.['replacement']).toBe('[[Steve Yegge|Stevey]]');
+  });
+
+  it('uses the display form to preserve surface casing that differs from the name', () => {
+    const index = indexFor(personNotes);
+    const issues = detectUnlinkedMentions('saw steve yegge yesterday', 'Notes/Daily.md', index);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.meta?.['replacement']).toBe('[[Steve Yegge|steve yegge]]');
+  });
+
+  it('does not flag a mention already inside a wikilink', () => {
+    const index = indexFor(personNotes);
+    const issues = detectUnlinkedMentions('I talked to [[Steve Yegge]] today.', 'Notes/Daily.md', index);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('does not flag a note mentioning its own name', () => {
+    const index = indexFor(personNotes);
+    const issues = detectUnlinkedMentions('I am Steve Yegge.', 'People/Steve Yegge.md', index);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('does not flag a note mentioning its own alias', () => {
+    const index = indexFor(personNotes);
+    const issues = detectUnlinkedMentions('People call me Stevey.', 'People/Steve Yegge.md', index);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('respects word boundaries (no substring matches)', () => {
+    const index = indexFor([
+      { relativePath: 'People/Ada.md', resolvedType: 'person', frontmatter: { type: 'person' } },
+    ]);
+    // "Adafruit" and "Canada" both contain "Ada" but must not match.
+    const issues = detectUnlinkedMentions('Bought an Adafruit board in Canada.', 'Notes/Daily.md', index);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('flags a fuzzy near-match as a flag-only review item (never auto-fixed)', () => {
+    const index = indexFor(personNotes);
+    const issues = detectUnlinkedMentions('Reading a post by Steve Yeg.', 'Notes/Daily.md', index);
+    const fuzzy = issues.find((i) => i.meta?.['tier'] === 'fuzzy');
+    expect(fuzzy).toBeDefined();
+    expect(fuzzy!.autoFixable).toBe(false);
+    expect(fuzzy!.similarFiles).toContain('Steve Yegge');
+  });
+
+  it('flags an ambiguous mention as flag-only with multiple candidates', () => {
+    // Two distinct entities both expose the surface "Mercury": one by name,
+    // one by alias.
+    const index = indexFor([
+      { relativePath: 'Notes/Mercury.md', resolvedType: 'note', frontmatter: { type: 'note' } },
+      { relativePath: 'People/Freddie.md', resolvedType: 'person', frontmatter: { type: 'person', aliases: ['Mercury'] } },
+    ]);
+    const issues = detectUnlinkedMentions('Talking about Mercury.', 'Notes/Daily.md', index);
+    const ambiguous = issues.find((i) => i.meta?.['tier'] === 'ambiguous');
+    expect(ambiguous).toBeDefined();
+    expect(ambiguous!.autoFixable).toBe(false);
+    expect(ambiguous!.candidates).toEqual(['Freddie', 'Mercury']);
+  });
+
+  it('does not flag inside code fences, inline code, or URLs', () => {
+    const index = indexFor(personNotes);
+    const body = [
+      '```',
+      'Steve Yegge',
+      '```',
+      'A `Steve Yegge` token.',
+      'See https://example.com/Steve%20Yegge',
+    ].join('\n');
+    const issues = detectUnlinkedMentions(body, 'Notes/Daily.md', index);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('skips surfaces shorter than the minimum length', () => {
+    const index = indexFor([
+      { relativePath: 'Notes/Hi.md', resolvedType: 'note', frontmatter: { type: 'note' } },
+    ]);
+    const issues = detectUnlinkedMentions('Hi there.', 'Notes/Daily.md', index);
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests through runAudit / runAutoFix on a real vault
+// ---------------------------------------------------------------------------
+
+describe('unlinked-mention: end-to-end audit + fix', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-unlinked-'));
+    await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+    await writeFile(join(vaultDir, '.bwrb', 'schema.json'), JSON.stringify(SCHEMA, null, 2));
+    await mkdir(join(vaultDir, 'People'), { recursive: true });
+    await mkdir(join(vaultDir, 'Notes'), { recursive: true });
+
+    await writeFile(
+      join(vaultDir, 'People', 'Steve Yegge.md'),
+      `---\ntype: person\naliases:\n  - Stevey\n---\n`
+    );
+  });
+
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('detects and auto-fixes an exact unlinked mention to a wikilink', async () => {
+    await writeFile(
+      join(vaultDir, 'Notes', 'Daily.md'),
+      `---\ntype: note\n---\nI spoke with Steve Yegge today.\n`
+    );
+    const schema = await loadSchema(vaultDir);
+
+    const results = await runAudit(schema, vaultDir, { strict: false });
+    const daily = results.find((r) => r.relativePath === 'Notes/Daily.md');
+    expect(daily?.issues.some((i) => i.code === 'unlinked-mention' && i.autoFixable)).toBe(true);
+
+    await runAutoFix(results, schema, vaultDir, { dryRun: false });
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(after).toContain('[[Steve Yegge]]');
+    expect(after).not.toMatch(/(?<!\[\[)Steve Yegge(?!\]\])/);
+  });
+
+  it('auto-fixes an alias mention using the display form', async () => {
+    await writeFile(
+      join(vaultDir, 'Notes', 'Daily.md'),
+      `---\ntype: note\n---\nNotes from Stevey.\n`
+    );
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false });
+    await runAutoFix(results, schema, vaultDir, { dryRun: false });
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(after).toContain('[[Steve Yegge|Stevey]]');
+  });
+
+  it('does not modify an already-linked mention', async () => {
+    const original = `---\ntype: note\n---\nI spoke with [[Steve Yegge]] today.\n`;
+    await writeFile(join(vaultDir, 'Notes', 'Daily.md'), original);
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false });
+    const daily = results.find((r) => r.relativePath === 'Notes/Daily.md');
+    expect(daily?.issues.some((i) => i.code === 'unlinked-mention')).toBeFalsy();
+  });
+
+  it('does not auto-fix a fuzzy near-match', async () => {
+    await writeFile(
+      join(vaultDir, 'Notes', 'Daily.md'),
+      `---\ntype: note\n---\nReading Steve Yeg today.\n`
+    );
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false });
+    await runAutoFix(results, schema, vaultDir, { dryRun: false });
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    // The fuzzy mention is left untouched.
+    expect(after).toContain('Steve Yeg today');
+    expect(after).not.toContain('[[Steve Yegge|Steve Yeg]]');
+  });
+
+  it('only-filter scopes the run to unlinked-mention issues', async () => {
+    await writeFile(
+      join(vaultDir, 'Notes', 'Daily.md'),
+      `---\ntype: note\n---\nMet Steve Yegge.\n`
+    );
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false, onlyIssue: 'unlinked-mention' });
+    for (const r of results) {
+      for (const i of r.issues) {
+        expect(i.code).toBe('unlinked-mention');
+      }
+    }
+  });
+
+  it('ignore-filter suppresses unlinked-mention issues', async () => {
+    await writeFile(
+      join(vaultDir, 'Notes', 'Daily.md'),
+      `---\ntype: note\n---\nMet Steve Yegge.\n`
+    );
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false, ignoreIssue: 'unlinked-mention' });
+    const daily = results.find((r) => r.relativePath === 'Notes/Daily.md');
+    expect(daily?.issues.some((i) => i.code === 'unlinked-mention')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `unlinked-mention` audit detection — the closed-world web-integrity check at the center of the [ingest safety net](plans/features/ingest-safety-net.md). bwrb knows every note (by name) and, via the alias field role (#266), every registered alias. This scans note **bodies** for a known name/alias that appears as plain text but is **not** wikilinked, and flags it, keeping the vault a connected graph.

## The trust line (key contract)

| Tier | Match | Behavior |
|------|-------|----------|
| **Exact / alias** | Literal name or registered alias, unlinked, resolving to exactly one entity | **Trusted → auto-fixable** (`--fix --auto --execute`) |
| **Fuzzy** | Capitalized phrase a small Levenshtein distance from a known name (e.g. `Steve Yeg` ≈ `Steve Yegge`) | **Flag-only "did you mean?"** — never auto-linked |
| **Ambiguous** | Surface matching multiple distinct entities (e.g. `Mercury`) | **Flag-only** — never auto-resolved |

## Auto-fix output format
- Surface equals canonical name → `[[Steve Yegge]]`
- Surface differs (alias / casing) → display form `[[Steve Yegge|Stevey]]`

```text
before: Met Steve Yegge and Stevey. Also Steve Yeg writes well.
after:  Met [[Steve Yegge]] and [[Steve Yegge|Stevey]]. Also Steve Yeg writes well.
```
(Fuzzy `Steve Yeg` and ambiguous surfaces are left untouched.)

## False-positive guards
- Masks existing `[[wikilinks]]`, markdown links, fenced code blocks, inline code, and bare URLs before scanning.
- Word-boundary + case-insensitive matching (preserves surface casing in the fix).
- A note never flags a mention of its own name/alias.
- Ignores surfaces shorter than 3 chars.

## Performance
Entity index is built **once per run** (not per file); each body is scanned in a **single combined-regex pass**, so cost scales with body size rather than notes × entities (no regression on #500).

## Reuse
`getEntityAliases` / alias role (#266) and `levenshteinDistance` (#93) — no reinvention.

## Tests / docs
- New `tests/ts/lib/audit-unlinked-mention.test.ts` (19 tests): exact/alias/fuzzy/ambiguous tiers, already-linked, self-mention, code/inline/URL guards, word-boundary, end-to-end auto-fix, `--only`/`--ignore`.
- Documents the detection and trust tiers in the audit command reference.

## Quality gates
- `pnpm qa` ✅ (typecheck, lint, docs:lint, docs:doctor, build, 2061 tests pass / 4 skipped)
- `pnpm knip` ✅
- `pnpm docs:build` ✅

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)