### PR TITLE
refactor(list): extract sort/comparison + tree helpers into tested lib module

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -7,7 +7,18 @@ import {
   getTypeDefByPath,
   getAllFieldsForType,
 } from '../lib/schema.js';
-import { extractWikilinkTarget } from '../lib/links.js';
+import {
+  buildParentMap,
+  buildChildrenMap,
+  collectDescendants,
+  createFileComparator,
+  buildTree,
+  treeHasNestedNotes,
+  buildDirectoryTree,
+  extractNoteName,
+  type TreeNode,
+  type DirectoryTreeNode,
+} from '../lib/list-helpers.js';
 
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts, resolveGlobalPickerMode } from '../lib/command.js';
@@ -698,254 +709,11 @@ function printTable(
 }
 
 // ============================================================================
-// Hierarchy Helpers for Recursive Types
+// Tree Rendering (I/O) for Recursive Types
+//
+// Pure sort/comparison and tree-building helpers live in ../lib/list-helpers.ts.
+// The functions below handle console output and stay in the command.
 // ============================================================================
-
-type FileWithFrontmatter = { path: string; frontmatter: Record<string, unknown> };
-type FileComparator = (a: FileWithFrontmatter, b: FileWithFrontmatter) => number;
-
-function compareByName(a: FileWithFrontmatter, b: FileWithFrontmatter): number {
-  return basename(a.path, '.md').localeCompare(basename(b.path, '.md'));
-}
-
-function getSortValue(file: FileWithFrontmatter, vaultDir: string, field: string): unknown {
-  if (field === 'name' || field === '_name') {
-    return basename(file.path, '.md');
-  }
-  if (field === '_path') {
-    return relative(vaultDir, file.path);
-  }
-  return file.frontmatter[field];
-}
-
-function isMissingSortValue(value: unknown): boolean {
-  return value === undefined ||
-    value === null ||
-    value === '' ||
-    (Array.isArray(value) && value.length === 0);
-}
-
-function normalizeSortValue(value: unknown): string | number | boolean {
-  if (Array.isArray(value)) {
-    return value.map(item => String(item)).join(', ');
-  }
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return value;
-  }
-  return String(value);
-}
-
-function compareSortValues(a: unknown, b: unknown): number {
-  const normalizedA = normalizeSortValue(a);
-  const normalizedB = normalizeSortValue(b);
-
-  if (typeof normalizedA === 'number' && typeof normalizedB === 'number') {
-    return normalizedA - normalizedB;
-  }
-
-  if (typeof normalizedA === 'boolean' && typeof normalizedB === 'boolean') {
-    return Number(normalizedA) - Number(normalizedB);
-  }
-
-  return String(normalizedA).localeCompare(String(normalizedB), undefined, {
-    numeric: true,
-    sensitivity: 'base',
-  });
-}
-
-function createFileComparator(
-  vaultDir: string,
-  sortField: string | undefined,
-  descending: boolean | undefined
-): FileComparator {
-  if (!sortField) {
-    return compareByName;
-  }
-
-  return (a, b) => {
-    const valueA = getSortValue(a, vaultDir, sortField);
-    const valueB = getSortValue(b, vaultDir, sortField);
-    const missingA = isMissingSortValue(valueA);
-    const missingB = isMissingSortValue(valueB);
-
-    if (missingA && missingB) {
-      return compareByName(a, b);
-    }
-    if (missingA) return 1;
-    if (missingB) return -1;
-
-    const comparison = compareSortValues(valueA, valueB);
-    if (comparison !== 0) {
-      return descending ? -comparison : comparison;
-    }
-    return compareByName(a, b);
-  };
-}
-
-/**
- * Build a map from note name -> parent note name from frontmatter.
- */
-function buildParentMap(files: FileWithFrontmatter[]): Map<string, string> {
-  const parentMap = new Map<string, string>();
-  
-  for (const file of files) {
-    const name = basename(file.path, '.md');
-    const parentValue = file.frontmatter['parent'];
-    if (parentValue) {
-      const parentName = extractNoteName(String(parentValue));
-      if (parentName) {
-        parentMap.set(name, parentName);
-      }
-    }
-  }
-  
-  return parentMap;
-}
-
-/**
- * Build a map from note name -> set of children note names.
- */
-function buildChildrenMap(parentMap: Map<string, string>): Map<string, Set<string>> {
-  const childrenMap = new Map<string, Set<string>>();
-  
-  for (const [child, parent] of parentMap) {
-    if (!childrenMap.has(parent)) {
-      childrenMap.set(parent, new Set());
-    }
-    childrenMap.get(parent)!.add(child);
-  }
-  
-  return childrenMap;
-}
-
-/**
- * Extract note name from a value (handles wikilinks and plain text).
- * Returns null if the value is empty or cannot be parsed.
- */
-function extractNoteName(value: string): string | null {
-  if (!value) return null;
-  
-  // Use the imported extractWikilinkTarget for wikilink handling
-  const wikilinkTarget = extractWikilinkTarget(value);
-  if (wikilinkTarget) {
-    return wikilinkTarget;
-  }
-  
-  // Plain text - just return trimmed value
-  return value.trim() || null;
-}
-
-/**
- * Collect all descendants of a note up to a given depth.
- * @param rootName The root note name to start from
- * @param childrenMap Map of parent -> children
- * @param maxDepth Maximum depth to traverse (undefined = unlimited)
- * @returns Set of all descendant note names
- */
-function collectDescendants(
-  rootName: string,
-  childrenMap: Map<string, Set<string>>,
-  maxDepth?: number | undefined
-): Set<string> {
-  const descendants = new Set<string>();
-  
-  function traverse(name: string, currentDepth: number): void {
-    if (maxDepth !== undefined && currentDepth >= maxDepth) {
-      return;
-    }
-    
-    const children = childrenMap.get(name);
-    if (!children) return;
-    
-    for (const child of children) {
-      descendants.add(child);
-      traverse(child, currentDepth + 1);
-    }
-  }
-  
-  traverse(rootName, 0);
-  return descendants;
-}
-
-/**
- * Build a tree structure from files and parent relationships.
- */
-interface TreeNode {
-  name: string;
-  path: string;
-  frontmatter: Record<string, unknown>;
-  children: TreeNode[];
-  depth: number;
-}
-
-interface DirectoryTreeNode {
-  name: string;
-  path: string;
-  directories: DirectoryTreeNode[];
-  notes: FileWithFrontmatter[];
-  depth: number;
-}
-
-function buildTree(
-  files: FileWithFrontmatter[],
-  parentMap: Map<string, string>,
-  maxDepth?: number | undefined,
-  fileComparator: FileComparator = compareByName
-): TreeNode[] {
-  // Create nodes for all files
-  const nodeMap = new Map<string, TreeNode>();
-  for (const file of files) {
-    const name = basename(file.path, '.md');
-    nodeMap.set(name, {
-      name,
-      path: file.path,
-      frontmatter: file.frontmatter,
-      children: [],
-      depth: 0,
-    });
-  }
-  
-  // Build parent-child relationships
-  const roots: TreeNode[] = [];
-  for (const [name, node] of nodeMap) {
-    const parentName = parentMap.get(name);
-    if (parentName && nodeMap.has(parentName)) {
-      const parentNode = nodeMap.get(parentName)!;
-      parentNode.children.push(node);
-    } else {
-      roots.push(node);
-    }
-  }
-  
-  // Compute depths and sort children
-  function computeDepth(node: TreeNode, depth: number): void {
-    node.depth = depth;
-    node.children.sort((a, b) => fileComparator(a, b));
-    for (const child of node.children) {
-      computeDepth(child, depth + 1);
-    }
-  }
-  
-  for (const root of roots) {
-    computeDepth(root, 0);
-  }
-  
-  roots.sort((a, b) => fileComparator(a, b));
-  
-  // Filter by max depth if specified
-  if (maxDepth !== undefined) {
-    const depthLimit = maxDepth; // Capture for closure
-    function filterByDepth(nodes: TreeNode[]): TreeNode[] {
-      return nodes.map(node => ({
-        ...node,
-        children: node.depth < depthLimit - 1 ? filterByDepth(node.children) : [],
-      }));
-    }
-    return filterByDepth(roots);
-  }
-  
-  return roots;
-}
 
 /**
  * Print tree structure to console.
@@ -973,76 +741,6 @@ function printTree(
     const isLast = i === roots.length - 1;
     printNode(root, '', isLast);
   }
-}
-
-function treeHasNestedNotes(nodes: TreeNode[]): boolean {
-  return nodes.some(node => node.children.length > 0 || treeHasNestedNotes(node.children));
-}
-
-function buildDirectoryTree(
-  files: FileWithFrontmatter[],
-  vaultDir: string,
-  maxDepth?: number | undefined,
-  fileComparator: FileComparator = compareByName
-): DirectoryTreeNode[] {
-  const root: DirectoryTreeNode = {
-    name: '',
-    path: '',
-    directories: [],
-    notes: [],
-    depth: -1,
-  };
-
-  for (const file of files) {
-    const relativePath = relative(vaultDir, file.path);
-    const segments = relativePath.split('/');
-    const noteName = basename(file.path, '.md');
-    const directorySegments = segments.slice(0, -1);
-
-    let current = root;
-    const traversed: string[] = [];
-
-    for (const segment of directorySegments) {
-      if (maxDepth !== undefined && current.depth + 1 >= maxDepth) {
-        break;
-      }
-
-      traversed.push(segment);
-      let next = current.directories.find(directory => directory.name === segment);
-      if (!next) {
-        next = {
-          name: segment,
-          path: traversed.join('/'),
-          directories: [],
-          notes: [],
-          depth: current.depth + 1,
-        };
-        current.directories.push(next);
-      }
-      current = next;
-    }
-
-    current.notes.push({
-      ...file,
-      path: file.path,
-      frontmatter: {
-        ...file.frontmatter,
-        _displayName: noteName,
-        _relativePath: relativePath,
-      },
-    });
-  }
-
-  const sortNode = (node: DirectoryTreeNode): void => {
-    node.directories.sort((a, b) => a.name.localeCompare(b.name));
-    node.notes.sort(fileComparator);
-    for (const directory of node.directories) {
-      sortNode(directory);
-    }
-  };
-
-  sortNode(root);
-  return root.directories;
 }
 
 function printDirectoryTree(roots: DirectoryTreeNode[], showPaths: boolean): void {

--- a/src/lib/list-helpers.ts
+++ b/src/lib/list-helpers.ts
@@ -1,0 +1,383 @@
+/**
+ * Pure helpers for the `list` command.
+ *
+ * This module contains the sort/comparison logic and the tree-building logic
+ * used by `list` (and the dashboard command via `listObjects`). Everything here
+ * is pure and deterministic — it takes data plus options and returns sorted /
+ * tree-structured results, with no I/O or console output. The actual rendering
+ * (printing trees and tables) stays in the command, since that is I/O-bound.
+ *
+ * Extracted from `src/commands/list.ts` so the logic is isolated and directly
+ * unit-testable. See issue #597.
+ */
+
+import { basename, relative } from 'path';
+import { extractWikilinkTarget } from './links.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type FileWithFrontmatter = {
+  path: string;
+  frontmatter: Record<string, unknown>;
+};
+
+export type FileComparator = (a: FileWithFrontmatter, b: FileWithFrontmatter) => number;
+
+export interface TreeNode {
+  name: string;
+  path: string;
+  frontmatter: Record<string, unknown>;
+  children: TreeNode[];
+  depth: number;
+}
+
+export interface DirectoryTreeNode {
+  name: string;
+  path: string;
+  directories: DirectoryTreeNode[];
+  notes: FileWithFrontmatter[];
+  depth: number;
+}
+
+// ============================================================================
+// Sort / Comparison Helpers
+// ============================================================================
+
+/**
+ * Default comparator: order files alphabetically by note name (basename).
+ */
+export function compareByName(a: FileWithFrontmatter, b: FileWithFrontmatter): number {
+  return basename(a.path, '.md').localeCompare(basename(b.path, '.md'));
+}
+
+/**
+ * Resolve the raw value to sort by for a given field.
+ *
+ * Handles the reserved fields `name`/`_name` (note basename) and `_path`
+ * (vault-relative path); everything else is read from frontmatter.
+ */
+export function getSortValue(file: FileWithFrontmatter, vaultDir: string, field: string): unknown {
+  if (field === 'name' || field === '_name') {
+    return basename(file.path, '.md');
+  }
+  if (field === '_path') {
+    return relative(vaultDir, file.path);
+  }
+  return file.frontmatter[field];
+}
+
+/**
+ * Whether a sort value should be treated as missing (sorted to the end).
+ */
+export function isMissingSortValue(value: unknown): boolean {
+  return value === undefined ||
+    value === null ||
+    value === '' ||
+    (Array.isArray(value) && value.length === 0);
+}
+
+/**
+ * Normalize an arbitrary value into a comparable primitive.
+ * Arrays are joined; numbers/booleans pass through; everything else is stringified.
+ */
+export function normalizeSortValue(value: unknown): string | number | boolean {
+  if (Array.isArray(value)) {
+    return value.map(item => String(item)).join(', ');
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  return String(value);
+}
+
+/**
+ * Compare two (present) sort values. Numbers compare numerically, booleans by
+ * truthiness, and everything else via locale-aware, numeric-sensitive string
+ * comparison (so "2" sorts before "10").
+ */
+export function compareSortValues(a: unknown, b: unknown): number {
+  const normalizedA = normalizeSortValue(a);
+  const normalizedB = normalizeSortValue(b);
+
+  if (typeof normalizedA === 'number' && typeof normalizedB === 'number') {
+    return normalizedA - normalizedB;
+  }
+
+  if (typeof normalizedA === 'boolean' && typeof normalizedB === 'boolean') {
+    return Number(normalizedA) - Number(normalizedB);
+  }
+
+  return String(normalizedA).localeCompare(String(normalizedB), undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
+}
+
+/**
+ * Build a comparator for the given sort field/direction.
+ *
+ * When no field is given, falls back to {@link compareByName}. Missing values
+ * always sort last (regardless of direction); ties break alphabetically by name.
+ */
+export function createFileComparator(
+  vaultDir: string,
+  sortField: string | undefined,
+  descending: boolean | undefined
+): FileComparator {
+  if (!sortField) {
+    return compareByName;
+  }
+
+  return (a, b) => {
+    const valueA = getSortValue(a, vaultDir, sortField);
+    const valueB = getSortValue(b, vaultDir, sortField);
+    const missingA = isMissingSortValue(valueA);
+    const missingB = isMissingSortValue(valueB);
+
+    if (missingA && missingB) {
+      return compareByName(a, b);
+    }
+    if (missingA) return 1;
+    if (missingB) return -1;
+
+    const comparison = compareSortValues(valueA, valueB);
+    if (comparison !== 0) {
+      return descending ? -comparison : comparison;
+    }
+    return compareByName(a, b);
+  };
+}
+
+// ============================================================================
+// Hierarchy / Tree-Building Helpers
+// ============================================================================
+
+/**
+ * Extract a note name from a value (handles wikilinks and plain text).
+ * Returns null if the value is empty or cannot be parsed.
+ */
+export function extractNoteName(value: string): string | null {
+  if (!value) return null;
+
+  // Use the imported extractWikilinkTarget for wikilink handling
+  const wikilinkTarget = extractWikilinkTarget(value);
+  if (wikilinkTarget) {
+    return wikilinkTarget;
+  }
+
+  // Plain text - just return trimmed value
+  return value.trim() || null;
+}
+
+/**
+ * Build a map from note name -> parent note name from frontmatter.
+ */
+export function buildParentMap(files: FileWithFrontmatter[]): Map<string, string> {
+  const parentMap = new Map<string, string>();
+
+  for (const file of files) {
+    const name = basename(file.path, '.md');
+    const parentValue = file.frontmatter['parent'];
+    if (parentValue) {
+      const parentName = extractNoteName(String(parentValue));
+      if (parentName) {
+        parentMap.set(name, parentName);
+      }
+    }
+  }
+
+  return parentMap;
+}
+
+/**
+ * Build a map from note name -> set of children note names.
+ */
+export function buildChildrenMap(parentMap: Map<string, string>): Map<string, Set<string>> {
+  const childrenMap = new Map<string, Set<string>>();
+
+  for (const [child, parent] of parentMap) {
+    if (!childrenMap.has(parent)) {
+      childrenMap.set(parent, new Set());
+    }
+    childrenMap.get(parent)!.add(child);
+  }
+
+  return childrenMap;
+}
+
+/**
+ * Collect all descendants of a note up to a given depth.
+ * @param rootName The root note name to start from
+ * @param childrenMap Map of parent -> children
+ * @param maxDepth Maximum depth to traverse (undefined = unlimited)
+ * @returns Set of all descendant note names
+ */
+export function collectDescendants(
+  rootName: string,
+  childrenMap: Map<string, Set<string>>,
+  maxDepth?: number | undefined
+): Set<string> {
+  const descendants = new Set<string>();
+
+  function traverse(name: string, currentDepth: number): void {
+    if (maxDepth !== undefined && currentDepth >= maxDepth) {
+      return;
+    }
+
+    const children = childrenMap.get(name);
+    if (!children) return;
+
+    for (const child of children) {
+      descendants.add(child);
+      traverse(child, currentDepth + 1);
+    }
+  }
+
+  traverse(rootName, 0);
+  return descendants;
+}
+
+/**
+ * Build a tree structure from files and parent relationships.
+ */
+export function buildTree(
+  files: FileWithFrontmatter[],
+  parentMap: Map<string, string>,
+  maxDepth?: number | undefined,
+  fileComparator: FileComparator = compareByName
+): TreeNode[] {
+  // Create nodes for all files
+  const nodeMap = new Map<string, TreeNode>();
+  for (const file of files) {
+    const name = basename(file.path, '.md');
+    nodeMap.set(name, {
+      name,
+      path: file.path,
+      frontmatter: file.frontmatter,
+      children: [],
+      depth: 0,
+    });
+  }
+
+  // Build parent-child relationships
+  const roots: TreeNode[] = [];
+  for (const [name, node] of nodeMap) {
+    const parentName = parentMap.get(name);
+    if (parentName && nodeMap.has(parentName)) {
+      const parentNode = nodeMap.get(parentName)!;
+      parentNode.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  // Compute depths and sort children
+  function computeDepth(node: TreeNode, depth: number): void {
+    node.depth = depth;
+    node.children.sort((a, b) => fileComparator(a, b));
+    for (const child of node.children) {
+      computeDepth(child, depth + 1);
+    }
+  }
+
+  for (const root of roots) {
+    computeDepth(root, 0);
+  }
+
+  roots.sort((a, b) => fileComparator(a, b));
+
+  // Filter by max depth if specified
+  if (maxDepth !== undefined) {
+    const depthLimit = maxDepth; // Capture for closure
+    function filterByDepth(nodes: TreeNode[]): TreeNode[] {
+      return nodes.map(node => ({
+        ...node,
+        children: node.depth < depthLimit - 1 ? filterByDepth(node.children) : [],
+      }));
+    }
+    return filterByDepth(roots);
+  }
+
+  return roots;
+}
+
+/**
+ * Whether any node in the tree has nested children (i.e. the tree is more than
+ * a flat list of roots).
+ */
+export function treeHasNestedNotes(nodes: TreeNode[]): boolean {
+  return nodes.some(node => node.children.length > 0 || treeHasNestedNotes(node.children));
+}
+
+/**
+ * Build a directory-based tree structure from files, grouping notes by their
+ * vault-relative directory path. Notes carry `_displayName` and `_relativePath`
+ * in their (copied) frontmatter for rendering.
+ */
+export function buildDirectoryTree(
+  files: FileWithFrontmatter[],
+  vaultDir: string,
+  maxDepth?: number | undefined,
+  fileComparator: FileComparator = compareByName
+): DirectoryTreeNode[] {
+  const root: DirectoryTreeNode = {
+    name: '',
+    path: '',
+    directories: [],
+    notes: [],
+    depth: -1,
+  };
+
+  for (const file of files) {
+    const relativePath = relative(vaultDir, file.path);
+    const segments = relativePath.split('/');
+    const noteName = basename(file.path, '.md');
+    const directorySegments = segments.slice(0, -1);
+
+    let current = root;
+    const traversed: string[] = [];
+
+    for (const segment of directorySegments) {
+      if (maxDepth !== undefined && current.depth + 1 >= maxDepth) {
+        break;
+      }
+
+      traversed.push(segment);
+      let next = current.directories.find(directory => directory.name === segment);
+      if (!next) {
+        next = {
+          name: segment,
+          path: traversed.join('/'),
+          directories: [],
+          notes: [],
+          depth: current.depth + 1,
+        };
+        current.directories.push(next);
+      }
+      current = next;
+    }
+
+    current.notes.push({
+      ...file,
+      path: file.path,
+      frontmatter: {
+        ...file.frontmatter,
+        _displayName: noteName,
+        _relativePath: relativePath,
+      },
+    });
+  }
+
+  const sortNode = (node: DirectoryTreeNode): void => {
+    node.directories.sort((a, b) => a.name.localeCompare(b.name));
+    node.notes.sort(fileComparator);
+    for (const directory of node.directories) {
+      sortNode(directory);
+    }
+  };
+
+  sortNode(root);
+  return root.directories;
+}

--- a/tests/ts/lib/list-helpers.test.ts
+++ b/tests/ts/lib/list-helpers.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect } from 'vitest';
+import {
+  compareByName,
+  getSortValue,
+  isMissingSortValue,
+  normalizeSortValue,
+  compareSortValues,
+  createFileComparator,
+  extractNoteName,
+  buildParentMap,
+  buildChildrenMap,
+  collectDescendants,
+  buildTree,
+  treeHasNestedNotes,
+  buildDirectoryTree,
+  type FileWithFrontmatter,
+} from '../../../src/lib/list-helpers.js';
+
+const VAULT = '/vault';
+
+function file(relPath: string, frontmatter: Record<string, unknown> = {}): FileWithFrontmatter {
+  return { path: `${VAULT}/${relPath}`, frontmatter };
+}
+
+/** Sort a copy of files with a comparator and return their note names. */
+function sortedNames(files: FileWithFrontmatter[], comparator: (a: FileWithFrontmatter, b: FileWithFrontmatter) => number): string[] {
+  return [...files]
+    .sort(comparator)
+    .map(f => f.path.split('/').pop()!.replace(/\.md$/, ''));
+}
+
+describe('list-helpers: sort/comparison', () => {
+  describe('getSortValue', () => {
+    it('returns basename for name and _name', () => {
+      const f = file('Projects/Alpha.md', { title: 'x' });
+      expect(getSortValue(f, VAULT, 'name')).toBe('Alpha');
+      expect(getSortValue(f, VAULT, '_name')).toBe('Alpha');
+    });
+
+    it('returns vault-relative path for _path', () => {
+      const f = file('Projects/Alpha.md');
+      expect(getSortValue(f, VAULT, '_path')).toBe('Projects/Alpha.md');
+    });
+
+    it('reads arbitrary fields from frontmatter', () => {
+      const f = file('A.md', { priority: 3 });
+      expect(getSortValue(f, VAULT, 'priority')).toBe(3);
+      expect(getSortValue(f, VAULT, 'missing')).toBeUndefined();
+    });
+  });
+
+  describe('isMissingSortValue', () => {
+    it('treats undefined, null, empty string, and empty array as missing', () => {
+      expect(isMissingSortValue(undefined)).toBe(true);
+      expect(isMissingSortValue(null)).toBe(true);
+      expect(isMissingSortValue('')).toBe(true);
+      expect(isMissingSortValue([])).toBe(true);
+    });
+
+    it('treats present values as not missing', () => {
+      expect(isMissingSortValue(0)).toBe(false);
+      expect(isMissingSortValue(false)).toBe(false);
+      expect(isMissingSortValue('x')).toBe(false);
+      expect(isMissingSortValue(['a'])).toBe(false);
+    });
+  });
+
+  describe('normalizeSortValue', () => {
+    it('passes numbers and booleans through', () => {
+      expect(normalizeSortValue(5)).toBe(5);
+      expect(normalizeSortValue(true)).toBe(true);
+    });
+
+    it('joins arrays with ", "', () => {
+      expect(normalizeSortValue(['a', 'b', 'c'])).toBe('a, b, c');
+    });
+
+    it('stringifies other values', () => {
+      expect(normalizeSortValue('hello')).toBe('hello');
+      const date = new Date('2024-01-01T00:00:00Z');
+      expect(normalizeSortValue(date)).toBe(String(date));
+    });
+  });
+
+  describe('compareSortValues', () => {
+    it('compares numbers numerically', () => {
+      expect(compareSortValues(2, 10)).toBeLessThan(0);
+      expect(compareSortValues(10, 2)).toBeGreaterThan(0);
+      expect(compareSortValues(5, 5)).toBe(0);
+    });
+
+    it('compares booleans by truthiness (false < true)', () => {
+      expect(compareSortValues(false, true)).toBeLessThan(0);
+      expect(compareSortValues(true, false)).toBeGreaterThan(0);
+    });
+
+    it('compares strings with numeric sensitivity', () => {
+      // "2" before "10" thanks to numeric collation
+      expect(compareSortValues('2', '10')).toBeLessThan(0);
+    });
+
+    it('compares date strings lexically (ISO sorts chronologically)', () => {
+      expect(compareSortValues('2024-01-01', '2024-12-31')).toBeLessThan(0);
+      expect(compareSortValues('2024-12-31', '2024-01-01')).toBeGreaterThan(0);
+    });
+
+    it('is case-insensitive (base sensitivity)', () => {
+      expect(compareSortValues('apple', 'Apple')).toBe(0);
+    });
+  });
+
+  describe('createFileComparator', () => {
+    it('sorts by name when no sort field given', () => {
+      const files = [file('Charlie.md'), file('alpha.md'), file('Bravo.md')];
+      expect(sortedNames(files, createFileComparator(VAULT, undefined, undefined)))
+        .toEqual(['alpha', 'Bravo', 'Charlie']);
+    });
+
+    it('sorts ascending by a numeric field', () => {
+      const files = [
+        file('A.md', { priority: 3 }),
+        file('B.md', { priority: 1 }),
+        file('C.md', { priority: 2 }),
+      ];
+      expect(sortedNames(files, createFileComparator(VAULT, 'priority', false)))
+        .toEqual(['B', 'C', 'A']);
+    });
+
+    it('sorts descending by a numeric field', () => {
+      const files = [
+        file('A.md', { priority: 3 }),
+        file('B.md', { priority: 1 }),
+        file('C.md', { priority: 2 }),
+      ];
+      expect(sortedNames(files, createFileComparator(VAULT, 'priority', true)))
+        .toEqual(['A', 'C', 'B']);
+    });
+
+    it('sorts by date field chronologically', () => {
+      const files = [
+        file('A.md', { deadline: '2024-06-01' }),
+        file('B.md', { deadline: '2024-01-15' }),
+        file('C.md', { deadline: '2024-12-31' }),
+      ];
+      expect(sortedNames(files, createFileComparator(VAULT, 'deadline', false)))
+        .toEqual(['B', 'A', 'C']);
+    });
+
+    it('sorts by string field', () => {
+      const files = [
+        file('A.md', { status: 'done' }),
+        file('B.md', { status: 'active' }),
+        file('C.md', { status: 'blocked' }),
+      ];
+      expect(sortedNames(files, createFileComparator(VAULT, 'status', false)))
+        .toEqual(['B', 'C', 'A']);
+    });
+
+    it('always sorts missing values last, even when descending', () => {
+      const asc = [
+        file('A.md', { priority: 2 }),
+        file('B.md', {}),
+        file('C.md', { priority: 1 }),
+      ];
+      expect(sortedNames(asc, createFileComparator(VAULT, 'priority', false)))
+        .toEqual(['C', 'A', 'B']);
+
+      const desc = [
+        file('A.md', { priority: 2 }),
+        file('B.md', {}),
+        file('C.md', { priority: 1 }),
+      ];
+      expect(sortedNames(desc, createFileComparator(VAULT, 'priority', true)))
+        .toEqual(['A', 'C', 'B']);
+    });
+
+    it('breaks ties by name (ascending) regardless of direction', () => {
+      const files = [
+        file('Charlie.md', { priority: 1 }),
+        file('alpha.md', { priority: 1 }),
+        file('Bravo.md', { priority: 1 }),
+      ];
+      // Equal priority -> tiebreak by name ascending
+      expect(sortedNames(files, createFileComparator(VAULT, 'priority', false)))
+        .toEqual(['alpha', 'Bravo', 'Charlie']);
+      expect(sortedNames(files, createFileComparator(VAULT, 'priority', true)))
+        .toEqual(['alpha', 'Bravo', 'Charlie']);
+    });
+
+    it('breaks ties by name when both values are missing', () => {
+      const files = [file('Beta.md', {}), file('Alpha.md', {})];
+      expect(sortedNames(files, createFileComparator(VAULT, 'priority', false)))
+        .toEqual(['Alpha', 'Beta']);
+    });
+  });
+
+  describe('compareByName', () => {
+    it('orders by basename case-insensitively', () => {
+      expect(compareByName(file('apple.md'), file('Banana.md'))).toBeLessThan(0);
+    });
+  });
+});
+
+describe('list-helpers: hierarchy/tree', () => {
+  describe('extractNoteName', () => {
+    it('extracts the target from a wikilink', () => {
+      expect(extractNoteName('[[Project Alpha]]')).toBe('Project Alpha');
+    });
+
+    it('returns trimmed plain text', () => {
+      expect(extractNoteName('  Plain Name  ')).toBe('Plain Name');
+    });
+
+    it('returns null for empty input', () => {
+      expect(extractNoteName('')).toBeNull();
+      expect(extractNoteName('   ')).toBeNull();
+    });
+  });
+
+  describe('buildParentMap', () => {
+    it('maps note name to parent name from frontmatter (wikilink and plain)', () => {
+      const files = [
+        file('Child A.md', { parent: '[[Root]]' }),
+        file('Child B.md', { parent: 'Root' }),
+        file('Root.md', {}),
+      ];
+      const map = buildParentMap(files);
+      expect(map.get('Child A')).toBe('Root');
+      expect(map.get('Child B')).toBe('Root');
+      expect(map.has('Root')).toBe(false);
+    });
+
+    it('ignores notes without a parent value', () => {
+      const map = buildParentMap([file('Solo.md', {})]);
+      expect(map.size).toBe(0);
+    });
+  });
+
+  describe('buildChildrenMap', () => {
+    it('inverts a parent map into parent -> set of children', () => {
+      const parentMap = new Map<string, string>([
+        ['A', 'Root'],
+        ['B', 'Root'],
+        ['C', 'A'],
+      ]);
+      const children = buildChildrenMap(parentMap);
+      expect([...children.get('Root')!].sort()).toEqual(['A', 'B']);
+      expect([...children.get('A')!]).toEqual(['C']);
+    });
+  });
+
+  describe('collectDescendants', () => {
+    const childrenMap = new Map<string, Set<string>>([
+      ['Root', new Set(['A', 'B'])],
+      ['A', new Set(['A1'])],
+      ['A1', new Set(['A1a'])],
+    ]);
+
+    it('collects all descendants unbounded', () => {
+      expect([...collectDescendants('Root', childrenMap)].sort())
+        .toEqual(['A', 'A1', 'A1a', 'B']);
+    });
+
+    it('respects maxDepth', () => {
+      expect([...collectDescendants('Root', childrenMap, 1)].sort()).toEqual(['A', 'B']);
+      expect([...collectDescendants('Root', childrenMap, 2)].sort()).toEqual(['A', 'A1', 'B']);
+    });
+
+    it('returns empty set for a leaf', () => {
+      expect(collectDescendants('A1a', childrenMap).size).toBe(0);
+    });
+  });
+
+  describe('buildTree', () => {
+    it('nests children under parents and identifies roots', () => {
+      const files = [
+        file('Root.md', {}),
+        file('Child.md', { parent: '[[Root]]' }),
+        file('Grandchild.md', { parent: '[[Child]]' }),
+      ];
+      const tree = buildTree(files, buildParentMap(files));
+      expect(tree).toHaveLength(1);
+      expect(tree[0]!.name).toBe('Root');
+      expect(tree[0]!.depth).toBe(0);
+      expect(tree[0]!.children.map(c => c.name)).toEqual(['Child']);
+      expect(tree[0]!.children[0]!.depth).toBe(1);
+      expect(tree[0]!.children[0]!.children[0]!.name).toBe('Grandchild');
+      expect(tree[0]!.children[0]!.children[0]!.depth).toBe(2);
+    });
+
+    it('treats notes whose parent is absent from the set as roots (orphans)', () => {
+      const files = [file('Orphan.md', { parent: '[[Missing]]' })];
+      const tree = buildTree(files, buildParentMap(files));
+      expect(tree.map(n => n.name)).toEqual(['Orphan']);
+    });
+
+    it('sorts roots and children by the provided comparator', () => {
+      const files = [
+        file('Root.md', {}),
+        file('Zeta.md', { parent: '[[Root]]' }),
+        file('Alpha.md', { parent: '[[Root]]' }),
+      ];
+      const tree = buildTree(files, buildParentMap(files));
+      expect(tree[0]!.children.map(c => c.name)).toEqual(['Alpha', 'Zeta']);
+    });
+
+    it('sorts multiple roots by comparator', () => {
+      const files = [file('Zed.md', {}), file('Ann.md', {})];
+      const tree = buildTree(files, buildParentMap(files));
+      expect(tree.map(n => n.name)).toEqual(['Ann', 'Zed']);
+    });
+
+    it('prunes nodes beyond maxDepth', () => {
+      const files = [
+        file('Root.md', {}),
+        file('Child.md', { parent: '[[Root]]' }),
+        file('Grandchild.md', { parent: '[[Child]]' }),
+      ];
+      const tree = buildTree(files, buildParentMap(files), 2);
+      expect(tree[0]!.children[0]!.name).toBe('Child');
+      // Depth limit of 2 means grandchildren are pruned
+      expect(tree[0]!.children[0]!.children).toEqual([]);
+    });
+  });
+
+  describe('treeHasNestedNotes', () => {
+    it('returns false for a flat list of roots', () => {
+      const files = [file('A.md', {}), file('B.md', {})];
+      expect(treeHasNestedNotes(buildTree(files, buildParentMap(files)))).toBe(false);
+    });
+
+    it('returns true when any node has children', () => {
+      const files = [file('Root.md', {}), file('Child.md', { parent: '[[Root]]' })];
+      expect(treeHasNestedNotes(buildTree(files, buildParentMap(files)))).toBe(true);
+    });
+  });
+
+  describe('buildDirectoryTree', () => {
+    it('groups notes under their directory segments', () => {
+      const files = [
+        file('Projects/Alpha.md'),
+        file('Projects/Beta.md'),
+        file('Ideas/Spark.md'),
+      ];
+      const tree = buildDirectoryTree(files, VAULT);
+      // Directories sorted alphabetically: Ideas before Projects
+      expect(tree.map(d => d.name)).toEqual(['Ideas', 'Projects']);
+      const projects = tree.find(d => d.name === 'Projects')!;
+      expect(projects.notes.map(n => n.frontmatter._displayName)).toEqual(['Alpha', 'Beta']);
+    });
+
+    it('nests subdirectories and records relative paths', () => {
+      const files = [file('Projects/Web/Site.md')];
+      const tree = buildDirectoryTree(files, VAULT);
+      const projects = tree[0]!;
+      expect(projects.name).toBe('Projects');
+      const web = projects.directories[0]!;
+      expect(web.name).toBe('Web');
+      expect(web.notes[0]!.frontmatter._relativePath).toBe('Projects/Web/Site.md');
+    });
+
+    it('sorts notes within a directory by comparator', () => {
+      const files = [
+        file('Dir/charlie.md'),
+        file('Dir/alpha.md'),
+        file('Dir/Bravo.md'),
+      ];
+      const tree = buildDirectoryTree(files, VAULT);
+      expect(tree[0]!.notes.map(n => n.frontmatter._displayName))
+        .toEqual(['alpha', 'Bravo', 'charlie']);
+    });
+
+    it('respects maxDepth by keeping notes at the truncation boundary', () => {
+      const files = [file('A/B/C/Deep.md')];
+      const tree = buildDirectoryTree(files, VAULT, 1);
+      // Only the first directory level is created; the note lands there.
+      expect(tree[0]!.name).toBe('A');
+      expect(tree[0]!.directories).toEqual([]);
+      expect(tree[0]!.notes).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Internal refactor (no user-facing behavior change). Extracts the pure sort/comparison and tree-building logic out of `src/commands/list.ts` into a new, directly unit-tested lib module `src/lib/list-helpers.ts`.

## What moved

Extracted (verbatim, behavior unchanged) into `src/lib/list-helpers.ts`:

- **Sort/comparison:** `getSortValue`, `isMissingSortValue`, `normalizeSortValue`, `compareSortValues`, `createFileComparator`, `compareByName`
- **Hierarchy/tree:** `extractNoteName`, `buildParentMap`, `buildChildrenMap`, `collectDescendants`, `buildTree`, `treeHasNestedNotes`, `buildDirectoryTree`
- **Types:** `FileWithFrontmatter`, `FileComparator`, `TreeNode`, `DirectoryTreeNode`

Console rendering (`printTree`, `printDirectoryTree`, `printTable`) stays in `list.ts` since it is I/O-bound. `list.ts` now imports the helpers; `extractNoteName` is consumed both by the command (deprecation-warning strings) and internally by the helpers, so every export is used by production code (knip clean).

## Preserving identical behavior

The functions were moved with their logic byte-for-byte identical — same missing-value-last rule, same name tiebreak, same numeric/locale string collation, same depth-limit pruning, same directory grouping/sort order. The existing `tests/ts/commands/list.test.ts` integration suite passes unchanged, confirming list output, ordering, and tree structure are preserved.

## Tests

New `tests/ts/lib/list-helpers.test.ts` (42 unit tests): sorting by string/number/date fields, ascending/descending, missing/null ordering (last in both directions), multi-key tiebreaks, and tree building (nesting, root/child ordering, orphans, depth limits) plus directory-tree grouping/sorting/depth truncation.

## Quality gates

- `pnpm qa` — pass (typecheck, lint, docs:lint, docs:doctor, build, 2276 tests)
- `pnpm knip` — pass

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)