### PR TITLE
feat(schema): add `schema discover` deterministic field-usage report

### DIFF
--- a/docs-site/src/content/docs/concepts/validation-and-audit.md
+++ b/docs-site/src/content/docs/concepts/validation-and-audit.md
@@ -86,6 +86,33 @@ bwrb audit --output json
 # Exit code 1 if violations found
 ```
 
+## Describe vs. enforce: `discover` vs. `audit`
+
+`audit` is **prescriptive** — it reports what is *wrong* relative to the schema,
+exits non-zero when it finds violations, and can `--fix` them.
+
+[`bwrb schema discover`](/reference/commands/schema/#discover) is the
+**descriptive** counterpart. It reports frontmatter *facts* over a folder — every
+field, its frequency, the value-types it holds, which files diverge, and (when a
+schema exists) drift such as used-but-undefined fields, defined-but-unused fields,
+and values diverging from declared options. It never passes or fails and is safe
+to run anytime.
+
+Two ways to reach for it:
+
+- **Before a schema exists** — point `discover` at a messy folder to gather raw
+  material for designing types.
+- **After a schema exists** — use it to *see* drift descriptively, then use
+  `audit` to *enforce* the schema.
+
+```bash
+# Describe what's in a folder (no judgment)
+bwrb schema discover ./notes
+
+# Enforce the schema (pass/fail, fixable)
+bwrb audit
+```
+
 ## Next Steps
 
 - [Migrations](/concepts/migrations/) — Evolving your schema over time

--- a/docs-site/src/content/docs/reference/commands/schema.md
+++ b/docs-site/src/content/docs/reference/commands/schema.md
@@ -19,6 +19,7 @@ bwrb schema <subcommand>
 | [fields](#fields-alias) | Alias for `schema list <typePath>` |
 | [list](#list) | List schema contents |
 | [validate](#validate) | Validate schema structure |
+| [discover](#discover) | Report frontmatter field-usage facts (descriptive) |
 | [diff](#diff) | Show pending schema changes |
 | [migrate](#migrate) | Apply schema changes to notes |
 | [history](#history) | Show migration history |
@@ -36,6 +37,9 @@ bwrb schema fields task
 
 # Validate schema structure
 bwrb schema validate
+
+# Report frontmatter field-usage facts over a folder (descriptive)
+bwrb schema discover ./notes
 
 # Preview migration
 bwrb schema diff
@@ -219,6 +223,119 @@ bwrb schema validate --output json
 |------|---------|
 | `0` | Schema is valid |
 | `1` | Validation errors found |
+
+---
+
+## discover
+
+Report **descriptive** facts about the frontmatter across a folder of Markdown
+notes. `discover` reports what is there — every field, how often it appears, the
+value-types it holds, and which files diverge. It never passes or fails, never
+prescribes, and is safe to run anytime, including on a messy folder that has no
+schema yet.
+
+It works on an **arbitrary folder path**, not only a managed vault, so you can
+point it at unmanaged Markdown during onboarding.
+
+### Descriptive vs. audit
+
+`discover` is **descriptive**: it states facts and exits non-zero only for a real
+error (such as an unreadable path), never for "non-conforming" data.
+[`bwrb audit`](/reference/commands/audit/) is **prescriptive**: it reports what is
+*wrong* relative to the schema, with exit codes and `--fix`. Use `discover` to
+understand a folder; use `audit` to enforce the schema.
+
+### Two roles
+
+| Role | When | What it surfaces |
+|------|------|------------------|
+| Onboarding | Before a schema exists | Every field, its frequency, value-type consistency, and which files diverge — raw material for designing types. |
+| Drift detection | After a schema exists | Additionally: fields **used but not defined**, fields **defined but unused**, and values **diverging from declared `select` options**. |
+
+A schema is used automatically when a `.bwrb/schema.json` is found at or above the
+scanned folder (or via `--vault`). When none is found, `discover` runs in the
+onboarding role. Use `--no-schema` to force the onboarding view even when a schema
+is present.
+
+### Synopsis
+
+```bash
+bwrb schema discover [path] [options]
+```
+
+`path` defaults to the current directory.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--output <format>` | Output format: `text` (default), `json` |
+| `--no-schema` | Skip drift detection; report raw field facts only |
+
+### Examples
+
+```bash
+# Scan the current directory
+bwrb schema discover
+
+# Scan an arbitrary folder (onboarding)
+bwrb schema discover ./notes
+
+# Structured facts for scripting or agents
+bwrb schema discover ./notes --output json
+
+# Skip drift even if a schema is present
+bwrb schema discover ./notes --no-schema
+```
+
+### JSON output
+
+`--output json` emits the standard `{ "success": true, "data": ... }` envelope.
+The `data` object has this shape:
+
+```jsonc
+{
+  "root": "/abs/path/scanned",
+  "totalFiles": 4,
+  "filesWithFrontmatter": 3,
+  "unreadable": [],                 // { file, error } for files skipped (never fatal)
+  "schemaPresent": true,            // whether a schema was loaded for drift
+  "fields": [
+    {
+      "field": "status",
+      "count": 3,                   // notes in which the field appears
+      "frequency": 1,               // count / filesWithFrontmatter (0..1)
+      "types": [                    // observed value-types, by descending count
+        { "type": "string", "count": 3 }
+      ],
+      "mixedTypes": false,          // true when >1 non-empty value-type
+      "divergingFiles": [],         // files whose type differs from the most common
+      "defined": true,              // schema role: declared by any type?
+      "divergingOptions": [         // schema role: values outside declared options
+        { "value": "wibble", "files": ["c.md"] }
+      ]
+    }
+  ],
+  "drift": {                        // present only when a schema was loaded
+    "usedButUndefined": ["deadline"],
+    "definedButUnused": ["rating"],
+    "optionDivergences": [
+      { "field": "status", "values": [ { "value": "wibble", "files": ["c.md"] } ] }
+    ]
+  }
+}
+```
+
+Value-types are coarse, frontmatter-shaped buckets: `string`, `number`,
+`boolean`, `date` (an ISO-ish date string), `list`, `object`, and `empty`
+(null / empty string / empty list).
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Report produced (including for non-conforming data) |
+| `2` | Real error (for example, the path is missing or unreadable) |
 
 ---
 

