### PR TITLE
refactor(migration): unify null handling in change preview formatter

### DIFF
--- a/src/lib/migration/execute.ts
+++ b/src/lib/migration/execute.ts
@@ -415,7 +415,7 @@ export function formatMigrationResult(result: MigrationResult): string {
  */
 function formatAppliedChange(change: AppliedChange): string {
   const formatValue = (v: unknown): string =>
-    formatDisplayValue(v, { empty: '(empty)', arrayStyle: 'bracketed', nullIsEmpty: false });
+    formatDisplayValue(v, { empty: '(empty)', arrayStyle: 'bracketed' });
 
   switch (change.kind) {
     case 'set':

--- a/src/lib/value-format.ts
+++ b/src/lib/value-format.ts
@@ -16,8 +16,8 @@
 
 export interface DisplayValueOptions {
   /**
-   * Placeholder returned for empty values (`undefined`, and `null` unless
-   * `nullIsEmpty` is false). Defaults to an empty string.
+   * Placeholder returned for empty values (`undefined` and `null`). Defaults to
+   * an empty string.
    */
   empty?: string;
   /**
@@ -26,11 +26,6 @@ export interface DisplayValueOptions {
    * - `'bracketed'`: `"[a, b]"`, and `"[]"` for an empty array.
    */
   arrayStyle?: 'plain' | 'bracketed';
-  /**
-   * Whether `null` is treated as empty (returns the `empty` placeholder).
-   * Defaults to `true`. When `false`, `null` is stringified to `"null"`.
-   */
-  nullIsEmpty?: boolean;
 }
 
 /**
@@ -40,9 +35,9 @@ export function formatDisplayValue(
   value: unknown,
   options: DisplayValueOptions = {}
 ): string {
-  const { empty = '', arrayStyle = 'plain', nullIsEmpty = true } = options;
+  const { empty = '', arrayStyle = 'plain' } = options;
 
-  if (value === undefined || (nullIsEmpty && value === null)) {
+  if (value === undefined || value === null) {
     return empty;
   }
 

--- a/tests/ts/lib/migration/format.test.ts
+++ b/tests/ts/lib/migration/format.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import { formatMigrationResult } from "../../../../src/lib/migration/execute.js";
+import type {
+  AppliedChange,
+  MigrationResult,
+} from "../../../../src/types/migration.js";
+
+/**
+ * Tests for the migration change-preview formatter (#595).
+ *
+ * Null-ish values (`null`, `undefined`, missing) must render consistently as
+ * the single `(empty)` placeholder across every change branch (set / delete /
+ * rename), matching the bulk change preview. Previously `null` fell through to
+ * the literal string `"null"`.
+ */
+
+function resultWith(changes: AppliedChange[]): MigrationResult {
+  return {
+    dryRun: true,
+    fromVersion: "1.0.0",
+    toVersion: "1.1.0",
+    totalFiles: 1,
+    affectedFiles: 1,
+    fileResults: [
+      {
+        filePath: "/vault/Note.md",
+        relativePath: "Note.md",
+        changes,
+        applied: false,
+      },
+    ],
+    errors: [],
+  };
+}
+
+/** Extract just the change line for a single-change result. */
+function changeLine(change: AppliedChange): string {
+  const out = formatMigrationResult(resultWith([change]));
+  const line = out.split("\n").find((l) => l.trim().startsWith(change.field));
+  if (!line) throw new Error(`No change line found in:\n${out}`);
+  return line.trim();
+}
+
+describe("formatMigrationResult - null/empty rendering", () => {
+  describe("adding a field (no prior value)", () => {
+    it("renders undefined oldValue as (empty)", () => {
+      expect(
+        changeLine({
+          kind: "set",
+          field: "status",
+          oldValue: undefined,
+          newValue: "todo",
+        })
+      ).toBe("status: (empty) → todo");
+    });
+
+    it("renders null oldValue as (empty), not the literal 'null'", () => {
+      expect(
+        changeLine({
+          kind: "set",
+          field: "status",
+          oldValue: null,
+          newValue: "todo",
+        })
+      ).toBe("status: (empty) → todo");
+    });
+  });
+
+  describe("removing a field (no new value)", () => {
+    it("renders a value being removed", () => {
+      expect(
+        changeLine({
+          kind: "delete",
+          field: "legacy",
+          oldValue: "x",
+          newValue: undefined,
+        })
+      ).toBe("legacy: x → (removed)");
+    });
+
+    it("renders an explicit-null oldValue as (empty) on delete", () => {
+      expect(
+        changeLine({
+          kind: "delete",
+          field: "legacy",
+          oldValue: null,
+          newValue: undefined,
+        })
+      ).toBe("legacy: (empty) → (removed)");
+    });
+  });
+
+  describe("changing a value", () => {
+    it("value → null renders newValue as (empty)", () => {
+      expect(
+        changeLine({
+          kind: "set",
+          field: "owner",
+          oldValue: "alice",
+          newValue: null,
+        })
+      ).toBe("owner: alice → (empty)");
+    });
+
+    it("null → value renders oldValue as (empty)", () => {
+      expect(
+        changeLine({
+          kind: "set",
+          field: "owner",
+          oldValue: null,
+          newValue: "bob",
+        })
+      ).toBe("owner: (empty) → bob");
+    });
+
+    it("value → value renders both", () => {
+      expect(
+        changeLine({
+          kind: "set",
+          field: "owner",
+          oldValue: "alice",
+          newValue: "bob",
+        })
+      ).toBe("owner: alice → bob");
+    });
+
+    it("null and undefined render identically (consistency)", () => {
+      const fromNull = changeLine({
+        kind: "set",
+        field: "f",
+        oldValue: null,
+        newValue: "v",
+      });
+      const fromUndefined = changeLine({
+        kind: "set",
+        field: "f",
+        oldValue: undefined,
+        newValue: "v",
+      });
+      expect(fromNull).toBe(fromUndefined);
+    });
+  });
+
+  describe("renaming a field", () => {
+    it("carries the value across the rename", () => {
+      expect(
+        changeLine({
+          kind: "rename",
+          field: "old_name",
+          newField: "new_name",
+          oldValue: "v",
+          newValue: "v",
+        })
+      ).toBe("old_name → new_name: v");
+    });
+
+    it("renders a null carried value as (empty)", () => {
+      expect(
+        changeLine({
+          kind: "rename",
+          field: "old_name",
+          newField: "new_name",
+          oldValue: null,
+          newValue: null,
+        })
+      ).toBe("old_name → new_name: (empty)");
+    });
+  });
+
+  describe("array values", () => {
+    it("renders arrays in bracketed style", () => {
+      expect(
+        changeLine({
+          kind: "set",
+          field: "tags",
+          oldValue: ["a", "b"],
+          newValue: [],
+        })
+      ).toBe("tags: [a, b] → []");
+    });
+  });
+});

--- a/tests/ts/lib/value-format.test.ts
+++ b/tests/ts/lib/value-format.test.ts
@@ -45,16 +45,6 @@ describe('formatDisplayValue', () => {
     });
   });
 
-  describe('nullIsEmpty: false', () => {
-    it('stringifies null instead of using the placeholder', () => {
-      expect(formatDisplayValue(null, { empty: '(empty)', nullIsEmpty: false })).toBe('null');
-    });
-
-    it('still treats undefined as empty', () => {
-      expect(formatDisplayValue(undefined, { empty: '(empty)', nullIsEmpty: false })).toBe('(empty)');
-    });
-  });
-
   // The following groups lock in the exact behavior of the four call sites this
   // helper replaced, so any future change to the shared helper that would alter
   // one of those outputs fails loudly.
@@ -82,12 +72,14 @@ describe('formatDisplayValue', () => {
     });
   });
 
