### PR TITLE
feat(tasks): event-driven recurrence + offset multi-spawn (#107)

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -96,6 +96,7 @@ export default defineConfig({
 					label: 'Automation',
 					collapsed: true,
 					items: [
+						{ slug: 'automation/task-system' },
 						{ slug: 'automation/json-mode' },
 						{ slug: 'automation/shell-completion' },
 						{ slug: 'automation/ai-integration' },

--- a/docs-site/src/content/docs/automation/task-system.md
+++ b/docs-site/src/content/docs/automation/task-system.md
@@ -1,0 +1,175 @@
+---
+title: Task System (Recurrence & Multi-Spawn)
+description: Declarative, event-driven task recurrence and staggered multi-spawn templating — no cron, no daemon, no LLM.
+---
+
+Bowerbird's task system is **declarative**: recurrence and templating together make a
+real task system out of the schema itself. There is **no cron, no daemon, and no LLM** —
+the schema is the system.
+
+It has two mechanisms:
+
+1. **Recurrence** — spawn a successor note when a field transitions (e.g. `status` enters
+   `done`).
+2. **Multi-spawn templating** — a parent template that scaffolds several staggered child
+   notes on creation.
+
+## Recurrence: spawn-on-transition
+
+The trigger is a **field transition, not a clock**. Declaratively: "when `status` enters
+`done`, spawn a successor from a template, with the successor's date field offset from a
+predecessor date field."
+
+Recurrence rides on a **trait** (see
+[Types and Inheritance](/concepts/types-and-inheritance/)). Add a `recurrence` block to a
+trait, and any type that composes that trait recurs.
+
+```yaml
+# .bwrb/schema.json (shown as YAML for readability)
+traits:
+  recurring:
+    fields:
+      next: { prompt: relation, source: task }   # the chain field (see below)
+      prev: { prompt: relation, source: task }
+    recurrence:
+      on: "status = done"          # trigger transition
+      template: <name>             # optional; defaults to the type's default template
+      set:
+        deadline: "deadline + 7d"  # FIELD-OFFSET ONLY; base must be a date field
+
+types:
+  task:
+    output_dir: tasks
+    traits: [recurring]
+    fields:
+      name: { prompt: text, required: true }
+      status: { prompt: select, options: [todo, doing, done], default: todo }
+      deadline: { prompt: date }
+```
+
+Completing a task now spawns its successor automatically.
+
+### The date rule: field-offset only
+
+The successor's date is computed as:
+
+```
+successor.<dateField> = <predecessor date field> + <offset>     e.g. deadline + 7d
+```
+
+- The referenced **base must be a date field.**
+- **Transition-time offsets** (e.g. "a week after I actually finished") are **not
+  supported** — they can only be exact on the immediate write, never reproducible by the
+  audit backstop, so they would be inconsistent. Field-offset is computed identically on
+  both paths.
+- **Calendar-anchored bases** ("next Monday") are **deferred.**
+
+Offsets accept `min`, `h`, `d`, `w`, `mon` (or `m`), and `y`. Day/week offsets are exact;
+month/year offsets are calendar-aware (e.g. `deadline + 1mon` lands on the same day next
+month).
+
+### The template
+
+The successor's template defaults to **the completed note's type default template** (a
+task begets a task). Naming a template can spawn a **different type** — finish a `draft`,
+spawn a `review`:
+
+```yaml
+    recurrence:
+      on: "status = done"
+      template: review-checklist   # a template whose template-for is `review`
+```
+
+The audit validates that the referenced template exists (a rule pointing at a deleted
+template is a deterministic error — see below).
+
+### The `next` field does three jobs
+
+A single `next` relation field collapses three requirements into one mechanism:
+
+1. **Graph chain / history** — the linked thread of recurring instances, for free. The
+   spawned successor's `prev` links back to its predecessor.
+2. **Idempotency** — a successor is spawned **only if `next` is empty.** Re-completing a
+   task that already has a `next` is a **no-op**.
+3. **Audit backstop check** — "missing successor" is literally _trigger satisfied + `next`
+   empty + type recurs_.
+
+## Two-path execution (reliability)
+
+Recurrence integrity holds **regardless of how a task was completed.**
+
+### Fast path
+
+Completing a recurring note **through bwrb** spawns the successor immediately as a
+deterministic side-effect of the write:
+
+```sh
+bwrb edit "tasks/Water plants.md" --json '{"status":"done"}'
+# or
+bwrb bulk --type task --where "status == 'doing'" --set status=done --execute
+```
+
+Either spawns one successor with the offset deadline and the `next`/`prev` chain links.
+
+### Backstop (audit)
+
+Completing a note **outside bwrb** (e.g. hand-editing frontmatter in Obsidian) is caught
+on the next audit:
+
+```sh
+bwrb audit --path "tasks/**"            # flags: missing-successor
+bwrb audit --path "tasks/**" --fix      # spawns the missing successor
+bwrb audit --all --fix --auto --execute # headless: spawn all missing successors
+```
+
+The backstop uses the **same engine** as the fast path, so it produces an **identical**
+successor (same offset date, same chain links). Both paths are idempotent: re-running
+never spawns a duplicate.
+
+> **Tip for AI/agent workflows:** always edit note fields **via bwrb**, never by writing
+> frontmatter directly. That feeds the fast path and keeps the chain consistent in real
+> time. The audit backstop is there for everything else.
+
+### Config validation
+
+A broken recurrence rule is a deterministic **config** error, surfaced by `bwrb audit` as
+`invalid-recurrence` (never auto-fixed):
+
+- a malformed `on` trigger,
+- an offset whose base is not a date field,
+- a `template` that does not exist in the vault.
+
+## Multi-spawn templating
+
+A parent template can scaffold several related child notes on creation, with staggered
+deadlines computed from today via [date expressions](/templates/creating-templates/):
+
+```yaml
+# .bwrb/templates/project/write-an-article.md
+---
+type: template
+template-for: project
+instances:
+  - { type: task, defaults: { title: "Outline", deadline: "@today+1d" } }
+  - { type: task, defaults: { title: "Draft",   deadline: "@today+3d" } }
+  - { type: task, defaults: { title: "Edit",    deadline: "@today+5d" } }
+  - { type: task, defaults: { title: "Publish", deadline: "@today+7d" } }
+---
+```
+
+```sh
+bwrb new project --template write-an-article
+```
+
+This creates the project **and four staggered task notes**, each with a distinct,
+meaningful filename derived from its `title` (no more collapsing into a single
+`task.md`). Multiple instances of the same type are automatically disambiguated.
+
+## Synthesis
+
+- **Templates** define what work _looks like_ (the staggered plan).
+- **Recurrence rules** define when work _regenerates_ (on completion).
+- bwrb executes deterministically (fast path) and `audit` backstops it.
+
+The whole system is declared in schema + templates, so an agent operates it natively. No
+daemon, no cron, no LLM.

--- a/docs-site/src/content/docs/automation/task-system.md
+++ b/docs-site/src/content/docs/automation/task-system.md
@@ -150,10 +150,10 @@ deadlines computed from today via [date expressions](/templates/creating-templat
 type: template
 template-for: project
 instances:
-  - { type: task, defaults: { title: "Outline", deadline: "@today+1d" } }
-  - { type: task, defaults: { title: "Draft",   deadline: "@today+3d" } }
-  - { type: task, defaults: { title: "Edit",    deadline: "@today+5d" } }
-  - { type: task, defaults: { title: "Publish", deadline: "@today+7d" } }
+  - { type: task, defaults: { name: "Outline", deadline: "@today+1d" } }
+  - { type: task, defaults: { name: "Draft",   deadline: "@today+3d" } }
+  - { type: task, defaults: { name: "Edit",    deadline: "@today+5d" } }
+  - { type: task, defaults: { name: "Publish", deadline: "@today+7d" } }
 ---
 ```
 
@@ -162,8 +162,18 @@ bwrb new project --template write-an-article
 ```
 
 This creates the project **and four staggered task notes**, each with a distinct,
-meaningful filename derived from its `title` (no more collapsing into a single
+meaningful filename derived from its `name` (no more collapsing into a single
 `task.md`). Multiple instances of the same type are automatically disambiguated.
+
+> [!IMPORTANT]
+> `defaults` must use the child type's **real fields**. Here the `task` type's
+> required field is `name`, so each instance sets `name` (not `title`). Using a
+> field the child type doesn't declare would make every scaffolded note fail
+> `bwrb audit` with `unknown-field` and `missing-required`.
+
+Each scaffolded instance is filed in **its own child type's `output_dir`** (here
+`tasks/`), not the parent project's directory — so the multi-spawn workflow stays
+`bwrb audit`-clean (no `wrong-directory`).
 
 ## Synthesis
 

--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -78,6 +78,8 @@ Delete semantics in repair mode:
 | `illegal-aliases` | An [`alias`-role field](/reference/schema/#alias) has empty or non-string entries (the Obsidian aliases format requires non-empty, unique strings) |
 | `unlinked-mention` | A known entity's name or [registered alias](/reference/schema/#alias) appears in body prose as plain text but is not wikilinked (warning; exact/alias matches auto-fixable, fuzzy/ambiguous matches flag-only — see below) |
 | `frequent-unlinked-term` | A proper-noun-ish term mentioned frequently across the vault that has **no note yet** (warning; **advisory heuristic, never auto-fixable** — see below) |
+| `missing-successor` | A [recurring](/automation/task-system/) note satisfies its trigger (e.g. `status = done`) but its chain field (`next`) is empty — a successor was never spawned (e.g. completed outside bwrb). Warning; **auto-fixable** (`--fix` spawns it, identical to the fast path) |
+| `invalid-recurrence` | A [recurrence](/automation/task-system/) rule is broken at the config level — a malformed trigger, a non-date offset base, or a template that doesn't exist (error; **never auto-fixable** — a config error gets the same safety net as data) |
 
 Note: built-in fields written by `bwrb new` (currently `id` and `name`) are always allowed and do not produce `unknown-field` issues.
 Invalid option values inside list fields are reported as `invalid-option` with `listIndex` metadata, not a separate issue code.

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -174,8 +174,36 @@ A `task` now has every field from `objective` (and its ancestors) **plus** `stat
 |----------|------|-------------|
 | `description` | string | What the trait bundles and when to use it. Surfaced by `bwrb schema list` |
 | `fields` | object | Field definitions contributed by the trait |
+| `recurrence` | object | Spawn-on-transition recurrence config (see [Recurrence](#recurrence)) |
 
-Traits are **flat**: a trait carries only `fields` (and an optional `description`). A trait cannot `extends` a type or compose other traits. This keeps resolution simple and deterministic.
+Traits are **flat**: a trait carries only `fields` (and an optional `description`, plus an optional `recurrence` block). A trait cannot `extends` a type or compose other traits. This keeps resolution simple and deterministic.
+
+### Recurrence
+
+A trait may carry a `recurrence` block. Any type that composes the trait then spawns a successor note when a field transitions into a value — the foundation of the [task system](/automation/task-system/). The trigger is a field transition, **not a clock** (no cron, no daemon).
+
+```json
+"traits": {
+  "recurring": {
+    "fields": {
+      "next": { "prompt": "relation", "source": "task" }
+    },
+    "recurrence": {
+      "on": "status = done",
+      "template": "review-checklist",
+      "set": { "deadline": "deadline + 7d" }
+    }
+  }
+}
+```
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `on` | string | Yes | Trigger transition, `<field> = <value>` (e.g. `"status = done"`). The successor is spawned when the field transitions **into** this value |
+| `template` | string | No | Template to spawn from. Defaults to the type's own default template (a task begets a task); a named template can spawn a different type |
+| `set` | object | No | Field-offset assignments. Each value is `<dateField> + <duration>` (e.g. `"deadline + 7d"`); the base **must** be a date field |
+
+The `next` relation field does triple duty: it is the **chain link** (history), the **idempotency guard** (a successor is spawned only when `next` is empty), and the basis for the audit **backstop** (`missing-successor`). See the [task system guide](/automation/task-system/) for the full two-path execution model and validation rules.
 
 ### Precedence
 

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -44,7 +44,7 @@
   "definitions": {
     "trait": {
       "type": "object",
-      "description": "A reusable bundle of fields composed into a type. Traits are flat: they carry only fields (and an optional description) and cannot extend types or compose other traits.",
+      "description": "A reusable bundle of fields composed into a type. Traits are flat: they carry only fields (and an optional description, plus an optional recurrence block) and cannot extend types or compose other traits.",
       "additionalProperties": false,
       "properties": {
         "description": {
@@ -57,6 +57,30 @@
           "additionalProperties": {
             "$ref": "#/definitions/frontmatterField"
           }
+        },
+        "recurrence": {
+          "$ref": "#/definitions/recurrence"
+        }
+      }
+    },
+    "recurrence": {
+      "type": "object",
+      "description": "Event-driven, spawn-on-transition recurrence (#107). When a field transitions into a value (e.g. status enters done), spawn a successor note from a template, offsetting the successor's date field from a predecessor date field. No cron, no daemon, no LLM.",
+      "additionalProperties": false,
+      "required": ["on"],
+      "properties": {
+        "on": {
+          "type": "string",
+          "description": "Trigger transition, written as `<field> = <value>` (e.g. \"status = done\"). The successor is spawned when the trigger field transitions INTO this value."
+        },
+        "template": {
+          "type": "string",
+          "description": "Template to spawn the successor from. Defaults to the completed note's type default template (a task begets a task). A named template can spawn a different type (finish \"draft\" -> spawn \"review\")."
+        },
+        "set": {
+          "type": "object",
+          "description": "Field-offset assignments for the successor. Each value is a field-offset expression `<dateField> <+|-> <duration>` (e.g. \"deadline + 7d\"). The base must be a date field on the predecessor. Transition-time offsets and calendar-anchored bases are not supported.",
+          "additionalProperties": { "type": "string" }
         }
       }
     },

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -140,9 +140,21 @@ Examples:
 
       // Check if query is an absolute path to an existing file
       if (query && isAbsolute(query)) {
+        // Only the existence check may fall through to name resolution. Once we
+        // know the file exists, edit errors (e.g. a recurrence spawn failure:
+        // "Recurrence template 'X' was not found", "Cannot compute recurrence
+        // offset: ...") MUST propagate to the outer catch so the user sees the
+        // real message — never swallowed into a misleading "No matching notes".
+        let fileExists = false;
         try {
           await fs.access(query);
-          // It's a valid absolute path - use it directly
+          fileExists = true;
+        } catch {
+          // File doesn't exist or isn't accessible - fall through to normal resolution.
+        }
+
+        if (fileExists) {
+          // It's a valid absolute path - use it directly.
           if (patchMode) {
             const editResult = await editNoteFromJson(schema, vaultDir, query, options.json!, { jsonMode });
             printEditSuccess(relative(vaultDir, query), editResult.updatedFields, jsonMode);
@@ -159,8 +171,6 @@ Examples:
             }
           }
           process.exit(0);
-        } catch {
-          // File doesn't exist or isn't accessible - fall through to normal resolution
         }
       }
 

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -15,6 +15,7 @@ import {
   getTypeFamilies,
   getDescendants,
   resolveDateGranularity,
+  getRecurrenceForType,
 } from '../schema.js';
 import { readStructuralFrontmatter } from './structural.js';
 import {
@@ -54,6 +55,15 @@ import {
   isMarkdownLink,
   isWikilink,
 } from '../links.js';
+import {
+  needsSuccessor,
+  validateRecurrenceRule,
+  CHAIN_NEXT_FIELD,
+} from '../recurrence.js';
+import {
+  findDefaultTemplateWithInheritance,
+  findAllTemplates,
+} from '../template.js';
 
 // Import file discovery functions from shared module
 import {
@@ -632,6 +642,28 @@ export async function auditFile(
     }
   }
 
+  // Recurrence backstop + config validation (#107). Skipped when the caller
+  // filtered these issue codes out.
+  const wantMissingSuccessor =
+    options.ignoreIssue !== 'missing-successor' &&
+    (options.onlyIssue === undefined || options.onlyIssue === 'missing-successor');
+  const wantInvalidRecurrence =
+    options.ignoreIssue !== 'invalid-recurrence' &&
+    (options.onlyIssue === undefined || options.onlyIssue === 'invalid-recurrence');
+
+  if (wantInvalidRecurrence || wantMissingSuccessor) {
+    issues.push(
+      ...(await checkRecurrenceIssues(
+        schema,
+        _vaultDir,
+        resolvedTypePath,
+        frontmatter,
+        wantInvalidRecurrence,
+        wantMissingSuccessor
+      ))
+    );
+  }
+
   // Check unknown fields
   for (const fieldName of Object.keys(frontmatter)) {
     // Skip discriminator fields (type, <type>-type, etc.)
@@ -904,6 +936,88 @@ function checkRelationFieldIssues(
       }
     }
 
+  }
+
+  return issues;
+}
+
+/**
+ * Recurrence detection (#107):
+ * - `invalid-recurrence`: the type's recurrence rule is broken at the config
+ *   level (malformed trigger, non-date offset base, or a template that doesn't
+ *   exist). A deterministic config error — config gets the same safety net as
+ *   data. Reported once per recurring note (so it surfaces during normal audits).
+ * - `missing-successor`: the note satisfies the trigger but its chain field
+ *   (`next`) is empty — a successor was never spawned (e.g. completed outside
+ *   bwrb). Auto-fixable: --fix spawns the missing successor (same engine as the
+ *   fast path). Suppressed when the rule is invalid (fixing it would fail).
+ */
+async function checkRecurrenceIssues(
+  schema: LoadedSchema,
+  vaultDir: string,
+  typePath: string,
+  frontmatter: Record<string, unknown>,
+  wantInvalidRecurrence: boolean,
+  wantMissingSuccessor: boolean
+): Promise<AuditIssue[]> {
+  const issues: AuditIssue[] = [];
+
+  const resolved = getRecurrenceForType(schema, typePath);
+  if (!resolved) return issues;
+
+  // Static rule validation (trigger parses; offsets are field-offsets with a
+  // date base; offset target fields exist).
+  const ruleIssues = validateRecurrenceRule(schema, typePath);
+
+  // Template existence (needs vault I/O). The successor template defaults to the
+  // type's own default template; a named template can target any type.
+  if (resolved.recurrence.template) {
+    const all = await findAllTemplates(vaultDir);
+    const named = resolved.recurrence.template;
+    const match = all.find((t) => t.name === named);
+    if (!match) {
+      ruleIssues.push({
+        message: `Recurrence trait '${resolved.trait}' on type '${typePath}' references template '${named}', which does not exist in the vault.`,
+      });
+    } else if (!getType(schema, match.templateFor)) {
+      ruleIssues.push({
+        message: `Recurrence template '${named}' targets unknown type '${match.templateFor}'.`,
+      });
+    }
+  } else {
+    // Default path: the type must have a (possibly inherited) default template
+    // to spawn from.
+    const def = await findDefaultTemplateWithInheritance(vaultDir, typePath, schema);
+    if (!def) {
+      ruleIssues.push({
+        message: `Recurrence trait '${resolved.trait}' on type '${typePath}' spawns from the type's default template, but no default template was found for '${typePath}'.`,
+      });
+    }
+  }
+
+  const ruleInvalid = ruleIssues.length > 0;
+
+  if (wantInvalidRecurrence && ruleInvalid) {
+    for (const ruleIssue of ruleIssues) {
+      issues.push({
+        severity: 'error',
+        code: 'invalid-recurrence',
+        message: ruleIssue.message,
+        autoFixable: false,
+      });
+    }
+  }
+
+  // Missing-successor backstop: only meaningful when the rule is valid (a fix
+  // would otherwise fail). Predicate: trigger satisfied AND `next` empty.
+  if (wantMissingSuccessor && !ruleInvalid && needsSuccessor(schema, typePath, frontmatter)) {
+    issues.push({
+      severity: 'warning',
+      code: 'missing-successor',
+      message: `Recurring note satisfies its trigger but has no successor ('${CHAIN_NEXT_FIELD}' is empty). Run with --fix to spawn it.`,
+      field: CHAIN_NEXT_FIELD,
+      autoFixable: true,
+    });
   }
 
   return issues;

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -55,6 +55,7 @@ import {
   type FixContext,
 } from './types.js';
 import { toMarkdownLink, toWikilink } from '../links.js';
+import { spawnSuccessor, needsSuccessor, CHAIN_NEXT_FIELD } from '../recurrence.js';
 import { maskNonProse } from './unlinked-mention.js';
 import {
   readStructuralFrontmatterFromRaw,
@@ -176,6 +177,64 @@ async function applyUnlinkedMentionFix(
   }
 
   return { file: filePath, issue, action: 'fixed' };
+}
+
+/**
+ * Apply a `missing-successor` auto-fix (#107): spawn the missing successor for a
+ * recurring note completed outside bwrb. Uses the SAME `spawnSuccessor` engine
+ * as the fast path, so the backstop produces an identical successor.
+ *
+ * Re-reads the note and re-checks `needsSuccessor` so the fix is idempotent: if
+ * the chain field is no longer empty (e.g. fixed earlier in the run, or the rule
+ * changed), it skips rather than spawning a duplicate. Honors dry-run by not
+ * writing — but spawning a file IS a write, so in dry-run we skip the spawn.
+ */
+async function applyMissingSuccessorFix(
+  schema: LoadedSchema,
+  vaultDir: string,
+  filePath: string,
+  issue: AuditIssue
+): Promise<FixResult> {
+  if (isDryRunEnabled()) {
+    return { file: filePath, issue, action: 'skipped', message: 'Dry-run: would spawn successor' };
+  }
+
+  const parsed = await parseNote(filePath);
+  const typePath = resolveTypeFromFrontmatter(schema, parsed.frontmatter);
+  if (!typePath) {
+    return { file: filePath, issue, action: 'failed', message: 'Could not resolve note type' };
+  }
+
+  // Idempotency: only spawn if still needed (trigger satisfied AND next empty).
+  if (!needsSuccessor(schema, typePath, parsed.frontmatter)) {
+    return { file: filePath, issue, action: 'skipped', message: 'Successor no longer needed' };
+  }
+
+  const predecessorName = basename(filePath, '.md');
+  const typeDef = getTypeDefByPath(schema, typePath);
+  const order = typeDef?.fieldOrder;
+
+  try {
+    const successorPath = await spawnSuccessor(
+      schema,
+      vaultDir,
+      typePath,
+      parsed.frontmatter,
+      predecessorName,
+      async (nextLink) => {
+        // Re-read to avoid clobbering any concurrent edits, then set `next`.
+        const latest = await parseNote(filePath);
+        const updated = { ...latest.frontmatter, [CHAIN_NEXT_FIELD]: nextLink };
+        await writeNote(filePath, updated, latest.body, order);
+      }
+    );
+    if (!successorPath) {
+      return { file: filePath, issue, action: 'skipped', message: 'Type does not recur' };
+    }
+    return { file: filePath, issue, action: 'fixed', message: successorPath };
+  } catch (err) {
+    return { file: filePath, issue, action: 'failed', message: (err as Error).message };
+  }
 }
 
 async function applyTrailingWhitespaceFix(filePath: string, issue: AuditIssue): Promise<FixResult> {
@@ -1430,6 +1489,25 @@ export async function runAutoFix(
           console.log(chalk.red(`    ✗ Failed to rename ${issue.field}: ${fixResult.message}`));
           failed++;
         }
+      } else if (issue.code === 'missing-successor') {
+        // Spawn the missing recurrence successor (same engine as the fast path).
+        const fixResult = await applyMissingSuccessorFix(schema, vaultDir, result.path, issue);
+        if (fixResult.action === 'fixed') {
+          console.log(chalk.cyan(`  ${result.relativePath}`));
+          console.log(chalk.green(`    ✓ Spawned successor${fixResult.message ? `: ${fixResult.message}` : ''}`));
+          fixed++;
+        } else if (fixResult.action === 'skipped') {
+          console.log(chalk.cyan(`  ${result.relativePath}`));
+          console.log(chalk.yellow(`    ⚠ ${fixResult.message}`));
+          skipped++;
+          if (!isDryRunEnabled()) {
+            registerManualReview(manualReviewNeeded, result.relativePath, issue);
+          }
+        } else {
+          console.log(chalk.cyan(`  ${result.relativePath}`));
+          console.log(chalk.red(`    ✗ Failed to spawn successor: ${fixResult.message}`));
+          failed++;
+        }
       } else {
         skipped++;
       }
@@ -1614,6 +1692,8 @@ async function handleInteractiveFix(
       return handleKeyCasingFix(schema, result, issue);
     case 'unlinked-mention':
       return handleUnlinkedMentionFix(schema, result, issue);
+    case 'missing-successor':
+      return handleMissingSuccessorFix(context, result, issue);
     default:
       // Truly non-fixable issues
       if (issue.suggestion) {
@@ -1622,6 +1702,42 @@ async function handleInteractiveFix(
       console.log(chalk.dim('    (Manual fix required - skipping)'));
       return 'skipped';
   }
+}
+
+/**
+ * Interactive handler for `missing-successor` (#107): prompt to spawn the
+ * missing recurrence successor, using the shared engine.
+ */
+async function handleMissingSuccessorFix(
+  context: FixContext,
+  result: FileAuditResult,
+  issue: AuditIssue
+): Promise<'fixed' | 'skipped' | 'failed' | 'quit'> {
+  const { schema, vaultDir, dryRun } = context;
+
+  if (dryRun) {
+    console.log(chalk.yellow('    ⚠ Would spawn missing successor'));
+    return 'fixed';
+  }
+
+  const confirmed = await promptConfirm('    Spawn the missing successor?');
+  if (confirmed === null) return 'quit';
+  if (!confirmed) {
+    console.log(chalk.dim('    → Skipped'));
+    return 'skipped';
+  }
+
+  const fixResult = await applyMissingSuccessorFix(schema, vaultDir, result.path, issue);
+  if (fixResult.action === 'fixed') {
+    console.log(chalk.green(`    ✓ Spawned successor${fixResult.message ? `: ${fixResult.message}` : ''}`));
+    return 'fixed';
+  }
+  if (fixResult.action === 'skipped') {
+    console.log(chalk.yellow(`    ⚠ ${fixResult.message}`));
+    return 'skipped';
+  }
+  console.log(chalk.red(`    ✗ ${fixResult.message}`));
+  return 'failed';
 }
 
 async function deleteNoteWithSafety(

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -56,7 +56,15 @@ export type IssueCode =
   | 'unlinked-mention'
   // Ingest safety net (#601): a proper-noun-ish term mentioned frequently across
   // the vault with no note yet. Advisory-only heuristic; NEVER auto-fixable.
-  | 'frequent-unlinked-term';
+  | 'frequent-unlinked-term'
+  // Task system (#107): a recurring note whose trigger is satisfied but whose
+  // chain field (`next`) is empty — a successor was never spawned (e.g. completed
+  // outside bwrb). Auto-fixable: --fix spawns the missing successor.
+  | 'missing-successor'
+  // Task system (#107): a recurrence rule that is broken at the config level —
+  // a non-date offset base, a malformed trigger, or a template that doesn't
+  // exist. Deterministic config error; NEVER auto-fixable.
+  | 'invalid-recurrence';
 
 /**
  * A single audit issue.

--- a/src/lib/bulk/execute.ts
+++ b/src/lib/bulk/execute.ts
@@ -3,6 +3,8 @@
  */
 
 import { parseNote, writeNote } from '../frontmatter.js';
+import { resolveTypeFromFrontmatter } from '../schema.js';
+import { applyRecurrenceFastPath } from '../recurrence-fast-path.js';
 import { discoverManagedFiles } from '../discovery.js';
 import { searchContent } from '../content-search.js';
 import { filterByPath } from '../targeting.js';
@@ -182,6 +184,28 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
       if (execute && changes.length > 0) {
         await writeNote(file.path, modified, file.body);
         fileChange.applied = true;
+
+        // Recurrence fast path: completing a recurring note via bulk
+        // (e.g. --set status=done) spawns its successor deterministically,
+        // sharing the engine with the audit backstop. No-op for non-recurring
+        // types or non-transitions; a spawn failure is recorded per file.
+        const resolvedType = resolveTypeFromFrontmatter(schema, modified);
+        if (resolvedType) {
+          try {
+            await applyRecurrenceFastPath(
+              schema,
+              vaultDir,
+              resolvedType,
+              file.path,
+              file.frontmatter,
+              modified,
+              file.body
+            );
+          } catch (recErr) {
+            const recMessage = recErr instanceof Error ? recErr.message : String(recErr);
+            result.errors.push(`Recurrence spawn failed for ${file.relativePath}: ${recMessage}`);
+          }
+        }
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/lib/bulk/execute.ts
+++ b/src/lib/bulk/execute.ts
@@ -4,7 +4,7 @@
 
 import { parseNote, writeNote } from '../frontmatter.js';
 import { resolveTypeFromFrontmatter } from '../schema.js';
-import { applyRecurrenceFastPath } from '../recurrence-fast-path.js';
+import { prepareRecurrenceFastPath, commitRecurrenceFastPath } from '../recurrence-fast-path.js';
 import { discoverManagedFiles } from '../discovery.js';
 import { searchContent } from '../content-search.js';
 import { filterByPath } from '../targeting.js';
@@ -182,17 +182,17 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
       fileChange.changes = changes;
 
       if (execute && changes.length > 0) {
-        await writeNote(file.path, modified, file.body);
-        fileChange.applied = true;
-
-        // Recurrence fast path: completing a recurring note via bulk
-        // (e.g. --set status=done) spawns its successor deterministically,
-        // sharing the engine with the audit backstop. No-op for non-recurring
-        // types or non-transitions; a spawn failure is recorded per file.
+        // Recurrence fast path (atomicity, #107): VALIDATE + COMPUTE the
+        // successor BEFORE writing the predecessor's change, so a spawn that
+        // cannot succeed (missing template, partial/unparseable offset base)
+        // leaves the predecessor UNMUTATED. A spawn failure is recorded per file
+        // and the predecessor's bulk change is skipped (not half-applied).
         const resolvedType = resolveTypeFromFrontmatter(schema, modified);
+        let recError: string | null = null;
+        let fastPathPlan = null;
         if (resolvedType) {
           try {
-            await applyRecurrenceFastPath(
+            fastPathPlan = await prepareRecurrenceFastPath(
               schema,
               vaultDir,
               resolvedType,
@@ -202,8 +202,26 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
               file.body
             );
           } catch (recErr) {
-            const recMessage = recErr instanceof Error ? recErr.message : String(recErr);
-            result.errors.push(`Recurrence spawn failed for ${file.relativePath}: ${recMessage}`);
+            recError = recErr instanceof Error ? recErr.message : String(recErr);
+          }
+        }
+
+        if (recError) {
+          // Do NOT mutate the predecessor when its successor can't be produced.
+          fileChange.error = recError;
+          result.errors.push(`Recurrence spawn failed for ${file.relativePath}: ${recError}`);
+        } else {
+          await writeNote(file.path, modified, file.body);
+          fileChange.applied = true;
+
+          // Commit the prepared spawn (create successor + back-link `next`).
+          if (fastPathPlan) {
+            try {
+              await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+            } catch (recErr) {
+              const recMessage = recErr instanceof Error ? recErr.message : String(recErr);
+              result.errors.push(`Recurrence spawn failed for ${file.relativePath}: ${recMessage}`);
+            }
           }
         }
       }

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -37,6 +37,7 @@ import {
 import { type LoadedSchema, type Field, type BodySection, getOptionValues } from '../types/schema.js';
 import { UserCancelledError } from './errors.js';
 import { expandStaticValue } from './local-date.js';
+import { applyRecurrenceFastPath } from './recurrence-fast-path.js';
 
 // ============================================================================
 // Types
@@ -229,6 +230,19 @@ export async function editNoteFromJson(
   // Write updated note
   await writeNote(filePath, normalizedFrontmatter, body, orderedFields);
 
+  // Recurrence fast path: if this write completed a recurring note (trigger
+  // transition into the trigger value, chain field empty), spawn the successor
+  // deterministically. Shared engine with the audit backstop → identical result.
+  await applyRecurrenceFastPath(
+    schema,
+    vaultDir,
+    typeDef.name,
+    filePath,
+    frontmatter,
+    normalizedFrontmatter,
+    body
+  );
+
   return { updatedFields, path: filePath };
 }
 
@@ -316,6 +330,21 @@ export async function editNoteInteractive(
   // Write updated file
   await writeNote(filePath, newFrontmatter, updatedBody, orderedFields);
   printSuccess(`\n✓ Updated: ${filePath}`);
+
+  // Recurrence fast path (see editNoteFromJson). Interactive edit reconstructs
+  // the full frontmatter, so `frontmatter` (read at the top) is the old state.
+  const fastPath = await applyRecurrenceFastPath(
+    schema,
+    vaultDir,
+    typeDef.name,
+    filePath,
+    frontmatter,
+    newFrontmatter,
+    updatedBody
+  );
+  if (fastPath.successorPath) {
+    printSuccess(`✓ Spawned recurrence successor: ${fastPath.successorPath}`);
+  }
 }
 
 // ============================================================================

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -37,7 +37,7 @@ import {
 import { type LoadedSchema, type Field, type BodySection, getOptionValues } from '../types/schema.js';
 import { UserCancelledError } from './errors.js';
 import { expandStaticValue } from './local-date.js';
-import { applyRecurrenceFastPath } from './recurrence-fast-path.js';
+import { prepareRecurrenceFastPath, commitRecurrenceFastPath } from './recurrence-fast-path.js';
 
 // ============================================================================
 // Types
@@ -227,13 +227,12 @@ export async function editNoteFromJson(
   const fieldOrder = getFrontmatterOrder(typeDef);
   const orderedFields = fieldOrder.length > 0 ? fieldOrder : Object.keys(normalizedFrontmatter);
 
-  // Write updated note
-  await writeNote(filePath, normalizedFrontmatter, body, orderedFields);
-
-  // Recurrence fast path: if this write completed a recurring note (trigger
-  // transition into the trigger value, chain field empty), spawn the successor
-  // deterministically. Shared engine with the audit backstop → identical result.
-  await applyRecurrenceFastPath(
+  // Recurrence fast path (atomicity, #107): VALIDATE + COMPUTE the successor
+  // BEFORE mutating the predecessor. If this completion would spawn a successor
+  // but the spawn can't succeed (missing template, partial/unparseable offset
+  // base), prepare throws here and we abort WITHOUT writing the predecessor —
+  // never leaving it `done` with no successor.
+  const fastPathPlan = await prepareRecurrenceFastPath(
     schema,
     vaultDir,
     typeDef.name,
@@ -242,6 +241,13 @@ export async function editNoteFromJson(
     normalizedFrontmatter,
     body
   );
+
+  // Write updated note (predecessor status change is now safe to commit).
+  await writeNote(filePath, normalizedFrontmatter, body, orderedFields);
+
+  // Commit the prepared spawn (create successor + back-link `next`). Identical
+  // result to the audit backstop, which shares the same engine.
+  await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
 
   return { updatedFields, path: filePath };
 }
@@ -327,13 +333,10 @@ export async function editNoteInteractive(
     }
   }
 
-  // Write updated file
-  await writeNote(filePath, newFrontmatter, updatedBody, orderedFields);
-  printSuccess(`\n✓ Updated: ${filePath}`);
-
-  // Recurrence fast path (see editNoteFromJson). Interactive edit reconstructs
-  // the full frontmatter, so `frontmatter` (read at the top) is the old state.
-  const fastPath = await applyRecurrenceFastPath(
+  // Recurrence fast path (atomicity, #107): VALIDATE + COMPUTE before mutating
+  // the predecessor (see editNoteFromJson). Interactive edit reconstructs the
+  // full frontmatter, so `frontmatter` (read at the top) is the old state.
+  const fastPathPlan = await prepareRecurrenceFastPath(
     schema,
     vaultDir,
     typeDef.name,
@@ -342,6 +345,13 @@ export async function editNoteInteractive(
     newFrontmatter,
     updatedBody
   );
+
+  // Write updated file (predecessor change is now safe to commit).
+  await writeNote(filePath, newFrontmatter, updatedBody, orderedFields);
+  printSuccess(`\n✓ Updated: ${filePath}`);
+
+  // Commit the prepared spawn.
+  const fastPath = await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
   if (fastPath.successorPath) {
     printSuccess(`✓ Spawned recurrence successor: ${fastPath.successorPath}`);
   }

--- a/src/lib/recurrence-fast-path.ts
+++ b/src/lib/recurrence-fast-path.ts
@@ -1,0 +1,99 @@
+/**
+ * Recurrence fast path (#107).
+ * ============================
+ *
+ * The deterministic side-effect that fires when a recurring note is completed
+ * THROUGH bwrb (`bwrb edit`, `bwrb bulk --set status=done`). It detects the
+ * trigger transition, guards idempotency, and spawns the successor via the
+ * shared recurrence engine — so the fast path and the audit backstop produce
+ * identical successors.
+ *
+ * The caller has already written the predecessor's new frontmatter to disk.
+ * This helper:
+ *   1. checks the type recurs and the write transitioned the trigger field
+ *      INTO its trigger value (old != trigger, new == trigger),
+ *   2. checks the chain field (`next`) is empty (idempotency guard),
+ *   3. spawns the successor and writes the predecessor's `next` link back.
+ *
+ * It is a no-op (and never throws) when the type does not recur or no
+ * transition occurred. A spawn failure is surfaced as a thrown error so the
+ * command can report it.
+ */
+
+import { writeNote } from './frontmatter.js';
+import { getFrontmatterOrder, getRecurrenceForType } from './schema.js';
+import { getType } from './schema.js';
+import {
+  CHAIN_NEXT_FIELD,
+  isTriggerTransition,
+  parseTrigger,
+  spawnSuccessor,
+} from './recurrence.js';
+import type { LoadedSchema } from '../types/schema.js';
+
+export interface FastPathResult {
+  /** Path of the spawned successor, if one was created. */
+  successorPath: string | null;
+}
+
+/**
+ * Apply the recurrence fast path after a note write.
+ *
+ * @param schema - loaded schema
+ * @param vaultDir - vault directory
+ * @param typeName - resolved type of the written note
+ * @param filePath - absolute path of the written (predecessor) note
+ * @param oldFrontmatter - frontmatter BEFORE the write (to detect the transition)
+ * @param newFrontmatter - frontmatter AFTER the write (now on disk)
+ * @param body - the note body (preserved when rewriting the `next` link)
+ */
+export async function applyRecurrenceFastPath(
+  schema: LoadedSchema,
+  vaultDir: string,
+  typeName: string,
+  filePath: string,
+  oldFrontmatter: Record<string, unknown>,
+  newFrontmatter: Record<string, unknown>,
+  body: string
+): Promise<FastPathResult> {
+  const resolved = getRecurrenceForType(schema, typeName);
+  if (!resolved) return { successorPath: null };
+
+  const trigger = parseTrigger(resolved.recurrence.on);
+  if (!trigger) return { successorPath: null };
+
+  // Only spawn on a transition INTO the trigger value.
+  if (!isTriggerTransition(trigger, oldFrontmatter[trigger.field], newFrontmatter[trigger.field])) {
+    return { successorPath: null };
+  }
+
+  // Idempotency guard: never spawn if the chain field already points somewhere.
+  const chainValue = newFrontmatter[CHAIN_NEXT_FIELD];
+  const chainEmpty =
+    chainValue === undefined ||
+    chainValue === null ||
+    (typeof chainValue === 'string' && chainValue.trim() === '') ||
+    (Array.isArray(chainValue) && chainValue.length === 0);
+  if (!chainEmpty) {
+    return { successorPath: null };
+  }
+
+  const predecessorName = filePath.split('/').pop()?.replace(/\.md$/, '') ?? '';
+  const typeDef = getType(schema, typeName);
+  const order = typeDef ? getFrontmatterOrder(typeDef) : undefined;
+
+  const successorPath = await spawnSuccessor(
+    schema,
+    vaultDir,
+    typeName,
+    newFrontmatter,
+    predecessorName,
+    async (nextLink) => {
+      // Persist the predecessor's `next` link by rewriting the just-written note.
+      const updated = { ...newFrontmatter, [CHAIN_NEXT_FIELD]: nextLink };
+      await writeNote(filePath, updated, body, order && order.length > 0 ? order : Object.keys(updated));
+    }
+  );
+
+  return { successorPath };
+}

--- a/src/lib/recurrence-fast-path.ts
+++ b/src/lib/recurrence-fast-path.ts
@@ -8,16 +8,20 @@
  * shared recurrence engine — so the fast path and the audit backstop produce
  * identical successors.
  *
- * The caller has already written the predecessor's new frontmatter to disk.
- * This helper:
- *   1. checks the type recurs and the write transitioned the trigger field
- *      INTO its trigger value (old != trigger, new == trigger),
- *   2. checks the chain field (`next`) is empty (idempotency guard),
- *   3. spawns the successor and writes the predecessor's `next` link back.
+ * ATOMICITY (#107 blocker): completing a recurring note must be all-or-nothing.
+ * The predecessor must never be left `status: done` with no successor because
+ * the spawn failed (missing template, unparseable/partial offset base). To
+ * guarantee this, the fast path is two-phase:
  *
- * It is a no-op (and never throws) when the type does not recur or no
- * transition occurred. A spawn failure is surfaced as a thrown error so the
- * command can report it.
+ *   1. `prepareRecurrenceFastPath` — VALIDATE and COMPUTE the successor (template
+ *      exists, trigger transition detected, offset base parses to a real date)
+ *      WITHOUT writing anything. Called BEFORE the predecessor's status change is
+ *      written. If the successor can't be produced, it throws and the caller
+ *      aborts without mutating the predecessor.
+ *   2. `commitRecurrenceFastPath` — create the successor and back-link the
+ *      predecessor's `next`. Called AFTER the predecessor write has succeeded.
+ *
+ * It is a no-op when the type does not recur or no transition occurred.
  */
 
 import { writeNote } from './frontmatter.js';
@@ -27,7 +31,9 @@ import {
   CHAIN_NEXT_FIELD,
   isTriggerTransition,
   parseTrigger,
-  spawnSuccessor,
+  prepareSuccessor,
+  commitSuccessor,
+  type PreparedSuccessor,
 } from './recurrence.js';
 import type { LoadedSchema } from '../types/schema.js';
 
@@ -37,17 +43,33 @@ export interface FastPathResult {
 }
 
 /**
- * Apply the recurrence fast path after a note write.
+ * A validated fast-path spawn, ready to commit once the predecessor write has
+ * landed. Null `prepared` means "no spawn needed" (no transition / already
+ * chained / type doesn't recur) — committing it is a no-op.
+ */
+export interface PreparedFastPath {
+  prepared: PreparedSuccessor | null;
+  predecessorName: string;
+  order: string[] | undefined;
+  filePath: string;
+  body: string;
+}
+
+/**
+ * Phase 1: validate + compute the fast-path successor WITHOUT writing anything.
+ *
+ * Throws the real, deterministic error (missing template, partial/unparseable
+ * offset base) so the caller can abort BEFORE mutating the predecessor.
  *
  * @param schema - loaded schema
  * @param vaultDir - vault directory
- * @param typeName - resolved type of the written note
- * @param filePath - absolute path of the written (predecessor) note
+ * @param typeName - resolved type of the note being written
+ * @param filePath - absolute path of the (predecessor) note
  * @param oldFrontmatter - frontmatter BEFORE the write (to detect the transition)
- * @param newFrontmatter - frontmatter AFTER the write (now on disk)
+ * @param newFrontmatter - frontmatter AFTER the write (about to be on disk)
  * @param body - the note body (preserved when rewriting the `next` link)
  */
-export async function applyRecurrenceFastPath(
+export async function prepareRecurrenceFastPath(
   schema: LoadedSchema,
   vaultDir: string,
   typeName: string,
@@ -55,16 +77,23 @@ export async function applyRecurrenceFastPath(
   oldFrontmatter: Record<string, unknown>,
   newFrontmatter: Record<string, unknown>,
   body: string
-): Promise<FastPathResult> {
+): Promise<PreparedFastPath> {
+  const predecessorName = filePath.split('/').pop()?.replace(/\.md$/, '') ?? '';
+  const typeDef = getType(schema, typeName);
+  const orderList = typeDef ? getFrontmatterOrder(typeDef) : undefined;
+  const order = orderList && orderList.length > 0 ? orderList : undefined;
+
+  const noop: PreparedFastPath = { prepared: null, predecessorName, order, filePath, body };
+
   const resolved = getRecurrenceForType(schema, typeName);
-  if (!resolved) return { successorPath: null };
+  if (!resolved) return noop;
 
   const trigger = parseTrigger(resolved.recurrence.on);
-  if (!trigger) return { successorPath: null };
+  if (!trigger) return noop;
 
   // Only spawn on a transition INTO the trigger value.
   if (!isTriggerTransition(trigger, oldFrontmatter[trigger.field], newFrontmatter[trigger.field])) {
-    return { successorPath: null };
+    return noop;
   }
 
   // Idempotency guard: never spawn if the chain field already points somewhere.
@@ -75,23 +104,46 @@ export async function applyRecurrenceFastPath(
     (typeof chainValue === 'string' && chainValue.trim() === '') ||
     (Array.isArray(chainValue) && chainValue.length === 0);
   if (!chainEmpty) {
-    return { successorPath: null };
+    return noop;
   }
 
-  const predecessorName = filePath.split('/').pop()?.replace(/\.md$/, '') ?? '';
-  const typeDef = getType(schema, typeName);
-  const order = typeDef ? getFrontmatterOrder(typeDef) : undefined;
+  // Validate + compute WITHOUT writing. Throws on a spawn that cannot succeed
+  // (missing template, partial/unparseable offset base) — the caller aborts
+  // before mutating the predecessor.
+  const prepared = await prepareSuccessor(schema, vaultDir, typeName, newFrontmatter, predecessorName);
+  return { prepared, predecessorName, order, filePath, body };
+}
 
-  const successorPath = await spawnSuccessor(
+/**
+ * Phase 2: commit a prepared fast-path spawn — create the successor and write
+ * the predecessor's `next` link. Call only AFTER the predecessor write landed.
+ * A no-op when nothing was prepared.
+ */
+export async function commitRecurrenceFastPath(
+  schema: LoadedSchema,
+  vaultDir: string,
+  plan: PreparedFastPath
+): Promise<FastPathResult> {
+  if (!plan.prepared) return { successorPath: null };
+
+  // The latest predecessor frontmatter is the one just written. Re-read so the
+  // `next` link is added on top of the committed status change.
+  const { parseNote } = await import('./frontmatter.js');
+
+  const successorPath = await commitSuccessor(
     schema,
     vaultDir,
-    typeName,
-    newFrontmatter,
-    predecessorName,
+    plan.predecessorName,
+    plan.prepared,
     async (nextLink) => {
-      // Persist the predecessor's `next` link by rewriting the just-written note.
-      const updated = { ...newFrontmatter, [CHAIN_NEXT_FIELD]: nextLink };
-      await writeNote(filePath, updated, body, order && order.length > 0 ? order : Object.keys(updated));
+      const latest = await parseNote(plan.filePath);
+      const updated = { ...latest.frontmatter, [CHAIN_NEXT_FIELD]: nextLink };
+      await writeNote(
+        plan.filePath,
+        updated,
+        latest.body,
+        plan.order ?? Object.keys(updated)
+      );
     }
   );
 

--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -12,7 +12,8 @@
  *
  * - Fast path: completing via `bwrb edit` / `bwrb bulk --set status=done`
  *   spawns the successor immediately as a deterministic side-effect of the
- *   write (see `maybeSpawnSuccessor`, called from the edit layer).
+ *   write (see `prepareRecurrenceFastPath` / `commitRecurrenceFastPath`, called
+ *   from the edit and bulk layers).
  * - Backstop: completing OUTSIDE bwrb (hand-edited frontmatter) is caught on
  *   the next `bwrb audit` — "trigger satisfied AND chain field empty AND type
  *   recurs" → `missing-successor`, auto-fixable via the same spawn.
@@ -24,15 +25,32 @@
 
 import { basename, join } from 'path';
 import { existsSync } from 'fs';
-import type { LoadedSchema } from '../types/schema.js';
+import type { LoadedSchema, Template } from '../types/schema.js';
 import { getRecurrenceForType, getFieldsForType, getType, getOutputDir } from './schema.js';
-import { parseDate } from './local-date.js';
+import { parseDate, parsePartialIsoDate } from './local-date.js';
 import { formatDateWithPattern } from './local-date.js';
 import { formatValue } from './vault.js';
 import { getFilenamePattern } from './template.js';
 import { createNoteFromJson } from '../commands/new/json-mode.js';
 import { findDefaultTemplateWithInheritance } from './template.js';
 import type { NoteCreationResult } from '../commands/new/types.js';
+
+/**
+ * Build a CLEAN chain link value for a note name — i.e. an UN-pre-quoted link
+ * (`[[name]]` or `[name](name.md)`), NOT the raw-YAML pre-quoted string that
+ * `formatValue` returns (`"[[name]]"`).
+ *
+ * This is the value to place into a frontmatter OBJECT before YAML serialization:
+ * the serializer quotes it exactly once, producing `"[[name]]"` on disk. Using
+ * `formatValue` here instead would double-wrap (`'"[[name]]"'`) — the corrupted
+ * `next` bug (#107). The successor's `prev` link is symmetric: it flows through
+ * `createNoteFromJson`, whose `stripRedundantWikilinkQuotes` strips the
+ * pre-quoting before serialization, so both links end up byte-identical.
+ */
+function cleanChainLink(name: string, linkFormat: 'wikilink' | 'markdown'): string {
+  if (!name) return '';
+  return linkFormat === 'markdown' ? `[${name}](${name}.md)` : `[[${name}]]`;
+}
 
 /** The forward chain field. Empty `next` is the idempotency guard. */
 export const CHAIN_NEXT_FIELD = 'next';
@@ -260,11 +278,20 @@ export function computeOffsetFields(
     }
     const baseRaw = predecessor[offset.baseField];
     if (baseRaw === undefined || baseRaw === null || String(baseRaw).trim() === '') {
-      throw new Error(`Recurrence set.${field}: base date field '${offset.baseField}' is empty on the predecessor.`);
+      throw new Error(`Cannot compute recurrence offset: '${offset.baseField}' has no date value on the predecessor.`);
     }
     const parsed = parseDate(String(baseRaw));
     if (!parsed.valid || !parsed.date) {
-      throw new Error(`Recurrence set.${field}: base date field '${offset.baseField}' value "${String(baseRaw)}" is not a valid date.`);
+      // A partial date (year or year-month granularity) is a valid value but
+      // cannot be offset by a day/week rule — surface a clear, deterministic
+      // error rather than the generic "not a valid date".
+      const partial = parsePartialIsoDate(String(baseRaw));
+      if (partial.valid && partial.precision !== 'day') {
+        throw new Error(
+          `Cannot compute recurrence offset: '${offset.baseField}' has a partial date value "${String(baseRaw)}" (${partial.precision} granularity) that cannot be offset by "${expr}".`
+        );
+      }
+      throw new Error(`Cannot compute recurrence offset: '${offset.baseField}' value "${String(baseRaw)}" is not a valid date.`);
     }
     const next = addOffset(parsed.date, offset);
     out[field] = formatDateWithPattern(next, schema.config.dateFormat);
@@ -402,36 +429,44 @@ function resolveSuccessorName(
 }
 
 /**
- * Spawn a successor for a recurring note, then back-link the predecessor's
- * `next` field to it. Shared by the fast path and the backstop so both produce
- * identical successors.
- *
- * IDEMPOTENCY: callers MUST confirm the chain field is empty before calling
- * (the fast path checks the transition; the backstop checks `needsSuccessor`).
- * This function does not re-check, so it is the single spawn primitive.
- *
- * Returns the created successor path, or null when the rule produces no
- * successor (e.g. type does not recur).
- *
- * @param writePredecessorNext - callback to persist the predecessor's `next`
- *   link. The two paths persist differently (edit layer rewrites the note it
- *   already holds; the backstop writes the file directly), so the caller owns
- *   the write while this function owns the value.
+ * A validated, ready-to-commit successor spawn. Produced by `prepareSuccessor`
+ * WITHOUT mutating anything; committed by `commitSuccessor`. Splitting the two
+ * phases lets a caller validate the spawn (template exists, offsets compute to
+ * real dates) BEFORE writing the predecessor's status change, so a spawn that
+ * cannot succeed never leaves the predecessor `done` with no successor (#107).
  */
-export async function spawnSuccessor(
+export interface PreparedSuccessor {
+  spawnType: string;
+  template: Template | null;
+  input: Record<string, unknown>;
+}
+
+/**
+ * Validate and compute a successor spawn WITHOUT writing anything.
+ *
+ * Resolves the successor template (throws if a named template is missing or
+ * targets an unknown type) and computes the offset date fields (throws if the
+ * offset base is missing, partial, or unparseable). Returns null only when the
+ * type does not recur.
+ *
+ * This is the atomicity guard: callers run this BEFORE mutating the predecessor,
+ * so any failure aborts the whole operation with the real error and the
+ * predecessor is left untouched.
+ */
+export async function prepareSuccessor(
   schema: LoadedSchema,
   vaultDir: string,
   typeName: string,
   predecessor: Record<string, unknown>,
-  predecessorName: string,
-  writePredecessorNext: (nextLink: string) => Promise<void>
-): Promise<string | null> {
+  predecessorName: string
+): Promise<PreparedSuccessor | null> {
   const resolved = getRecurrenceForType(schema, typeName);
   if (!resolved) return null;
 
   const { template, spawnType } = await resolveSuccessorTemplate(schema, vaultDir, typeName);
 
-  // Offset fields are computed against the recurring type's date fields.
+  // Offset fields are computed against the recurring type's date fields. This
+  // throws a clear, deterministic error for a missing/partial/unparseable base.
   const offsetFields = computeOffsetFields(schema, typeName, predecessor);
 
   // Resolve a successor name that won't collide with the predecessor's filename.
@@ -453,14 +488,33 @@ export async function spawnSuccessor(
     offsetFields
   );
 
+  return { spawnType, template, input };
+}
+
+/**
+ * Commit a previously-prepared successor: create the successor note, then
+ * back-link the predecessor's `next` field to it.
+ *
+ * @param writePredecessorNext - callback to persist the predecessor's `next`
+ *   link. The two paths persist differently (edit layer rewrites the note it
+ *   already holds; the backstop writes the file directly), so the caller owns
+ *   the write while this function owns the value.
+ */
+export async function commitSuccessor(
+  schema: LoadedSchema,
+  vaultDir: string,
+  predecessorName: string,
+  prepared: PreparedSuccessor,
+  writePredecessorNext: (nextLink: string) => Promise<void>
+): Promise<string> {
   let result: NoteCreationResult;
   try {
     result = await createNoteFromJson(
       schema,
       vaultDir,
-      spawnType,
-      JSON.stringify(input),
-      template,
+      prepared.spawnType,
+      JSON.stringify(prepared.input),
+      prepared.template,
       { noInstances: true }
     );
   } catch (err) {
@@ -468,10 +522,45 @@ export async function spawnSuccessor(
   }
 
   // Back-link the predecessor's `next` to the freshly created successor (using
-  // the actual created filename, in case a filename pattern reshaped it).
+  // the actual created filename, in case a filename pattern reshaped it). Write
+  // a CLEAN link (`[[name]]`) — NOT a pre-quoted `formatValue` string — so the
+  // YAML serializer quotes it exactly once, byte-symmetric with the successor's
+  // `prev` (which flows through createNoteFromJson's quote-stripping).
   const createdName = basenameNoExt(result.path);
-  const nextLink = formatValue(createdName, schema.config.linkFormat);
+  const nextLink = cleanChainLink(createdName, schema.config.linkFormat);
   await writePredecessorNext(nextLink);
 
   return result.path;
+}
+
+/**
+ * Spawn a successor for a recurring note, then back-link the predecessor's
+ * `next` field to it. Shared by the fast path and the backstop so both produce
+ * identical successors.
+ *
+ * IDEMPOTENCY: callers MUST confirm the chain field is empty before calling
+ * (the fast path checks the transition; the backstop checks `needsSuccessor`).
+ * This function does not re-check, so it is the single spawn primitive.
+ *
+ * Returns the created successor path, or null when the rule produces no
+ * successor (e.g. type does not recur).
+ *
+ * NOTE: this is a convenience wrapper that prepares and commits in one step. For
+ * ATOMIC completion (validate before mutating the predecessor), callers should
+ * use `prepareSuccessor` first and only `commitSuccessor` after writing.
+ *
+ * @param writePredecessorNext - callback to persist the predecessor's `next`
+ *   link.
+ */
+export async function spawnSuccessor(
+  schema: LoadedSchema,
+  vaultDir: string,
+  typeName: string,
+  predecessor: Record<string, unknown>,
+  predecessorName: string,
+  writePredecessorNext: (nextLink: string) => Promise<void>
+): Promise<string | null> {
+  const prepared = await prepareSuccessor(schema, vaultDir, typeName, predecessor, predecessorName);
+  if (!prepared) return null;
+  return commitSuccessor(schema, vaultDir, predecessorName, prepared, writePredecessorNext);
 }

--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -1,0 +1,477 @@
+/**
+ * Task recurrence: spawn-on-transition (#107).
+ * =============================================
+ *
+ * The heart of the task system. Declaratively: "when a field transitions to a
+ * value (e.g. `status` enters `done`), spawn a successor note from a template,
+ * with the successor's date field offset from a predecessor date field." No
+ * cron, no daemon, no LLM — the trigger is a field transition, not a clock.
+ *
+ * This module is the SINGLE source of truth shared by BOTH execution paths so
+ * they produce identical successors:
+ *
+ * - Fast path: completing via `bwrb edit` / `bwrb bulk --set status=done`
+ *   spawns the successor immediately as a deterministic side-effect of the
+ *   write (see `maybeSpawnSuccessor`, called from the edit layer).
+ * - Backstop: completing OUTSIDE bwrb (hand-edited frontmatter) is caught on
+ *   the next `bwrb audit` — "trigger satisfied AND chain field empty AND type
+ *   recurs" → `missing-successor`, auto-fixable via the same spawn.
+ *
+ * Idempotency is paramount: a successor is spawned ONLY when the chain field
+ * (`next`) is empty. Re-completing a task that already has a `next` is a no-op
+ * on either path.
+ */
+
+import { basename, join } from 'path';
+import { existsSync } from 'fs';
+import type { LoadedSchema } from '../types/schema.js';
+import { getRecurrenceForType, getFieldsForType, getType, getOutputDir } from './schema.js';
+import { parseDate } from './local-date.js';
+import { formatDateWithPattern } from './local-date.js';
+import { formatValue } from './vault.js';
+import { getFilenamePattern } from './template.js';
+import { createNoteFromJson } from '../commands/new/json-mode.js';
+import { findDefaultTemplateWithInheritance } from './template.js';
+import type { NoteCreationResult } from '../commands/new/types.js';
+
+/** The forward chain field. Empty `next` is the idempotency guard. */
+export const CHAIN_NEXT_FIELD = 'next';
+/** The optional back-link chain field, set on the spawned successor. */
+const CHAIN_PREV_FIELD = 'prev';
+
+/**
+ * A parsed `on:` trigger, e.g. `"status = done"` → { field: 'status', value: 'done' }.
+ */
+export interface RecurrenceTrigger {
+  field: string;
+  value: string;
+}
+
+/**
+ * Parse an `on:` trigger expression of the form `<field> = <value>`.
+ * Returns null when the expression is malformed.
+ */
+export function parseTrigger(on: string): RecurrenceTrigger | null {
+  const eq = on.indexOf('=');
+  if (eq === -1) return null;
+  const field = on.slice(0, eq).trim();
+  // Strip an optional surrounding pair of quotes from the value.
+  let value = on.slice(eq + 1).trim();
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    value = value.slice(1, -1);
+  }
+  if (!field || !value) return null;
+  return { field, value };
+}
+
+/**
+ * A parsed field-offset expression, e.g. `"deadline + 7d"`.
+ */
+export interface FieldOffset {
+  baseField: string;
+  sign: 1 | -1;
+  amount: number;
+  unit: OffsetUnit;
+}
+
+type OffsetUnit = 'min' | 'h' | 'd' | 'w' | 'mon' | 'y';
+
+const OFFSET_PATTERN = /^([A-Za-z0-9_-]+)\s*([+-])\s*(\d+)(min|h|d|w|mon|m|y)$/;
+
+/**
+ * Parse a field-offset expression `<dateField> <+|-> <amount><unit>`.
+ * Returns null when it isn't a field-offset expression.
+ */
+export function parseFieldOffset(expr: string): FieldOffset | null {
+  const m = expr.trim().match(OFFSET_PATTERN);
+  if (!m) return null;
+  const rawUnit = m[4]!;
+  const unit: OffsetUnit = rawUnit === 'm' ? 'mon' : (rawUnit as OffsetUnit);
+  return {
+    baseField: m[1]!,
+    sign: m[2] === '-' ? -1 : 1,
+    amount: parseInt(m[3]!, 10),
+    unit,
+  };
+}
+
+/**
+ * Add a calendar offset to a Date. Days/weeks/hours/minutes use exact
+ * arithmetic; months and years use calendar-aware addition so "deadline + 1mon"
+ * lands on the same day-of-month next month rather than drifting by 30 days.
+ */
+function addOffset(date: Date, offset: FieldOffset): Date {
+  const d = new Date(date.getTime());
+  const n = offset.sign * offset.amount;
+  switch (offset.unit) {
+    case 'min':
+      d.setMinutes(d.getMinutes() + n);
+      break;
+    case 'h':
+      d.setHours(d.getHours() + n);
+      break;
+    case 'd':
+      d.setDate(d.getDate() + n);
+      break;
+    case 'w':
+      d.setDate(d.getDate() + n * 7);
+      break;
+    case 'mon':
+      d.setMonth(d.getMonth() + n);
+      break;
+    case 'y':
+      d.setFullYear(d.getFullYear() + n);
+      break;
+  }
+  return d;
+}
+
+/**
+ * Result of validating a recurrence rule against the schema. Used by the audit
+ * template/offset validation so a broken rule is a deterministic error.
+ */
+export interface RecurrenceValidationIssue {
+  message: string;
+}
+
+/**
+ * Validate a recurrence rule statically against the schema (no vault I/O):
+ * - the trigger parses,
+ * - every `set` value is a field-offset expression whose base is a DATE field,
+ * - the target field of each `set` exists on the spawned type.
+ *
+ * Template existence is checked separately (it needs vault I/O) by the audit.
+ */
+export function validateRecurrenceRule(
+  schema: LoadedSchema,
+  typeName: string
+): RecurrenceValidationIssue[] {
+  const issues: RecurrenceValidationIssue[] = [];
+  const resolved = getRecurrenceForType(schema, typeName);
+  if (!resolved) return issues;
+
+  const { recurrence, trait } = resolved;
+
+  const trigger = parseTrigger(recurrence.on);
+  if (!trigger) {
+    issues.push({
+      message: `Recurrence trait '${trait}' on type '${typeName}' has an invalid 'on' trigger: "${recurrence.on}". Expected "<field> = <value>".`,
+    });
+  }
+
+  // The successor's type is the spawned type. Without a named template we spawn
+  // the same type (a task begets a task), so validate offsets against this type.
+  const targetFields = getFieldsForType(schema, typeName);
+
+  for (const [field, expr] of Object.entries(recurrence.set ?? {})) {
+    const offset = parseFieldOffset(expr);
+    if (!offset) {
+      issues.push({
+        message: `Recurrence trait '${trait}' on type '${typeName}': set.${field} = "${expr}" is not a field-offset expression. Use "<dateField> + <duration>" (e.g. "deadline + 7d").`,
+      });
+      continue;
+    }
+    const baseFieldDef = targetFields[offset.baseField];
+    if (!baseFieldDef) {
+      issues.push({
+        message: `Recurrence trait '${trait}' on type '${typeName}': set.${field} references unknown base field '${offset.baseField}'.`,
+      });
+      continue;
+    }
+    if (baseFieldDef.prompt !== 'date') {
+      issues.push({
+        message: `Recurrence trait '${trait}' on type '${typeName}': set.${field} base '${offset.baseField}' must be a date field (offset base must be a date).`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Whether a note (by its current frontmatter) currently satisfies the trigger
+ * AND has not yet spawned a successor (chain field empty). This is exactly the
+ * backstop predicate: "trigger satisfied AND `next` empty AND type recurs".
+ */
+export function needsSuccessor(
+  schema: LoadedSchema,
+  typeName: string,
+  frontmatter: Record<string, unknown>
+): boolean {
+  const resolved = getRecurrenceForType(schema, typeName);
+  if (!resolved) return false;
+
+  const trigger = parseTrigger(resolved.recurrence.on);
+  if (!trigger) return false;
+
+  if (!valueEquals(frontmatter[trigger.field], trigger.value)) return false;
+
+  return isChainFieldEmpty(frontmatter[CHAIN_NEXT_FIELD]);
+}
+
+/**
+ * Detect whether a write transitions the trigger field INTO its trigger value
+ * (old != trigger, new == trigger). Used by the fast path.
+ */
+export function isTriggerTransition(
+  trigger: RecurrenceTrigger,
+  oldValue: unknown,
+  newValue: unknown
+): boolean {
+  return !valueEquals(oldValue, trigger.value) && valueEquals(newValue, trigger.value);
+}
+
+function valueEquals(value: unknown, target: string): boolean {
+  if (value === undefined || value === null) return false;
+  return String(value) === target;
+}
+
+function isChainFieldEmpty(value: unknown): boolean {
+  if (value === undefined || value === null) return true;
+  if (typeof value === 'string') return value.trim() === '';
+  if (Array.isArray(value)) return value.length === 0;
+  return false;
+}
+
+/**
+ * Compute the successor's field-offset assignments from the predecessor
+ * frontmatter. Throws when a base date field is missing or unparseable — these
+ * are surfaced to the caller (fast path → error; backstop → fix failure).
+ *
+ * Returned values are formatted with the vault's date format, so they match the
+ * normalization both creation paths apply.
+ */
+export function computeOffsetFields(
+  schema: LoadedSchema,
+  typeName: string,
+  predecessor: Record<string, unknown>
+): Record<string, string> {
+  const resolved = getRecurrenceForType(schema, typeName);
+  if (!resolved?.recurrence.set) return {};
+
+  const out: Record<string, string> = {};
+  for (const [field, expr] of Object.entries(resolved.recurrence.set)) {
+    const offset = parseFieldOffset(expr);
+    if (!offset) {
+      throw new Error(`Recurrence set.${field} = "${expr}" is not a valid field-offset expression.`);
+    }
+    const baseRaw = predecessor[offset.baseField];
+    if (baseRaw === undefined || baseRaw === null || String(baseRaw).trim() === '') {
+      throw new Error(`Recurrence set.${field}: base date field '${offset.baseField}' is empty on the predecessor.`);
+    }
+    const parsed = parseDate(String(baseRaw));
+    if (!parsed.valid || !parsed.date) {
+      throw new Error(`Recurrence set.${field}: base date field '${offset.baseField}' value "${String(baseRaw)}" is not a valid date.`);
+    }
+    const next = addOffset(parsed.date, offset);
+    out[field] = formatDateWithPattern(next, schema.config.dateFormat);
+  }
+  return out;
+}
+
+/**
+ * The successor note's basename (used to write the predecessor's `next` link).
+ * Derived from the created file path.
+ */
+function basenameNoExt(filePath: string): string {
+  return basename(filePath, '.md');
+}
+
+/**
+ * Build the successor frontmatter input (the JSON given to the real creation
+ * path), shared by both execution paths so they produce identical successors.
+ *
+ * - `name` is carried over from the predecessor (so the chain reads naturally),
+ *   unless a filename pattern makes it unnecessary; we always pass it as a safe
+ *   fallback.
+ * - The trigger field is reset so the successor starts fresh (never spawned
+ *   already-done → no infinite chain).
+ * - `prev` points back at the predecessor; `next` is left empty.
+ * - Offset date fields are computed from the predecessor.
+ */
+function buildSuccessorInput(
+  schema: LoadedSchema,
+  recurringTypeName: string,
+  spawnTypeName: string,
+  predecessorName: string,
+  successorName: string,
+  offsetFields: Record<string, string>
+): Record<string, unknown> {
+  const resolved = getRecurrenceForType(schema, recurringTypeName)!;
+  const trigger = parseTrigger(resolved.recurrence.on)!;
+  const fields = getFieldsForType(schema, spawnTypeName);
+
+  const input: Record<string, unknown> = {};
+
+  // The successor's name (disambiguated by the caller so it never collides with
+  // the predecessor's filename).
+  input['name'] = successorName;
+
+  // Reset the trigger field so the successor starts fresh (not already-done).
+  // Prefer the field's schema default; otherwise drop it so defaults apply.
+  const triggerFieldDef = fields[trigger.field];
+  if (triggerFieldDef?.default !== undefined) {
+    input[trigger.field] = triggerFieldDef.default;
+  }
+  // (If there's no default, omit it: applyDefaults / schema handle the rest, and
+  // crucially we never set it to the trigger value.)
+
+  // Apply computed offset date fields.
+  for (const [field, value] of Object.entries(offsetFields)) {
+    input[field] = value;
+  }
+
+  // Back-link to the predecessor; leave the forward link empty.
+  if (fields[CHAIN_PREV_FIELD]) {
+    input[CHAIN_PREV_FIELD] = formatValue(predecessorName, schema.config.linkFormat);
+  }
+
+  return input;
+}
+
+/**
+ * Resolve which template the successor is spawned from. Defaults to the
+ * completed note's type default template; a named template (`recurrence.template`)
+ * can spawn a different type. Returns the resolved template and the type to
+ * create. Throws when a named template is missing or its `template-for` type is
+ * unknown (deterministic config error).
+ */
+async function resolveSuccessorTemplate(
+  schema: LoadedSchema,
+  vaultDir: string,
+  typeName: string
+): Promise<{ template: import('../types/schema.js').Template | null; spawnType: string }> {
+  const resolved = getRecurrenceForType(schema, typeName)!;
+  const named = resolved.recurrence.template;
+
+  if (named) {
+    // A named template can spawn a DIFFERENT type. Search the whole vault for a
+    // template with this name, regardless of the type it targets.
+    const { findAllTemplates } = await import('./template.js');
+    const all = await findAllTemplates(vaultDir);
+    const match = all.find((t) => t.name === named);
+    if (!match) {
+      throw new Error(`Recurrence template '${named}' (type '${typeName}') was not found in the vault.`);
+    }
+    const spawnType = match.templateFor;
+    if (!getType(schema, spawnType)) {
+      throw new Error(`Recurrence template '${named}' targets unknown type '${spawnType}'.`);
+    }
+    return { template: match, spawnType };
+  }
+
+  // Default: the type's own default template (a task begets a task).
+  const def = await findDefaultTemplateWithInheritance(vaultDir, typeName, schema);
+  return { template: def, spawnType: typeName };
+}
+
+/**
+ * Resolve a collision-free successor name.
+ *
+ * If the spawn type (or its template) defines a filename pattern, that pattern
+ * disambiguates the filename (commonly via a date), so the carried-forward name
+ * is returned unchanged. Otherwise the successor would be filed as
+ * `<name>.md` — identical to the predecessor — so we suffix ` 2`, ` 3`, ...
+ * against the spawn type's output directory until a free name is found.
+ */
+function resolveSuccessorName(
+  schema: LoadedSchema,
+  vaultDir: string,
+  spawnType: string,
+  template: import('../types/schema.js').Template | null,
+  baseName: string
+): string {
+  const typeDef = getType(schema, spawnType);
+  const pattern = typeDef ? getFilenamePattern(template, typeDef) : null;
+  if (pattern) {
+    return baseName;
+  }
+
+  const outputDir = getOutputDir(schema, spawnType);
+  const dir = outputDir ? join(vaultDir, outputDir) : vaultDir;
+
+  const exists = (name: string): boolean => existsSync(join(dir, `${name}.md`));
+  if (!exists(baseName)) return baseName;
+
+  let counter = 2;
+  while (exists(`${baseName} ${counter}`)) counter++;
+  return `${baseName} ${counter}`;
+}
+
+/**
+ * Spawn a successor for a recurring note, then back-link the predecessor's
+ * `next` field to it. Shared by the fast path and the backstop so both produce
+ * identical successors.
+ *
+ * IDEMPOTENCY: callers MUST confirm the chain field is empty before calling
+ * (the fast path checks the transition; the backstop checks `needsSuccessor`).
+ * This function does not re-check, so it is the single spawn primitive.
+ *
+ * Returns the created successor path, or null when the rule produces no
+ * successor (e.g. type does not recur).
+ *
+ * @param writePredecessorNext - callback to persist the predecessor's `next`
+ *   link. The two paths persist differently (edit layer rewrites the note it
+ *   already holds; the backstop writes the file directly), so the caller owns
+ *   the write while this function owns the value.
+ */
+export async function spawnSuccessor(
+  schema: LoadedSchema,
+  vaultDir: string,
+  typeName: string,
+  predecessor: Record<string, unknown>,
+  predecessorName: string,
+  writePredecessorNext: (nextLink: string) => Promise<void>
+): Promise<string | null> {
+  const resolved = getRecurrenceForType(schema, typeName);
+  if (!resolved) return null;
+
+  const { template, spawnType } = await resolveSuccessorTemplate(schema, vaultDir, typeName);
+
+  // Offset fields are computed against the recurring type's date fields.
+  const offsetFields = computeOffsetFields(schema, typeName, predecessor);
+
+  // Resolve a successor name that won't collide with the predecessor's filename.
+  // When the spawn type uses a filename pattern, the pattern disambiguates (so we
+  // keep the carried-forward name); otherwise we suffix a counter against the
+  // spawn type's output directory.
+  const carriedName =
+    typeof predecessor['name'] === 'string' && predecessor['name'].trim() !== ''
+      ? (predecessor['name'] as string)
+      : predecessorName;
+  const successorName = resolveSuccessorName(schema, vaultDir, spawnType, template, carriedName);
+
+  const input = buildSuccessorInput(
+    schema,
+    typeName,
+    spawnType,
+    predecessorName,
+    successorName,
+    offsetFields
+  );
+
+  let result: NoteCreationResult;
+  try {
+    result = await createNoteFromJson(
+      schema,
+      vaultDir,
+      spawnType,
+      JSON.stringify(input),
+      template,
+      { noInstances: true }
+    );
+  } catch (err) {
+    throw new Error(`Failed to spawn recurrence successor for '${predecessorName}': ${(err as Error).message}`);
+  }
+
+  // Back-link the predecessor's `next` to the freshly created successor (using
+  // the actual created filename, in case a filename pattern reshaped it).
+  const createdName = basenameNoExt(result.path);
+  const nextLink = formatValue(createdName, schema.config.linkFormat);
+  await writePredecessorNext(nextLink);
+
+  return result.path;
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -10,6 +10,7 @@ import {
   type Schema,
   type Field,
   type Trait,
+  type Recurrence,
   type ResolvedType,
   type ResolvedConfig,
   type LoadedSchema,
@@ -1277,4 +1278,38 @@ export function getFieldOrderForTrait(
  */
 export function getTraitNames(schema: LoadedSchema): string[] {
   return Object.keys(schema.raw.traits ?? {});
+}
+
+// ============================================================================
+// Recurrence (Task System, #107)
+// ============================================================================
+
+/**
+ * Resolve the recurrence configuration for a type, if any of its composed
+ * traits carry one.
+ *
+ * Recurrence rides on a trait (the `recurring` trait). A type can compose
+ * multiple traits; if more than one carries a `recurrence` block, the LATER
+ * trait in the type's `traits` array wins — matching the last-wins precedence
+ * used for trait fields. Returns the resolved recurrence config plus the name
+ * of the trait that provided it, or undefined when the type recurs through no
+ * trait.
+ */
+export function getRecurrenceForType(
+  schema: LoadedSchema,
+  typeName: string
+): { recurrence: Recurrence; trait: string } | undefined {
+  const type = getType(schema, typeName);
+  if (!type) return undefined;
+
+  const declared = schema.raw.traits ?? {};
+  // Scan in reverse so the last trait that declares recurrence wins.
+  for (let i = type.traits.length - 1; i >= 0; i--) {
+    const traitName = type.traits[i]!;
+    const recurrence = declared[traitName]?.recurrence;
+    if (recurrence) {
+      return { recurrence, trait: traitName };
+    }
+  }
+  return undefined;
 }

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -1,4 +1,4 @@
-import { readdir } from 'fs/promises';
+import { readdir, mkdir } from 'fs/promises';
 import { join, basename, relative } from 'path';
 import { existsSync } from 'fs';
 import { parseNote, writeNote, generateBodySections } from './frontmatter.js';
@@ -1462,7 +1462,11 @@ export async function createScaffoldedInstances(
   const created: string[] = [];
   const skipped: string[] = [];
   const errors: ScaffoldError[] = [];
-  
+
+  // Track filenames chosen during this run, per directory, so multiple
+  // instances of the same type don't collide (#630). Keyed by absolute dir.
+  const usedNames = new Map<string, Set<string>>();
+
   for (const instance of instances) {
     try {
       // Validate type exists
@@ -1475,24 +1479,14 @@ export async function createScaffoldedInstances(
         });
         continue;
       }
-      
-      // Determine filename
-      const filename = instance.filename ?? `${instance.type}.md`;
-      const filePath = join(instanceDir, filename);
-      
-      // Skip if file exists (warn but continue)
-      if (existsSync(filePath)) {
-        skipped.push(filePath);
-        continue;
-      }
-      
+
       // Load instance template if specified
       let instanceTemplate: Template | null = null;
       if (instance.template) {
         instanceTemplate = await findTemplateByName(vaultDir, instance.type, instance.template);
         // If not found, don't error - just continue without template
       }
-      
+
       // Build frontmatter with defaults
       let frontmatter: Record<string, unknown> = {};
 
@@ -1514,9 +1508,33 @@ export async function createScaffoldedInstances(
           frontmatter[key] = evaluateTemplateDefault(value, schema.config.dateFormat, instanceFields[key]?.prompt);
         }
       }
-      
+
       // Apply schema defaults for any missing required fields
       frontmatter = applyDefaults(schema, instance.type, frontmatter);
+
+      // --- Placement (#630) -------------------------------------------------
+      // Disambiguate filenames so multi-spawn of the same type no longer
+      // collapses into a single `<type>.md` (the #630 bug). Instances are
+      // colocated in the parent's instance folder (the scaffold contract), but
+      // each now gets a meaningful, unique filename derived from its filename
+      // pattern / `title` / `name`, falling back to the type name.
+      const targetDir = instanceDir;
+
+      const baseName = resolveInstanceFilenameBase(
+        instance,
+        instanceTemplate,
+        instanceType,
+        frontmatter,
+        schema.config.dateFormat
+      );
+      const filename = ensureUniqueInstanceFilename(targetDir, baseName, usedNames);
+      const filePath = join(targetDir, filename);
+
+      // Skip if file exists on disk (warn but continue)
+      if (existsSync(filePath)) {
+        skipped.push(filePath);
+        continue;
+      }
 
       // System-managed stable note id (v1.0)
       const noteId = await generateUniqueNoteId(vaultDir);
@@ -1542,11 +1560,14 @@ export async function createScaffoldedInstances(
         instanceType.fieldOrder.length > 0 ? instanceType.fieldOrder : Object.keys(frontmatter)
       );
 
+      // Ensure the (possibly new) child output directory exists.
+      await mkdir(targetDir, { recursive: true });
+
       // Write file
       await writeNote(filePath, frontmatter, body, orderedFields);
       await registerIssuedNoteId(vaultDir, noteId, filePath);
       created.push(filePath);
-      
+
     } catch (e) {
       errors.push({
         subtype: instance.type,
@@ -1555,6 +1576,78 @@ export async function createScaffoldedInstances(
       });
     }
   }
-  
+
   return { created, skipped, errors };
+}
+
+/**
+ * Resolve the base filename (without `.md`) for a scaffolded instance (#630).
+ *
+ * Precedence (highest to lowest):
+ * 1. Explicit `instance.filename` (strip a trailing `.md`).
+ * 2. The instance/template filename pattern resolved against frontmatter.
+ * 3. The frontmatter `title` or `name` value (the staggered-task common case).
+ * 4. The type name as a last resort (disambiguated by the caller).
+ */
+function resolveInstanceFilenameBase(
+  instance: InstanceScaffold,
+  instanceTemplate: Template | null,
+  instanceType: ResolvedType,
+  frontmatter: Record<string, unknown>,
+  dateFormat: string
+): string {
+  if (instance.filename) {
+    return instance.filename.replace(/\.md$/, '');
+  }
+
+  const pattern = getFilenamePattern(instanceTemplate, instanceType);
+  if (pattern) {
+    const resolved = resolveFilenamePattern(pattern, frontmatter, dateFormat);
+    if (resolved.resolved && resolved.filename) {
+      return resolved.filename;
+    }
+  }
+
+  const title = frontmatter['title'];
+  if (typeof title === 'string' && title.trim() !== '') {
+    return sanitizeFilenameBase(title).sanitized || instance.type;
+  }
+  const name = frontmatter['name'];
+  if (typeof name === 'string' && name.trim() !== '') {
+    return sanitizeFilenameBase(name).sanitized || instance.type;
+  }
+
+  return instance.type;
+}
+
+/**
+ * Disambiguate a base filename against names already chosen EARLIER IN THIS
+ * scaffold run (#630), so multi-spawn of the same type no longer collapses into
+ * a single `<type>.md`. Appends ` 2`, ` 3`, ... until a free name is found.
+ *
+ * On-disk collisions are intentionally NOT disambiguated here — they are handled
+ * by the caller's skip-if-exists check, preserving the scaffold contract that a
+ * deliberately-named instance pointing at an existing file is skipped, not
+ * duplicated.
+ */
+function ensureUniqueInstanceFilename(
+  targetDir: string,
+  baseName: string,
+  usedNames: Map<string, Set<string>>
+): string {
+  let used = usedNames.get(targetDir);
+  if (!used) {
+    used = new Set<string>();
+    usedNames.set(targetDir, used);
+  }
+
+  let candidate = baseName;
+  let counter = 2;
+  while (used.has(candidate)) {
+    candidate = `${baseName} ${counter}`;
+    counter++;
+  }
+
+  used.add(candidate);
+  return `${candidate}.md`;
 }

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -4,7 +4,7 @@ import { existsSync } from 'fs';
 import { parseNote, writeNote, generateBodySections } from './frontmatter.js';
 import { levenshteinDistance } from './levenshtein.js';
 import { TemplateFrontmatterSchema, type Template, type LoadedSchema, type Field, type Constraint, type InstanceScaffold, type ResolvedType } from '../types/schema.js';
-import { getType, getFieldsForType, getFieldOptions } from './schema.js';
+import { getType, getFieldsForType, getFieldOptions, getOutputDir } from './schema.js';
 import { isBwrbBuiltinFrontmatterField } from './frontmatter/systemFields.js';
 import { matchesExpression, parseExpression, type EvalContext } from './expression.js';
 import { applyDefaults } from './validation.js';
@@ -1433,7 +1433,9 @@ export interface ScaffoldResult {
  * @param schema - The vault schema
  * @param vaultDir - Path to vault directory
  * @param _parentTypeName - Type name of parent (e.g., "draft") - unused in new model
- * @param instanceDir - Path to instance folder
+ * @param instanceDir - Fallback instance folder (used only if a child type has
+ *   no resolvable output_dir; normally each instance is filed in its own child
+ *   type's output_dir per #107/#630)
  * @param instances - Instance definitions from template
  * @param parentFrontmatter - Frontmatter from parent note (for variable substitution)
  * @returns Result with created files, skipped files, and any errors
@@ -1512,13 +1514,18 @@ export async function createScaffoldedInstances(
       // Apply schema defaults for any missing required fields
       frontmatter = applyDefaults(schema, instance.type, frontmatter);
 
-      // --- Placement (#630) -------------------------------------------------
-      // Disambiguate filenames so multi-spawn of the same type no longer
-      // collapses into a single `<type>.md` (the #630 bug). Instances are
-      // colocated in the parent's instance folder (the scaffold contract), but
-      // each now gets a meaningful, unique filename derived from its filename
-      // pattern / `title` / `name`, falling back to the type name.
-      const targetDir = instanceDir;
+      // --- Placement (#630 / #107) ------------------------------------------
+      // Each scaffolded instance is placed in ITS OWN child type's output_dir,
+      // NOT the parent template's directory (the deferred half of #630). Filing a
+      // child-type task under the parent's directory makes `bwrb audit` flag it
+      // `wrong-directory`; resolving the child type's own output dir keeps the
+      // multi-spawn workflow audit-clean.
+      //
+      // Filenames are still disambiguated (derived from filename pattern /
+      // `title` / `name`, falling back to the type name) so multiple instances of
+      // the same type don't collapse into a single `<type>.md`.
+      const childOutputDir = getOutputDir(schema, instance.type);
+      const targetDir = childOutputDir ? join(vaultDir, childOutputDir) : instanceDir;
 
       const baseName = resolveInstanceFilenameBase(
         instance,

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -95,6 +95,36 @@ export const BodySectionSchema: z.ZodType<BodySection, z.ZodTypeDef, BodySection
 // ============================================================================
 
 /**
+ * Recurrence configuration carried by a trait (the `recurring` trait, #107).
+ *
+ * Declares event-driven, spawn-on-transition recurrence: "when a field
+ * transitions to a value (e.g. `status` enters `done`), spawn a successor note
+ * from a template, with the successor's date field offset from a predecessor
+ * date field." No cron, no daemon, no LLM — the trigger is a field transition,
+ * not a clock.
+ *
+ * Date rule is FIELD-OFFSET ONLY: `successor.<dateField> = <predecessor date
+ * field> + <offset>` (e.g. `deadline + 7d`). The base must be a DATE field.
+ * Transition-time offsets and calendar-anchored bases are intentionally not
+ * supported (they cannot be reproduced identically across both execution paths).
+ */
+export const RecurrenceSchema = z.object({
+  // The trigger transition, written as `<field> = <value>` (e.g. "status = done").
+  // The successor is spawned when the trigger field transitions INTO this value.
+  on: z.string(),
+  // Template name to spawn the successor from. Defaults to the completed note's
+  // type default template (a task begets a task). Naming a template can spawn a
+  // different type (finish "draft" → spawn "review").
+  template: z.string().optional(),
+  // Field-offset assignments for the successor. Each value is a field-offset
+  // expression `<dateField> <+|-> <duration>` (e.g. "deadline + 7d"). The base
+  // must be a date field on the predecessor.
+  set: z.record(z.string()).optional(),
+});
+
+export type Recurrence = z.infer<typeof RecurrenceSchema>;
+
+/**
  * A reusable bundle of fields composed into a type via `traits`.
  *
  * Traits are *composition* ("also-has") alongside `extends` *inheritance*
@@ -103,7 +133,8 @@ export const BodySectionSchema: z.ZodType<BodySection, z.ZodTypeDef, BodySection
  * and mix them into unrelated type families.
  *
  * Traits are flat: a trait carries only `fields` (and an optional
- * `description`). A trait cannot extend a type or compose other traits, which
+ * `description`), plus — for the `recurring` trait — an optional `recurrence`
+ * block (#107). A trait cannot extend a type or compose other traits, which
  * keeps resolution deterministic and easy to reason about.
  */
 export const TraitSchema = z.object({
@@ -112,6 +143,9 @@ export const TraitSchema = z.object({
   description: z.string().optional(),
   // Field definitions contributed by this trait.
   fields: z.record(FieldSchema).optional(),
+  // Recurrence configuration (spawn-on-transition). When present, types that
+  // compose this trait gain event-driven successor spawning. See RecurrenceSchema.
+  recurrence: RecurrenceSchema.optional(),
 });
 
 // ============================================================================

--- a/tests/ts/commands/edit.test.ts
+++ b/tests/ts/commands/edit.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { readFile, writeFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import { createTestVault, cleanupTestVault, runCLI, TEST_SCHEMA } from '../fixtures/setup.js';
 
@@ -914,5 +915,176 @@ describe('edit command --open flag', () => {
       const json = JSON.parse(result.stdout);
       expect(json.success).toBe(false);
     });
+  });
+});
+
+// ============================================================================
+// Recurrence completion: atomicity + error surfacing (#107 blocker 2)
+// ============================================================================
+
+describe('edit command: recurrence completion atomicity (#107)', () => {
+  // A recurring `task` schema whose successor template is MISSING, so completing
+  // a task cannot spawn a successor.
+  const RECURRING_NO_TEMPLATE = {
+    version: 2,
+    traits: {
+      recurring: {
+        fields: {
+          next: { prompt: 'relation', source: 'task' },
+          prev: { prompt: 'relation', source: 'task' },
+        },
+        recurrence: {
+          on: 'status = done',
+          template: 'does-not-exist',
+          set: { deadline: 'deadline + 7d' },
+        },
+      },
+    },
+    types: {
+      task: {
+        output_dir: 'tasks',
+        traits: ['recurring'],
+        fields: {
+          name: { prompt: 'text', required: true },
+          status: { prompt: 'select', options: ['todo', 'doing', 'done'], default: 'todo' },
+          deadline: { prompt: 'date' },
+        },
+      },
+    },
+  };
+
+  // A recurring `task` schema with a partial-date base that cannot be offset.
+  const RECURRING_PARTIAL_BASE = {
+    version: 2,
+    traits: {
+      recurring: {
+        fields: {
+          next: { prompt: 'relation', source: 'task' },
+          prev: { prompt: 'relation', source: 'task' },
+        },
+        recurrence: {
+          on: 'status = done',
+          set: { deadline: 'deadline + 7d' },
+        },
+      },
+    },
+    types: {
+      task: {
+        output_dir: 'tasks',
+        traits: ['recurring'],
+        fields: {
+          name: { prompt: 'text', required: true },
+          status: { prompt: 'select', options: ['todo', 'doing', 'done'], default: 'todo' },
+          deadline: { prompt: 'date', granularity: 'month' },
+        },
+      },
+    },
+  };
+
+  async function setupRecurringVault(schema: unknown): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'edit-recur-'));
+    await mkdir(join(dir, '.bwrb'), { recursive: true });
+    await writeFile(join(dir, '.bwrb', 'schema.json'), JSON.stringify(schema, null, 2));
+    await mkdir(join(dir, 'tasks'), { recursive: true });
+    return dir;
+  }
+
+  async function writeTask(dir: string, name: string, fm: string): Promise<string> {
+    const p = join(dir, 'tasks', `${name}.md`);
+    await writeFile(p, fm);
+    return p;
+  }
+
+  it('missing template: leaves predecessor UNMUTATED + surfaces the real error (by-name branch)', async () => {
+    const dir = await setupRecurringVault(RECURRING_NO_TEMPLATE);
+    try {
+      const taskPath = await writeTask(
+        dir,
+        'ByName',
+        `---\ntype: task\nname: ByName\nstatus: doing\ndeadline: 2026-03-01\n---\n`
+      );
+
+      const result = await runCLI(
+        ['edit', 'ByName', '--json', '{"status":"done"}', '--picker', 'none'],
+        dir
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/template 'does-not-exist'|was not found/i);
+      // NOT the misleading "No matching notes found".
+      expect(combined).not.toMatch(/No matching notes found/i);
+
+      // Predecessor must NOT have been mutated to done.
+      const content = await readFile(taskPath, 'utf-8');
+      expect(content).toContain('status: doing');
+      expect(content).not.toContain('status: done');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('missing template: leaves predecessor UNMUTATED + surfaces the real error (absolute-path branch)', async () => {
+    const dir = await setupRecurringVault(RECURRING_NO_TEMPLATE);
+    try {
+      const taskPath = await writeTask(
+        dir,
+        'ByPath',
+        `---\ntype: task\nname: ByPath\nstatus: doing\ndeadline: 2026-03-01\n---\n`
+      );
+
+      const result = await runCLI(
+        ['edit', taskPath, '--json', '{"status":"done"}'],
+        dir
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      const combined = result.stdout + result.stderr;
+      // The absolute-path branch must surface the REAL error, not swallow it.
+      expect(combined).toMatch(/template 'does-not-exist'|was not found/i);
+      expect(combined).not.toMatch(/No matching notes found/i);
+
+      const content = await readFile(taskPath, 'utf-8');
+      expect(content).toContain('status: doing');
+      expect(content).not.toContain('status: done');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('partial-date offset base: clear deterministic error, predecessor unmutated', async () => {
+    const dir = await setupRecurringVault(RECURRING_PARTIAL_BASE);
+    try {
+      // A default task template exists so template resolution succeeds; the
+      // failure is the un-offsettable partial (month-granularity) base date.
+      const tplDir = join(dir, '.bwrb', 'templates', 'task');
+      await mkdir(tplDir, { recursive: true });
+      await writeFile(
+        join(tplDir, 'default.md'),
+        `---\ntype: template\ntemplate-for: task\n---\n\n# {name}\n`
+      );
+
+      const taskPath = await writeTask(
+        dir,
+        'Partial',
+        `---\ntype: task\nname: Partial\nstatus: doing\ndeadline: 2026-03\n---\n`
+      );
+
+      const result = await runCLI(
+        ['edit', taskPath, '--json', '{"status":"done"}'],
+        dir
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/Cannot compute recurrence offset/i);
+      expect(combined).toMatch(/partial date|granularity/i);
+
+      const content = await readFile(taskPath, 'utf-8');
+      expect(content).toContain('status: doing');
+      expect(content).not.toContain('status: done');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/ts/commands/new.pty.test.ts
+++ b/tests/ts/commands/new.pty.test.ts
@@ -202,9 +202,11 @@ status: in-flight
           const exitCode = await proc.waitForExit(10000);
           expect(exitCode).toBe(0);
 
+          // Parent note in the project's output_dir; scaffolded research
+          // instances in the CHILD type's output_dir (`Research/`), per #107/#630.
           const parentExists = await vaultFileExists(vaultPath, 'Projects/Test.md');
-          const backgroundExists = await vaultFileExists(vaultPath, 'Projects/Background Research.md');
-          const competitorExists = await vaultFileExists(vaultPath, 'Projects/Competitor Analysis.md');
+          const backgroundExists = await vaultFileExists(vaultPath, 'Research/Background Research.md');
+          const competitorExists = await vaultFileExists(vaultPath, 'Research/Competitor Analysis.md');
 
           expect(parentExists).toBe(true);
           expect(backgroundExists).toBe(true);
@@ -212,8 +214,8 @@ status: in-flight
 
           const output = proc.getOutput().replace(/\\/g, '/');
           expect(output).toContain('Instances created:');
-          expect(output).toContain('Projects/Background Research.md');
-          expect(output).toContain('Projects/Competitor Analysis.md');
+          expect(output).toContain('Research/Background Research.md');
+          expect(output).toContain('Research/Competitor Analysis.md');
           expect(output).toContain('Created 3 files (1 parent + 2 instances)');
         },
         { schema: INSTANCE_SCAFFOLD_SCHEMA, includeTemplates: ['project'] }

--- a/tests/ts/commands/new.test.ts
+++ b/tests/ts/commands/new.test.ts
@@ -350,8 +350,10 @@ describe('new command - instance scaffolding', () => {
     expect(parentContent).toContain('status: in-flight');
     expect(parentContent).toContain('# Project Overview');
 
-    // Verify instance files exist and have correct content
-    const instanceDir = join(vaultDir, 'Projects');
+    // Verify instance files exist and have correct content. Scaffolded instances
+    // are filed in the CHILD type's output_dir (#107/#630): `research` →
+    // `Research/`, NOT the parent project's `Projects/` directory.
+    const instanceDir = join(vaultDir, 'Research');
     const bgResearchPath = join(instanceDir, 'Background Research.md');
     await waitForFile(bgResearchPath);
     const bgResearch = await readFile(bgResearchPath, 'utf-8');
@@ -394,20 +396,22 @@ describe('new command - instance scaffolding', () => {
     const parentContent = await readFile(join(vaultDir, output.path), 'utf-8');
     expect(parentContent).toContain('status: in-flight');
 
-    // Verify instance files were NOT created
+    // Verify instance files were NOT created (in either parent or child dirs).
     const { existsSync } = await import('fs');
-    const instanceDir = join(vaultDir, 'Projects');
-    expect(existsSync(join(instanceDir, 'Background Research.md'))).toBe(false);
-    expect(existsSync(join(instanceDir, 'Competitor Analysis.md'))).toBe(false);
+    expect(existsSync(join(vaultDir, 'Research', 'Background Research.md'))).toBe(false);
+    expect(existsSync(join(vaultDir, 'Research', 'Competitor Analysis.md'))).toBe(false);
+    expect(existsSync(join(vaultDir, 'Projects', 'Background Research.md'))).toBe(false);
+    expect(existsSync(join(vaultDir, 'Projects', 'Competitor Analysis.md'))).toBe(false);
   });
 
   it('should skip existing instance files without error', async () => {
-    // Create one of the instance files first
+    // Create one of the instance files first, in the CHILD type's output_dir
+    // (`Research/`) where the instance would be filed.
     const { mkdir, writeFile } = await import('fs/promises');
-    const projectsDir = join(vaultDir, 'Projects');
-    await mkdir(projectsDir, { recursive: true });
+    const researchDir = join(vaultDir, 'Research');
+    await mkdir(researchDir, { recursive: true });
     await writeFile(
-      join(projectsDir, 'Background Research.md'),
+      join(researchDir, 'Background Research.md'),
       '---\ntype: research\nstatus: settled\n---\nExisting content',
       'utf-8'
     );
@@ -430,7 +434,7 @@ describe('new command - instance scaffolding', () => {
     expect(output.instances.errors).toHaveLength(0);
 
     // Existing file should not be overwritten
-    const existing = await readFile(join(projectsDir, 'Background Research.md'), 'utf-8');
+    const existing = await readFile(join(researchDir, 'Background Research.md'), 'utf-8');
     expect(existing).toContain('status: settled'); // Original content preserved
     expect(existing).toContain('Existing content');
   });

--- a/tests/ts/lib/recurrence.test.ts
+++ b/tests/ts/lib/recurrence.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { join } from 'path';
-import { mkdtemp, mkdir, writeFile, readdir, rm } from 'fs/promises';
+import { mkdtemp, mkdir, writeFile, readFile, readdir, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import { tmpdir } from 'os';
 
@@ -100,6 +100,14 @@ async function listTasks(vaultDir: string): Promise<string[]> {
   const dir = join(vaultDir, 'tasks');
   if (!existsSync(dir)) return [];
   return (await readdir(dir)).filter((f) => f.endsWith('.md')).sort();
+}
+
+/** Extract the raw text after `<key>:` on its frontmatter line (verbatim). */
+async function rawFieldLine(filePath: string, key: string): Promise<string> {
+  const content = await readFile(filePath, 'utf-8');
+  const line = content.split('\n').find((l) => l.startsWith(`${key}:`));
+  if (!line) throw new Error(`No '${key}:' line in ${filePath}`);
+  return line.slice(`${key}:`.length).trim();
 }
 
 describe('recurrence: pure helpers', () => {
@@ -212,6 +220,67 @@ deadline: 2026-03-01
     expect(succFm['next'] ?? '').toBe('');
   });
 
+  it('writes a CLEAN, byte-symmetric next/prev; audit clean; --fix converges (#107 blocker 1)', async () => {
+    const taskPath = join(vaultDir, 'tasks', 'Symmetric.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Symmetric
+status: doing
+deadline: 2026-03-01
+---
+
+# Symmetric
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, taskPath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+
+    const tasks = await listTasks(vaultDir);
+    expect(tasks).toHaveLength(2);
+    const successorName = tasks.find((f) => f !== 'Symmetric.md')!;
+    const succPath = join(vaultDir, 'tasks', successorName);
+
+    // Predecessor's `next` must be a CLEAN wikilink — exactly one quoting layer,
+    // NO embedded literal quote characters. The double-wrap bug produced
+    // `'"[[Successor]]"'` (YAML single-quoted around a literal `"[[...]]"`) or
+    // `"\"[[Successor]]\""`. The clean form is `"[[Successor]]"`.
+    const rawNext = await rawFieldLine(taskPath, 'next');
+    expect(rawNext.startsWith("'")).toBe(false); // not YAML single-quoted (double-wrap)
+    expect(rawNext).not.toContain('\\"'); // no escaped embedded quote
+    expect(rawNext).toMatch(/^"\[\[[^"\\]+\]\]"$/); // single YAML quote layer, no inner quote
+
+    // The parsed value is the bare wikilink (no embedded quote characters).
+    const nextValue = String((await readFrontmatter(taskPath))['next']);
+    expect(nextValue).toMatch(/^\[\[.+\]\]$/);
+    expect(nextValue).not.toContain('"');
+
+    // Byte-symmetric with the successor's `prev`: same shape, same quoting.
+    const rawPrev = await rawFieldLine(succPath, 'prev');
+    expect(rawPrev).toMatch(/^"\[\[[^"\\]+\]\]"$/);
+    const prevValue = String((await readFrontmatter(succPath))['prev']);
+    // next points at successor, prev points at predecessor; strip the names and
+    // confirm the LINK SHELL is byte-identical.
+    expect(nextValue.replace(/\[\[.*\]\]/, '[[X]]')).toBe(prevValue.replace(/\[\[.*\]\]/, '[[X]]'));
+
+    // Audit is clean immediately after the spawn: no format-violation on `next`.
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const issues = results.flatMap((r) => r.issues);
+    expect(issues.some((i) => i.code === 'format-violation')).toBe(false);
+
+    // `--fix` converges: a second run reports 0 fixes (non-converging double-wrap
+    // would re-report "Fixed next format" forever).
+    const r1 = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    await runAutoFix(r1, schema, vaultDir, { dryRun: false });
+    const r2 = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const summary2 = await runAutoFix(r2, schema, vaultDir, { dryRun: false });
+    expect(summary2.fixed).toBe(0);
+  });
+
   it('is idempotent: re-completing a task with a `next` does NOT spawn a duplicate', async () => {
     const taskPath = join(vaultDir, 'tasks', 'Recur.md');
     await writeFile(
@@ -306,6 +375,58 @@ deadline: 2026-05-10
     const successorName = tasks.find((f) => f !== 'Bulk task.md')!;
     const succFm = await readFrontmatter(join(vaultDir, 'tasks', successorName));
     expect(succFm['deadline']).toBe('2026-05-17');
+
+    // The bulk-written `next` is also a clean, single-quoted wikilink (#107).
+    const rawNext = await rawFieldLine(join(vaultDir, 'tasks', 'Bulk task.md'), 'next');
+    expect(rawNext.startsWith("'")).toBe(false);
+    expect(rawNext).toMatch(/^"\[\[[^"\\]+\]\]"$/);
+  });
+
+  it('atomic: a bulk completion whose spawn fails leaves the predecessor UNMUTATED', async () => {
+    // Point the recurrence at a missing template so the spawn cannot succeed.
+    const badSchema: Schema = JSON.parse(JSON.stringify(RECURRING_SCHEMA));
+    badSchema.traits!.recurring!.recurrence!.template = 'does-not-exist';
+    const badVault = await setupVault(badSchema);
+    await mkdir(join(badVault, 'tasks'), { recursive: true });
+    const taskPath = join(badVault, 'tasks', 'Bulk atomic.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Bulk atomic
+status: doing
+deadline: 2026-05-10
+---
+`
+    );
+
+    try {
+      const schema = await loadSchema(badVault);
+      const result = await executeBulk({
+        typePath: 'task',
+        operations: [{ type: 'set', field: 'status', value: 'done' }],
+        whereExpressions: [],
+        execute: true,
+        backup: false,
+        verbose: false,
+        quiet: true,
+        jsonMode: true,
+        vaultDir: badVault,
+        schema,
+      });
+
+      // The spawn failure is reported...
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors.join(' ')).toMatch(/does-not-exist|was not found/);
+
+      // ...and the predecessor was NOT mutated (still doing, no successor).
+      const fm = await readFrontmatter(taskPath);
+      expect(fm['status']).toBe('doing');
+      expect(fm['next'] ?? '').toBe('');
+      expect(await listTasks(badVault)).toEqual(['Bulk atomic.md']);
+    } finally {
+      await rm(badVault, { recursive: true, force: true });
+    }
   });
 });
 
@@ -361,6 +482,47 @@ deadline: 2026-07-01
     const results2 = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
     const taskResult2 = results2.find((r) => r.relativePath.endsWith('Hand done.md'));
     expect(taskResult2?.issues.some((i) => i.code === 'missing-successor') ?? false).toBe(false);
+  });
+
+  it('backstop spawn writes a CLEAN, symmetric next/prev; audit clean; --fix converges (#107 blocker 1)', async () => {
+    const taskPath = join(vaultDir, 'tasks', 'Backstop clean.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Backstop clean
+status: done
+deadline: 2026-08-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    await runAutoFix(results, schema, vaultDir, { dryRun: false });
+
+    const tasks = await listTasks(vaultDir);
+    expect(tasks).toHaveLength(2);
+    const successorName = tasks.find((f) => f !== 'Backstop clean.md')!;
+    const succPath = join(vaultDir, 'tasks', successorName);
+
+    const rawNext = await rawFieldLine(taskPath, 'next');
+    expect(rawNext.startsWith("'")).toBe(false);
+    expect(rawNext).not.toContain('\\"');
+    expect(rawNext).toMatch(/^"\[\[[^"\\]+\]\]"$/);
+    const nextValue = String((await readFrontmatter(taskPath))['next']);
+    expect(nextValue).not.toContain('"');
+
+    const rawPrev = await rawFieldLine(succPath, 'prev');
+    expect(rawPrev).toMatch(/^"\[\[[^"\\]+\]\]"$/);
+
+    // Audit clean post-spawn (no format-violation), and --fix converges.
+    const after = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    expect(after.flatMap((r) => r.issues).some((i) => i.code === 'format-violation')).toBe(false);
+
+    const r2 = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const summary2 = await runAutoFix(r2, schema, vaultDir, { dryRun: false });
+    expect(summary2.fixed).toBe(0);
   });
 
   it('fast path and backstop produce the SAME successor deadline', async () => {
@@ -460,6 +622,82 @@ deadline: 2026-01-01
   });
 });
 
+describe('recurrence: atomic spawn failure (#107 blocker 2)', () => {
+  let vaultDir: string;
+  afterEach(async () => {
+    if (vaultDir) await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('missing template: predecessor stays UNMUTATED and the real error surfaces', async () => {
+    const schemaWithNamedTemplate: Schema = JSON.parse(JSON.stringify(RECURRING_SCHEMA));
+    schemaWithNamedTemplate.traits!.recurring!.recurrence!.template = 'does-not-exist';
+    vaultDir = await setupVault(schemaWithNamedTemplate);
+    await mkdir(join(vaultDir, 'tasks'), { recursive: true });
+
+    const taskPath = join(vaultDir, 'tasks', 'Atomic.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Atomic
+status: doing
+deadline: 2026-03-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+
+    // Completing must throw the real error...
+    await expect(
+      editNoteFromJson(schema, vaultDir, taskPath, JSON.stringify({ status: 'done' }), {
+        jsonMode: false,
+      })
+    ).rejects.toThrow(/does-not-exist|was not found/);
+
+    // ...and must NOT have mutated the predecessor (still doing, no `next`).
+    const fm = await readFrontmatter(taskPath);
+    expect(fm['status']).toBe('doing');
+    expect(fm['next'] ?? '').toBe('');
+
+    // No successor was created.
+    expect(await listTasks(vaultDir)).toEqual(['Atomic.md']);
+  });
+
+  it('partial-date offset base: clear deterministic error, predecessor unmutated', async () => {
+    // deadline granularity = month, so "2026-03" is a valid value that cannot be
+    // offset by "deadline + 7d".
+    const partialSchema: Schema = JSON.parse(JSON.stringify(RECURRING_SCHEMA));
+    partialSchema.types!.task!.fields!.deadline = { prompt: 'date', granularity: 'month' };
+    vaultDir = await setupVault(partialSchema);
+    await writeDefaultTaskTemplate(vaultDir);
+    await mkdir(join(vaultDir, 'tasks'), { recursive: true });
+
+    const taskPath = join(vaultDir, 'tasks', 'PartialBase.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: PartialBase
+status: doing
+deadline: 2026-03
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+
+    await expect(
+      editNoteFromJson(schema, vaultDir, taskPath, JSON.stringify({ status: 'done' }), {
+        jsonMode: false,
+      })
+    ).rejects.toThrow(/Cannot compute recurrence offset.*partial date|partial date.*cannot be offset/i);
+
+    const fm = await readFrontmatter(taskPath);
+    expect(fm['status']).toBe('doing');
+    expect(fm['next'] ?? '').toBe('');
+    expect(await listTasks(vaultDir)).toEqual(['PartialBase.md']);
+  });
+});
+
 describe('recurrence: back-compat (non-recurring type)', () => {
   let vaultDir: string;
   beforeEach(async () => {
@@ -502,8 +740,10 @@ describe('recurrence: multi-spawn template (#630)', () => {
     if (vaultDir) await rm(vaultDir, { recursive: true, force: true });
   });
 
-  it('spawns N correctly-placed staggered notes from a parent template', async () => {
+  it('files staggered instances in the CHILD type output_dir and audits clean', async () => {
     // A `project` parent type whose default template scaffolds 4 staggered tasks.
+    // The child `task` type has a DIFFERENT output_dir than the parent — so the
+    // instances must land in `tasks/`, not `projects/` (the deferred #630 half).
     const schema: Schema = {
       version: 2,
       types: {
@@ -517,7 +757,6 @@ describe('recurrence: multi-spawn template (#630)', () => {
           output_dir: 'tasks',
           fields: {
             name: { prompt: 'text', required: true },
-            title: { prompt: 'text' },
             deadline: { prompt: 'date' },
             status: { prompt: 'select', options: ['todo', 'done'], default: 'todo' },
           },
@@ -526,7 +765,8 @@ describe('recurrence: multi-spawn template (#630)', () => {
     };
     vaultDir = await setupVault(schema);
 
-    // Parent template with staggered instances (date expressions via #603).
+    // Parent template with staggered instances (date expressions via #603). The
+    // `defaults` use the child type's REAL field (`name`), not `title`.
     const projTplDir = join(vaultDir, '.bwrb', 'templates', 'project');
     await mkdir(projTplDir, { recursive: true });
     await writeFile(
@@ -535,10 +775,10 @@ describe('recurrence: multi-spawn template (#630)', () => {
 type: template
 template-for: project
 instances:
-  - { type: task, defaults: { title: "Outline", deadline: "@today+1d" } }
-  - { type: task, defaults: { title: "Draft",   deadline: "@today+3d" } }
-  - { type: task, defaults: { title: "Edit",    deadline: "@today+5d" } }
-  - { type: task, defaults: { title: "Publish", deadline: "@today+7d" } }
+  - { type: task, defaults: { name: "Outline", deadline: "@today+1d" } }
+  - { type: task, defaults: { name: "Draft",   deadline: "@today+3d" } }
+  - { type: task, defaults: { name: "Edit",    deadline: "@today+5d" } }
+  - { type: task, defaults: { name: "Publish", deadline: "@today+7d" } }
 ---
 
 # {name}
@@ -551,7 +791,7 @@ instances:
     );
     expect(tpl).not.toBeNull();
 
-    const parent = await createNoteFromJson(
+    await createNoteFromJson(
       loaded,
       vaultDir,
       'project',
@@ -559,23 +799,31 @@ instances:
       tpl
     );
 
-    // Instances are colocated alongside the parent note (parent's directory).
-    const parentDir = join(vaultDir, 'projects');
-    const parentName = parent.path.split('/').pop()!;
-    const instanceFiles = (await readdir(parentDir))
-      .filter((f) => f.endsWith('.md') && f !== parentName)
+    // The parent's directory holds ONLY the project note — no task instances.
+    const projectFiles = (await readdir(join(vaultDir, 'projects')))
+      .filter((f) => f.endsWith('.md'))
       .sort();
+    expect(projectFiles).toEqual(['My Article.md']);
 
-    // Exactly 4 task instances, each a distinct file with a meaningful,
-    // disambiguated name (no `task.md` collapse — the #630 bug).
+    // The 4 task instances are filed in the CHILD type's output_dir (`tasks/`),
+    // each a distinct, disambiguated file (no `task.md` collapse — #630).
+    const instanceFiles = await listTasks(vaultDir);
     expect(instanceFiles).toEqual(['Draft.md', 'Edit.md', 'Outline.md', 'Publish.md'].sort());
 
     // Deadlines are staggered (4 distinct values).
     const deadlines = new Set<string>();
     for (const f of instanceFiles) {
-      const fm = await readFrontmatter(join(parentDir, f));
+      const fm = await readFrontmatter(join(vaultDir, 'tasks', f));
       deadlines.add(String(fm['deadline']));
     }
     expect(deadlines.size).toBe(4);
+
+    // `bwrb audit` is clean: no wrong-directory (correct output_dir), no
+    // unknown-field/missing-required (correct child field `name`).
+    const results = await runAudit(loaded, vaultDir, { strict: false, vaultDir, schema: loaded });
+    const issues = results.flatMap((r) => r.issues);
+    expect(issues.some((i) => i.code === 'wrong-directory')).toBe(false);
+    expect(issues.some((i) => i.code === 'unknown-field')).toBe(false);
+    expect(issues.some((i) => i.code === 'missing-required')).toBe(false);
   });
 });

--- a/tests/ts/lib/recurrence.test.ts
+++ b/tests/ts/lib/recurrence.test.ts
@@ -1,0 +1,581 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdtemp, mkdir, writeFile, readdir, rm } from 'fs/promises';
+import { existsSync } from 'fs';
+import { tmpdir } from 'os';
+
+import { loadSchema } from '../../../src/lib/schema.js';
+import { editNoteFromJson } from '../../../src/lib/edit.js';
+import { executeBulk } from '../../../src/lib/bulk/execute.js';
+import { runAudit } from '../../../src/lib/audit/detection.js';
+import { runAutoFix } from '../../../src/lib/audit/fix.js';
+import { createNoteFromJson } from '../../../src/commands/new/json-mode.js';
+import {
+  parseTrigger,
+  parseFieldOffset,
+  computeOffsetFields,
+  needsSuccessor,
+  validateRecurrenceRule,
+} from '../../../src/lib/recurrence.js';
+import type { Schema } from '../../../src/types/schema.js';
+
+// A schema whose `task` type composes a `recurring` trait: completing a task
+// (status -> done) spawns a successor whose deadline is offset 7 days from the
+// predecessor's deadline. The `next`/`prev` relation fields form the chain.
+const RECURRING_SCHEMA: Schema = {
+  version: 2,
+  traits: {
+    recurring: {
+      description: 'Spawn-on-transition recurrence',
+      fields: {
+        next: { prompt: 'relation', source: 'task' },
+        prev: { prompt: 'relation', source: 'task' },
+      },
+      recurrence: {
+        on: 'status = done',
+        set: {
+          deadline: 'deadline + 7d',
+        },
+      },
+    },
+  },
+  types: {
+    task: {
+      output_dir: 'tasks',
+      traits: ['recurring'],
+      fields: {
+        name: { prompt: 'text', required: true },
+        status: { prompt: 'select', options: ['todo', 'doing', 'done'], default: 'todo' },
+        deadline: { prompt: 'date' },
+      },
+    },
+  },
+};
+
+// A non-recurring schema (back-compat): a plain `note` type.
+const PLAIN_SCHEMA: Schema = {
+  version: 2,
+  types: {
+    note: {
+      output_dir: 'notes',
+      fields: {
+        name: { prompt: 'text', required: true },
+        status: { prompt: 'select', options: ['open', 'done'], default: 'open' },
+      },
+    },
+  },
+};
+
+async function setupVault(schema: Schema): Promise<string> {
+  const vaultDir = await mkdtemp(join(tmpdir(), 'recurrence-test-'));
+  await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+  await writeFile(join(vaultDir, '.bwrb', 'schema.json'), JSON.stringify(schema, null, 2));
+  return vaultDir;
+}
+
+async function writeDefaultTaskTemplate(vaultDir: string): Promise<void> {
+  const dir = join(vaultDir, '.bwrb', 'templates', 'task');
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, 'default.md'),
+    `---
+type: template
+template-for: task
+defaults:
+  status: todo
+---
+
+# {name}
+`
+  );
+}
+
+async function readFrontmatter(filePath: string): Promise<Record<string, unknown>> {
+  const { parseNote } = await import('../../../src/lib/frontmatter.js');
+  const { frontmatter } = await parseNote(filePath);
+  return frontmatter;
+}
+
+async function listTasks(vaultDir: string): Promise<string[]> {
+  const dir = join(vaultDir, 'tasks');
+  if (!existsSync(dir)) return [];
+  return (await readdir(dir)).filter((f) => f.endsWith('.md')).sort();
+}
+
+describe('recurrence: pure helpers', () => {
+  it('parses a trigger expression', () => {
+    expect(parseTrigger('status = done')).toEqual({ field: 'status', value: 'done' });
+    expect(parseTrigger('status=done')).toEqual({ field: 'status', value: 'done' });
+    expect(parseTrigger("status = 'done'")).toEqual({ field: 'status', value: 'done' });
+    expect(parseTrigger('garbage')).toBeNull();
+  });
+
+  it('parses a field-offset expression', () => {
+    expect(parseFieldOffset('deadline + 7d')).toEqual({
+      baseField: 'deadline',
+      sign: 1,
+      amount: 7,
+      unit: 'd',
+    });
+    expect(parseFieldOffset('deadline+1w')).toEqual({
+      baseField: 'deadline',
+      sign: 1,
+      amount: 1,
+      unit: 'w',
+    });
+    expect(parseFieldOffset('due - 2mon')?.unit).toBe('mon');
+    // m is normalized to mon
+    expect(parseFieldOffset('due + 3m')?.unit).toBe('mon');
+    // not a field-offset (transition-time offset would have no date field base
+    // we recognize, but "completed + 7d" is still parsed as a field offset on
+    // the `completed` field — the date-base validation rejects non-date bases).
+    expect(parseFieldOffset('justtext')).toBeNull();
+  });
+});
+
+describe('recurrence: validation', () => {
+  let vaultDir: string;
+  afterEach(async () => {
+    if (vaultDir) await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('accepts a valid date-base offset rule', async () => {
+    vaultDir = await setupVault(RECURRING_SCHEMA);
+    const schema = await loadSchema(vaultDir);
+    expect(validateRecurrenceRule(schema, 'task')).toEqual([]);
+  });
+
+  it('rejects a non-date offset base', async () => {
+    const badSchema: Schema = JSON.parse(JSON.stringify(RECURRING_SCHEMA));
+    // base `status` is a select field, not a date field
+    badSchema.traits!.recurring!.recurrence!.set = { deadline: 'status + 7d' };
+    vaultDir = await setupVault(badSchema);
+    const schema = await loadSchema(vaultDir);
+    const issues = validateRecurrenceRule(schema, 'task');
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues[0]!.message).toMatch(/must be a date field/);
+  });
+
+  it('computes the offset date from the predecessor', async () => {
+    vaultDir = await setupVault(RECURRING_SCHEMA);
+    const schema = await loadSchema(vaultDir);
+    const out = computeOffsetFields(schema, 'task', { deadline: '2026-01-01' });
+    expect(out).toEqual({ deadline: '2026-01-08' });
+  });
+});
+
+describe('recurrence: fast path (edit --json)', () => {
+  let vaultDir: string;
+  beforeEach(async () => {
+    vaultDir = await setupVault(RECURRING_SCHEMA);
+    await writeDefaultTaskTemplate(vaultDir);
+    await mkdir(join(vaultDir, 'tasks'), { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('spawns one successor with correct offset + chain links on status->done', async () => {
+    const taskPath = join(vaultDir, 'tasks', 'Water plants.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Water plants
+status: doing
+deadline: 2026-03-01
+---
+
+# Water plants
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, taskPath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+
+    const tasks = await listTasks(vaultDir);
+    expect(tasks).toHaveLength(2); // predecessor + successor
+
+    // Predecessor now points forward via `next`.
+    const predFm = await readFrontmatter(taskPath);
+    expect(predFm['status']).toBe('done');
+    expect(String(predFm['next'])).toContain('[[');
+
+    // Successor: fresh status, offset deadline, back-link, empty next.
+    const successorName = tasks.find((f) => f !== 'Water plants.md')!;
+    const succFm = await readFrontmatter(join(vaultDir, 'tasks', successorName));
+    expect(succFm['status']).not.toBe('done');
+    expect(succFm['deadline']).toBe('2026-03-08');
+    expect(String(succFm['prev'])).toContain('Water plants');
+    expect(succFm['next'] ?? '').toBe('');
+  });
+
+  it('is idempotent: re-completing a task with a `next` does NOT spawn a duplicate', async () => {
+    const taskPath = join(vaultDir, 'tasks', 'Recur.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Recur
+status: doing
+deadline: 2026-03-01
+---
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, taskPath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+    expect(await listTasks(vaultDir)).toHaveLength(2);
+
+    // Re-run the same completion: `next` is now set, so this is a no-op.
+    await editNoteFromJson(
+      schema,
+      vaultDir,
+      taskPath,
+      JSON.stringify({ status: 'done', deadline: '2026-03-01' }),
+      { jsonMode: false }
+    );
+    expect(await listTasks(vaultDir)).toHaveLength(2);
+  });
+
+  it('does not spawn when status is set to a non-trigger value', async () => {
+    const taskPath = join(vaultDir, 'tasks', 'Stay open.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Stay open
+status: todo
+deadline: 2026-03-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, taskPath, JSON.stringify({ status: 'doing' }), {
+      jsonMode: false,
+    });
+    expect(await listTasks(vaultDir)).toHaveLength(1);
+  });
+});
+
+describe('recurrence: fast path (bulk)', () => {
+  let vaultDir: string;
+  beforeEach(async () => {
+    vaultDir = await setupVault(RECURRING_SCHEMA);
+    await writeDefaultTaskTemplate(vaultDir);
+    await mkdir(join(vaultDir, 'tasks'), { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('spawns a successor when bulk --set status=done transitions a task', async () => {
+    const taskPath = join(vaultDir, 'tasks', 'Bulk task.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Bulk task
+status: doing
+deadline: 2026-05-10
+---
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    const result = await executeBulk({
+      typePath: 'task',
+      operations: [{ type: 'set', field: 'status', value: 'done' }],
+      whereExpressions: [],
+      execute: true,
+      backup: false,
+      verbose: false,
+      quiet: true,
+      jsonMode: true,
+      vaultDir,
+      schema,
+    });
+
+    expect(result.errors).toEqual([]);
+    const tasks = await listTasks(vaultDir);
+    expect(tasks).toHaveLength(2);
+    const successorName = tasks.find((f) => f !== 'Bulk task.md')!;
+    const succFm = await readFrontmatter(join(vaultDir, 'tasks', successorName));
+    expect(succFm['deadline']).toBe('2026-05-17');
+  });
+});
+
+describe('recurrence: backstop (audit missing-successor)', () => {
+  let vaultDir: string;
+  beforeEach(async () => {
+    vaultDir = await setupVault(RECURRING_SCHEMA);
+    await writeDefaultTaskTemplate(vaultDir);
+    await mkdir(join(vaultDir, 'tasks'), { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('flags a hand-completed task (done + empty next) and --fix spawns the successor', async () => {
+    // Simulate completion OUTSIDE bwrb: status=done written directly, no `next`.
+    const taskPath = join(vaultDir, 'tasks', 'Hand done.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Hand done
+status: done
+deadline: 2026-07-01
+---
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+
+    // needsSuccessor predicate matches.
+    const fm = await readFrontmatter(taskPath);
+    expect(needsSuccessor(schema, 'task', fm)).toBe(true);
+
+    // Audit flags missing-successor.
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const taskResult = results.find((r) => r.relativePath.endsWith('Hand done.md'));
+    expect(taskResult).toBeDefined();
+    expect(taskResult!.issues.some((i) => i.code === 'missing-successor')).toBe(true);
+
+    // --fix spawns the missing successor (identical to fast path).
+    const summary = await runAutoFix(results, schema, vaultDir, { dryRun: false });
+    expect(summary.fixed).toBeGreaterThan(0);
+
+    const tasks = await listTasks(vaultDir);
+    expect(tasks).toHaveLength(2);
+    const successorName = tasks.find((f) => f !== 'Hand done.md')!;
+    const succFm = await readFrontmatter(join(vaultDir, 'tasks', successorName));
+    expect(succFm['deadline']).toBe('2026-07-08'); // same offset as fast path
+    expect(succFm['status']).not.toBe('done');
+
+    // Predecessor now has a `next` → re-auditing flags nothing (idempotent).
+    const results2 = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const taskResult2 = results2.find((r) => r.relativePath.endsWith('Hand done.md'));
+    expect(taskResult2?.issues.some((i) => i.code === 'missing-successor') ?? false).toBe(false);
+  });
+
+  it('fast path and backstop produce the SAME successor deadline', async () => {
+    // Fast path
+    const fastPath = join(vaultDir, 'tasks', 'Fast.md');
+    await writeFile(
+      fastPath,
+      `---
+type: task
+name: Fast
+status: doing
+deadline: 2026-09-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, fastPath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+    const fastTasks = await listTasks(vaultDir);
+    const fastSucc = fastTasks.find((f) => f !== 'Fast.md')!;
+    const fastDeadline = (await readFrontmatter(join(vaultDir, 'tasks', fastSucc)))['deadline'];
+
+    // Backstop on an identical predecessor
+    const handPath = join(vaultDir, 'tasks', 'Hand.md');
+    await writeFile(
+      handPath,
+      `---
+type: task
+name: Hand
+status: done
+deadline: 2026-09-01
+---
+`
+    );
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    await runAutoFix(results, schema, vaultDir, { dryRun: false });
+    const allTasks = await listTasks(vaultDir);
+    const handSucc = allTasks.find(
+      (f) => f !== 'Fast.md' && f !== 'Hand.md' && f !== fastSucc
+    )!;
+    const handDeadline = (await readFrontmatter(join(vaultDir, 'tasks', handSucc)))['deadline'];
+
+    expect(handDeadline).toBe(fastDeadline);
+    expect(handDeadline).toBe('2026-09-08');
+  });
+
+  it('does not spawn duplicates on a second --fix run (idempotent backstop)', async () => {
+    const taskPath = join(vaultDir, 'tasks', 'Once.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Once
+status: done
+deadline: 2026-10-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+
+    const r1 = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    await runAutoFix(r1, schema, vaultDir, { dryRun: false });
+    expect(await listTasks(vaultDir)).toHaveLength(2);
+
+    const r2 = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    await runAutoFix(r2, schema, vaultDir, { dryRun: false });
+    expect(await listTasks(vaultDir)).toHaveLength(2);
+  });
+});
+
+describe('recurrence: invalid-recurrence audit', () => {
+  let vaultDir: string;
+  afterEach(async () => {
+    if (vaultDir) await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('flags a missing successor template as a config error', async () => {
+    const schemaWithNamedTemplate: Schema = JSON.parse(JSON.stringify(RECURRING_SCHEMA));
+    schemaWithNamedTemplate.traits!.recurring!.recurrence!.template = 'does-not-exist';
+    vaultDir = await setupVault(schemaWithNamedTemplate);
+    await mkdir(join(vaultDir, 'tasks'), { recursive: true });
+    await writeFile(
+      join(vaultDir, 'tasks', 'T.md'),
+      `---
+type: task
+name: T
+status: todo
+deadline: 2026-01-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const issues = results.flatMap((r) => r.issues);
+    expect(issues.some((i) => i.code === 'invalid-recurrence')).toBe(true);
+  });
+});
+
+describe('recurrence: back-compat (non-recurring type)', () => {
+  let vaultDir: string;
+  beforeEach(async () => {
+    vaultDir = await setupVault(PLAIN_SCHEMA);
+    await mkdir(join(vaultDir, 'notes'), { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('completing a non-recurring note never spawns anything', async () => {
+    const notePath = join(vaultDir, 'notes', 'Plain.md');
+    await writeFile(
+      notePath,
+      `---
+type: note
+name: Plain
+status: open
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, notePath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+    const notes = (await readdir(join(vaultDir, 'notes'))).filter((f) => f.endsWith('.md'));
+    expect(notes).toHaveLength(1);
+
+    // Audit raises no recurrence issues.
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const issues = results.flatMap((r) => r.issues);
+    expect(issues.some((i) => i.code === 'missing-successor')).toBe(false);
+    expect(issues.some((i) => i.code === 'invalid-recurrence')).toBe(false);
+  });
+});
+
+describe('recurrence: multi-spawn template (#630)', () => {
+  let vaultDir: string;
+  afterEach(async () => {
+    if (vaultDir) await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('spawns N correctly-placed staggered notes from a parent template', async () => {
+    // A `project` parent type whose default template scaffolds 4 staggered tasks.
+    const schema: Schema = {
+      version: 2,
+      types: {
+        project: {
+          output_dir: 'projects',
+          fields: {
+            name: { prompt: 'text', required: true },
+          },
+        },
+        task: {
+          output_dir: 'tasks',
+          fields: {
+            name: { prompt: 'text', required: true },
+            title: { prompt: 'text' },
+            deadline: { prompt: 'date' },
+            status: { prompt: 'select', options: ['todo', 'done'], default: 'todo' },
+          },
+        },
+      },
+    };
+    vaultDir = await setupVault(schema);
+
+    // Parent template with staggered instances (date expressions via #603).
+    const projTplDir = join(vaultDir, '.bwrb', 'templates', 'project');
+    await mkdir(projTplDir, { recursive: true });
+    await writeFile(
+      join(projTplDir, 'write-an-article.md'),
+      `---
+type: template
+template-for: project
+instances:
+  - { type: task, defaults: { title: "Outline", deadline: "@today+1d" } }
+  - { type: task, defaults: { title: "Draft",   deadline: "@today+3d" } }
+  - { type: task, defaults: { title: "Edit",    deadline: "@today+5d" } }
+  - { type: task, defaults: { title: "Publish", deadline: "@today+7d" } }
+---
+
+# {name}
+`
+    );
+
+    const loaded = await loadSchema(vaultDir);
+    const tpl = await import('../../../src/lib/template.js').then((m) =>
+      m.findTemplateByName(vaultDir, 'project', 'write-an-article')
+    );
+    expect(tpl).not.toBeNull();
+
+    const parent = await createNoteFromJson(
+      loaded,
+      vaultDir,
+      'project',
+      JSON.stringify({ name: 'My Article' }),
+      tpl
+    );
+
+    // Instances are colocated alongside the parent note (parent's directory).
+    const parentDir = join(vaultDir, 'projects');
+    const parentName = parent.path.split('/').pop()!;
+    const instanceFiles = (await readdir(parentDir))
+      .filter((f) => f.endsWith('.md') && f !== parentName)
+      .sort();
+
+    // Exactly 4 task instances, each a distinct file with a meaningful,
+    // disambiguated name (no `task.md` collapse — the #630 bug).
+    expect(instanceFiles).toEqual(['Draft.md', 'Edit.md', 'Outline.md', 'Publish.md'].sort());
+
+    // Deadlines are staggered (4 distinct values).
+    const deadlines = new Set<string>();
+    for (const f of instanceFiles) {
+      const fm = await readFrontmatter(join(parentDir, f));
+      deadlines.add(String(fm['deadline']));
+    }
+    expect(deadlines.size).toBe(4);
+  });
+});

--- a/tests/ts/lib/schema-schema-drift.test.ts
+++ b/tests/ts/lib/schema-schema-drift.test.ts
@@ -95,6 +95,21 @@ describe('schema.schema.json drift guards', () => {
     );
   });
 
+  it('exposes a recurrence block on the trait definition (#107)', () => {
+    const trait = metaSchema.definitions.trait;
+    expect(trait.properties.recurrence).toBeDefined();
+    expect(trait.properties.recurrence.$ref).toBe('#/definitions/recurrence');
+
+    const recurrence = metaSchema.definitions.recurrence;
+    expect(recurrence).toBeDefined();
+    expect(recurrence.type).toBe('object');
+    expect(recurrence.required).toEqual(expect.arrayContaining(['on']));
+    expect(recurrence.properties.on.type).toBe('string');
+    expect(recurrence.properties.template.type).toBe('string');
+    expect(recurrence.properties.set.type).toBe('object');
+    expect(recurrence.properties.set.additionalProperties.type).toBe('string');
+  });
+
   it('includes filename on type definitions', () => {
     const typeDefProps = metaSchema.definitions.typeDefinition.properties;
     expect(typeDefProps.filename).toBeDefined();

--- a/tests/ts/lib/template.test.ts
+++ b/tests/ts/lib/template.test.ts
@@ -820,14 +820,19 @@ describe('createScaffoldedInstances', () => {
     expect(result.created).toHaveLength(2);
     expect(result.errors).toHaveLength(0);
     expect(result.skipped).toHaveLength(0);
-    expect(existsSync(join(tempDir, 'Drafts', 'My Project', 'Draft v1.md'))).toBe(true);
-    expect(existsSync(join(tempDir, 'Drafts', 'My Project', 'Research.md'))).toBe(true);
+    // Instances are filed in each child type's own output_dir (#107/#630).
+    // `version` and `research` both extend `draft` (output_dir 'Drafts'), so they
+    // land in 'Drafts/', NOT the parent instance folder 'Drafts/My Project/'.
+    expect(existsSync(join(tempDir, 'Drafts', 'Draft v1.md'))).toBe(true);
+    expect(existsSync(join(tempDir, 'Drafts', 'Research.md'))).toBe(true);
   });
 
   it('skips existing files and reports them', async () => {
-    // Create an existing file
+    // Create an existing file in the CHILD type's output_dir (where the instance
+    // would be filed), so the on-disk collision is detected.
+    await mkdir(join(tempDir, 'Drafts'), { recursive: true });
     await writeFile(
-      join(tempDir, 'Drafts', 'My Project', 'Existing.md'),
+      join(tempDir, 'Drafts', 'Existing.md'),
       '---\ntype: notes\n---\n'
     );
 
@@ -867,9 +872,9 @@ describe('createScaffoldedInstances', () => {
 
     expect(result.created).toHaveLength(1);
     
-    // Read the file and check frontmatter
-    const content = await import('fs/promises').then(fs => 
-      fs.readFile(join(tempDir, 'Drafts', 'My Project', 'SEO.md'), 'utf-8')
+    // Read the file (filed in the child `research` type's output_dir) and check.
+    const content = await import('fs/promises').then(fs =>
+      fs.readFile(join(tempDir, 'Drafts', 'SEO.md'), 'utf-8')
     );
     expect(content).toContain('topic: SEO Analysis');
   });
@@ -909,8 +914,8 @@ describe('createScaffoldedInstances', () => {
     );
 
     expect(result.created).toHaveLength(1);
-    // Default filename should be "{type}.md"
-    expect(existsSync(join(tempDir, 'Drafts', 'My Project', 'version.md'))).toBe(true);
+    // Default filename should be "{type}.md", filed in the child output_dir.
+    expect(existsSync(join(tempDir, 'Drafts', 'version.md'))).toBe(true);
   });
 
   it('loads and applies template if specified', async () => {
@@ -946,9 +951,9 @@ Template body here.
 
     expect(result.created).toHaveLength(1);
     
-    // Read the file and check it has template defaults and body
-    const content = await import('fs/promises').then(fs => 
-      fs.readFile(join(tempDir, 'Drafts', 'My Project', 'SEO Research.md'), 'utf-8')
+    // Read the file (filed in the child `research` type's output_dir).
+    const content = await import('fs/promises').then(fs =>
+      fs.readFile(join(tempDir, 'Drafts', 'SEO Research.md'), 'utf-8')
     );
     expect(content).toContain('topic: SEO Template Default');
     expect(content).toContain('## SEO Research');
@@ -993,9 +998,9 @@ Template body here.
 
       expect(result.created).toHaveLength(1);
       
-      // Read the file and check the date expression was evaluated
-      const content = await import('fs/promises').then(fs => 
-        fs.readFile(join(tempDir, 'Drafts', 'My Project', 'Dated Research.md'), 'utf-8')
+      // Read the file (filed in the child `research` type's output_dir).
+      const content = await import('fs/promises').then(fs =>
+        fs.readFile(join(tempDir, 'Drafts', 'Dated Research.md'), 'utf-8')
       );
       // today() + '7d' from 2025-06-15 = 2025-06-22 (date field evaluates)
       // YAML serializes simple strings without quotes


### PR DESCRIPTION
Implements the declarative **task system** from `plans/features/task-system.md`: event-driven recurrence (spawn-on-transition) + template multi-spawn with staggered, offset deadlines. **No cron, no daemon, no LLM** — the schema is the system. Builds on traits (#442) and date-expression-in-template-values (#603).

Closes #107

## A. Recurrence = spawn-on-transition
Config rides on a **`recurring` trait** via a new `recurrence` block `{ on, template?, set }`. Completing a recurring note (its trigger field transitions *into* the trigger value, e.g. `status = done`) spawns a successor.

- **Date rule = field-offset only**: `successor.<dateField> = <predecessor date field> + <offset>` (e.g. `deadline + 7d`). Base **must** be a date field. Transition-time offsets are rejected; calendar-anchored bases deferred.
- **Template** defaults to the type's own default template (a task begets a task); a named template can spawn a **different type**.
- **`next` field, three jobs**: chain/history, idempotency guard (spawn only when `next` is empty), and the audit backstop predicate. The spawned successor's `prev` back-links to its predecessor.

### Two-path execution (shared engine → identical successors)
- **Fast path** — `bwrb edit` / `bwrb bulk --set status=done` spawns the successor as a deterministic side-effect of the write.
- **Backstop** — completing outside bwrb is caught by `bwrb audit` as the new auto-fixable **`missing-successor`** detection; `--fix` spawns it. A broken rule (non-date base, malformed trigger, missing template) is the never-fixable **`invalid-recurrence`** config error.

Both paths run the same `src/lib/recurrence.ts` engine, so they produce the **same** successor. Idempotent on both paths: re-completing a task that already has a `next` is a no-op.

## B. Template multi-spawn + #630 fix
Instance scaffolding no longer collapses spawned files into a single `<type>.md`. Each instance gets a meaningful, **disambiguated** filename (filename pattern / `title` / `name`), so a parent template's N staggered instances (`deadline: "@today+3d"`, …) produce N correctly-named, correctly-staggered notes.

## Where things live
- `src/types/schema.ts` — `RecurrenceSchema` on the trait; `schema.schema.json` + drift-guard test updated.
- `src/lib/schema.ts` — `getRecurrenceForType` (last-wins across composed traits).
- `src/lib/recurrence.ts` — single spawn engine (trigger parse, field-offset compute, successor build, template resolution, idempotency predicate, rule validation).
- `src/lib/recurrence-fast-path.ts` — wired into `edit.ts` (JSON + interactive) and `bulk/execute.ts`.
- `src/lib/audit/{types,detection,fix}.ts` — `missing-successor` + `invalid-recurrence` detection, auto-fix, and interactive fix.
- `src/lib/template.ts` — #630 placement fix.
- Docs — `automation/task-system` guide + schema/audit reference.

## Deliberately deferred
- Calendar-anchored bases ("next Monday").
- Transition-time offsets (rejected by design).

## Gates
- `pnpm qa` ✅ (typecheck, lint, docs:lint, docs:doctor, build, 2168 tests)
- `pnpm knip` ✅
- `pnpm docs:build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)