### PR TITLE
feat(where): add `under` operator for relation-target ancestor queries

### DIFF
--- a/docs-site/src/content/docs/reference/commands/list.md
+++ b/docs-site/src/content/docs/reference/commands/list.md
@@ -98,7 +98,15 @@ bwrb list --type task --where "isChildOf('[[Epic]]')"
 
 # All descendants (with depth limit)
 bwrb list --type task --where "isDescendantOf('[[Q1 Goals]]')" --depth 2
+
+# Follow a relation field, then walk THAT target's ancestors.
+# Matches tasks whose `context` is career or anything under it.
+bwrb list --type task --where "under(context, '[[career]]')"
 ```
+
+`under(field, '[[Node]]')` differs from `isDescendantOf`: it dereferences the
+named relation `field` and walks the *target's* ancestor chain, rather than the
+note's own `parent` chain. See [Targeting Model](/reference/targeting/) for details.
 
 ### Output Formats
 

--- a/docs-site/src/content/docs/reference/targeting.md
+++ b/docs-site/src/content/docs/reference/targeting.md
@@ -73,12 +73,58 @@ bwrb audit --where "isEmpty(tags)"
 - `isRoot()` — note has no parent-like note link (for example `parent`, `owner`, or a singular relation like `milestone`)
 - `isChildOf('[[Note]]')` — direct child of specified note
 - `isDescendantOf('[[Note]]')` — any descendant of specified note
+- `under(field, '[[Note]]')` — the note's `field` relation points at `Note` **or any descendant of `Note`**
 
 ```bash
 bwrb list --type task --where "isRoot()"
 bwrb list --type task --where "isChildOf('[[Epic]]')"
 bwrb list --type task --where "isDescendantOf('[[Q1 Goals]]')" --depth 2
+bwrb list --type task --where "under(context, '[[career]]')"
 ```
+
+#### `under(field, '[[Node]]')` vs `isDescendantOf('[[Node]]')`
+
+Both ask a hierarchy question, but they walk **different** chains:
+
+- `isDescendantOf('[[Node]]')` walks the **filtered note's own** `parent`
+  chain. It answers "is *this note* structurally beneath `Node`?" (for example
+  task → milestone → objective).
+- `under(field, '[[Node]]')` first **dereferences a relation `field`** on the
+  note, then walks **that target's** `parent` chain. It answers "does this
+  note's `field` point into the subtree rooted at `Node`?"
+
+Example. Contexts are real notes in a `parent` hierarchy
+(`Builder.parent = [[career]]`, `Vercel.parent = [[Builder]]`), and a task
+records only the leaf:
+
+```yaml
+# a task
+context: "[[Vercel]]"
+```
+
+```bash
+# Everything in the career domain, at any altitude — Builder, Vercel, deeper.
+bwrb list --type task --where "under(context, '[[career]]')"
+
+# Exact context only.
+bwrb list --type task --where "context = [[Vercel]]"
+```
+
+Notes:
+
+- **Inclusive of the direct target.** `under(context, '[[career]]')` matches a
+  note whose `context` is `[[career]]` itself as well as any descendant of
+  career. (`under(field, '[[X]]')` ≡ `field = [[X]]` OR `field` points to a
+  descendant of `X`.)
+- **Any relation field.** The first argument is the field to dereference —
+  `under(milestone, '[[Q2]]')`, `under(owner, '[[Platform]]')`, etc.
+- **Multi-valued fields.** If the relation holds a list, the note matches when
+  **any** target is under the node.
+- **Resolution scope.** `under` resolves relation targets and their ancestors
+  across the **whole vault**, so the target notes do not need to share the
+  filtered type.
+- **Robustness.** A dangling (unresolvable) relation target simply doesn't
+  match; a malformed `parent` cycle is walked safely and never loops forever.
 
 ### Body (`-b, --body <query>`)
 

--- a/docs/product/cli-targeting.md
+++ b/docs/product/cli-targeting.md
@@ -101,12 +101,14 @@ When running `bwrb audit` without `--type`, each file's type is resolved from it
 **Hierarchy functions** (for recursive types):
 - `isRoot()` — note has no parent
 - `isChildOf('[[Note]]')` — direct child of specified note
-- `isDescendantOf('[[Note]]')` — any descendant of specified note
+- `isDescendantOf('[[Note]]')` — any descendant of specified note (walks the note's own `parent` chain)
+- `under(field, '[[Note]]')` — dereferences the relation `field`, then walks the *target's* `parent` chain; matches when `field` points at `Note` or any descendant of `Note`
 
 ```bash
 bwrb list --type task --where "isRoot()"
 bwrb list --type task --where "isChildOf('[[Epic]]')"
 bwrb list --type task --where "isDescendantOf('[[Q1 Goals]]')" --depth 2
