### PR TITLE
perf(audit): build backlink index once per fix run (#500)

### DIFF
--- a/src/lib/audit/backlink-index.ts
+++ b/src/lib/audit/backlink-index.ts
@@ -1,0 +1,121 @@
+/**
+ * Backlink index for audit `--fix` runs.
+ *
+ * Delete-safety and move handlers in `fix.ts` need to know which notes link to a
+ * given file. The naive approach calls {@link findWikilinksToFile} per operation,
+ * and that function re-reads and re-regex-scans EVERY markdown file in the vault
+ * every time — so a run with D delete/move operations does O(D x N) file reads
+ * over N vault files.
+ *
+ * {@link BacklinkScanner} reads each file at most once per run and caches its
+ * content, so repeated reference lookups cost O(N) regex passes over cached
+ * strings instead of O(N) fresh disk reads. The cache is kept correct as the
+ * graph mutates during a run:
+ *
+ * - {@link BacklinkScanner.noteDeleted} drops a deleted note from the scan set
+ *   (it can no longer be a backlink source, matching the live filesystem after
+ *   `unlink`).
+ * - {@link BacklinkScanner.invalidate} drops cached content for files a move
+ *   rewrote/renamed, so the next lookup re-reads them fresh.
+ *
+ * The reference computation reuses the exact same file list, regex, and
+ * {@link wikilinkMatchesFile} logic as {@link findWikilinksToFile}, so the
+ * results are byte-for-byte identical to the unoptimized path for a given
+ * on-disk state.
+ */
+
+import { readFile } from 'fs/promises';
+import { relative } from 'path';
+import {
+  findAllMarkdownFiles,
+  scanWikilinkReferencesInContent,
+  type WikilinkReference,
+} from '../bulk/move.js';
+
+export class BacklinkScanner {
+  private readonly vaultDir: string;
+  /** Ordered list of source files to scan. Mirrors `findAllMarkdownFiles`. */
+  private files: string[] | null = null;
+  /** Cached file contents, keyed by absolute path. */
+  private readonly contentCache = new Map<string, string>();
+
+  constructor(vaultDir: string) {
+    this.vaultDir = vaultDir;
+  }
+
+  private async ensureFiles(): Promise<string[]> {
+    if (this.files === null) {
+      this.files = await findAllMarkdownFiles(this.vaultDir);
+    }
+    return this.files;
+  }
+
+  private async getContent(filePath: string): Promise<string> {
+    const cached = this.contentCache.get(filePath);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const content = await readFile(filePath, 'utf-8');
+    this.contentCache.set(filePath, content);
+    return content;
+  }
+
+  /**
+   * Find all wikilink references to `targetFilePath` across the vault.
+   *
+   * Output is identical to {@link findWikilinksToFile} for the current on-disk
+   * state, but reuses cached file contents instead of re-reading every file.
+   */
+  async findReferences(targetFilePath: string): Promise<WikilinkReference[]> {
+    const files = await this.ensureFiles();
+    const references: WikilinkReference[] = [];
+
+    for (const sourceFile of files) {
+      if (sourceFile === targetFilePath) {
+        continue;
+      }
+      const content = await this.getContent(sourceFile);
+      const sourceRelativePath = relative(this.vaultDir, sourceFile);
+      references.push(
+        ...scanWikilinkReferencesInContent(
+          content,
+          sourceFile,
+          sourceRelativePath,
+          targetFilePath,
+          this.vaultDir
+        )
+      );
+    }
+
+    return references;
+  }
+
+  /**
+   * Mark a note as deleted: remove it from the scan set and drop its cached
+   * content, matching the live filesystem after `unlink`.
+   */
+  noteDeleted(filePath: string): void {
+    if (this.files !== null) {
+      this.files = this.files.filter((f) => f !== filePath);
+    }
+    this.contentCache.delete(filePath);
+  }
+
+  /**
+   * Invalidate the file list and any cached content for the given paths.
+   *
+   * Used after a move/rename mutates the vault (source files rewritten, target
+   * renamed): the file list is rebuilt and affected contents are re-read on the
+   * next lookup, keeping results correct.
+   */
+  invalidate(paths?: Iterable<string>): void {
+    this.files = null;
+    if (paths) {
+      for (const p of paths) {
+        this.contentCache.delete(p);
+      }
+    } else {
+      this.contentCache.clear();
+    }
+  }
+}

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -39,9 +39,11 @@ import {
   findAllMarkdownFiles,
   findWikilinksToFile,
   executeBulkMove,
+  type WikilinkReference,
 } from '../bulk/move.js';
 import { formatValue } from '../vault.js';
 import { buildNoteTargetIndex, type NoteTargetIndex } from '../discovery.js';
+import { BacklinkScanner } from './backlink-index.js';
 import { isBwrbBuiltinFrontmatterField } from '../frontmatter/systemFields.js';
 
 // Alias for backward compatibility
@@ -924,6 +926,10 @@ export async function runAutoFix(
   const manualReviewNeeded: { file: string; issue: AuditIssue }[] = [];
   const resolvedNonFixable = new Set<AuditIssue>();
 
+  // Per-run backlink scanner: caches vault file contents so the repeated move
+  // backlink-count lookups below don't re-read the whole vault per operation.
+  const backlinkScanner = new BacklinkScanner(vaultDir);
+
   for (const result of results) {
     const fixableIssues = result.issues.filter(i => i.autoFixable);
     const nonFixableIssues = result.issues.filter(i => !i.autoFixable);
@@ -945,14 +951,13 @@ export async function runAutoFix(
         }
         
         // Get wikilink count for warning
-        const allFiles = await findAllMarkdownFiles(vaultDir);
-        const refs = await findWikilinksToFile(vaultDir, result.path, allFiles);
-        
+        const refs = await backlinkScanner.findReferences(result.path);
+
         if (refs.length > 0) {
           console.log(chalk.cyan(`  ${result.relativePath}`));
           console.log(chalk.yellow(`    ⚠ ${refs.length} wikilink(s) will be updated`));
         }
-        
+
         // Execute the move
         const targetDir = join(vaultDir, issue.expectedDirectory);
         const moveResult = await executeBulkMove({
@@ -960,9 +965,12 @@ export async function runAutoFix(
           targetDir,
           filesToMove: [result.path],
           execute: true,
-          allVaultFiles: allFiles,
         });
-        
+
+        // The move rewrote source files and renamed the moved file; rebuild the
+        // backlink index so subsequent lookups reflect the mutated graph.
+        backlinkScanner.invalidate();
+
         if (moveResult.errors.length === 0) {
           console.log(chalk.cyan(`  ${result.relativePath}`));
           console.log(chalk.green(`    ✓ Moved to ${issue.expectedDirectory}/`));
@@ -975,13 +983,13 @@ export async function runAutoFix(
           console.log(chalk.red(`    ✗ Failed to move: ${moveResult.errors[0]}`));
           failed++;
         }
-        
+
         // Remove from fixableIssues so we don't process it again
         const idx = fixableIssues.indexOf(issue);
         if (idx > -1) fixableIssues.splice(idx, 1);
         continue;
       }
-      
+
       // Handle owned-wrong-location issues
       if (issue.code === 'owned-wrong-location' && issue.expectedDirectory) {
         if (dryRun) {
@@ -994,14 +1002,13 @@ export async function runAutoFix(
         }
         
         // Get wikilink count for warning
-        const allFiles = await findAllMarkdownFiles(vaultDir);
-        const refs = await findWikilinksToFile(vaultDir, result.path, allFiles);
-        
+        const refs = await backlinkScanner.findReferences(result.path);
+
         if (refs.length > 0) {
           console.log(chalk.cyan(`  ${result.relativePath}`));
           console.log(chalk.yellow(`    ⚠ ${refs.length} wikilink(s) will be updated`));
         }
-        
+
         // Execute the move
         const targetDir = join(vaultDir, issue.expectedDirectory);
         const moveResult = await executeBulkMove({
@@ -1009,9 +1016,12 @@ export async function runAutoFix(
           targetDir,
           filesToMove: [result.path],
           execute: true,
-          allVaultFiles: allFiles,
         });
-        
+
+        // The move rewrote source files and renamed the moved file; rebuild the
+        // backlink index so subsequent lookups reflect the mutated graph.
+        backlinkScanner.invalidate();
+
         if (moveResult.errors.length === 0) {
           console.log(chalk.cyan(`  ${result.relativePath}`));
           console.log(chalk.green(`    ✓ Moved to ${issue.expectedDirectory}/`));
@@ -1024,13 +1034,13 @@ export async function runAutoFix(
           console.log(chalk.red(`    ✗ Failed to move: ${moveResult.errors[0]}`));
           failed++;
         }
-        
+
         const idx = fixableIssues.indexOf(issue);
         if (idx > -1) fixableIssues.splice(idx, 1);
         continue;
       }
     }
-    
+
     // Handle stale-reference issues with high-confidence matches and safe unknown-field migrations
     for (const issue of nonFixableIssues) {
       if (issue.code === 'stale-reference' && !issue.inBody && issue.field) {
@@ -1556,8 +1566,9 @@ export async function runInteractiveFix(
   const dryRunReason = dryRun ? 'explicit' : undefined;
   dryRunStorage.enterWith(dryRun);
   const noteTargetIndex = await buildNoteTargetIndex(schema, vaultDir);
-  const context: FixContext = { schema, vaultDir, dryRun, noteTargetIndex };
-  
+  const backlinkScanner = new BacklinkScanner(vaultDir);
+  const context: FixContext = { schema, vaultDir, dryRun, noteTargetIndex, backlinkScanner };
+
   console.log(chalk.bold('Auditing vault...\n'));
 
   if (results.length === 0) {
@@ -1740,15 +1751,34 @@ async function handleMissingSuccessorFix(
   return 'failed';
 }
 
+/**
+ * Find all wikilink backlinks to a file, reusing the per-run backlink scanner
+ * when available so repeated delete-safety / move lookups don't re-read the
+ * whole vault each time. Falls back to a one-off scan when no scanner is present
+ * (e.g. callers that build a `FixContext` without one).
+ *
+ * The fallback path is behavior-identical to the cached path for a given on-disk
+ * state — both ultimately use the same `scanWikilinkReferencesInContent` logic.
+ */
+async function findBacklinkReferences(
+  context: FixContext,
+  targetPath: string
+): Promise<WikilinkReference[]> {
+  if (context.backlinkScanner) {
+    return context.backlinkScanner.findReferences(targetPath);
+  }
+  const allFiles = await findAllMarkdownFiles(context.vaultDir);
+  return findWikilinksToFile(context.vaultDir, targetPath, allFiles);
+}
+
 async function deleteNoteWithSafety(
   context: FixContext,
   result: FileAuditResult
 ): Promise<'fixed' | 'skipped' | 'failed' | 'quit'> {
-  const { vaultDir, dryRun } = context;
+  const { dryRun } = context;
 
   try {
-    const allFiles = await findAllMarkdownFiles(vaultDir);
-    const refs = await findWikilinksToFile(vaultDir, result.path, allFiles);
+    const refs = await findBacklinkReferences(context, result.path);
 
     console.log(chalk.yellow(`    ⚠ Permanent delete requested for ${result.relativePath}`));
     if (refs.length > 0) {
@@ -1792,6 +1822,9 @@ async function deleteNoteWithSafety(
     }
 
     await unlink(result.path);
+    // Keep the backlink index consistent with the live filesystem: the deleted
+    // note can no longer be a backlink source for subsequent operations.
+    context.backlinkScanner?.noteDeleted(result.path);
     console.log(chalk.green(`    ✓ Deleted ${result.relativePath}`));
     if (refs.length > 0) {
       console.log(chalk.yellow(`    ⚠ ${refs.length} note(s) still contain links to this file`));
@@ -2461,17 +2494,16 @@ async function handleOwnedWrongLocationFix(
   // Show context
   console.log(chalk.dim(`    Expected location: ${issue.expectedDirectory}/`));
   console.log(chalk.dim(`    Owner: ${issue.ownerPath}`));
-  
+
   // Check for wikilinks that will be affected
-  const allFiles = await findAllMarkdownFiles(vaultDir);
-  const refs = await findWikilinksToFile(vaultDir, result.path, allFiles);
-  
+  const refs = await findBacklinkReferences(context, result.path);
+
   if (refs.length > 0) {
     console.log(chalk.yellow(`    ⚠ ${refs.length} wikilink(s) will be updated`));
   }
 
   const options = ['[move file]', '[skip]', '[quit]'];
-  
+
   const selected = await promptSelection(
     `    Action for misplaced owned note:`,
     options
@@ -2492,9 +2524,12 @@ async function handleOwnedWrongLocationFix(
       targetDir,
       filesToMove: [result.path],
       execute: true,
-      allVaultFiles: allFiles,
     });
-    
+
+    // The move rewrote source files and renamed the moved file; rebuild the
+    // backlink index so subsequent lookups reflect the mutated graph.
+    context.backlinkScanner?.invalidate();
+
     if (moveResult.errors.length === 0) {
       console.log(chalk.green(`    ✓ Moved to ${issue.expectedDirectory}/`));
       if (moveResult.totalLinksUpdated > 0) {
@@ -2530,17 +2565,16 @@ async function handleWrongDirectoryFix(
   // Show context
   console.log(chalk.dim(`    Current location: ${dirname(result.relativePath)}/`));
   console.log(chalk.dim(`    Expected location: ${issue.expectedDirectory}/`));
-  
+
   // Check for wikilinks that will be affected
-  const allFiles = await findAllMarkdownFiles(vaultDir);
-  const refs = await findWikilinksToFile(vaultDir, result.path, allFiles);
-  
+  const refs = await findBacklinkReferences(context, result.path);
+
   if (refs.length > 0) {
     console.log(chalk.yellow(`    ⚠ ${refs.length} wikilink(s) will be updated`));
   }
 
   const options = ['[move file]', '[skip]', '[quit]'];
-  
+
   const selected = await promptSelection(
     `    Action for wrong directory:`,
     options
@@ -2561,9 +2595,12 @@ async function handleWrongDirectoryFix(
       targetDir,
       filesToMove: [result.path],
       execute: true,
-      allVaultFiles: allFiles,
     });
-    
+
+    // The move rewrote source files and renamed the moved file; rebuild the
+    // backlink index so subsequent lookups reflect the mutated graph.
+    context.backlinkScanner?.invalidate();
+
     if (moveResult.errors.length === 0) {
       console.log(chalk.green(`    ✓ Moved to ${issue.expectedDirectory}/`));
       if (moveResult.totalLinksUpdated > 0) {

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -6,6 +6,7 @@
 
 import type { LoadedSchema } from '../../types/schema.js';
 import type { NoteTargetIndex } from '../discovery.js';
+import type { BacklinkScanner } from './backlink-index.js';
 // Issue Types
 // ============================================================================
 
@@ -235,6 +236,13 @@ export interface FixContext {
   dryRun: boolean;
   /** Precomputed note target index for relation fixes. */
   noteTargetIndex?: NoteTargetIndex;
+  /**
+   * Per-run backlink scanner. Caches vault file contents so repeated
+   * delete-safety / move backlink lookups in one run avoid re-reading the whole
+   * vault per operation. Kept correct across deletes/moves via its mutation
+   * hooks (`noteDeleted` / `invalidate`).
+   */
+  backlinkScanner?: BacklinkScanner;
 }
 
 // ============================================================================

--- a/src/lib/bulk/move.ts
+++ b/src/lib/bulk/move.ts
@@ -170,6 +170,63 @@ export function wikilinkMatchesFile(
 }
 
 /**
+ * Scan a single file's content for wikilinks that reference a specific target.
+ *
+ * Extracted from {@link findWikilinksToFile} so callers that already hold the
+ * file content (e.g. a cached backlink index) can compute references without
+ * re-reading from disk, while producing byte-for-byte identical results.
+ */
+export function scanWikilinkReferencesInContent(
+  content: string,
+  sourceFile: string,
+  sourceRelativePath: string,
+  targetFilePath: string,
+  vaultDir: string
+): WikilinkReference[] {
+  // Skip the target file itself
+  if (sourceFile === targetFilePath) {
+    return [];
+  }
+
+  const references: WikilinkReference[] = [];
+
+  // Determine where frontmatter ends
+  let frontmatterEnd = 0;
+  if (content.startsWith('---')) {
+    const endMatch = content.indexOf('\n---', 3);
+    if (endMatch !== -1) {
+      frontmatterEnd = endMatch + 4; // Include the closing ---\n
+    }
+  }
+
+  // Find all wikilinks
+  const regex = new RegExp(WIKILINK_REGEX.source, 'g');
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(content)) !== null) {
+    const linkTarget = match[1]!;
+
+    if (wikilinkMatchesFile(linkTarget, targetFilePath, vaultDir)) {
+      // Calculate line number
+      const lineNumber = content.slice(0, match.index).split('\n').length;
+      const inFrontmatter = match.index < frontmatterEnd;
+
+      references.push({
+        sourceFile,
+        sourceRelativePath,
+        match: match[0],
+        linkTarget,
+        position: match.index,
+        lineNumber,
+        inFrontmatter,
+      });
+    }
+  }
+
+  return references;
+}
+
+/**
  * Find all wikilinks in the vault that reference a specific file.
  */
 export async function findWikilinksToFile(
@@ -178,50 +235,27 @@ export async function findWikilinksToFile(
   allFiles: string[]
 ): Promise<WikilinkReference[]> {
   const references: WikilinkReference[] = [];
-  
+
   for (const sourceFile of allFiles) {
     // Skip the target file itself
     if (sourceFile === targetFilePath) {
       continue;
     }
-    
+
     const content = await readFile(sourceFile, 'utf-8');
     const sourceRelativePath = relative(vaultDir, sourceFile);
-    
-    // Determine where frontmatter ends
-    let frontmatterEnd = 0;
-    if (content.startsWith('---')) {
-      const endMatch = content.indexOf('\n---', 3);
-      if (endMatch !== -1) {
-        frontmatterEnd = endMatch + 4; // Include the closing ---\n
-      }
-    }
-    
-    // Find all wikilinks
-    const regex = new RegExp(WIKILINK_REGEX.source, 'g');
-    let match: RegExpExecArray | null;
-    
-    while ((match = regex.exec(content)) !== null) {
-      const linkTarget = match[1]!;
-      
-      if (wikilinkMatchesFile(linkTarget, targetFilePath, vaultDir)) {
-        // Calculate line number
-        const lineNumber = content.slice(0, match.index).split('\n').length;
-        const inFrontmatter = match.index < frontmatterEnd;
-        
-        references.push({
-          sourceFile,
-          sourceRelativePath,
-          match: match[0],
-          linkTarget,
-          position: match.index,
-          lineNumber,
-          inFrontmatter,
-        });
-      }
-    }
+
+    references.push(
+      ...scanWikilinkReferencesInContent(
+        content,
+        sourceFile,
+        sourceRelativePath,
+        targetFilePath,
+        vaultDir
+      )
+    );
   }
-  
+
   return references;
 }
 

--- a/tests/ts/lib/audit-backlink-index.test.ts
+++ b/tests/ts/lib/audit-backlink-index.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for the per-run backlink scanner used by `audit --fix` (#500).
+ *
+ * These verify that:
+ * - The cached scanner produces results identical to `findWikilinksToFile`.
+ * - File contents are read at most once per run (the scan is reused, not
+ *   repeated, across multiple delete-safety / move lookups).
+ * - Mutation hooks keep the index correct as the graph changes during a run:
+ *   `noteDeleted` drops a deleted source; `invalidate` forces a re-read.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile, unlink, rename } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { BacklinkScanner } from '../../../src/lib/audit/backlink-index.js';
+import {
+  findAllMarkdownFiles,
+  findWikilinksToFile,
+} from '../../../src/lib/bulk/move.js';
+
+describe('BacklinkScanner (#500)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'bwrb-backlink-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function seedVault(): Promise<{ target: string }> {
+    await mkdir(join(tempDir, 'Notes'));
+    const target = join(tempDir, 'Notes', 'Target.md');
+    await writeFile(target, '---\ntype: note\n---\n\nThe target note.\n');
+    await writeFile(
+      join(tempDir, 'Notes', 'A.md'),
+      '---\ntype: note\n---\n\nLinks to [[Target]] here.\n'
+    );
+    await writeFile(
+      join(tempDir, 'Notes', 'B.md'),
+      '---\nrel: "[[Target]]"\n---\n\nAlso mentions [[Target]] twice [[Target]].\n'
+    );
+    await writeFile(
+      join(tempDir, 'Notes', 'C.md'),
+      '---\ntype: note\n---\n\nNo links at all.\n'
+    );
+    return { target };
+  }
+
+  it('produces results identical to findWikilinksToFile', async () => {
+    const { target } = await seedVault();
+
+    const allFiles = await findAllMarkdownFiles(tempDir);
+    const expected = await findWikilinksToFile(tempDir, target, allFiles);
+
+    const scanner = new BacklinkScanner(tempDir);
+    const actual = await scanner.findReferences(target);
+
+    expect(actual).toEqual(expected);
+    // Sanity: A (1) + B (3) = 4 references, none from the target itself or C.
+    expect(actual).toHaveLength(4);
+  });
+
+  it('reuses cached content across repeated lookups (no re-read)', async () => {
+    const { target } = await seedVault();
+    const bPath = join(tempDir, 'Notes', 'B.md');
+
+    const scanner = new BacklinkScanner(tempDir);
+    const before = await scanner.findReferences(target);
+    expect(before).toHaveLength(4);
+
+    // Mutate B's content on disk WITHOUT notifying the scanner. A cached scanner
+    // must NOT observe this change on a subsequent lookup — proving it did not
+    // re-read the file. (A naive per-lookup re-scan would see only 1 ref.)
+    await writeFile(bPath, '---\ntype: note\n---\n\nNo more links.\n');
+
+    const after = await scanner.findReferences(target);
+    expect(after).toEqual(before);
+    expect(after).toHaveLength(4);
+  });
+
+  it('noteDeleted removes a deleted source from later scans (matches live FS)', async () => {
+    const { target } = await seedVault();
+    const aPath = join(tempDir, 'Notes', 'A.md');
+
+    const scanner = new BacklinkScanner(tempDir);
+    const before = await scanner.findReferences(target);
+    expect(before.some((r) => r.sourceFile === aPath)).toBe(true);
+
+    // Delete A from disk AND from the index, mirroring deleteNoteWithSafety.
+    await unlink(aPath);
+    scanner.noteDeleted(aPath);
+
+    const after = await scanner.findReferences(target);
+    expect(after.some((r) => r.sourceFile === aPath)).toBe(false);
+
+    // Result still matches a fresh, uncached scan of the mutated vault.
+    const allFiles = await findAllMarkdownFiles(tempDir);
+    const fresh = await findWikilinksToFile(tempDir, target, allFiles);
+    expect(after).toEqual(fresh);
+  });
+
+  it('invalidate re-reads after a source file is rewritten/moved', async () => {
+    const { target } = await seedVault();
+    const bPath = join(tempDir, 'Notes', 'B.md');
+
+    const scanner = new BacklinkScanner(tempDir);
+    const before = await scanner.findReferences(target);
+    expect(before).toHaveLength(4);
+
+    // Rewrite B so it no longer links to Target, then invalidate (as a move
+    // would, since it rewrites source files and renames the moved file).
+    await writeFile(bPath, '---\ntype: note\n---\n\nNo more links.\n');
+    scanner.invalidate();
+
+    const after = await scanner.findReferences(target);
+    // Only A's single link remains.
+    expect(after).toHaveLength(1);
+
+    const allFiles = await findAllMarkdownFiles(tempDir);
+    const fresh = await findWikilinksToFile(tempDir, target, allFiles);
+    expect(after).toEqual(fresh);
+  });
+
+  it('invalidate picks up newly added files', async () => {
+    const { target } = await seedVault();
+
+    const scanner = new BacklinkScanner(tempDir);
+    await scanner.findReferences(target);
+
+    await writeFile(
+      join(tempDir, 'Notes', 'D.md'),
+      '---\ntype: note\n---\n\nLate link to [[Target]].\n'
+    );
+    scanner.invalidate();
+
+    const after = await scanner.findReferences(target);
+    expect(after.some((r) => r.sourceFile.endsWith('D.md'))).toBe(true);
+    expect(after).toHaveLength(5);
+  });
+
+  it('stays correct as the moved file itself is renamed', async () => {
+    const { target } = await seedVault();
+    const aPath = join(tempDir, 'Notes', 'A.md');
+
+    const scanner = new BacklinkScanner(tempDir);
+    await scanner.findReferences(target);
+
+    // Rename A into an Archive folder (a move).
+    await mkdir(join(tempDir, 'Archive'));
+    const newAPath = join(tempDir, 'Archive', 'A.md');
+    await rename(aPath, newAPath);
+    scanner.invalidate();
+
+    const after = await scanner.findReferences(target);
+    const allFiles = await findAllMarkdownFiles(tempDir);
+    const fresh = await findWikilinksToFile(tempDir, target, allFiles);
+    expect(after).toEqual(fresh);
+    expect(after.some((r) => r.sourceFile === newAPath)).toBe(true);
+    expect(after.some((r) => r.sourceFile === aPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`audit --fix` delete-safety and move handlers repeatedly scanned the whole vault for backlinks — one full re-read + regex pass per operation. This refactor computes the backlink/reference info from a per-run cache instead, with no change in behavior.

Closes #500

## Hot path (before)
Both the interactive delete-safety check (`deleteNoteWithSafety`) and the wrong-directory / owned-wrong-location move handlers called `findWikilinksToFile(vaultDir, path, allFiles)`, which **reads and regex-scans every markdown file in the vault on every call**. The auto-fix move paths did the same. With `D` delete/move operations over `N` notes this is **O(D x N) fresh disk reads** (plus an `O(N)` directory walk per op).

## Optimization (after)
New `src/lib/audit/backlink-index.ts` `BacklinkScanner`:
- Reads each file **at most once per run** and caches its content.
- Repeated reference lookups become **O(N) regex passes over cached strings** — no redundant disk reads. For `D` operations: roughly `N` reads total instead of `D x N`.
- Wired into `runInteractiveFix` (via `FixContext.backlinkScanner`) and `runAutoFix`.

## Correctness as the graph mutates mid-run
- **Delete:** after `unlink`, `noteDeleted(path)` removes the note from the scan set so it can no longer appear as a backlink source — matching the live filesystem for the next operation.
- **Move:** `executeBulkMove` rewrites source files and renames the moved file, so `invalidate()` rebuilds the file list and clears cached content; the next lookup re-reads fresh.

## Identical-behavior guarantee
Reference matching is extracted into `scanWikilinkReferencesInContent` (in `bulk/move.ts`) and reused by **both** `findWikilinksToFile` and the scanner, so for any given on-disk state the scanner returns byte-for-byte identical `WikilinkReference[]`. No change to which deletes are blocked/allowed, the confirmation prompts, or any reported counts/output. A fallback (`findBacklinkReferences`) preserves the old one-off scan when no scanner is present.

## Tests
- New `tests/ts/lib/audit-backlink-index.test.ts` (6 tests): output identical to `findWikilinksToFile`; cached content reused across lookups (mutate-on-disk-without-notifying proves no re-read); `noteDeleted` drops a deleted source and still matches a fresh scan; `invalidate` re-reads after rewrite, picks up new files, and handles the moved file being renamed.
- Existing delete-safety / move PTY + unit tests unchanged and green.

## Quality gates
- `pnpm qa`: pass (2234 passed, 4 skipped).
- `pnpm knip`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)