--- a/src/commands/schema/discover.ts
+++ b/src/commands/schema/discover.ts
@@ -1,0 +1,245 @@
+/**
+ * `bwrb schema discover [path]` — deterministic frontmatter field-usage report.
+ *
+ * DESCRIPTIVE, not prescriptive. It reports facts about the frontmatter across a
+ * folder of Markdown notes and never passes/fails. It exits non-zero only for
+ * real errors (e.g. an unreadable path), never for "non-conforming" data.
+ *
+ * Two roles:
+ *   - Pre-schema (onboarding): point it at any folder; get raw material for
+ *     designing types — every field, its frequency, value-type consistency, and
+ *     which files diverge.
+ *   - Post-schema (drift): when a schema is found, it additionally reports
+ *     fields used-but-undefined, defined-but-unused, and values diverging from
+ *     declared `select` options.
+ *
+ * Contrast with `audit`, which is PRESCRIPTIVE (what is wrong vs the schema).
+ */
+
+import { Command } from 'commander';
+import { resolve, dirname, join } from 'path';
+import { stat } from 'fs/promises';
+import { existsSync } from 'fs';
+import chalk from 'chalk';
+import { getGlobalOpts } from '../../lib/command.js';
+import { printJson, jsonSuccess, jsonError, ExitCodes } from '../../lib/output.js';
+import { printError } from '../../lib/prompt.js';
+import { getTtyContext } from '../../lib/tty/context.js';
+import { renderTable } from '../../lib/tty/table.js';
+import { loadSchema } from '../../lib/schema.js';
+import { SCHEMA_RELATIVE_PATH } from '../../lib/bwrb-paths.js';
+import { buildDiscoverReport, type DiscoverReport, type FieldFacts } from '../../lib/discover.js';
+
+interface DiscoverOptions {
+  output?: string;
+  /**
+   * Commander stores `--no-schema` as `schema: false` (defaults to true).
+   * When false, skip drift detection even if a schema is found.
+   */
+  schema?: boolean;
+}
+
+/**
+ * Walk upward from `start` looking for a directory containing
+ * `.bwrb/schema.json`. Returns that directory, or undefined if none is found.
+ * Keeps the pre-schema role working on an arbitrary folder with no vault.
+ */
+function findSchemaVaultDir(start: string): string | undefined {
+  let dir = start;
+  for (;;) {
+    if (existsSync(join(dir, SCHEMA_RELATIVE_PATH))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+export const discoverCommand = new Command('discover')
+  .description('Report frontmatter field-usage facts over a folder (descriptive)')
+  .argument('[path]', 'Folder to scan (defaults to current directory)')
+  .option('--output <format>', 'Output format: text (default) or json')
+  .option('--no-schema', 'Skip drift detection; report raw field facts only')
+  .addHelpText('after', `
+Discover is DESCRIPTIVE: it reports facts and never passes/fails. It is safe to
+run anytime, including on a messy folder that has no schema yet. (For a
+PRESCRIPTIVE report of what is wrong vs the schema, use 'bwrb audit'.)
+
+Roles:
+  Before a schema exists  Onboarding — raw material for designing types.
+  After a schema exists    Drift — fields used-but-undefined, defined-but-unused,
+                           and values diverging from declared select options.
+
+Examples:
+  bwrb schema discover                  # Scan the current directory
+  bwrb schema discover ./notes          # Scan an arbitrary folder
+  bwrb schema discover --output json    # Structured facts for scripting/agents
+  bwrb schema discover --no-schema      # Skip drift even if a schema is present`)
+  .action(async (path: string | undefined, options: DiscoverOptions, cmd: Command) => {
+    const globalOpts = getGlobalOpts(cmd);
+    const jsonMode = options.output === 'json' || globalOpts.output === 'json';
+
+    try {
+      const root = resolve(path ?? globalOpts.vault ?? process.cwd());
+
+      // Validate the path is a real, readable directory (a real error → non-zero).
+      let info;
+      try {
+        info = await stat(root);
+      } catch {
+        throw new Error(`Path not found or unreadable: ${root}`);
+      }
+      if (!info.isDirectory()) {
+        throw new Error(`Not a directory: ${root}`);
+      }
+
+      // Locate a schema for drift detection (optional). Prefer --vault, else
+      // walk up from the scanned folder. Never required.
+      const driftEnabled = options.schema !== false;
+      let schema;
+      if (driftEnabled) {
+        const vaultDir = globalOpts.vault
+          ? resolve(globalOpts.vault)
+          : findSchemaVaultDir(root);
+        if (vaultDir && existsSync(join(vaultDir, SCHEMA_RELATIVE_PATH))) {
+          try {
+            schema = await loadSchema(vaultDir);
+          } catch {
+            // A broken schema must not break a descriptive report; fall back to
+            // the pre-schema (onboarding) view rather than erroring.
+            schema = undefined;
+          }
+        }
+      }
+
+      const report = await buildDiscoverReport(root, { schema });
+
+      if (jsonMode) {
+        printJson(jsonSuccess({ data: report }));
+        return;
+      }
+
+      printTextReport(report);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (jsonMode) {
+        printJson(jsonError(message, { code: ExitCodes.IO_ERROR }));
+        process.exit(ExitCodes.IO_ERROR);
+      }
+      printError(message);
+      process.exit(ExitCodes.IO_ERROR);
+    }
+  });
+
+// ============================================================================
+// Text rendering
+// ============================================================================
+
+function formatTypes(field: FieldFacts): string {
+  return field.types.map((t) => `${t.type} (${t.count})`).join(', ');
+}
+
+function formatNotes(field: FieldFacts): string {
+  const notes: string[] = [];
+  if (field.mixedTypes) {
+    notes.push(`mixed types in ${field.divergingFiles.length} file(s)`);
+  }
+  if (field.defined === false) {
+    notes.push('not in schema');
+  }
+  if (field.divergingOptions && field.divergingOptions.length > 0) {
+    const total = field.divergingOptions.reduce((n, d) => n + d.files.length, 0);
+    notes.push(`${field.divergingOptions.length} off-option value(s) in ${total} file(s)`);
+  }
+  return notes.join('; ');
+}
+
+function printTextReport(report: DiscoverReport): void {
+  const context = getTtyContext();
+
+  console.log('');
+  console.log(chalk.bold(`Field usage in ${report.root}`));
+  console.log(
+    chalk.gray(
+      `${report.totalFiles} markdown file(s), ` +
+        `${report.filesWithFrontmatter} with frontmatter` +
+        (report.schemaPresent ? ', schema loaded' : ', no schema')
+    )
+  );
+  console.log('');
+
+  if (report.fields.length === 0) {
+    console.log(chalk.gray('No frontmatter fields found.'));
+  } else {
+    const rows = report.fields.map((f) => ({
+      field: f.field,
+      count: String(f.count),
+      frequency: `${Math.round(f.frequency * 100)}%`,
+      types: formatTypes(f),
+      notes: formatNotes(f),
+    }));
+
+    const lines = renderTable({
+      context,
+      rows,
+      columns: [
+        { key: 'field', title: 'Field', minWidth: 6, style: chalk.cyan },
+        { key: 'count', title: 'Count', align: 'right' },
+        { key: 'frequency', title: 'Freq', align: 'right' },
+        { key: 'types', title: 'Value types', mode: 'wrap', weight: 2 },
+        { key: 'notes', title: 'Notes', mode: 'wrap', weight: 3, canDrop: true, style: chalk.yellow },
+      ],
+    });
+    for (const line of lines) console.log(line);
+  }
+
+  if (report.drift) {
+    printDriftSection(report);
+  }
+
+  if (report.unreadable.length > 0) {
+    console.log('');
+    console.log(chalk.gray(`Skipped ${report.unreadable.length} unreadable file(s):`));
+    for (const u of report.unreadable) {
+      console.log(chalk.gray(`  ${u.file}: ${u.error}`));
+    }
+  }
+
+  console.log('');
+}
+
+function printDriftSection(report: DiscoverReport): void {
+  const drift = report.drift!;
+  console.log('');
+  console.log(chalk.bold('Drift vs schema'));
+
+  if (
+    drift.usedButUndefined.length === 0 &&
+    drift.definedButUnused.length === 0 &&
+    drift.optionDivergences.length === 0
+  ) {
+    console.log(chalk.gray('  No drift observed.'));
+    return;
+  }
+
+  if (drift.usedButUndefined.length > 0) {
+    console.log(chalk.yellow('  Used but not defined in schema:'));
+    for (const field of drift.usedButUndefined) {
+      console.log(`    - ${field}`);
+    }
+  }
+  if (drift.definedButUnused.length > 0) {
+    console.log(chalk.yellow('  Defined in schema but unused:'));
+    for (const field of drift.definedButUnused) {
+      console.log(`    - ${field}`);
+    }
+  }
+  if (drift.optionDivergences.length > 0) {
+    console.log(chalk.yellow('  Values diverging from declared options:'));
+    for (const entry of drift.optionDivergences) {
+      const values = entry.values
+        .map((v) => `"${v.value}" (${v.files.length} file(s))`)
+        .join(', ');
+      console.log(`    - ${entry.field}: ${values}`);
+    }
+  }
+}

--- a/src/commands/schema/index.ts
+++ b/src/commands/schema/index.ts
@@ -16,6 +16,7 @@ import { listCommand, runSchemaListOverview, runSchemaListTypeDetails } from './
 import { registerNewTypeCommand, registerEditTypeCommand, registerDeleteTypeCommand } from './type.js';
 import { registerNewFieldCommand, registerEditFieldCommand, registerDeleteFieldCommand } from './field.js';
 import { registerMigrationCommands } from './migrate.js';
+import { discoverCommand } from './discover.js';
 import { promptSchemaEntityType, inferSchemaEntity, getTypesWithOwnField } from './helpers/pickers.js';
 import { promptSelection } from '../../lib/prompt.js';
 
@@ -33,7 +34,8 @@ Examples:
   bwrb schema list type objective  # Show objective type details (canonical)
   bwrb schema list objective/task  # Alias for schema list type objective/task
   bwrb schema list -t task --output json  # Type details as JSON for AI/scripting
-  bwrb schema validate          # Validate schema structure`);
+  bwrb schema validate          # Validate schema structure
+  bwrb schema discover ./notes  # Descriptive frontmatter field-usage facts`);
 
 interface SchemaTypesAliasOptions {
   output?: string;
@@ -169,6 +171,12 @@ schemaCommand
       process.exit(1);
     }
   });
+
+// ============================================================================
+// Discover Command (descriptive field-usage facts)
+// ============================================================================
+
+schemaCommand.addCommand(discoverCommand);
 
 // ============================================================================
 // Unified Verb Commands (new, edit, delete)

--- a/src/lib/discover.ts
+++ b/src/lib/discover.ts
@@ -1,0 +1,429 @@
+/**
+ * `schema discover` — deterministic frontmatter field-usage facts.
+ *
+ * This module is purely DESCRIPTIVE. It reports facts about the frontmatter
+ * across a folder of Markdown notes — never a pass/fail judgment. It powers two
+ * roles:
+ *   1. Before a schema exists → onboarding: raw material for designing types.
+ *   2. After a schema exists  → drift detection: fields used-but-undefined,
+ *      defined-but-unused, and values diverging from declared `select` options.
+ *
+ * It deliberately does NOT depend on a vault layout. It walks an arbitrary
+ * folder so it can be pointed at a messy, unmanaged directory of Markdown.
+ *
+ * Contrast with `audit` (which is PRESCRIPTIVE: what is *wrong* vs the schema,
+ * with exit codes and fixes). `discover` simply describes what is there.
+ */
+
+import { readdir } from 'fs/promises';
+import { join, relative } from 'path';
+import { parseNote } from './frontmatter.js';
+import {
+  getAllOwnFieldNames,
+  getConcreteTypeNames,
+  getFieldsForType,
+} from './schema.js';
+import { type LoadedSchema, type Field, getOptionValues } from '../types/schema.js';
+
+// ============================================================================
+// Value-type classification
+// ============================================================================
+
+/**
+ * The descriptive value-type buckets `discover` reports per observed value.
+ *
+ * These are deliberately coarse and frontmatter-shaped (not the schema's
+ * `prompt` taxonomy). `date` is a string that matches an ISO-ish date shape —
+ * surfaced separately because it is a common, meaningful distinction when
+ * eyeballing a messy folder. `empty` covers null / empty string / empty list.
+ */
+export type ValueType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'date'
+  | 'list'
+  | 'object'
+  | 'empty';
+
+// YYYY, YYYY-MM, or YYYY-MM-DD (optionally with a time component).
+const DATE_LIKE = /^\d{4}(-\d{2}(-\d{2}(T[\d:.]+Z?)?)?)?$/;
+
+/**
+ * Classify a single frontmatter value into a descriptive {@link ValueType}.
+ *
+ * `parseNote` already normalizes YAML dates to `YYYY-MM-DD` strings, so dates
+ * arrive here as strings and are re-detected by shape.
+ */
+function classifyValue(value: unknown): ValueType {
+  if (value === null || value === undefined) return 'empty';
+  if (typeof value === 'boolean') return 'boolean';
+  if (typeof value === 'number') return 'number';
+  if (typeof value === 'string') {
+    if (value.trim().length === 0) return 'empty';
+    if (DATE_LIKE.test(value.trim())) return 'date';
+    return 'string';
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0 ? 'empty' : 'list';
+  }
+  if (typeof value === 'object') return 'object';
+  return 'string';
+}
+
+/**
+ * Collect the scalar string values a field holds in a note, for matching
+ * against declared `select` options. Scalars contribute their string form;
+ * lists contribute each scalar element; everything else contributes nothing.
+ */
+function collectComparableValues(value: unknown): string[] {
+  if (value === null || value === undefined) return [];
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? [trimmed] : [];
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return [String(value)];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectComparableValues(item));
+  }
+  return [];
+}
+
+// ============================================================================
+// Report shape
+// ============================================================================
+
+/** A value that diverged from a field's declared `select` options. */
+export interface DivergingValue {
+  value: string;
+  /** Note paths (relative to the scanned root) that used this value. */
+  files: string[];
+}
+
+/** Per-field descriptive facts aggregated across the scanned notes. */
+export interface FieldFacts {
+  field: string;
+  /** Number of notes in which this field appears (its key is present). */
+  count: number;
+  /** Fraction of notes-with-frontmatter that use this field (0..1). */
+  frequency: number;
+  /**
+   * Observed value-types and how many notes exhibited each, sorted by
+   * descending count then name. More than one entry = mixed value types.
+   */
+  types: Array<{ type: ValueType; count: number }>;
+  /** True when the field shows more than one (non-empty) value-type. */
+  mixedTypes: boolean;
+  /**
+   * Files whose value-type for this field differs from the field's most common
+   * value-type. Purely descriptive ("these diverge"), never an error.
+   */
+  divergingFiles: string[];
+  /**
+   * Drift facts present only when a schema was loaded.
+   * `defined` — whether the field is declared by any concrete type's schema.
+   * `divergingOptions` — values that fall outside the field's declared
+   *   `select` options (only computed for fields that declare options).
+   */
+  defined?: boolean;
+  divergingOptions?: DivergingValue[];
+}
+
+/** Drift facts that only make sense relative to a loaded schema. */
+export interface DriftFacts {
+  /** Fields that appear in notes but are not declared by any type. */
+  usedButUndefined: string[];
+  /** Fields declared by the schema but never seen in any scanned note. */
+  definedButUnused: string[];
+  /** Fields whose values diverge from their declared `select` options. */
+  optionDivergences: Array<{ field: string; values: DivergingValue[] }>;
+}
+
+/** The complete descriptive report. */
+export interface DiscoverReport {
+  /** Absolute path that was scanned. */
+  root: string;
+  /** Total Markdown files seen. */
+  totalFiles: number;
+  /** Files that had a (non-empty) frontmatter block. */
+  filesWithFrontmatter: number;
+  /** Files that could not be parsed (path + reason). Never fatal. */
+  unreadable: Array<{ file: string; error: string }>;
+  /** Whether a schema was found and loaded for drift detection. */
+  schemaPresent: boolean;
+  /** Per-field facts, sorted by descending count then field name. */
+  fields: FieldFacts[];
+  /** Drift section — present only when a schema was loaded. */
+  drift?: DriftFacts;
+}
+
+// ============================================================================
+// File walking
+// ============================================================================
+
+/**
+ * Recursively collect `.md` files under `dir`. Hidden directories (`.git`,
+ * `.bwrb`, …) are skipped. Standalone helper so discover can run on an
+ * arbitrary folder without the vault's schema-aware discovery machinery.
+ */
+async function collectMarkdownFiles(dir: string): Promise<string[]> {
+  const results: string[] = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await collectMarkdownFiles(full)));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      results.push(full);
+    }
+  }
+  return results.sort((a, b) => a.localeCompare(b));
+}
+
+// ============================================================================
+// Schema field collation
+// ============================================================================
+
+/**
+ * Field names that are recognized but are not schema-declared fields: the
+ * `type` discriminator and bwrb built-ins (`id`, `name`). They count as
+ * "defined" for the used-but-undefined check, but are excluded from the
+ * defined-but-unused check (they are not fields a user designs).
+ */
+const ALWAYS_DEFINED_FIELDS = new Set(['type', 'id', 'name']);
+
+interface SchemaFieldInfo {
+  /** Field names declared by any concrete type (excludes built-ins). */
+  schemaFields: Set<string>;
+  /** Names treated as "defined" — schema fields plus recognized built-ins. */
+  definedFields: Set<string>;
+  /** field name -> declared `select` option values (only fields with options). */
+  optionsByField: Map<string, Set<string>>;
+}
+
+/**
+ * Collate the union of declared field names and declared `select` options
+ * across all concrete types. Discover aggregates by bare field name (it has no
+ * per-note type discriminator guarantee), so this intentionally flattens
+ * across types. If two types declare the same field name with different option
+ * sets, the union of their options is used (a value is "diverging" only if it
+ * matches no type's declaration).
+ */
+function collateSchemaFields(schema: LoadedSchema): SchemaFieldInfo {
+  const schemaFields = new Set<string>(getAllOwnFieldNames(schema));
+  const optionsByField = new Map<string, Set<string>>();
+
+  for (const typeName of getConcreteTypeNames(schema)) {
+    const fields = getFieldsForType(schema, typeName);
+    for (const [fieldName, field] of Object.entries(fields)) {
+      schemaFields.add(fieldName);
+      const opts = getDeclaredOptions(field);
+      if (opts.length > 0) {
+        const existing = optionsByField.get(fieldName) ?? new Set<string>();
+        for (const opt of opts) existing.add(opt);
+        optionsByField.set(fieldName, existing);
+      }
+    }
+  }
+
+  const definedFields = new Set<string>(schemaFields);
+  for (const builtin of ALWAYS_DEFINED_FIELDS) definedFields.add(builtin);
+
+  return { schemaFields, definedFields, optionsByField };
+}
+
+function getDeclaredOptions(field: Field): string[] {
+  if (!field.options) return [];
+  return getOptionValues(field.options);
+}
+
+// ============================================================================
+// Aggregation
+// ============================================================================
+
+interface FieldAccumulator {
+  count: number;
+  typeCounts: Map<ValueType, number>;
+  /** relativePath -> the (non-empty) value-type observed there. */
+  fileTypes: Map<string, ValueType>;
+  /** option value -> relativePaths that used it (only for declared-option fields). */
+  divergingOptionFiles: Map<string, Set<string>>;
+}
+
+export interface BuildReportOptions {
+  /** Loaded schema for drift detection, or undefined for the pre-schema role. */
+  schema?: LoadedSchema | undefined;
+}
+
+/**
+ * Build a {@link DiscoverReport} over all Markdown notes under `root`.
+ *
+ * Purely descriptive: it never throws on "non-conforming" data and never
+ * returns a pass/fail verdict. Unreadable individual files are recorded in
+ * `unreadable` and skipped, not thrown.
+ */
+export async function buildDiscoverReport(
+  root: string,
+  options: BuildReportOptions = {}
+): Promise<DiscoverReport> {
+  const { schema } = options;
+  const files = await collectMarkdownFiles(root);
+
+  const accumulators = new Map<string, FieldAccumulator>();
+  const unreadable: Array<{ file: string; error: string }> = [];
+  let filesWithFrontmatter = 0;
+
+  const schemaInfo = schema ? collateSchemaFields(schema) : undefined;
+
+  for (const filePath of files) {
+    const rel = relative(root, filePath);
+    let frontmatter: Record<string, unknown>;
+    try {
+      ({ frontmatter } = await parseNote(filePath));
+    } catch (err) {
+      unreadable.push({
+        file: rel,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    const keys = Object.keys(frontmatter);
+    if (keys.length > 0) filesWithFrontmatter++;
+
+    for (const key of keys) {
+      const value = frontmatter[key];
+      const valueType = classifyValue(value);
+
+      let acc = accumulators.get(key);
+      if (!acc) {
+        acc = {
+          count: 0,
+          typeCounts: new Map(),
+          fileTypes: new Map(),
+          divergingOptionFiles: new Map(),
+        };
+        accumulators.set(key, acc);
+      }
+      acc.count++;
+      acc.typeCounts.set(valueType, (acc.typeCounts.get(valueType) ?? 0) + 1);
+      // Only track non-empty value-types for divergence (empty is not a "type").
+      if (valueType !== 'empty') {
+        acc.fileTypes.set(rel, valueType);
+      }
+
+      // Option divergence (schema role only).
+      const declaredOptions = schemaInfo?.optionsByField.get(key);
+      if (declaredOptions) {
+        for (const candidate of collectComparableValues(value)) {
+          if (!declaredOptions.has(candidate)) {
+            const set = acc.divergingOptionFiles.get(candidate) ?? new Set<string>();
+            set.add(rel);
+            acc.divergingOptionFiles.set(candidate, set);
+          }
+        }
+      }
+    }
+  }
+
+  const fields = buildFieldFacts(accumulators, filesWithFrontmatter, schemaInfo);
+
+  const report: DiscoverReport = {
+    root,
+    totalFiles: files.length,
+    filesWithFrontmatter,
+    unreadable,
+    schemaPresent: Boolean(schema),
+    fields,
+  };
+
+  if (schemaInfo) {
+    report.drift = buildDriftFacts(fields, schemaInfo);
+  }
+
+  return report;
+}
+
+function buildFieldFacts(
+  accumulators: Map<string, FieldAccumulator>,
+  filesWithFrontmatter: number,
+  schemaInfo: SchemaFieldInfo | undefined
+): FieldFacts[] {
+  const facts: FieldFacts[] = [];
+
+  for (const [field, acc] of accumulators) {
+    const types = Array.from(acc.typeCounts.entries())
+      .map(([type, count]) => ({ type, count }))
+      .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type));
+
+    const nonEmptyTypes = types.filter((t) => t.type !== 'empty');
+    const mixedTypes = nonEmptyTypes.length > 1;
+
+    // Most common non-empty value-type is the "baseline"; others diverge.
+    const baseline = nonEmptyTypes[0]?.type;
+    const divergingFiles = baseline
+      ? Array.from(acc.fileTypes.entries())
+          .filter(([, t]) => t !== baseline)
+          .map(([file]) => file)
+          .sort((a, b) => a.localeCompare(b))
+      : [];
+
+    const factEntry: FieldFacts = {
+      field,
+      count: acc.count,
+      frequency: filesWithFrontmatter > 0 ? acc.count / filesWithFrontmatter : 0,
+      types,
+      mixedTypes,
+      divergingFiles,
+    };
+
+    if (schemaInfo) {
+      factEntry.defined = schemaInfo.definedFields.has(field);
+      if (schemaInfo.optionsByField.has(field)) {
+        factEntry.divergingOptions = Array.from(acc.divergingOptionFiles.entries())
+          .map(([value, files]) => ({
+            value,
+            files: Array.from(files).sort((a, b) => a.localeCompare(b)),
+          }))
+          .sort((a, b) => a.value.localeCompare(b.value));
+      }
+    }
+
+    facts.push(factEntry);
+  }
+
+  return facts.sort(
+    (a, b) => b.count - a.count || a.field.localeCompare(b.field)
+  );
+}
+
+function buildDriftFacts(
+  fields: FieldFacts[],
+  schemaInfo: SchemaFieldInfo
+): DriftFacts {
+  const usedFieldNames = new Set(fields.map((f) => f.field));
+
+  const usedButUndefined = fields
+    .filter((f) => f.defined === false)
+    .map((f) => f.field)
+    .sort((a, b) => a.localeCompare(b));
+
+  const definedButUnused = Array.from(schemaInfo.schemaFields)
+    .filter((name) => !usedFieldNames.has(name))
+    .sort((a, b) => a.localeCompare(b));
+
+  const optionDivergences = fields
+    .filter((f) => f.divergingOptions && f.divergingOptions.length > 0)
+    .map((f) => ({ field: f.field, values: f.divergingOptions! }))
+    .sort((a, b) => a.field.localeCompare(b.field));
+
+  return { usedButUndefined, definedButUnused, optionDivergences };
+}

--- a/tests/ts/commands/help.contract.test.ts
+++ b/tests/ts/commands/help.contract.test.ts
@@ -72,6 +72,7 @@ describe('help output contract snapshots', () => {
       'types',
       'fields',
       'validate',
+      'discover',
       'new',
       'edit',
       'delete',

--- a/tests/ts/commands/schema-discover.test.ts
+++ b/tests/ts/commands/schema-discover.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runCLI } from '../fixtures/setup.js';
+
+/**
+ * `schema discover` is DESCRIPTIVE — it reports frontmatter facts and never
+ * passes/fails. These tests exercise both roles (pre-schema onboarding and
+ * post-schema drift), the JSON shape, and edge cases.
+ */
+
+interface DiscoverData {
+  root: string;
+  totalFiles: number;
+  filesWithFrontmatter: number;
+  unreadable: Array<{ file: string; error: string }>;
+  schemaPresent: boolean;
+  fields: Array<{
+    field: string;
+    count: number;
+    frequency: number;
+    types: Array<{ type: string; count: number }>;
+    mixedTypes: boolean;
+    divergingFiles: string[];
+    defined?: boolean;
+    divergingOptions?: Array<{ value: string; files: string[] }>;
+  }>;
+  drift?: {
+    usedButUndefined: string[];
+    definedButUnused: string[];
+    optionDivergences: Array<{ field: string; values: Array<{ value: string; files: string[] }> }>;
+  };
+}
+
+function parseJson(stdout: string): DiscoverData {
+  const parsed = JSON.parse(stdout) as { success: boolean; data: DiscoverData };
+  expect(parsed.success).toBe(true);
+  return parsed.data;
+}
+
+function field(data: DiscoverData, name: string) {
+  return data.fields.find((f) => f.field === name);
+}
+
+describe('schema discover', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'bwrb-discover-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function writeNote(rel: string, content: string): Promise<void> {
+    const full = join(dir, rel);
+    await mkdir(join(full, '..'), { recursive: true });
+    await writeFile(full, content);
+  }
+
+  describe('pre-schema (onboarding) role', () => {
+    beforeEach(async () => {
+      await writeNote('notes/a.md', `---\ntype: idea\nstatus: raw\npriority: high\n---\nbody\n`);
+      await writeNote('notes/b.md', `---\ntype: idea\nstatus: backlog\npriority: medium\neffort: 2\n---\n`);
+      await writeNote('notes/sub/c.md', `---\ntype: task\nstatus: done\n---\n`);
+    });
+
+    it('reports per-field frequencies', async () => {
+      const result = await runCLI(['schema', 'discover', join(dir, 'notes'), '--output', 'json']);
+      expect(result.exitCode).toBe(0);
+      const data = parseJson(result.stdout);
+
+      expect(data.schemaPresent).toBe(false);
+      expect(data.totalFiles).toBe(3);
+      expect(data.filesWithFrontmatter).toBe(3);
+
+      expect(field(data, 'status')?.count).toBe(3);
+      expect(field(data, 'status')?.frequency).toBeCloseTo(1);
+      expect(field(data, 'priority')?.count).toBe(2);
+      expect(field(data, 'effort')?.count).toBe(1);
+    });
+
+    it('reports value-type consistency per field', async () => {
+      const result = await runCLI(['schema', 'discover', join(dir, 'notes'), '--output', 'json']);
+      const data = parseJson(result.stdout);
+
+      const status = field(data, 'status');
+      expect(status?.mixedTypes).toBe(false);
+      expect(status?.types).toEqual([{ type: 'string', count: 3 }]);
+
+      const effort = field(data, 'effort');
+      expect(effort?.types).toEqual([{ type: 'number', count: 1 }]);
+    });
+
+    it('renders a human-readable table by default', async () => {
+      const result = await runCLI(['schema', 'discover', join(dir, 'notes')]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Field usage in');
+      expect(result.stdout).toContain('status');
+      expect(result.stdout).toContain('no schema');
+    });
+
+    it('defaults to the current directory when no path is given', async () => {
+      const result = await runCLI(['schema', 'discover', '--output', 'json'], undefined, undefined, {
+        cwd: join(dir, 'notes'),
+      });
+      const data = parseJson(result.stdout);
+      expect(data.totalFiles).toBe(3);
+    });
+  });
+
+  describe('mixed value types', () => {
+    it('flags a field with mixed types descriptively and names diverging files', async () => {
+      await writeNote('a.md', `---\neffort: 2\n---\n`);
+      await writeNote('b.md', `---\neffort: 3\n---\n`);
+      await writeNote('c.md', `---\neffort: "two"\n---\n`);
+
+      const result = await runCLI(['schema', 'discover', dir, '--output', 'json']);
+      expect(result.exitCode).toBe(0);
+      const data = parseJson(result.stdout);
+
+      const effort = field(data, 'effort');
+      expect(effort?.mixedTypes).toBe(true);
+      // number is the baseline (2 of 3); the string note diverges.
+      expect(effort?.types).toEqual([
+        { type: 'number', count: 2 },
+        { type: 'string', count: 1 },
+      ]);
+      expect(effort?.divergingFiles).toEqual(['c.md']);
+    });
+
+    it('does not exit non-zero for non-conforming data', async () => {
+      await writeNote('a.md', `---\nx: 1\n---\n`);
+      await writeNote('b.md', `---\nx: "one"\n---\n`);
+      const result = await runCLI(['schema', 'discover', dir]);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe('post-schema (drift) role', () => {
+    beforeEach(async () => {
+      await mkdir(join(dir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(dir, '.bwrb', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          types: {
+            meta: {},
+            idea: {
+              extends: 'meta',
+              fields: {
+                status: { prompt: 'select', options: ['raw', 'backlog', 'active'] },
+                rating: { prompt: 'number' },
+              },
+            },
+          },
+        })
+      );
+      await writeNote('notes/a.md', `---\ntype: idea\nstatus: raw\ndeadline: 2024-01-15\n---\n`);
+      await writeNote('notes/b.md', `---\ntype: idea\nstatus: nonsense\n---\n`);
+    });
+
+    it('detects used-but-undefined fields', async () => {
+      const result = await runCLI(['schema', 'discover', dir, '--output', 'json']);
+      const data = parseJson(result.stdout);
+      expect(data.schemaPresent).toBe(true);
+      expect(data.drift?.usedButUndefined).toContain('deadline');
+      expect(data.drift?.usedButUndefined).not.toContain('status');
+      // The `type` discriminator is never reported as undefined.
+      expect(data.drift?.usedButUndefined).not.toContain('type');
+    });
+
+    it('detects defined-but-unused fields', async () => {
+      const result = await runCLI(['schema', 'discover', dir, '--output', 'json']);
+      const data = parseJson(result.stdout);
+      expect(data.drift?.definedButUnused).toContain('rating');
+      // Built-ins are excluded from defined-but-unused.
+      expect(data.drift?.definedButUnused).not.toContain('id');
+      expect(data.drift?.definedButUnused).not.toContain('name');
+    });
+
+    it('detects values diverging from declared select options', async () => {
+      const result = await runCLI(['schema', 'discover', dir, '--output', 'json']);
+      const data = parseJson(result.stdout);
+      const divergence = data.drift?.optionDivergences.find((d) => d.field === 'status');
+      expect(divergence).toBeDefined();
+      expect(divergence?.values[0]?.value).toBe('nonsense');
+      expect(divergence?.values[0]?.files).toEqual(['notes/b.md']);
+    });
+
+    it('renders a drift section in text mode', async () => {
+      const result = await runCLI(['schema', 'discover', dir]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Drift vs schema');
+      expect(result.stdout).toContain('Used but not defined');
+      expect(result.stdout).toContain('Defined in schema but unused');
+      expect(result.stdout).toContain('diverging from declared options');
+    });
+
+    it('--no-schema suppresses drift even when a schema is present', async () => {
+      const result = await runCLI(['schema', 'discover', dir, '--no-schema', '--output', 'json']);
+      const data = parseJson(result.stdout);
+      expect(data.schemaPresent).toBe(false);
+      expect(data.drift).toBeUndefined();
+      expect(field(data, 'status')?.defined).toBeUndefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles an empty folder', async () => {
+      const result = await runCLI(['schema', 'discover', dir, '--output', 'json']);
+      expect(result.exitCode).toBe(0);
+      const data = parseJson(result.stdout);
+      expect(data.totalFiles).toBe(0);
+      expect(data.fields).toEqual([]);
+    });
+
+    it('handles notes with no frontmatter', async () => {
+      await writeNote('a.md', `just text\n`);
+      await writeNote('b.md', `# Heading\n\nbody\n`);
+      const result = await runCLI(['schema', 'discover', dir, '--output', 'json']);
+      expect(result.exitCode).toBe(0);
+      const data = parseJson(result.stdout);
+      expect(data.totalFiles).toBe(2);
+      expect(data.filesWithFrontmatter).toBe(0);
+      expect(data.fields).toEqual([]);
+    });
+
+    it('exits non-zero for an unreadable path', async () => {
+      const result = await runCLI(['schema', 'discover', join(dir, 'does-not-exist')]);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('reports an error as JSON for an unreadable path in json mode', async () => {
+      const result = await runCLI([
+        'schema',
+        'discover',
+        join(dir, 'nope'),
+        '--output',
+        'json',
+      ]);
+      expect(result.exitCode).toBe(2);
+      const parsed = JSON.parse(result.stdout) as { success: boolean; error: string };
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('not found');
+    });
+
+    it('classifies dates, lists, and booleans distinctly', async () => {
+      await writeNote('a.md', `---\nwhen: 2024-03-01\ntags:\n  - x\nactive: true\n---\n`);
+      const result = await runCLI(['schema', 'discover', dir, '--output', 'json']);
+      const data = parseJson(result.stdout);
+      expect(field(data, 'when')?.types[0]?.type).toBe('date');
+      expect(field(data, 'tags')?.types[0]?.type).toBe('list');
+      expect(field(data, 'active')?.types[0]?.type).toBe('boolean');
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds `bwrb schema discover [path]` — a **descriptive** report of frontmatter facts over a folder of Markdown notes. It reports every field, its frequency, value-type consistency, and which files diverge; and, when a schema is present, drift (used-but-undefined, defined-but-unused, values diverging from declared `select` options).

This is the deterministic reframe of #97 ("AI schema discovery" framing is dead). It is pure aggregation — no LLM.

## Command surface

`bwrb schema discover [path]`, a new `schema` subcommand registered after `validate`. Chosen because it is schema-adjacent introspection that sits naturally next to `schema list` / `validate`, and reuses the existing `schema` command plumbing. It works on an **arbitrary folder path** (defaults to cwd), so it serves the pre-schema onboarding role without requiring a managed vault.

Reuses:
- `parseNote` (frontmatter parsing) from `src/lib/frontmatter.ts`
- schema loading + field/option collation from `src/lib/schema.ts`
- the `--output json` success/error envelope from `src/lib/output.ts`
- the TTY table renderer from `src/lib/tty/table.ts`

## Two roles

- **Pre-schema (onboarding):** raw field facts over any folder with no `.bwrb/schema.json`.
- **Post-schema (drift):** a schema found at/above the scanned folder (or via `--vault`) adds a drift section. `--no-schema` forces the onboarding view.

## Strictly descriptive (vs `audit`)

Never emits pass/fail and exits non-zero **only** for real errors (e.g. an unreadable path → exit 2). Non-conforming data still produces a report at exit 0. `audit` remains the prescriptive enforcer.

## JSON shape

`{ success, data }` where `data` = `{ root, totalFiles, filesWithFrontmatter, unreadable[], schemaPresent, fields[], drift? }`. Each field carries `count`, `frequency`, `types[]`, `mixedTypes`, `divergingFiles[]`, and (schema role) `defined` + `divergingOptions[]`. `drift` = `{ usedButUndefined[], definedButUnused[], optionDivergences[] }`.

## Tests

New `tests/ts/commands/schema-discover.test.ts` (16 cases): pre-schema frequencies/type-consistency, mixed types flagged descriptively, post-schema drift (all three categories), JSON shape, empty folder, no-frontmatter, `--no-schema`, and error/exit-code behavior. `help.contract` updated for the new subcommand.

## Docs

- `reference/commands/schema.md`: full `discover` section (both roles, descriptive-vs-audit, JSON shape, exit codes).
- `concepts/validation-and-audit.md`: "Describe vs. enforce" section.

## Quality gates

- `pnpm qa` ✅ (2217 passed, 4 skipped)
- `pnpm knip` ✅
- `pnpm docs:build` ✅

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)