+bwrb list --type task --where "under(context, '[[career]]')"
 ```
 
 ### 4. Body (`--body <query>`)

--- a/src/lib/expression.ts
+++ b/src/lib/expression.ts
@@ -2,6 +2,7 @@ import jsep from 'jsep';
 import type { Expression, BinaryExpression, UnaryExpression, CallExpression, Identifier, Literal, MemberExpression } from 'jsep';
 import { formatLocalDate } from './local-date.js';
 import { FRONTMATTER_IDENTIFIER } from './where-constants.js';
+import { extractLinkTargets } from './links.js';
 
 // Configure jsep for our expression language
 jsep.addBinaryOp('&&', 2);
@@ -40,7 +41,7 @@ export interface EvalContext {
     ctime?: Date;
     mtime?: Date;
   };
-  /** Optional hierarchy data for hierarchy functions (isRoot, isChildOf, isDescendantOf) */
+  /** Optional hierarchy data for hierarchy functions (isRoot, isChildOf, isDescendantOf, under) */
   hierarchyData?: HierarchyData;
 }
 
@@ -368,18 +369,76 @@ const FUNCTIONS: Record<string, FunctionImpl> = {
     const noteName = context.file?.name;
     if (!noteName || !targetAncestor || !context.hierarchyData) return false;
 
-    // Walk up the parent chain checking for the target ancestor
-    // Use a visited set to prevent infinite loops on cyclic parent references
-    const visited = new Set<string>();
-    let current = context.hierarchyData.parentMap.get(noteName);
-    while (current && !visited.has(current)) {
-      if (current === targetAncestor) return true;
-      visited.add(current);
-      current = context.hierarchyData.parentMap.get(current);
+    // Walk up the CURRENT note's own parent chain checking for the target.
+    const startParent = context.hierarchyData.parentMap.get(noteName);
+    if (!startParent) return false;
+    return ancestorChainContains(
+      startParent,
+      targetAncestor,
+      context.hierarchyData.parentMap
+    );
+  },
+
+  /**
+   * Dereference a RELATION FIELD on the current note, then walk each target's
+   * own ancestor (`parent`) chain, returning true if the given node is the
+   * target itself or anywhere in that chain (at any depth).
+   *
+   * Distinct from `isDescendantOf`, which walks the *current note's own* parent
+   * chain. `under` follows a field to ANOTHER note, then walks THAT note's
+   * ancestors. Generalizes to any relation field, not just `context`.
+   *
+   * Usage: under(context, '[[career]]')
+   *   - args[0]: the relation field value(s) (e.g. the value of `context`,
+   *     which may be a single wikilink/markdown link or a list of them)
+   *   - args[1]: the node to test for, in wikilink or plain form
+   *
+   * Semantics are INCLUSIVE of the direct target: `under(context, '[[career]]')`
+   * matches notes whose `context` is `[[career]]` itself OR any descendant of
+   * career. For multi-valued relation fields, matches if ANY target is under
+   * the node.
+   */
+  under: (args, context) => {
+    const targetNode = extractNoteNameFromArg(String(args[1] ?? ''));
+    if (!targetNode || !context.hierarchyData) return false;
+
+    // Resolve the relation field value(s) to note names. extractLinkTargets
+    // handles single values, arrays, wikilinks, and markdown links uniformly.
+    const relationTargets = extractLinkTargets(args[0]);
+    if (relationTargets.length === 0) return false;
+
+    const parentMap = context.hierarchyData.parentMap;
+    for (const relationTarget of relationTargets) {
+      // Inclusive of the direct target (depth 0).
+      if (relationTarget === targetNode) return true;
+      // Otherwise walk the target's own ancestor chain.
+      if (ancestorChainContains(relationTarget, targetNode, parentMap)) {
+        return true;
+      }
     }
     return false;
   },
 };
+
+/**
+ * Walk a parent chain starting from `start`, returning true if `target` is
+ * found anywhere in that chain. Cycle-safe via a visited set, so a malformed
+ * `parent` cycle never causes an infinite loop.
+ */
+function ancestorChainContains(
+  start: string,
+  target: string,
+  parentMap: Map<string, string>
+): boolean {
+  const visited = new Set<string>();
+  let current: string | undefined = start;
+  while (current && !visited.has(current)) {
+    if (current === target) return true;
+    visited.add(current);
+    current = parentMap.get(current);
+  }
+  return false;
+}
 
 /**
  * Extract a note name from an argument that may be in wikilink format.

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -4,6 +4,8 @@ import { getAllFieldsForType, getType, resolveTypeFromFrontmatter } from './sche
 import { matchesExpression, buildEvalContext, type HierarchyData } from './expression.js';
 import { collectFrontmatterKeys, normalizeWhereExpressions } from './where-normalize.js';
 import { extractLinkTarget } from './links.js';
+import { discoverManagedFiles } from './discovery.js';
+import { parseNote } from './frontmatter.js';
 
 /**
  * Validate that a field name is valid for a type.
@@ -47,7 +49,7 @@ export interface FrontmatterFilterOptions {
 // ============================================================================
 
 /** Names of functions that require hierarchy data */
-const HIERARCHY_FUNCTIONS = ['isRoot', 'isChildOf', 'isDescendantOf'];
+const HIERARCHY_FUNCTIONS = ['isRoot', 'isChildOf', 'isDescendantOf', 'under'];
 
 /**
  * Check if any expression uses hierarchy functions.
@@ -57,6 +59,18 @@ function expressionsUseHierarchyFunctions(expressions: string[]): boolean {
   return expressions.some(expr =>
     HIERARCHY_FUNCTIONS.some(fn => expr.includes(fn + '('))
   );
+}
+
+/**
+ * Check if any expression uses the `under` operator.
+ *
+ * `under` dereferences a relation field and walks the *target's* ancestor
+ * chain. The target note is usually NOT in the (type-)filtered candidate set,
+ * so its `parent` chain must be sourced from the full vault rather than only
+ * the files being filtered.
+ */
+function expressionsUseUnder(expressions: string[]): boolean {
+  return expressions.some(expr => expr.includes('under('));
 }
 
 /**
@@ -72,27 +86,73 @@ function buildHierarchyDataFromFiles(
   const hierarchyFieldCache = new Map<string, string[]>();
 
   for (const file of files) {
-    const noteName = basename(file.path, '.md');
-    const typeName = resolveHierarchyType(file.frontmatter, options);
-    const hierarchyFields = getHierarchyFields(typeName, options.schema, hierarchyFieldCache);
-    const parentValue = getHierarchyParentValue(file.frontmatter, hierarchyFields);
-
-    if (parentValue) {
-      const parentTarget = extractLinkTarget(String(parentValue)) ?? String(parentValue).trim();
-      if (parentTarget) {
-        // Set parent relationship
-        parentMap.set(noteName, parentTarget);
-
-        // Build reverse children relationship
-        if (!childrenMap.has(parentTarget)) {
-          childrenMap.set(parentTarget, new Set());
-        }
-        childrenMap.get(parentTarget)!.add(noteName);
-      }
-    }
+    addParentRelationship(file, parentMap, childrenMap, options, hierarchyFieldCache);
   }
 
   return { parentMap, childrenMap };
+}
+
+function addParentRelationship(
+  file: FileWithFrontmatter,
+  parentMap: Map<string, string>,
+  childrenMap: Map<string, Set<string>>,
+  options: Pick<FrontmatterFilterOptions, 'schema' | 'typePath'>,
+  hierarchyFieldCache: Map<string, string[]>
+): void {
+  const noteName = basename(file.path, '.md');
+  // Don't let a later (less specific, full-vault) pass clobber an entry the
+  // type-aware pass already resolved for the candidate set.
+  if (parentMap.has(noteName)) return;
+
+  const typeName = resolveHierarchyType(file.frontmatter, options);
+  const hierarchyFields = getHierarchyFields(typeName, options.schema, hierarchyFieldCache);
+  const parentValue = getHierarchyParentValue(file.frontmatter, hierarchyFields);
+
+  if (!parentValue) return;
+
+  const parentTarget = extractLinkTarget(String(parentValue)) ?? String(parentValue).trim();
+  if (!parentTarget) return;
+
+  parentMap.set(noteName, parentTarget);
+
+  if (!childrenMap.has(parentTarget)) {
+    childrenMap.set(parentTarget, new Set());
+  }
+  childrenMap.get(parentTarget)!.add(noteName);
+}
+
+/**
+ * Augment hierarchy data with parent relationships from the entire vault.
+ *
+ * Needed by `under`, which walks the ancestor chain of a relation target that
+ * usually lives outside the (type-)filtered candidate set. Relationships
+ * already present from the candidate pass are preserved.
+ */
+async function augmentHierarchyDataFromVault(
+  hierarchyData: HierarchyData,
+  options: Pick<FrontmatterFilterOptions, 'schema'> & { vaultDir: string }
+): Promise<void> {
+  if (!options.schema) return;
+
+  const managedFiles = await discoverManagedFiles(options.schema, options.vaultDir);
+  const hierarchyFieldCache = new Map<string, string[]>();
+
+  for (const managed of managedFiles) {
+    let frontmatter: Record<string, unknown>;
+    try {
+      ({ frontmatter } = await parseNote(managed.path));
+    } catch {
+      continue;
+    }
+    addParentRelationship(
+      { path: managed.path, frontmatter },
+      hierarchyData.parentMap,
+      hierarchyData.childrenMap,
+      // Resolve each note's own type from frontmatter for the full-vault pass.
+      options.schema ? { schema: options.schema } : {},
+      hierarchyFieldCache
+    );
+  }
 }
 
 function resolveHierarchyType(
@@ -230,6 +290,12 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
       ...(schema ? { schema } : {}),
       ...(typePath ? { typePath } : {}),
     });
+
+    // `under` resolves relation targets that typically live outside the
+    // filtered candidate set, so it needs the full vault's parent chains.
+    if (schema && expressionsUseUnder(normalizedExpressions)) {
+      await augmentHierarchyDataFromVault(hierarchyData, { schema, vaultDir });
+    }
   }
 
   for (const file of files) {

--- a/tests/ts/lib/expression.test.ts
+++ b/tests/ts/lib/expression.test.ts
@@ -356,6 +356,128 @@ describe('expression', () => {
       });
     });
 
+    describe('under()', () => {
+      // Context hierarchy (separate from the task hierarchy above):
+      // career (root)
+      //   └── Builder
+      //         └── Vercel
+      // personal (root)
+      const contextParentMap = new Map([
+        ['Builder', 'career'],
+        ['Vercel', 'Builder'],
+      ]);
+      const contextChildrenMap = new Map([
+        ['career', new Set(['Builder'])],
+        ['Builder', new Set(['Vercel'])],
+      ]);
+
+      // Helper: a note whose `context` relation field points somewhere, with
+      // the context hierarchy available for walking the target's ancestors.
+      const makeNoteWithContext = (
+        relationValue: unknown
+      ): EvalContext => ({
+        frontmatter: { context: relationValue },
+        file: { name: 'Some Task', path: 'Tasks/Some Task.md', folder: 'Tasks', ext: '.md' },
+        hierarchyData: { parentMap: contextParentMap, childrenMap: contextChildrenMap },
+      });
+
+      it('matches when relation target is a deep descendant of the node', () => {
+        const ctx = makeNoteWithContext('[[Vercel]]');
+        expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(true);
+      });
+
+      it('matches when relation target is a direct child of the node', () => {
+        const ctx = makeNoteWithContext('[[Builder]]');
+        expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(true);
+      });
+
+      it('matches the direct target itself (inclusive, depth 0)', () => {
+        const ctx = makeNoteWithContext('[[career]]');
+        expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(true);
+      });
+
+      it('does not match an unrelated node', () => {
+        const ctx = makeNoteWithContext('[[Vercel]]');
+        expect(matchesExpression("under(context, '[[personal]]')", ctx)).toBe(false);
+      });
+
+      it('does not crash and does not match on a dangling relation target', () => {
+        const ctx = makeNoteWithContext('[[Nonexistent]]');
+        expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(false);
+      });
+
+      it('returns false when the relation field is empty', () => {
+        const ctx = makeNoteWithContext('');
+        expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(false);
+      });
+
+      it('returns false when hierarchyData is missing', () => {
+        const ctx: EvalContext = {
+          frontmatter: { context: '[[Vercel]]' },
+          file: { name: 'Some Task', path: 'Tasks/Some Task.md', folder: 'Tasks', ext: '.md' },
+        };
+        expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(false);
+      });
+
+      it('matches if ANY target of a multi-valued relation is under the node', () => {
+        const ctx = makeNoteWithContext(['[[personal]]', '[[Vercel]]']);
+        expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(true);
+      });
+
+      it('does not match a multi-valued relation when no target is under the node', () => {
+        const ctx = makeNoteWithContext(['[[personal]]', '[[Nonexistent]]']);
+        expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(false);
+      });
+
+      it('accepts a plain (non-wikilink) node argument', () => {
+        const ctx = makeNoteWithContext('[[Vercel]]');
+        expect(matchesExpression("under(context, 'career')", ctx)).toBe(true);
+      });
+
+      it('resolves markdown-link relation values', () => {
+        const ctx = makeNoteWithContext('[Vercel](Vercel.md)');
+        expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(true);
+      });
+
+      it('generalizes to any relation field, not just context', () => {
+        const ctx: EvalContext = {
+          frontmatter: { sponsor: '[[Vercel]]' },
+          file: { name: 'Some Task', path: 'Tasks/Some Task.md', folder: 'Tasks', ext: '.md' },
+          hierarchyData: { parentMap: contextParentMap, childrenMap: contextChildrenMap },
+        };
+        expect(matchesExpression("under(sponsor, '[[career]]')", ctx)).toBe(true);
+      });
+
+      it('does not infinite-loop on a cyclic target ancestor chain', () => {
+        // Cycle among the target chain: A -> B -> C -> A
+        const cyclicParentMap = new Map([
+          ['A', 'C'],
+          ['B', 'A'],
+          ['C', 'B'],
+        ]);
+        const ctx: EvalContext = {
+          frontmatter: { context: '[[A]]' },
+          file: { name: 'Some Task', path: 'Tasks/Some Task.md', folder: 'Tasks', ext: '.md' },
+          hierarchyData: { parentMap: cyclicParentMap, childrenMap: new Map() },
+        };
+        // Should terminate and return false (target not in the cycle).
+        expect(matchesExpression("under(context, '[[Nonexistent]]')", ctx)).toBe(false);
+      });
+
+      it('is distinct from isDescendantOf — walks the RELATION target, not the note itself', () => {
+        // The note "Some Task" has NO parent of its own, so isDescendantOf is
+        // false. But its `context` relation points to Vercel, which IS under
+        // career, so `under` is true. Same node argument, opposite results.
+        const ctx: EvalContext = {
+          frontmatter: { context: '[[Vercel]]' },
+          file: { name: 'Some Task', path: 'Tasks/Some Task.md', folder: 'Tasks', ext: '.md' },
+          hierarchyData: { parentMap: contextParentMap, childrenMap: contextChildrenMap },
+        };
+        expect(matchesExpression("isDescendantOf('[[career]]')", ctx)).toBe(false);
+        expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(true);
+      });
+    });
+
     describe('hierarchy functions composability', () => {
       it('should combine with other expressions using AND', () => {
         const ctx: EvalContext = {

--- a/tests/ts/lib/query.test.ts
+++ b/tests/ts/lib/query.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { join } from 'path';
+import { writeFile, rm } from 'fs/promises';
 import {
   validateFieldForType,
   applyFrontmatterFilters,
@@ -195,6 +196,105 @@ describe('query', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0]?.path).toContain('Standalone Task.md');
+    });
+
+    describe('under() operator (full-vault relation-target resolution)', () => {
+      // Build a context hierarchy out of recursive `task` notes so they live in
+      // the vault and are discoverable by the full-vault augmentation pass:
+      //   career (root)
+      //     └── Builder
+      //           └── Vercel
+      const contextNotes: string[] = [];
+
+      beforeAll(async () => {
+        const write = async (name: string, parent: string | null) => {
+          const path = join(vaultDir, 'Objectives/Tasks', `${name}.md`);
+          const parentLine = parent ? `\nparent: "[[${parent}]]"` : '';
+          await writeFile(
+            path,
+            `---\ntype: task\nstatus: backlog${parentLine}\n---\n`
+          );
+          contextNotes.push(path);
+        };
+        await write('career', null);
+        await write('Builder', 'career');
+        await write('Vercel', 'Builder');
+      });
+
+      afterAll(async () => {
+        await Promise.all(contextNotes.map(p => rm(p, { force: true })));
+      });
+
+      it('matches a note whose relation target is a deep descendant of the node', async () => {
+        // Candidate task has NO parent of its own; its `milestone` relation
+        // points at Vercel, which is under career via Builder.
+        const files = makeFiles([
+          { path: 'Objectives/Tasks/Leaf.md', fm: { type: 'task', status: 'backlog', milestone: '"[[Vercel]]"' } },
+        ]);
+
+        const result = await applyFrontmatterFilters(files, {
+          whereExpressions: ["under(milestone, '[[career]]')"],
+          vaultDir,
+          schema,
+          typePath: 'task',
+        });
+
+        expect(result).toHaveLength(1);
+      });
+
+      it('does not match when the relation target is not under the node', async () => {
+        const files = makeFiles([
+          { path: 'Objectives/Tasks/Leaf.md', fm: { type: 'task', status: 'backlog', milestone: '"[[career]]"' } },
+        ]);
+
+        const result = await applyFrontmatterFilters(files, {
+          whereExpressions: ["under(milestone, '[[Builder]]')"],
+          vaultDir,
+          schema,
+          typePath: 'task',
+        });
+
+        expect(result).toHaveLength(0);
+      });
+
+      it('is distinct from isDescendantOf — relation chain vs the note\'s own chain', async () => {
+        // The candidate has no parent, so isDescendantOf('[[career]]') is false,
+        // but under(milestone, '[[career]]') follows the relation and is true.
+        const files = makeFiles([
+          { path: 'Objectives/Tasks/Leaf.md', fm: { type: 'task', status: 'backlog', milestone: '"[[Vercel]]"' } },
+        ]);
+
+        const descResult = await applyFrontmatterFilters(files, {
+          whereExpressions: ["isDescendantOf('[[career]]')"],
+          vaultDir,
+          schema,
+          typePath: 'task',
+        });
+        expect(descResult).toHaveLength(0);
+
+        const underResult = await applyFrontmatterFilters(files, {
+          whereExpressions: ["under(milestone, '[[career]]')"],
+          vaultDir,
+          schema,
+          typePath: 'task',
+        });
+        expect(underResult).toHaveLength(1);
+      });
+
+      it('does not match (and does not crash) on a dangling relation target', async () => {
+        const files = makeFiles([
+          { path: 'Objectives/Tasks/Leaf.md', fm: { type: 'task', status: 'backlog', milestone: '"[[Ghost]]"' } },
+        ]);
+
+        const result = await applyFrontmatterFilters(files, {
+          whereExpressions: ["under(milestone, '[[career]]')"],
+          vaultDir,
+          schema,
+          typePath: 'task',
+        });
+
+        expect(result).toHaveLength(0);
+      });
     });
 
     it('should throw on invalid expression syntax', async () => {


### PR DESCRIPTION
## Summary

Implements #602: a new `--where` operator, **`under`**, that dereferences a relation field on a note and walks the **target's** `parent` ancestor chain — distinct from `isDescendantOf`, which walks the filtered note's own chain.

Surface syntax (matches the engine's existing call-style hierarchy functions like `isDescendantOf('[[X]]')`):

```bash
bwrb list --type task --where "under(context, '[[career]]')"
```

- **arg 0** is the relation field to dereference (e.g. `context`); it evaluates to the field's value(s).
- **arg 1** is the node to test for, in wikilink or plain form.

## Semantics

- **Inclusive of the direct target (depth 0):** `under(field, '[[X]]')` ≡ `field = [[X]]` OR `field` points to a descendant of `X`. This lets you query "everything in the career domain" at any altitude.
- **Any relation field**, not just `context`.
- **Multi-valued** relations match if ANY target is under the node.
- Resolves both wikilinks and markdown links.

## How it differs from `isDescendantOf`

- `isDescendantOf('[[Node]]')` walks the **filtered note's own** `parent` chain (task → milestone → objective).
- `under(field, '[[Node]]')` follows a **relation field to another note**, then walks **that note's** ancestors.

Proven by tests in both `expression.test.ts` (unit) and `query.test.ts` (integration): a note with no `parent` of its own but `context: [[Vercel]]` is **not** matched by `isDescendantOf('[[career]]')` yet **is** matched by `under(context, '[[career]]')`.

## Engine hookup

- Added `under` to the `FUNCTIONS` map in `src/lib/expression.ts`; extracted a shared cycle-safe `ancestorChainContains` helper (reused by `isDescendantOf`).
- Registered `under` as a hierarchy function in `src/lib/query.ts`. Because `under` resolves targets that usually live **outside** the type-filtered candidate set, when an expression uses `under` the parent map is augmented from the **full vault** (`discoverManagedFiles` + `parseNote`) so target ancestor chains are resolvable regardless of type.
- Works anywhere the expression engine runs (`list`, `bulk`, `search`/`edit`, dashboards, etc.) via `applyFrontmatterFilters`.

## Edge cases

- **Cycle safety:** ancestor walk uses a visited set — a malformed `parent` cycle terminates and returns false.
- **Dangling target:** unresolvable relation target → no match, no crash.
- **Empty / missing field / missing hierarchy data:** no match.

## Docs

Documented in `reference/targeting.md` (with a dedicated `under` vs `isDescendantOf` section) and `reference/commands/list.md`, plus the product `docs/product/cli-targeting.md`. `pnpm docs:build` passes.

## Quality gates

- `pnpm qa` ✅ (2194 passed, 4 skipped)
- `pnpm knip` ✅
- `pnpm docs:build` ✅
- Verified end-to-end against a scratch vault (career → Builder → Vercel hierarchy + leaf tasks).

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)