### PR TITLE
docs: daily-note sweep/reviewed field convention (#87)

### DIFF
--- a/docs-site/src/content/docs/automation/ai-integration.md
+++ b/docs-site/src/content/docs/automation/ai-integration.md
@@ -39,6 +39,69 @@ bwrb list idea --where "status = 'raw'" --output json
 bwrb edit "My Idea" --json '{"status": "developing"}'
 ```
 
+### Daily-Note Sweep (Coverage)
+
+The goal: ramble into daily notes every day and **know nothing got swept under
+the rug**. The convention is a single boolean field on your daily-note type that
+records whether a note has been reviewed/swept for extractable items (tasks,
+ideas, people to link). bwrb itself ships no `daily-note` type — types are
+defined per-vault — so you declare the field in your schema:
+
+```json
+{
+  "types": {
+    "daily-note": {
+      "output_dir": "Daily Notes",
+      "fields": {
+        "reviewed": {
+          "prompt": "boolean",
+          "description": "Whether this note has been swept for tasks, ideas, and people to extract. Absent or false means not yet swept."
+        }
+      }
+    }
+  }
+}
+```
+
+The workflow:
+
+1. New daily notes start without `reviewed` (or with `reviewed: false`).
+2. An agent (or you) sweeps a note, extracts what matters, then stamps
+   `reviewed: true`.
+3. At any time, list the notes that still need a sweep.
+
+**The recipe — find unswept notes:**
+
+```bash
+bwrb list --type daily-note --where "reviewed != true"
+```
+
+Use `!= true`, **not** `== false`. A note that has never been touched has no
+`reviewed` field at all, and `reviewed == false` only matches notes where the
+field is *explicitly* `false` — it silently skips the never-reviewed notes, which
+are exactly the ones most likely to have been swept under the rug. `reviewed !=
+true` matches both the explicit `false` and the missing-field cases.
+
+Save it as a dashboard so the un-swept queue is one command away:
+
+```bash
+# Save the query as a reusable dashboard...
+bwrb list --type daily-note --where "reviewed != true" --save-as unswept-daily-notes
+
+# ...then run it any time
+bwrb dashboard unswept-daily-notes
+```
+
+Stamping a note as swept is a normal edit:
+
+```bash
+bwrb edit "Daily Notes/2026-06-20" --json '{"reviewed": true}'
+```
+
+> The risk in this loop is the agent forgetting to stamp `reviewed: true`. That is
+> prompting discipline, not a bwrb feature — but the `reviewed != true` query is
+> the deterministic backstop that makes a forgotten stamp visible instead of lost.
+
 ### Content Generation
 
 AI can create structured notes:

--- a/tests/ts/lib/daily-note-sweep.test.ts
+++ b/tests/ts/lib/daily-note-sweep.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises';
+import { join, basename } from 'path';
+import { tmpdir } from 'os';
+import { loadSchema } from '../../../src/lib/schema.js';
+import { discoverManagedFiles } from '../../../src/lib/discovery.js';
+import { parseNote } from '../../../src/lib/frontmatter.js';
+import { applyWhereExpressions } from '../../../src/lib/where-targeting.js';
+
+/**
+ * Guards the documented "daily-note sweep" coverage recipe
+ * (docs-site/.../automation/ai-integration.md → "Daily-Note Sweep").
+ *
+ * The convention: a `reviewed` boolean on a vault-defined daily-note type marks
+ * whether a note has been swept for extractable items. The recipe to surface
+ * un-swept notes is:
+ *
+ *   bwrb list --type daily-note --where "reviewed != true"
+ *
+ * The load-bearing detail this test pins down: `reviewed != true` must match
+ * BOTH notes with `reviewed: false` AND notes that have no `reviewed` field at
+ * all (never touched). `reviewed == false` must NOT — it silently skips the
+ * never-reviewed notes, which are exactly the ones at risk of being swept under
+ * the rug.
+ */
+
+const SWEEP_SCHEMA = {
+  $schema: 'https://bwrb.dev/schema.json',
+  version: 2,
+  config: { link_format: 'wikilink' as const },
+  types: {
+    'daily-note': {
+      description: 'A dated journal/ramble note.',
+      output_dir: 'Daily Notes',
+      fields: {
+        reviewed: {
+          prompt: 'boolean' as const,
+          description: 'Whether this note has been swept for extractable items.',
+        },
+      },
+    },
+  },
+};
+
+async function createSweepVault(): Promise<string> {
+  const vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-sweep-'));
+  await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+  await writeFile(
+    join(vaultDir, '.bwrb', 'schema.json'),
+    JSON.stringify(SWEEP_SCHEMA, null, 2)
+  );
+  await mkdir(join(vaultDir, 'Daily Notes'), { recursive: true });
+
+  // Never touched — no `reviewed` field at all.
+  await writeFile(
+    join(vaultDir, 'Daily Notes', 'never-touched.md'),
+    `---\ntype: daily-note\n---\nRambled about a new idea.\n`
+  );
+  // Explicitly not yet reviewed.
+  await writeFile(
+    join(vaultDir, 'Daily Notes', 'explicit-false.md'),
+    `---\ntype: daily-note\nreviewed: false\n---\nMore rambling.\n`
+  );
+  // Already swept.
+  await writeFile(
+    join(vaultDir, 'Daily Notes', 'reviewed-true.md'),
+    `---\ntype: daily-note\nreviewed: true\n---\nSwept this one.\n`
+  );
+
+  return vaultDir;
+}
+
+describe('daily-note sweep recipe', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await createSweepVault();
+  });
+
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  async function filter(where: string): Promise<string[]> {
+    const schema = await loadSchema(vaultDir);
+    const files = await discoverManagedFiles(schema, vaultDir, 'daily-note');
+
+    const parsed: Array<{ path: string; frontmatter: Record<string, unknown> }> = [];
+    for (const file of files) {
+      const { frontmatter } = await parseNote(file.path);
+      parsed.push({ path: file.path, frontmatter });
+    }
+
+    const result = await applyWhereExpressions(parsed, {
+      schema,
+      typePath: 'daily-note',
+      whereExpressions: [where],
+      vaultDir,
+    });
+
+    if (!result.ok) {
+      throw new Error(`where filter failed: ${result.error}`);
+    }
+    return result.files.map((f) => basename(f.path)).sort();
+  }
+
+  it('discovers all daily notes when unfiltered', async () => {
+    const all = await filter('isDefined(type)');
+    expect(all).toEqual([
+      'explicit-false.md',
+      'never-touched.md',
+      'reviewed-true.md',
+    ]);
+  });
+
+  it('"reviewed != true" surfaces both explicit-false AND never-touched notes', async () => {
+    // This is the documented recipe. It must catch the never-touched note.
+    const unswept = await filter('reviewed != true');
+    expect(unswept).toEqual(['explicit-false.md', 'never-touched.md']);
+  });
+
+  it('"reviewed == false" silently misses never-touched notes (why the recipe uses != true)', async () => {
+    const onlyExplicit = await filter('reviewed == false');
+    expect(onlyExplicit).toEqual(['explicit-false.md']);
+    // Documents the trap: the never-touched note is invisible to == false.
+    expect(onlyExplicit).not.toContain('never-touched.md');
+  });
+
+  it('"reviewed == true" surfaces only swept notes', async () => {
+    const swept = await filter('reviewed == true');
+    expect(swept).toEqual(['reviewed-true.md']);
+  });
+});


### PR DESCRIPTION
## What & why

Reframed scope of #87 ("daily-note: sweep/reviewed field convention", formerly "ai-process-stage support"). The end goal: ramble into daily notes and **know nothing got swept under the rug** — i.e. be able to find daily notes that haven't yet been reviewed/processed.

After investigation, this is the closed-world **coverage** piece of the ingest safety net (`plans/features/ingest-safety-net.md`, section 5), which explicitly calls for "almost no new code."

## Conclusion: minimal deliverable is docs + a guard test

bwrb is a generic tool — vaults define their own types. `bwrb init` writes `types: {}`, so there is **no shipped `daily-note` type** and nowhere to ship a default schema or dashboard (dashboards live per-vault in `.bwrb/dashboards.json`). The sweep field is therefore a documented **convention**, and the affordance to surface unreviewed notes already exists end-to-end:

- `list --where` (expression engine)
- `--save-as` (saves a query as a dashboard)
- `bwrb dashboard <name>` (runs it)

No production code change was required. The deliverable is:

1. **Docs** — a "Daily-Note Sweep (Coverage)" section in the AI Integration guide documenting the `reviewed` convention and the query/dashboard recipe.
2. **A test** guarding the recipe semantics so the documented query stays correct.

## The working recipe (verified against a real vault)

Declare the field on your daily-note type:

```json
{ "types": { "daily-note": { "output_dir": "Daily Notes",
  "fields": { "reviewed": { "prompt": "boolean" } } } } }
```

Find un-swept notes:

```bash
bwrb list --type daily-note --where "reviewed != true"
```

Save it as a dashboard:

```bash
bwrb list --type daily-note --where "reviewed != true" --save-as unswept-daily-notes
bwrb dashboard unswept-daily-notes
```

**Key finding — use `!= true`, not `== false`.** A never-touched note has no `reviewed` field at all; `reviewed == false` only matches notes where the field is *explicitly* false and silently skips the never-reviewed ones (exactly the notes at risk). `reviewed != true` matches both the explicit-`false` and missing-field cases. The new test pins this, including an assertion that `== false` misses the never-touched note.

## Quality gates

- `pnpm qa` — pass (typecheck, lint, docs:lint, docs:doctor, build, 2081 tests incl. 4 new)
- `pnpm knip` — clean
- `pnpm docs:build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)