### PR TITLE
fix(audit): validate each element of list/multiple date fields

### DIFF
--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -83,6 +83,7 @@ Delete semantics in repair mode:
 
 Note: built-in fields written by `bwrb new` (currently `id` and `name`) are always allowed and do not produce `unknown-field` issues.
 Invalid option values inside list fields are reported as `invalid-option` with `listIndex` metadata, not a separate issue code.
+For a [`date`](/reference/schema/) field with `multiple: true` (a list of dates), each element is validated against the field's granularity and an invalid element is reported as `invalid-date-format` with `listIndex` metadata identifying the offending value. List elements are reported for manual correction (not auto-fixed); only scalar date values are auto-normalized.
 
 ## Examples
 

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -528,41 +528,70 @@ export async function auditFile(
       }
     }
 
-    if (field.prompt === 'date' && (typeof value === 'string' || typeof value === 'number')) {
-      // A bare year (e.g. 2026) is parsed as a number by YAML; treat it as a
-      // partial date string for validation.
-      const dateStr = String(value);
+    if (field.prompt === 'date') {
       const granularity = resolveDateGranularity(field, schema.config);
-      if (!isAcceptableDate(dateStr, granularity)) {
-        const normalization = getUnambiguousDateNormalization(dateStr);
-        const expected =
-          granularity === 'day'
-            ? 'YYYY-MM-DD'
-            : granularity === 'month'
-              ? 'YYYY-MM-DD or YYYY-MM'
-              : 'YYYY-MM-DD, YYYY-MM, or YYYY';
-        issues.push({
-          severity: 'error',
-          code: 'invalid-date-format',
-          message: `Invalid date for ${fieldName}: must be ${expected}`,
-          field: fieldName,
-          value,
-          expected,
-          ...(normalization && { suggestion: `Suggested: ${normalization.normalized}` }),
-          ...(normalization && { meta: { normalized: normalization.normalized, normalizationKind: normalization.kind } }),
-          autoFixable: Boolean(normalization),
-        });
-      } else if (typeof value === 'number') {
-        // Valid date but stored as a YAML number — should be quoted as a string.
-        issues.push({
-          severity: 'error',
-          code: 'wrong-scalar-type',
-          message: `Non-string value for ${fieldName} should be a string`,
-          field: fieldName,
-          value,
-          expected: 'string',
-          autoFixable: true,
-        });
+
+      // Validate a single date element. `listIndex` is supplied for elements of
+      // a list/multiple date field so the reported issue identifies the element.
+      const checkDateElement = (element: unknown, listIndex?: number) => {
+        if (typeof element !== 'string' && typeof element !== 'number') return;
+
+        // A bare year (e.g. 2026) is parsed as a number by YAML; treat it as a
+        // partial date string for validation.
+        const dateStr = String(element);
+        if (!isAcceptableDate(dateStr, granularity)) {
+          const normalization = getUnambiguousDateNormalization(dateStr);
+          const expected =
+            granularity === 'day'
+              ? 'YYYY-MM-DD'
+              : granularity === 'month'
+                ? 'YYYY-MM-DD or YYYY-MM'
+                : 'YYYY-MM-DD, YYYY-MM, or YYYY';
+          issues.push({
+            severity: 'error',
+            code: 'invalid-date-format',
+            message:
+              listIndex === undefined
+                ? `Invalid date for ${fieldName}: must be ${expected}`
+                : `Invalid date for ${fieldName} at index ${listIndex} ('${dateStr}'): must be ${expected}`,
+            field: fieldName,
+            value: element,
+            expected,
+            ...(listIndex !== undefined && { listIndex }),
+            // The date auto-fixer overwrites the whole field, so it can only
+            // safely normalize scalar dates. List elements are reported but not
+            // auto-fixed (the offending value is surfaced for a manual fix).
+            ...(listIndex === undefined &&
+              normalization && { suggestion: `Suggested: ${normalization.normalized}` }),
+            ...(listIndex === undefined &&
+              normalization && {
+                meta: { normalized: normalization.normalized, normalizationKind: normalization.kind },
+              }),
+            autoFixable: listIndex === undefined && Boolean(normalization),
+          });
+        } else if (typeof element === 'number' && listIndex === undefined) {
+          // Valid scalar date stored as a YAML number — should be quoted as a
+          // string. A numeric element inside a list is instead reported (and
+          // coerced) by checkListElementIntegrity, so don't double-report here.
+          issues.push({
+            severity: 'error',
+            code: 'wrong-scalar-type',
+            message: `Non-string value for ${fieldName} should be a string`,
+            field: fieldName,
+            value: element,
+            expected: 'string',
+            autoFixable: true,
+          });
+        }
+      };
+
+      if (Array.isArray(value)) {
+        // List/multiple date field: validate every element as a date, reusing
+        // the same granularity-aware checker as scalar dates. Structural issues
+        // (null/empty/nested) are reported separately by checkListElementIntegrity.
+        value.forEach((element, index) => checkDateElement(element, index));
+      } else {
+        checkDateElement(value);
       }
     }
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -343,6 +343,53 @@ export function applyDefaults(
 /**
  * Validate field type against expected types.
  */
+/**
+ * Validate a single date value against a field's granularity. Used for both
+ * scalar date fields and per-element validation of list/multiple date fields.
+ * When `listIndex` is supplied, the error message identifies the offending
+ * element.
+ */
+function validateDateValue(
+  fieldName: string,
+  value: unknown,
+  granularity: DatePrecision,
+  listIndex?: number
+): ValidationError | null {
+  // Accept Date objects surfaced by YAML parsing, normalize elsewhere.
+  if (value instanceof Date) {
+    return null;
+  }
+
+  // A bare year (e.g. 2026) is parsed as a number by YAML; coerce so it can
+  // be validated against the field's granularity.
+  const dateValue = typeof value === 'number' ? String(value) : value;
+
+  const location = listIndex === undefined ? fieldName : `${fieldName} at index ${listIndex}`;
+
+  if (typeof dateValue !== 'string') {
+    return {
+      type: 'invalid_type',
+      field: fieldName,
+      value,
+      message: `Invalid type for ${location}: expected date string, got ${typeof value}`,
+      expected: 'date string (YYYY-MM-DD)',
+    };
+  }
+
+  const normalized = normalizeToIsoDate(dateValue, granularity);
+  if (!normalized.valid) {
+    return {
+      type: 'invalid_date',
+      field: fieldName,
+      value,
+      message: `Invalid date for ${location}: ${normalized.error}`,
+      expected: 'YYYY-MM-DD (recommended), or unambiguous MM/DD/YYYY or DD/MM/YYYY',
+    };
+  }
+
+  return null;
+}
+
 function validateFieldType(
   fieldName: string,
   value: unknown,
@@ -372,37 +419,21 @@ function validateFieldType(
 
   // Date fields
   if (field.prompt === 'date') {
-    // Accept Date objects surfaced by YAML parsing, normalize elsewhere.
-    if (value instanceof Date) {
+    // A list/multiple date field holds an array; validate each element against
+    // the field's granularity, reporting the first invalid element.
+    if (field.multiple && Array.isArray(value)) {
+      for (let index = 0; index < value.length; index++) {
+        const element = value[index];
+        // Skip structural gaps (null/empty); those are reported separately.
+        if (element === null || element === undefined) continue;
+        if (typeof element === 'string' && element.trim().length === 0) continue;
+        const elementError = validateDateValue(fieldName, element, granularity, index);
+        if (elementError) return elementError;
+      }
       return null;
     }
 
-    // A bare year (e.g. 2026) is parsed as a number by YAML; coerce so it can
-    // be validated against the field's granularity.
-    const dateValue = typeof value === 'number' ? String(value) : value;
-
-    if (typeof dateValue !== 'string') {
-      return {
-        type: 'invalid_type',
-        field: fieldName,
-        value,
-        message: `Invalid type for ${fieldName}: expected date string, got ${typeof value}`,
-        expected: 'date string (YYYY-MM-DD)',
-      };
-    }
-
-    const normalized = normalizeToIsoDate(dateValue, granularity);
-    if (!normalized.valid) {
-      return {
-        type: 'invalid_date',
-        field: fieldName,
-        value,
-        message: `Invalid date for ${fieldName}: ${normalized.error}`,
-        expected: 'YYYY-MM-DD (recommended), or unambiguous MM/DD/YYYY or DD/MM/YYYY',
-      };
-    }
-
-    return null;
+    return validateDateValue(fieldName, value, granularity);
   }
 
   // Boolean fields

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -3499,6 +3499,137 @@ effort: "3"
     });
   });
 
+  describe('list/multiple date fields (#593)', () => {
+    let tempVaultDir: string;
+
+    // A "list of dates" is modeled as a `date` prompt with `multiple: true`.
+    const LIST_DATE_SCHEMA = {
+      version: 2,
+      config: { date_granularity: 'day' as const },
+      types: {
+        log: {
+          output_dir: 'Logs',
+          fields: {
+            type: { value: 'log' },
+            dates: { prompt: 'date' as const, multiple: true },
+            months: { prompt: 'date' as const, multiple: true, granularity: 'month' as const },
+          },
+        },
+      },
+    };
+
+    beforeEach(async () => {
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-audit-list-date-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify(LIST_DATE_SCHEMA, null, 2)
+      );
+      await mkdir(join(tempVaultDir, 'Logs'), { recursive: true });
+    });
+
+    afterEach(async () => {
+      await rm(tempVaultDir, { recursive: true, force: true });
+    });
+
+    async function auditDateIssues(filename: string, body: string, field = 'dates') {
+      await writeFile(join(tempVaultDir, 'Logs', filename), body);
+      const result = await runCLI(['audit', 'log', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(result.stdout);
+      const file = output.files.find((f: { path: string }) => f.path.includes(filename));
+      const issues: { code: string; field?: string; listIndex?: number; value?: unknown }[] =
+        file?.issues ?? [];
+      return issues.filter((i) => i.code === 'invalid-date-format' && i.field === field);
+    }
+
+    it('flags an invalid element inside a list of dates (the #593 repro)', async () => {
+      const issues = await auditDateIssues(
+        'Repro.md',
+        `---\ntype: log\ndates:\n  - "2026-01-01"\n  - "2026/5/2"\n  - not-a-date\n---\n`
+      );
+      // Both malformed elements flagged; the valid first element is not.
+      expect(issues).toHaveLength(2);
+      const indexes = issues.map((i) => i.listIndex).sort();
+      expect(indexes).toEqual([1, 2]);
+      // The offending value is surfaced per element.
+      const byIndex = new Map(issues.map((i) => [i.listIndex, i.value]));
+      expect(byIndex.get(1)).toBe('2026/5/2');
+      expect(byIndex.get(2)).toBe('not-a-date');
+    });
+
+    it('reports a clean list of all-valid dates with no date issues', async () => {
+      const issues = await auditDateIssues(
+        'Clean.md',
+        `---\ntype: log\ndates:\n  - "2026-01-01"\n  - "2026-05-20"\n---\n`
+      );
+      expect(issues).toHaveLength(0);
+    });
+
+    it('treats an empty list as clean', async () => {
+      const issues = await auditDateIssues(
+        'Empty.md',
+        `---\ntype: log\ndates: []\n---\n`
+      );
+      expect(issues).toHaveLength(0);
+    });
+
+    it('flags only the invalid element in a mixed list', async () => {
+      const issues = await auditDateIssues(
+        'Mixed.md',
+        `---\ntype: log\ndates:\n  - "2026-01-01"\n  - bogus\n  - "2026-12-31"\n---\n`
+      );
+      expect(issues).toHaveLength(1);
+      expect(issues[0].listIndex).toBe(1);
+      expect(issues[0].value).toBe('bogus');
+    });
+
+    it('respects per-element granularity for a month-granularity list', async () => {
+      // YYYY-MM is acceptable at month granularity; a bare year is too coarse.
+      const issues = await auditDateIssues(
+        'Months.md',
+        `---\ntype: log\nmonths:\n  - "2026-05"\n  - "2026"\n---\n`,
+        'months'
+      );
+      expect(issues).toHaveLength(1);
+      expect(issues[0].listIndex).toBe(1);
+      expect(issues[0].value).toBe('2026');
+    });
+
+    it('does not regress scalar (single-value) date validation', async () => {
+      // Scalar date assigned to a multiple field still gets validated and the
+      // existing scalar code path is unaffected.
+      const scalarSchema = {
+        version: 2,
+        types: {
+          log: {
+            output_dir: 'Logs',
+            fields: {
+              type: { value: 'log' },
+              deadline: { prompt: 'date' as const },
+            },
+          },
+        },
+      };
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify(scalarSchema, null, 2)
+      );
+      await writeFile(
+        join(tempVaultDir, 'Logs', 'Scalar.md'),
+        `---\ntype: log\ndeadline: not-a-date\n---\n`
+      );
+      const result = await runCLI(['audit', 'log', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(result.stdout);
+      const file = output.files.find((f: { path: string }) => f.path.includes('Scalar.md'));
+      const issues: { code: string; field?: string; listIndex?: number }[] = file?.issues ?? [];
+      const dateIssues = issues.filter((i) => i.code === 'invalid-date-format');
+      expect(dateIssues).toHaveLength(1);
+      expect(dateIssues[0].field).toBe('deadline');
+      // A scalar date error carries no listIndex.
+      expect(dateIssues[0].listIndex).toBeUndefined();
+    });
+  });
+
   describe('unknown-enum-casing detection and fix', () => {
     let tempVaultDir: string;
 

--- a/tests/ts/lib/validation.test.ts
+++ b/tests/ts/lib/validation.test.ts
@@ -332,6 +332,78 @@ describe('validation', () => {
     });
   });
 
+  describe('multiple (list) date fields (#593)', () => {
+    // A "list of dates" is modeled as a `date` prompt with `multiple: true`.
+    function buildSchema(granularity?: 'day' | 'month' | 'year') {
+      return resolveSchema({
+        version: 1,
+        types: {
+          note: {
+            fields: {
+              type: { value: 'note' },
+              dates: {
+                prompt: 'date',
+                multiple: true,
+                ...(granularity && { granularity }),
+              },
+            },
+          },
+        },
+      } as never);
+    }
+
+    it('accepts a list where every element is a valid date', () => {
+      const s = buildSchema();
+      const result = validateFrontmatter(s, 'note', {
+        type: 'note',
+        dates: ['2026-01-01', '2026-05-20'],
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts an empty list', () => {
+      const s = buildSchema();
+      expect(validateFrontmatter(s, 'note', { type: 'note', dates: [] }).valid).toBe(true);
+    });
+
+    it('flags a list with an invalid element', () => {
+      const s = buildSchema();
+      const result = validateFrontmatter(s, 'note', {
+        type: 'note',
+        dates: ['2026-01-01', 'not-a-date'],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].type).toBe('invalid_date');
+      // The offending element value is surfaced.
+      expect(result.errors[0].value).toBe('not-a-date');
+      expect(result.errors[0].message).toContain('index 1');
+    });
+
+    it('respects per-element granularity', () => {
+      const monthSchema = buildSchema('month');
+      // YYYY-MM is acceptable at month granularity.
+      expect(
+        validateFrontmatter(monthSchema, 'note', { type: 'note', dates: ['2026-05', '2026-06'] }).valid
+      ).toBe(true);
+
+      const daySchema = buildSchema('day');
+      // YYYY-MM is too coarse at day granularity.
+      expect(
+        validateFrontmatter(daySchema, 'note', { type: 'note', dates: ['2026-05'] }).valid
+      ).toBe(false);
+    });
+
+    it('ignores structural gaps (empty strings) — those are reported elsewhere', () => {
+      const s = buildSchema();
+      const result = validateFrontmatter(s, 'note', {
+        type: 'note',
+        dates: ['2026-01-01', '   '],
+      });
+      // No invalid_date error for the blank element.
+      expect(result.errors.some((e) => e.type === 'invalid_date')).toBe(false);
+    });
+  });
+
   describe('applyDefaults', () => {
     it('should apply defaults for missing fields', () => {
       const result = applyDefaults(schema, 'idea', {


### PR DESCRIPTION
## Summary

A `date` field declared as a list (`{"prompt":"date","multiple":true}`) received **no per-element date validation** during `bwrb audit` or create/edit — invalid dates inside the list passed silently. Singular date fields were validated as before. This fix validates every element of a list/multiple date field, reusing the same granularity-aware date validation used for scalars.

## Root cause

- In `src/lib/audit/detection.ts`, the scalar date block only ran for `typeof value === 'string' | 'number'`, so array-valued date fields bypassed it entirely. `checkListElementIntegrity` only checked structural integrity (null/empty/nested/wrong scalar type), never date format.
- In `src/lib/validation.ts`, `validateFieldType`'s date branch fed the whole array into the scalar path, producing a single "expected date string, got object" type error instead of per-element validation.

## Fix

- **Audit** (`detection.ts`): when a `date` field's value is an array, validate each element with the existing `isAcceptableDate(String(el), resolveDateGranularity(field, schema.config))` — the *same* checker used for scalar dates. Each invalid element emits `invalid-date-format` carrying `listIndex` and the offending value; the message identifies the index and value. Scalar date behavior (including numeric-year `wrong-scalar-type` and auto-normalization) is unchanged.
- **Validation** (`validation.ts`): extracted a shared `validateDateValue(fieldName, value, granularity, listIndex?)` helper. Scalar dates call it directly; `multiple` date arrays call it per element and report the first invalid one with its index.
- Structural gaps (null / blank elements) are skipped in both paths since they are reported separately (`invalid-list-element` / `empty-string-required`).

## How invalid elements are reported

`invalid-date-format`, `severity: error`, `field` = field name, `value` = the offending element, `listIndex` = its position, message e.g. `Invalid date for dates at index 1 ('2026/5/2'): must be YYYY-MM-DD`. List-element date issues are **not** auto-fixable (the date fixer overwrites the whole field, which would corrupt the array) — they surface the bad value for manual correction. Scalar date normalization is unchanged.

## How "list of dates" is modeled

There is no `prompt: list` with a date item type — `prompt` is a single enum. A list of dates is `prompt: "date"` + `multiple: true`. That is exactly what #593 covers, and what this PR fixes on both the audit and create/edit paths.

## Tests

`validation.test.ts` + `audit.test.ts`: all-valid list (clean), empty list (clean), one invalid element (flagged with index+value), mixed valid/invalid (only invalid flagged), the #593 repro (`["2026-01-01","2026/5/2","not-a-date"]` → indexes 1 and 2 flagged), per-element month granularity, blank-element skip, and a scalar-date no-regression check.

## Gates

- `pnpm qa` — pass (2228 passed, 4 skipped)
- `pnpm knip` — pass
- `pnpm docs:build` — pass (minor audit reference note added)

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)