-  describe('parity: migration change formatter (empty: "(empty)", bracketed, null stringified)', () => {
+  describe('parity: migration change formatter (empty: "(empty)", bracketed)', () => {
     const fmt = (v: unknown) =>
-      formatDisplayValue(v, { empty: '(empty)', arrayStyle: 'bracketed', nullIsEmpty: false });
-    it('matches legacy behavior', () => {
+      formatDisplayValue(v, { empty: '(empty)', arrayStyle: 'bracketed' });
+    it('treats null and undefined identically as the empty placeholder', () => {
+      // Unified with the bulk change formatter (#595): null no longer renders
+      // as the literal string "null".
       expect(fmt(undefined)).toBe('(empty)');
-      expect(fmt(null)).toBe('null');
+      expect(fmt(null)).toBe('(empty)');
       expect(fmt([])).toBe('[]');
       expect(fmt(['a', 'b'])).toBe('[a, b]');
       expect(fmt('x')).toBe('x');


### PR DESCRIPTION
## Summary

The migration change-preview formatter (`bwrb schema migrate` before/after diff) only treated `undefined` as empty; `null` fell through to `String(null)` and rendered as the literal string `null`. This diverged from the bulk change preview and the other display formatters consolidated in #594, all of which treat `null` and `undefined` identically as the empty placeholder.

## Change

- Dropped the `nullIsEmpty: false` option at the migration call site in `src/lib/migration/execute.ts` (`formatAppliedChange`). All preview branches (set / delete / rename) now render null-ish values consistently as `(empty)` through the single shared `formatDisplayValue` helper.
- Removed the now-unused `nullIsEmpty` option from `src/lib/value-format.ts` entirely (no remaining consumers).
- Reused the existing `formatDisplayValue` helper from #594 rather than introducing a new convention.

## Bug vs cosmetic

Mostly cosmetic, but it does fix a minor real bug: `remove-field` and `rename-field` read `oldValue` straight from the note's frontmatter, so an explicit YAML `null` reaches the formatter and previously displayed as the literal `null` instead of `(empty)`.

## Tests

- New `tests/ts/lib/migration/format.test.ts` covering `formatMigrationResult` across all branches: add (no prior value), remove (no new value), value→null, null→value, value→value, rename, arrays, and null/undefined-render-identically.
- Updated `tests/ts/lib/value-format.test.ts`: removed the `nullIsEmpty: false` cases and the stale migration parity block; the migration parity block now asserts null === undefined === `(empty)`.

## Quality gates

- `pnpm qa`: pass (2295 passed, 4 skipped)
- `pnpm knip`: pass

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)