### PR TITLE
feat(audit): add frequent-unlinked-term advisory detection (#601)

### DIFF
--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -77,6 +77,7 @@ Delete semantics in repair mode:
 | `wrong-scalar-type` | Scalar value has wrong type for schema |
 | `illegal-aliases` | An [`alias`-role field](/reference/schema/#alias) has empty or non-string entries (the Obsidian aliases format requires non-empty, unique strings) |
 | `unlinked-mention` | A known entity's name or [registered alias](/reference/schema/#alias) appears in body prose as plain text but is not wikilinked (warning; exact/alias matches auto-fixable, fuzzy/ambiguous matches flag-only — see below) |
+| `frequent-unlinked-term` | A proper-noun-ish term mentioned frequently across the vault that has **no note yet** (warning; **advisory heuristic, never auto-fixable** — see below) |
 
 Note: built-in fields written by `bwrb new` (currently `id` and `name`) are always allowed and do not produce `unknown-field` issues.
 Invalid option values inside list fields are reported as `invalid-option` with `listIndex` metadata, not a separate issue code.
@@ -229,6 +230,35 @@ bwrb audit --path "Notes/**" --fix --auto --execute
 ```
 
 Fuzzy and ambiguous mentions are reported with a suggestion but are **never** modified by `--fix --auto`; resolve them with interactive `--fix` (which will skip them with the suggestion) or by editing manually.
+
+### Frequent-unlinked-term semantics (open-world nudge)
+
+`frequent-unlinked-term` is the **open-world** counterpart to `unlinked-mention`. Where `unlinked-mention` keeps *known* entities linked, this detection points at entities that probably *should* exist but don't yet — it surfaces proper-noun-ish terms mentioned a lot across the vault that have **no note**. It attacks the failure mode where the AI agent (or you) never links something because it doesn't know the entity exists in the first place. Create the note, and `unlinked-mention` keeps it wired up forever after.
+
+**Advisory only — this detection NEVER takes action.** It is always reported as a warning and is **never auto-fixable**: there is no `--fix` path for it, `--fix --auto` ignores it, and interactive `--fix` lists it as a manual item only. Because it never acts, it is *allowed* to be a little noisy; the thresholds exist purely to keep the report readable, not for correctness. Just ignore any suggestion that isn't a real entity.
+
+**The heuristic (and its honest limits).** Discovering an unknown "thing" in prose without an LLM is inherently fuzzy. The detection approximates proper nouns with **runs of Capitalized words** (1–3 words: `Rust`, `Steve Yegge`, `New York Times`), counted only in prose. Known limits, stated plainly:
+
+- **No semantic understanding.** A repeated capitalized non-entity (e.g. a recurring section title) can surface. That's expected — ignore it.
+- **Sentence-start noise.** Any word can be capitalized simply by starting a sentence. To suppress this, single-word candidates are held to a stricter bar (longer minimum length, full stopword filtering, and must appear at least once *mid-sentence*), and a small stopword list (days, months, pronouns, common sentence openers) is filtered. Leading filler words are stripped from phrases (`The Rust Foundation` → `Rust Foundation`).
+- **Multi-word phrases are favored** over single words, because a 2–3 word capitalized phrase is far more likely to be a genuine proper noun.
+
+**Thresholds (defaults).** A term is surfaced only when it appears **≥ 4 times in total** across **≥ 2 distinct notes**. These keep one-off capitalizations out of the report. (The thresholds live as documented constants — `FREQUENT_TERM_DEFAULTS` — in `src/lib/audit/frequent-unlinked-term.ts`; tune them there.)
+
+**Exclusions (the closed-world handoff).**
+
+- A term whose text matches an existing **note name** or a **registered alias** is never surfaced — that's `unlinked-mention`'s job. The two detections never overlap.
+- Terms that are already wikilinked are not counted: existing `[[wikilinks]]`, markdown links, fenced code blocks, inline code, and bare URLs are masked out (the same masking `unlinked-mention` uses), so only *prose* mentions count. A term that is always linked has zero prose mentions and can't reach the threshold.
+
+Because the threshold is vault-wide, this detection aggregates across all scanned notes and reports its findings under a single `(vault-wide)` heading rather than against one file. Each finding lists the term, how many times it was mentioned, and the notes it appeared in.
+
+```bash
+# Report frequent unlinked terms only
+bwrb audit --only frequent-unlinked-term
+
+# Suppress them (e.g. while focusing on fixable issues)
+bwrb audit --ignore frequent-unlinked-term
+```
 
 ### Non-interactive mode
 

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -121,6 +121,8 @@ Issue Types:
   malformed-wikilink    Near-wikilink bracket typo (frontmatter only)
   unlinked-mention      Known entity name/alias in body prose, not wikilinked
                         (exact/alias auto-fixable; fuzzy/ambiguous flag-only)
+  frequent-unlinked-term Proper-noun-ish term mentioned often across the vault
+                        with no note yet (advisory heuristic; never auto-fixed)
 
 Type Resolution:
   Audit resolves each file's type from its frontmatter 'type' field.

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -77,7 +77,16 @@ import {
   detectUnlinkedMentions,
   type EntityMentionIndex,
 } from './unlinked-mention.js';
+// Import frequent-unlinked-term detection (ingest safety net, #601)
+import { FrequentTermAccumulator } from './frequent-unlinked-term.js';
 import { parseNote } from '../frontmatter.js';
+
+/**
+ * Synthetic vault-relative path used to group vault-global (aggregate) findings
+ * such as `frequent-unlinked-term`, which belong to no single note. Rendered as
+ * a normal result header by the text/JSON output.
+ */
+const VAULT_GLOBAL_RESULT_PATH = '(vault-wide)';
 
 // ============================================================================
 // Main Audit Runner
@@ -194,6 +203,38 @@ export async function runAudit(
         path: file.path,
         relativePath: file.relativePath,
         issues: filteredIssues,
+      });
+    }
+  }
+
+  // Vault-global post-pass: frequent-unlinked-term (#601). This is an advisory,
+  // never-auto-fixable heuristic that aggregates Capitalized-phrase mentions
+  // across every scanned body and surfaces terms that appear frequently but
+  // have no note yet. Aggregation cannot happen per file (the threshold is
+  // vault-wide), so it runs here after the per-file loop. Skipped entirely when
+  // the caller filtered this issue out, to avoid the extra body reads.
+  const wantFrequentTerm =
+    options.ignoreIssue !== 'frequent-unlinked-term' &&
+    (options.onlyIssue === undefined || options.onlyIssue === 'frequent-unlinked-term');
+
+  if (wantFrequentTerm && entityMentionIndex) {
+    const accumulator = new FrequentTermAccumulator(entityMentionIndex);
+    for (const file of filteredFiles) {
+      try {
+        const { body } = await parseNote(file.path);
+        if (body && body.trim().length > 0) {
+          accumulator.addBody(body, file.relativePath);
+        }
+      } catch {
+        // Skip files whose body can't be parsed.
+      }
+    }
+    const aggregateIssues = accumulator.finish();
+    if (aggregateIssues.length > 0) {
+      results.push({
+        path: VAULT_GLOBAL_RESULT_PATH,
+        relativePath: VAULT_GLOBAL_RESULT_PATH,
+        issues: aggregateIssues,
       });
     }
   }

--- a/src/lib/audit/frequent-unlinked-term.ts
+++ b/src/lib/audit/frequent-unlinked-term.ts
@@ -1,0 +1,373 @@
+/**
+ * `frequent-unlinked-term` audit detection — the open-world nudge.
+ *
+ * This is the third leg of the ingest safety net (see
+ * plans/features/ingest-safety-net.md §4). It attacks a failure mode that the
+ * closed-world `unlinked-mention` (#600) cannot: *the agent forgets to link
+ * because it does not know the entity exists.* There is no note to match
+ * against yet, so there is nothing for `unlinked-mention` to flag.
+ *
+ * Instead this detection looks for **proper-noun-ish phrases mentioned a lot
+ * across the vault that have no note yet** and surfaces them as a gentle nudge:
+ * "you might want notes for these N things." It is the inverse of
+ * `unlinked-mention`: that one keeps *known* entities wired up; this one
+ * suggests *new* entities worth creating, after which `unlinked-mention` keeps
+ * them linked forever after.
+ *
+ * KEY CONTRACT — **advisory only.** This detection NEVER auto-acts and is NEVER
+ * auto-fixable (`autoFixable: false`, no fix-policy entry, no `--fix` path).
+ * Because it never takes action, it is *allowed* to be a bit noisy — that noise
+ * is harmless. It is gated behind thresholds purely to keep the report
+ * readable, not for correctness.
+ *
+ * ## The heuristic (and its honest limits)
+ *
+ * Discovering an unknown "thing" in prose without an LLM is inherently
+ * heuristic. We approximate proper nouns with **runs of Capitalized words**
+ * (1–3 words: "Rust", "Steve Yegge", "New York Times"), counted only in prose
+ * (code/links/URLs/existing wikilinks are masked out by reusing #600's
+ * {@link maskNonProse}). Known limits, documented for honesty:
+ *  - **Sentence-start false positives.** Any word can be capitalized because it
+ *    starts a sentence ("Today I…"). We drop a single-word candidate that sits
+ *    at the very start of a line/sentence, and filter a stopword list of common
+ *    capitalized words (days, months, pronouns, sentence openers).
+ *  - **No semantic understanding.** "The Plan" repeated a lot will surface even
+ *    though it is not an entity. That is acceptable: the user simply ignores it.
+ *  - **Multi-word phrases are favored** over single words: a 2–3 word
+ *    Capitalized phrase is much more likely a real proper noun, so single-word
+ *    candidates are held to a stricter bar (longer minimum length, full
+ *    stopword filtering, no sentence-start position).
+ *
+ * ## Exclusions (the closed-world handoff)
+ *  - A candidate whose lowercased text equals an existing note name OR a
+ *    registered alias is dropped — that is `unlinked-mention`'s job, not ours.
+ *    We reuse #600's {@link EntityMentionIndex.bySurface} as the known-surface
+ *    set so the two detections never overlap.
+ *  - Terms that are already wikilinked everywhere never reach us: masking blanks
+ *    `[[...]]`, so only *prose* occurrences are ever counted. A term that is
+ *    always linked has zero prose mentions and cannot meet the threshold.
+ *
+ * ## Aggregation
+ * This detection is **vault-global**: a term must clear a mention/notes
+ * threshold *across the vault*, which cannot be decided per file. The audit run
+ * therefore drives it as a post-pass over all scanned bodies (see
+ * detection.ts), aggregating candidate counts and emitting one issue per
+ * surfaced term.
+ */
+
+import type { EntityMentionIndex } from './unlinked-mention.js';
+import { maskNonProse } from './unlinked-mention.js';
+import type { AuditIssue } from './types.js';
+
+// ============================================================================
+// Thresholds & tunables
+// ============================================================================
+
+/** Default thresholds for surfacing a term. Tunable via {@link FrequentTermOptions}. */
+export const FREQUENT_TERM_DEFAULTS = {
+  /** A term must appear at least this many times in total across the vault. */
+  minMentions: 4,
+  /** A term must appear in at least this many distinct notes. */
+  minNotes: 2,
+  /** Minimum length for a single-word candidate (multi-word phrases bypass). */
+  minSingleWordLength: 4,
+  /** Maximum number of words in a candidate phrase. */
+  maxPhraseWords: 3,
+  /** Cap on how many surfaced terms to emit (highest-count first). */
+  maxResults: 25,
+} as const;
+
+/** Per-run options to tune the frequent-unlinked-term heuristic. */
+export interface FrequentTermOptions {
+  minMentions?: number;
+  minNotes?: number;
+  minSingleWordLength?: number;
+  maxPhraseWords?: number;
+  maxResults?: number;
+}
+
+// ============================================================================
+// Stopwords (false-positive management)
+// ============================================================================
+
+/**
+ * Common Capitalized words that are almost never entities on their own. Kept
+ * deliberately small and lowercased for case-insensitive membership checks.
+ * Used to reject *single-word* candidates and to strip leading filler from
+ * multi-word phrases. Documented as a known, intentionally-incomplete list —
+ * iterate over time (the cost of a miss is only a little report noise).
+ */
+const FREQUENT_TERM_STOPWORDS: ReadonlySet<string> = new Set(
+  [
+    // Days
+    'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday',
+    // Months
+    'january', 'february', 'march', 'april', 'may', 'june', 'july', 'august',
+    'september', 'october', 'november', 'december',
+    // Common sentence openers / pronouns / filler that are frequently capitalized
+    'the', 'a', 'an', 'and', 'but', 'or', 'so', 'then', 'this', 'that', 'these',
+    'those', 'there', 'here', 'it', 'its', 'we', 'i', 'you', 'he', 'she', 'they',
+    'my', 'our', 'your', 'his', 'her', 'their', 'me', 'us', 'them',
+    'today', 'tomorrow', 'yesterday', 'now', 'later', 'soon',
+    'when', 'where', 'what', 'who', 'why', 'how', 'which',
+    'if', 'as', 'at', 'by', 'for', 'from', 'in', 'into', 'of', 'on', 'to', 'up',
+    'with', 'about', 'after', 'before', 'over', 'under',
+    'yes', 'no', 'not', 'maybe', 'okay', 'ok',
+    'one', 'two', 'three', 'first', 'second', 'next', 'last',
+    'do', 'did', 'done', 'got', 'get', 'let', 'also', 'just', 'still', 'really',
+  ].map((w) => w.toLowerCase())
+);
+
+// ============================================================================
+// Candidate extraction
+// ============================================================================
+
+/** A located candidate occurrence within a single note body. */
+interface CandidateHit {
+  /** Normalized surface text (original casing, single-spaced). */
+  text: string;
+  /** True when the phrase began at the start of a line/sentence. */
+  atSentenceStart: boolean;
+}
+
+/**
+ * Extract Capitalized-phrase candidates from a single (already masked) body.
+ *
+ * A candidate is a run of 1..maxPhraseWords Capitalized words. We also track
+ * whether the run started at a sentence boundary (line start, or right after
+ * sentence-ending punctuation) so single-word sentence openers can be rejected.
+ */
+export function extractCandidates(
+  maskedBody: string,
+  maxPhraseWords: number
+): CandidateHit[] {
+  const hits: CandidateHit[] = [];
+  // A Capitalized word: leading uppercase letter, then letters/marks. We keep
+  // internal apostrophes/hyphens (O'Brien, Jean-Luc) but trim trailing ones.
+  const wordRe = /[A-Z][A-Za-z'À-ɏ-]*/g;
+
+  // Walk word-by-word, grouping consecutive Capitalized words that are
+  // separated only by a single space into a phrase.
+  let match: RegExpExecArray | null;
+  const words: Array<{ text: string; start: number; end: number }> = [];
+  while ((match = wordRe.exec(maskedBody)) !== null) {
+    words.push({ text: match[0], start: match.index, end: match.index + match[0].length });
+  }
+
+  let i = 0;
+  while (i < words.length) {
+    const run: Array<{ text: string; start: number; end: number }> = [words[i]!];
+    let j = i + 1;
+    // Extend the run while the next Capitalized word is separated only by
+    // spaces/tabs (not a newline or other punctuation) from the previous one.
+    while (j < words.length && run.length < maxPhraseWords) {
+      const prev = run[run.length - 1]!;
+      const between = maskedBody.slice(prev.end, words[j]!.start);
+      if (/^[ \t]+$/.test(between)) {
+        run.push(words[j]!);
+        j++;
+      } else {
+        break;
+      }
+    }
+
+    // Emit the full run as one candidate. (We intentionally do not emit every
+    // sub-phrase: the maximal Capitalized run is the best proper-noun guess.)
+    const start = run[0]!.start;
+    const text = stripTrailingPunct(run.map((w) => w.text).join(' '));
+    if (text.length > 0) {
+      hits.push({ text, atSentenceStart: isSentenceStart(maskedBody, start) });
+    }
+    i = j;
+  }
+
+  return hits;
+}
+
+/** Remove trailing apostrophes/hyphens left after tokenization. */
+function stripTrailingPunct(s: string): string {
+  return s.replace(/['-]+$/u, '');
+}
+
+/**
+ * Whether the offset begins a sentence: at file start, at a line start, or
+ * immediately after sentence-ending punctuation (`.`, `!`, `?`) and whitespace.
+ */
+function isSentenceStart(text: string, offset: number): boolean {
+  let k = offset - 1;
+  // Skip immediate whitespace before the candidate.
+  while (k >= 0 && (text[k] === ' ' || text[k] === '\t')) k--;
+  if (k < 0) return true;
+  const ch = text[k]!;
+  return ch === '\n' || ch === '.' || ch === '!' || ch === '?';
+}
+
+/**
+ * Strip leading stopword words from a candidate phrase ("Also Kubernetes" →
+ * "Kubernetes"; "The Rust Foundation" → "Rust Foundation"). Returns the trimmed
+ * phrase and whether any leading word was removed. A phrase that is entirely
+ * stopwords collapses to the empty string (and is then ignored by the caller).
+ */
+function stripLeadingStopwords(phrase: string): {
+  normalized: string;
+  strippedLeading: boolean;
+} {
+  const words = phrase.split(' ');
+  let i = 0;
+  while (i < words.length && FREQUENT_TERM_STOPWORDS.has(words[i]!.toLowerCase())) {
+    i++;
+  }
+  return { normalized: words.slice(i).join(' '), strippedLeading: i > 0 };
+}
+
+// ============================================================================
+// Aggregation
+// ============================================================================
+
+/** Running tally for one candidate term across the vault. */
+interface TermTally {
+  /** Display form: the most common original casing seen. */
+  display: string;
+  /** Total prose mentions across all notes. */
+  mentions: number;
+  /** Distinct note paths the term appears in. */
+  notes: Set<string>;
+  /** Number of words in the phrase. */
+  wordCount: number;
+  /** Whether every observed occurrence was at a sentence start. */
+  everyOccurrenceSentenceStart: boolean;
+}
+
+/**
+ * Stateful accumulator so the audit run can feed bodies one at a time and emit
+ * aggregated issues at the end. Build once per run; call {@link addBody} for
+ * each scanned note, then {@link finish} for the surfaced issues.
+ */
+export class FrequentTermAccumulator {
+  private readonly tallies = new Map<string, TermTally>();
+  private readonly opts: Required<FrequentTermOptions>;
+
+  constructor(
+    private readonly index: EntityMentionIndex,
+    options?: FrequentTermOptions
+  ) {
+    this.opts = {
+      minMentions: options?.minMentions ?? FREQUENT_TERM_DEFAULTS.minMentions,
+      minNotes: options?.minNotes ?? FREQUENT_TERM_DEFAULTS.minNotes,
+      minSingleWordLength:
+        options?.minSingleWordLength ?? FREQUENT_TERM_DEFAULTS.minSingleWordLength,
+      maxPhraseWords: options?.maxPhraseWords ?? FREQUENT_TERM_DEFAULTS.maxPhraseWords,
+      maxResults: options?.maxResults ?? FREQUENT_TERM_DEFAULTS.maxResults,
+    };
+  }
+
+  /** Feed one note body (raw markdown). Masks non-prose before counting. */
+  addBody(body: string, notePath: string): void {
+    if (!body || body.trim().length === 0) return;
+    const masked = maskNonProse(body);
+    const candidates = extractCandidates(masked, this.opts.maxPhraseWords);
+
+    for (const cand of candidates) {
+      const collapsed = cand.text.replace(/\s+/g, ' ').trim();
+      // Strip leading filler stopwords ("Also Kubernetes" → "Kubernetes",
+      // "The Rust Foundation" → "Rust Foundation") so the real proper noun is
+      // what gets counted. Once we strip a leading word the candidate is no
+      // longer at a sentence start in a meaningful sense.
+      const { normalized, strippedLeading } = stripLeadingStopwords(collapsed);
+      if (!normalized) continue;
+      const atSentenceStart = cand.atSentenceStart && !strippedLeading;
+      if (!this.isEligible(normalized, atSentenceStart)) continue;
+
+      const key = normalized.toLowerCase();
+      const existing = this.tallies.get(key);
+      if (existing) {
+        existing.mentions += 1;
+        existing.notes.add(notePath);
+        if (!atSentenceStart) existing.everyOccurrenceSentenceStart = false;
+      } else {
+        this.tallies.set(key, {
+          display: normalized,
+          mentions: 1,
+          notes: new Set([notePath]),
+          wordCount: normalized.split(' ').length,
+          everyOccurrenceSentenceStart: atSentenceStart,
+        });
+      }
+    }
+  }
+
+  /**
+   * Whether a normalized candidate is eligible to be *counted* at all.
+   *
+   * Drops: known note names/aliases (closed-world handoff), single-word
+   * stopwords, and single-word sentence-start openers / too-short words. Multi-
+   * word phrases are favored and held to a lighter bar.
+   */
+  private isEligible(normalized: string, atSentenceStart: boolean): boolean {
+    const lower = normalized.toLowerCase();
+
+    // Exclude anything that already has a note or registered alias (#600 owns it).
+    if (this.index.bySurface.has(lower)) return false;
+
+    const words = normalized.split(' ');
+    if (words.length === 1) {
+      const word = words[0]!;
+      // Single-word candidates: stricter to suppress sentence-start noise.
+      if (word.length < this.opts.minSingleWordLength) return false;
+      if (FREQUENT_TERM_STOPWORDS.has(lower)) return false;
+      // A lone capitalized word at a sentence start is most likely just an
+      // opener, not a proper noun — counted only via non-start occurrences.
+      if (atSentenceStart) return false;
+      return true;
+    }
+
+    // Multi-word phrase (leading stopwords already stripped by the caller).
+    // Drop a phrase that is nothing but stopwords; otherwise keep it.
+    if (words.every((w) => FREQUENT_TERM_STOPWORDS.has(w.toLowerCase()))) return false;
+    return true;
+  }
+
+  /** Emit aggregated, advisory issues for every term clearing the thresholds. */
+  finish(): AuditIssue[] {
+    const surfaced: TermTally[] = [];
+    for (const tally of this.tallies.values()) {
+      if (tally.mentions < this.opts.minMentions) continue;
+      if (tally.notes.size < this.opts.minNotes) continue;
+      // A single-word term whose every occurrence sat at a sentence start is too
+      // risky to surface; require at least one mid-sentence occurrence. (For
+      // multi-word phrases sentence position is not tracked as a gate.)
+      if (tally.wordCount === 1 && tally.everyOccurrenceSentenceStart) continue;
+      surfaced.push(tally);
+    }
+
+    // Highest count first, then most notes, then alphabetical for stability.
+    surfaced.sort(
+      (a, b) =>
+        b.mentions - a.mentions ||
+        b.notes.size - a.notes.size ||
+        a.display.localeCompare(b.display, 'en')
+    );
+
+    return surfaced.slice(0, this.opts.maxResults).map((t) => this.toIssue(t));
+  }
+
+  private toIssue(tally: TermTally): AuditIssue {
+    const noteList = Array.from(tally.notes).sort((a, b) => a.localeCompare(b, 'en'));
+    return {
+      severity: 'warning',
+      code: 'frequent-unlinked-term',
+      message: `'${tally.display}' is mentioned ${tally.mentions} times across ${tally.notes.size} notes but has no note yet`,
+      value: tally.display,
+      autoFixable: false,
+      suggestion: `Consider creating a note for '${tally.display}' (advisory heuristic — ignore if not an entity)`,
+      similarFiles: noteList,
+      meta: {
+        term: tally.display,
+        mentions: tally.mentions,
+        noteCount: tally.notes.size,
+        notes: noteList,
+        wordCount: tally.wordCount,
+      },
+    };
+  }
+}

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -53,7 +53,10 @@ export type IssueCode =
   | 'malformed-wikilink'
   // Ingest safety net (#600): a known entity name/alias mentioned in body prose
   // but not wikilinked. Exact/alias → auto-fixable; fuzzy/ambiguous → flag-only.
-  | 'unlinked-mention';
+  | 'unlinked-mention'
+  // Ingest safety net (#601): a proper-noun-ish term mentioned frequently across
+  // the vault with no note yet. Advisory-only heuristic; NEVER auto-fixable.
+  | 'frequent-unlinked-term';
 
 /**
  * A single audit issue.

--- a/tests/ts/lib/audit-frequent-unlinked-term.test.ts
+++ b/tests/ts/lib/audit-frequent-unlinked-term.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, writeFile, rm, mkdtemp } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadSchema, resolveSchema } from '../../../src/lib/schema.js';
+import { runAudit } from '../../../src/lib/audit/detection.js';
+import { buildEntityMentionIndex } from '../../../src/lib/audit/unlinked-mention.js';
+import {
+  FrequentTermAccumulator,
+  extractCandidates,
+  FREQUENT_TERM_DEFAULTS,
+} from '../../../src/lib/audit/frequent-unlinked-term.js';
+import type { Schema } from '../../../src/types/schema.js';
+
+const SCHEMA: Schema = {
+  version: 2,
+  types: {
+    meta: { fields: {} },
+    person: {
+      extends: 'meta',
+      output_dir: 'People',
+      fields: {
+        type: { value: 'person' },
+        aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
+      },
+      field_order: ['type', 'aliases'],
+    },
+    note: {
+      extends: 'meta',
+      output_dir: 'Notes',
+      fields: { type: { value: 'note' } },
+      field_order: ['type'],
+    },
+  },
+};
+
+const schema = resolveSchema(SCHEMA);
+
+function indexFor(
+  notes: Array<{ relativePath: string; frontmatter?: Record<string, unknown>; resolvedType?: string }>
+) {
+  return buildEntityMentionIndex(
+    {
+      notes: notes.map((n) => ({
+        path: n.relativePath,
+        relativePath: n.relativePath,
+        ...(n.frontmatter ? { frontmatter: n.frontmatter } : {}),
+        ...(n.resolvedType ? { resolvedType: n.resolvedType } : {}),
+      })),
+    },
+    schema
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Candidate extraction (unit)
+// ---------------------------------------------------------------------------
+
+describe('frequent-unlinked-term: extractCandidates', () => {
+  it('groups consecutive Capitalized words into multi-word phrases', () => {
+    const hits = extractCandidates('I read the New York Times today.', 3);
+    expect(hits.map((h) => h.text)).toContain('New York Times');
+  });
+
+  it('caps phrase length at maxPhraseWords', () => {
+    const hits = extractCandidates('Alpha Beta Gamma Delta here.', 2);
+    // Should not produce a single 4-word phrase.
+    expect(hits.every((h) => h.text.split(' ').length <= 2)).toBe(true);
+  });
+
+  it('marks sentence-start position', () => {
+    const hits = extractCandidates('Today was fine. Rust is great.', 3);
+    const today = hits.find((h) => h.text === 'Today');
+    const rust = hits.find((h) => h.text === 'Rust');
+    expect(today?.atSentenceStart).toBe(true);
+    expect(rust?.atSentenceStart).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Accumulator / thresholds (unit)
+// ---------------------------------------------------------------------------
+
+describe('frequent-unlinked-term: FrequentTermAccumulator', () => {
+  const emptyIndex = indexFor([]);
+
+  it('surfaces a multi-word phrase repeated >= threshold across >= threshold notes', () => {
+    const acc = new FrequentTermAccumulator(emptyIndex, { minMentions: 4, minNotes: 2 });
+    // 2 notes, 4 total mentions.
+    acc.addBody('We use Rust Foundation here. Rust Foundation is great.', 'a.md');
+    acc.addBody('The Rust Foundation again. Rust Foundation rules.', 'b.md');
+    const issues = acc.finish();
+    const term = issues.find((i) => i.value === 'Rust Foundation');
+    expect(term).toBeDefined();
+    expect(term?.code).toBe('frequent-unlinked-term');
+    expect(term?.autoFixable).toBe(false);
+    expect(term?.meta?.['mentions']).toBe(4);
+    expect(term?.meta?.['noteCount']).toBe(2);
+  });
+
+  it('does NOT surface a term below the mention threshold', () => {
+    const acc = new FrequentTermAccumulator(emptyIndex, { minMentions: 4, minNotes: 2 });
+    acc.addBody('Apache Kafka here. Apache Kafka again.', 'a.md');
+    acc.addBody('Apache Kafka once more.', 'b.md');
+    // 3 total mentions < 4.
+    expect(acc.finish().find((i) => i.value === 'Apache Kafka')).toBeUndefined();
+  });
+
+  it('does NOT surface a term confined to a single note', () => {
+    const acc = new FrequentTermAccumulator(emptyIndex, { minMentions: 4, minNotes: 2 });
+    acc.addBody('Apache Kafka. Apache Kafka. Apache Kafka. Apache Kafka.', 'a.md');
+    expect(acc.finish().find((i) => i.value === 'Apache Kafka')).toBeUndefined();
+  });
+
+  it('excludes terms that already have a note (closed-world handoff)', () => {
+    const index = indexFor([
+      { relativePath: 'People/Steve Yegge.md', resolvedType: 'person', frontmatter: { type: 'person' } },
+    ]);
+    const acc = new FrequentTermAccumulator(index, { minMentions: 2, minNotes: 1 });
+    acc.addBody('Steve Yegge wrote this. Steve Yegge again.', 'a.md');
+    expect(acc.finish().find((i) => i.value === 'Steve Yegge')).toBeUndefined();
+  });
+
+  it('excludes terms that match a registered alias', () => {
+    const index = indexFor([
+      {
+        relativePath: 'People/Steve Yegge.md',
+        resolvedType: 'person',
+        frontmatter: { type: 'person', aliases: ['Stevey'] },
+      },
+    ]);
+    const acc = new FrequentTermAccumulator(index, { minMentions: 2, minNotes: 1 });
+    acc.addBody('Stevey said this. Stevey said that.', 'a.md');
+    expect(acc.finish().find((i) => i.value?.toString().toLowerCase() === 'stevey')).toBeUndefined();
+  });
+
+  it('does not count text inside code/links/wikilinks (reuses #600 masking)', () => {
+    const acc = new FrequentTermAccumulator(emptyIndex, { minMentions: 3, minNotes: 2 });
+    // Only one prose mention; the rest are masked.
+    acc.addBody('Rust Foundation here. `Rust Foundation` [[Rust Foundation]] [x](Rust Foundation).', 'a.md');
+    acc.addBody('Rust Foundation in note b.', 'b.md');
+    // 2 prose mentions total (< 3) → not surfaced, proving masked ones were ignored.
+    expect(acc.finish().find((i) => i.value === 'Rust Foundation')).toBeUndefined();
+  });
+
+  it('excludes single-word stopwords even when frequent', () => {
+    const acc = new FrequentTermAccumulator(emptyIndex, { minMentions: 2, minNotes: 2 });
+    acc.addBody('Today rules. Things happen, Today.', 'a.md');
+    acc.addBody('Stuff, Today. More, Today.', 'b.md');
+    expect(acc.finish().find((i) => i.value?.toString().toLowerCase() === 'today')).toBeUndefined();
+  });
+
+  it('drops single-word candidates that only ever start sentences', () => {
+    const acc = new FrequentTermAccumulator(emptyIndex, { minMentions: 2, minNotes: 2 });
+    // "Coffee" appears only at sentence starts.
+    acc.addBody('Coffee is good. Coffee helps.', 'a.md');
+    acc.addBody('Coffee again. Coffee always.', 'b.md');
+    expect(acc.finish().find((i) => i.value === 'Coffee')).toBeUndefined();
+  });
+
+  it('surfaces a single-word term when it appears mid-sentence', () => {
+    const acc = new FrequentTermAccumulator(emptyIndex, { minMentions: 2, minNotes: 2 });
+    acc.addBody('we love Kubernetes a lot, and also Kubernetes elsewhere.', 'a.md');
+    acc.addBody('we use Kubernetes daily, plus Kubernetes again.', 'b.md');
+    expect(acc.finish().find((i) => i.value === 'Kubernetes')).toBeDefined();
+  });
+
+  it('never marks any surfaced issue auto-fixable', () => {
+    const acc = new FrequentTermAccumulator(emptyIndex);
+    acc.addBody('Rust Foundation. Rust Foundation. Rust Foundation. Rust Foundation.', 'a.md');
+    acc.addBody('Rust Foundation again.', 'b.md');
+    for (const issue of acc.finish()) {
+      expect(issue.autoFixable).toBe(false);
+    }
+  });
+
+  it('exposes sensible documented defaults', () => {
+    expect(FREQUENT_TERM_DEFAULTS.minMentions).toBe(4);
+    expect(FREQUENT_TERM_DEFAULTS.minNotes).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end through runAudit (filesystem)
+// ---------------------------------------------------------------------------
+
+describe('frequent-unlinked-term: runAudit integration', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-fut-'));
+    await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+    await writeFile(join(vaultDir, '.bwrb', 'schema.json'), JSON.stringify(SCHEMA, null, 2));
+    await mkdir(join(vaultDir, 'Notes'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('emits a vault-wide result for a frequent unlinked term', async () => {
+    await writeFile(
+      join(vaultDir, 'Notes', 'a.md'),
+      '---\ntype: note\n---\nI keep mentioning Project Phoenix. Project Phoenix is big.\n'
+    );
+    await writeFile(
+      join(vaultDir, 'Notes', 'b.md'),
+      '---\ntype: note\n---\nMore on Project Phoenix. Project Phoenix forever.\n'
+    );
+
+    const schemaLoaded = await loadSchema(vaultDir);
+    const results = await runAudit(schemaLoaded, vaultDir, {
+      strict: false,
+      onlyIssue: 'frequent-unlinked-term',
+      vaultDir,
+      schema: schemaLoaded,
+    });
+
+    const allIssues = results.flatMap((r) => r.issues);
+    const phoenix = allIssues.find((i) => i.value === 'Project Phoenix');
+    expect(phoenix).toBeDefined();
+    expect(phoenix?.code).toBe('frequent-unlinked-term');
+    expect(phoenix?.autoFixable).toBe(false);
+  });
+
+  it('does not surface a term once a note exists for it', async () => {
+    await mkdir(join(vaultDir, 'People'), { recursive: true });
+    await writeFile(
+      join(vaultDir, 'People', 'Project Phoenix.md'),
+      '---\ntype: person\n---\n'
+    );
+    await writeFile(
+      join(vaultDir, 'Notes', 'a.md'),
+      '---\ntype: note\n---\nMentioning Project Phoenix. Project Phoenix here.\n'
+    );
+    await writeFile(
+      join(vaultDir, 'Notes', 'b.md'),
+      '---\ntype: note\n---\nMore Project Phoenix. Project Phoenix again.\n'
+    );
+
+    const schemaLoaded = await loadSchema(vaultDir);
+    const results = await runAudit(schemaLoaded, vaultDir, {
+      strict: false,
+      onlyIssue: 'frequent-unlinked-term',
+      vaultDir,
+      schema: schemaLoaded,
+    });
+
+    const allIssues = results.flatMap((r) => r.issues);
+    expect(allIssues.find((i) => i.value === 'Project Phoenix')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the third leg of the ingest safety net (#601): **`frequent-unlinked-term`**, an advisory, open-world nudge that surfaces proper-noun-ish terms mentioned frequently across the vault that have **no note yet**. It attacks the failure mode where the agent never links an entity because it doesn't know the entity exists — the inverse of `unlinked-mention` (#600), which keeps *known* entities linked.

## Contract: advisory-only, never auto-acts

- Always a warning, **never auto-fixable** (`autoFixable: false`).
- No `--fix` path; `--fix --auto --execute` ignores it; interactive `--fix` lists it as manual-only.
- Because it never takes action, it's *allowed* to be a bit noisy — thresholds exist purely to keep the report readable.

## The heuristic

- Runs of **1–3 Capitalized words**, counted in **prose only**.
- **Reuses #600's `maskNonProse`** so code / links / URLs / existing `[[wikilinks]]` are excluded.
- **Reuses #600's `EntityMentionIndex.bySurface`** to drop any term that already matches an existing note name or registered alias (the closed-world case `unlinked-mention` owns). The two detections never overlap.
- Single-word candidates held to a stricter bar (min length, stopword filter, must appear mid-sentence); leading filler words stripped from phrases (`The Rust Foundation` → `Rust Foundation`); multi-word phrases favored.

## Thresholds (defaults)

A term is surfaced only when it appears **≥ 4 times** across **≥ 2 distinct notes** (`FREQUENT_TERM_DEFAULTS` in `src/lib/audit/frequent-unlinked-term.ts`).

## Aggregation

Vault-global, so it runs as a **post-pass** over all scanned bodies in `runAudit` and reports under a single `(vault-wide)` heading (term, mention count, notes).

## Tests

New `tests/ts/lib/audit-frequent-unlinked-term.test.ts` (16 tests) covering: surfacing above threshold, below-threshold/single-note non-surfacing, exclusion of existing notes/aliases, masking of code/links/wikilinks, stopword + sentence-start filtering, no-auto-fix, and end-to-end through `runAudit`.

## Quality gates

- `pnpm qa` ✅ (typecheck, lint, docs:lint, docs:doctor, build, 2077 tests)
- `pnpm knip` ✅
- `pnpm docs:build` ✅

## Docs

Documents the advisory nature, thresholds, heuristic limits, and closed-world handoff in `docs-site/.../reference/commands/audit.md`.

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)