### PR TITLE
feat(audit): validate required body sections (#510)

### DIFF
--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -78,6 +78,7 @@ Delete semantics in repair mode:
 | `illegal-aliases` | An [`alias`-role field](/reference/schema/#alias) has empty or non-string entries (the Obsidian aliases format requires non-empty, unique strings) |
 | `unlinked-mention` | A known entity's name or [registered alias](/reference/schema/#alias) appears in body prose as plain text but is not wikilinked (warning; exact/alias matches auto-fixable, fuzzy/ambiguous matches flag-only — see below) |
 | `frequent-unlinked-term` | A proper-noun-ish term mentioned frequently across the vault that has **no note yet** (warning; **advisory heuristic, never auto-fixable** — see below) |
+| `missing-body-section` | A heading section declared in the type's [`body_sections`](/reference/schema/) is missing from the note body, or present at the wrong heading level (warning; **auto-fixable** — `--fix` appends the canonical heading scaffold — see below) |
 | `missing-successor` | A [recurring](/automation/task-system/) note satisfies its trigger (e.g. `status = done`) but its chain field (`next`) is empty — a successor was never spawned (e.g. completed outside bwrb). Warning; **auto-fixable** (`--fix` spawns it, identical to the fast path) |
 | `invalid-recurrence` | A [recurrence](/automation/task-system/) rule is broken at the config level — a malformed trigger, a non-date offset base, or a template that doesn't exist (error; **never auto-fixable** — a config error gets the same safety net as data) |
 
@@ -261,6 +262,31 @@ bwrb audit --only frequent-unlinked-term
 
 # Suppress them (e.g. while focusing on fixable issues)
 bwrb audit --ignore frequent-unlinked-term
+```
+
+### Missing-body-section semantics (body structure)
+
+`missing-body-section` validates the **markdown body**, not the frontmatter. The schema heavily enforces YAML frontmatter, but the body has historically been unchecked: `bwrb new` and `bwrb edit` scaffold the heading sections declared in a type's [`body_sections`](/reference/schema/) (e.g. a `bug` gets `## Steps to Reproduce`), but nothing stops a user from later deleting or renaming one. This detection re-checks, at audit time, that every declared section heading is still present.
+
+What it checks:
+
+- For each section declared in the resolved type's `body_sections` (including nested `children`), the body must contain a matching ATX heading — the exact title at the declared `level`. Trailing whitespace and ATX closing hashes (`## Title ##`) are tolerated.
+- A heading written inside a fenced code block, inline code, or a link does **not** satisfy the requirement — the same [body masking](#unlinked-mention-semantics-web-integrity) used by `unlinked-mention` is applied, so only real prose headings count.
+- If a heading with the right title exists but at the **wrong level**, it is still flagged (with the offending `lineNumber`), and the fix appends a correctly-leveled heading rather than rewriting yours.
+
+What it does **not** check: it validates heading *presence/structure* only — not whether the body content under a section is filled in (bullets, checkboxes, paragraph counts). It also does not validate body wikilinks; that is the job of [`unlinked-mention`](#unlinked-mention-semantics-web-integrity) and [`frequent-unlinked-term`](#frequent-unlinked-term-semantics-open-world-nudge), which scan body links and never overlap with this structural check.
+
+**Auto-fixable.** Adding a declared heading is a safe, deterministic, **additive** repair — `--fix` appends the missing section using the *same* scaffold `bwrb new`/`bwrb edit` emit (heading + the section's `content_type` placeholder), so it never deletes or rewrites existing prose. It is idempotent: a re-run finds the now-present heading and does nothing (no duplicate headings). Types that declare no `body_sections` are never flagged.
+
+```bash
+# Report missing body sections only
+bwrb audit --only missing-body-section
+
+# Append missing sections automatically
+bwrb audit --fix --auto --execute --all
+
+# Suppress the check
+bwrb audit --ignore missing-body-section
 ```
 
 ### Non-interactive mode

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -123,6 +123,8 @@ Issue Types:
                         (exact/alias auto-fixable; fuzzy/ambiguous flag-only)
   frequent-unlinked-term Proper-noun-ish term mentioned often across the vault
                         with no note yet (advisory heuristic; never auto-fixed)
+  missing-body-section  Heading section declared in the type's body_sections is
+                        missing from the note body (auto-fixable: appends it)
 
 Type Resolution:
   Audit resolves each file's type from its frontmatter 'type' field.

--- a/src/lib/audit/body-sections.ts
+++ b/src/lib/audit/body-sections.ts
@@ -1,0 +1,135 @@
+/**
+ * Body-section validation (#510).
+ *
+ * The schema's `body_sections` declare the markdown headings a note of a given
+ * type is expected to carry (e.g. a `bug` type scaffolds "## Steps to Reproduce").
+ * `bwrb new`/`bwrb edit` write those headings, but nothing stops a user from
+ * deleting or renaming one later. This detection re-checks, at audit time, that
+ * every declared section heading is still present in the body at its declared
+ * level.
+ *
+ * Scope (deliberately narrow, per #510 and the issue author's note):
+ *   - We validate the PRESENCE of declared heading sections only. Heading text +
+ *     level must match what the schema declares. Nested `children` are recursed.
+ *   - We do NOT validate body CONTENT (whether bullets/checkboxes are filled in,
+ *     paragraph counts, etc.) — that would be noisy and is not what the issue
+ *     asks for.
+ *   - We do NOT validate body wikilinks here. That half of #510 overlaps with the
+ *     existing `unlinked-mention` (#600) / `frequent-unlinked-term` (#601) and
+ *     relation-field stale-reference detections, and the issue author explicitly
+ *     asked to coordinate the body-link half there rather than duplicate it.
+ *
+ * Auto-fixable: yes. A missing declared heading is appended using the SAME
+ * `generateBodySections` scaffold that `new`/`edit` use, so the fix is
+ * deterministic, additive (never deletes or rewrites existing prose), and
+ * idempotent (re-running finds the now-present heading and does nothing).
+ */
+
+import type { BodySection } from '../../types/schema.js';
+import type { AuditIssue } from './types.js';
+import { maskNonProse } from './unlinked-mention.js';
+
+/** Escape a string for safe inclusion in a RegExp. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Whether a heading with the given level and title is present in the (already
+ * non-prose-masked) body. Matches an ATX heading line: the exact number of `#`
+ * for the declared level, a single space, then the exact title (trailing
+ * whitespace and trailing `#` closing sequence tolerated). Matching is
+ * case-sensitive on the title to mirror how the scaffold writes it.
+ */
+function headingPresent(maskedBody: string, level: number, title: string): boolean {
+  const prefix = '#'.repeat(level);
+  // ^## Title  with optional trailing spaces and optional closing ### run.
+  const pattern = new RegExp(
+    `^[ \\t]*${prefix} ${escapeRegExp(title)}[ \\t]*#*[ \\t]*$`,
+    'm'
+  );
+  return pattern.test(maskedBody);
+}
+
+/**
+ * Find the 1-based line number of the first heading at any level whose title
+ * matches, regardless of level. Used to point a level-mismatch warning at the
+ * offending line. Returns undefined if not found.
+ */
+function findHeadingLine(maskedBody: string, title: string): number | undefined {
+  const pattern = new RegExp(`^[ \\t]*#{1,6} ${escapeRegExp(title)}[ \\t]*#*[ \\t]*$`);
+  const lines = maskedBody.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (pattern.test(lines[i]!)) return i + 1;
+  }
+  return undefined;
+}
+
+/**
+ * Recursively collect every declared section as a flat list of (section, level)
+ * entries. A child's level defaults to one deeper than its declared value via
+ * the schema's own `level` field (children carry their own `level`), so we read
+ * each section's `level` directly (default 2) rather than inferring depth.
+ */
+function flattenSections(
+  sections: BodySection[],
+  out: Array<{ title: string; level: number }> = []
+): Array<{ title: string; level: number }> {
+  for (const section of sections) {
+    out.push({ title: section.title, level: section.level ?? 2 });
+    if (section.children && section.children.length > 0) {
+      flattenSections(section.children, out);
+    }
+  }
+  return out;
+}
+
+/**
+ * Detect declared body sections that are missing from a note's body.
+ *
+ * @param body         The markdown body (frontmatter already stripped).
+ * @param bodySections The resolved type's declared body sections.
+ * @returns One `missing-body-section` issue per declared heading that is absent
+ *          at its declared level. When a heading with the same title exists but
+ *          at a different level, the issue notes that (still flagged, and the
+ *          fix appends the correctly-leveled heading rather than rewriting the
+ *          user's heading).
+ */
+export function detectMissingBodySections(
+  body: string,
+  bodySections: BodySection[]
+): AuditIssue[] {
+  if (!bodySections || bodySections.length === 0) return [];
+
+  const issues: AuditIssue[] = [];
+  // Mask code/links so a `## Heading` written inside a fenced code block or a
+  // link does not count as satisfying the requirement (and so we never point a
+  // line number at masked content).
+  const masked = maskNonProse(body);
+
+  for (const { title, level } of flattenSections(bodySections)) {
+    if (headingPresent(masked, level, title)) continue;
+
+    const wrongLevelLine = findHeadingLine(masked, title);
+    const meta: Record<string, unknown> = { title, level };
+    let message = `Missing required body section: "${'#'.repeat(level)} ${title}"`;
+    if (wrongLevelLine !== undefined) {
+      message = `Body section "${title}" is present but not at the expected heading level (expected ${'#'.repeat(level)})`;
+      meta['wrongLevel'] = true;
+    }
+
+    issues.push({
+      severity: 'warning',
+      code: 'missing-body-section',
+      message,
+      // Conservative: appending the canonical heading scaffold is safe and
+      // deterministic, so this is auto-fixable.
+      autoFixable: true,
+      inBody: true,
+      ...(wrongLevelLine !== undefined ? { lineNumber: wrongLevelLine } : {}),
+      meta,
+    });
+  }
+
+  return issues;
+}

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -89,6 +89,8 @@ import {
 } from './unlinked-mention.js';
 // Import frequent-unlinked-term detection (ingest safety net, #601)
 import { FrequentTermAccumulator } from './frequent-unlinked-term.js';
+// Import body-section validation (#510)
+import { detectMissingBodySections } from './body-sections.js';
 import { parseNote } from '../frontmatter.js';
 
 /**
@@ -718,24 +720,40 @@ export async function auditFile(
   // Note: Body stale-reference detection is deferred to v2.0
   // Per product scope, v1.0 only validates frontmatter relation fields
 
-  // Unlinked-mention detection (#600): scan body prose for known entity
-  // names/aliases that are not wikilinked. Skipped entirely when the caller
-  // filtered this issue out, to avoid the extra body read.
-  if (
-    entityMentionIndex &&
-    entityMentionIndex.surfacePattern &&
+  // Body checks share a single body read. `parseNote` is only invoked when at
+  // least one body check is going to run, and at most once per file.
+  const wantsUnlinkedMention =
+    Boolean(entityMentionIndex?.surfacePattern) &&
     options.ignoreIssue !== 'unlinked-mention' &&
-    (options.onlyIssue === undefined || options.onlyIssue === 'unlinked-mention')
-  ) {
+    (options.onlyIssue === undefined || options.onlyIssue === 'unlinked-mention');
+
+  // Body-section validation (#510): the type declares heading sections in
+  // `body_sections`; flag any that are missing from the note body. Distinct
+  // from unlinked-mention/relation checks (those validate links; this validates
+  // heading structure). Skipped when filtered out or when the type has none.
+  const wantsBodySections =
+    typeDef.bodySections.length > 0 &&
+    options.ignoreIssue !== 'missing-body-section' &&
+    (options.onlyIssue === undefined || options.onlyIssue === 'missing-body-section');
+
+  if (wantsUnlinkedMention || wantsBodySections) {
     try {
       const { body } = await parseNote(file.path);
-      if (body && body.trim().length > 0) {
+      const hasBody = Boolean(body && body.trim().length > 0);
+
+      if (wantsUnlinkedMention && hasBody && entityMentionIndex) {
         issues.push(
           ...detectUnlinkedMentions(body, file.relativePath, entityMentionIndex)
         );
       }
+
+      // A note with an empty body is still missing every declared section, so
+      // body-section validation runs even when the body is blank.
+      if (wantsBodySections) {
+        issues.push(...detectMissingBodySections(body ?? '', typeDef.bodySections));
+      }
     } catch {
-      // If the body can't be parsed, skip mention detection for this file.
+      // If the body can't be parsed, skip body-level detections for this file.
     }
   }
 

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -31,10 +31,10 @@ import {
   getUnambiguousDateNormalization,
   isCanonicalIsoDate,
 } from './fix-policy.js';
-import { parseNote, writeNote } from '../frontmatter.js';
+import { parseNote, writeNote, generateBodySections } from '../frontmatter.js';
 import { levenshteinDistance } from '../levenshtein.js';
 import { promptSelection, promptConfirm, promptInput } from '../prompt.js';
-import type { LoadedSchema, Field } from '../../types/schema.js';
+import type { LoadedSchema, Field, BodySection } from '../../types/schema.js';
 import {
   findAllMarkdownFiles,
   findWikilinksToFile,
@@ -174,6 +174,103 @@ async function applyUnlinkedMentionFix(
   const typeDef = typePath ? getTypeDefByPath(schema, typePath) : undefined;
   const order = typeDef?.fieldOrder;
 
+  if (!isDryRunEnabled()) {
+    await writeNote(filePath, parsed.frontmatter, newBody, order);
+  }
+
+  return { file: filePath, issue, action: 'fixed' };
+}
+
+/**
+ * Find a declared body section by title anywhere in a (possibly nested) section
+ * tree. Returns the full `BodySection` so the fix can regenerate the canonical
+ * scaffold (heading + content_type placeholder), not just a bare heading line.
+ */
+function findBodySectionByTitle(
+  sections: BodySection[],
+  title: string
+): BodySection | undefined {
+  for (const section of sections) {
+    if (section.title === title) return section;
+    if (section.children && section.children.length > 0) {
+      const found = findBodySectionByTitle(section.children, title);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Whether a heading at the given level/title already exists in the body. Mirrors
+ * the detector's matcher so the fix is idempotent: if a prior fix (or the user)
+ * already added the heading, we skip rather than appending a duplicate.
+ */
+function bodyHasSectionHeading(body: string, level: number, title: string): boolean {
+  const masked = maskNonProse(body);
+  const prefix = '#'.repeat(level);
+  const pattern = new RegExp(
+    `^[ \\t]*${prefix} ${escapeRegExp(title)}[ \\t]*#*[ \\t]*$`,
+    'm'
+  );
+  return pattern.test(masked);
+}
+
+/**
+ * Apply a `missing-body-section` auto-fix (#510): append the declared heading
+ * section (with its canonical content-type placeholder) to the end of the body.
+ *
+ * Deterministic and additive — it only appends the missing heading using the
+ * SAME `generateBodySections` scaffold that `new`/`edit` emit, so it never
+ * deletes or rewrites existing prose. Re-reads + re-checks before writing so the
+ * fix is idempotent (a now-present heading is skipped, never duplicated).
+ */
+async function applyBodySectionFix(
+  schema: LoadedSchema,
+  filePath: string,
+  issue: AuditIssue
+): Promise<FixResult> {
+  const title = issue.meta?.['title'] as string | undefined;
+  const level = (issue.meta?.['level'] as number | undefined) ?? 2;
+  if (!title) {
+    return { file: filePath, issue, action: 'failed', message: 'Missing section title' };
+  }
+
+  const parsed = await parseNote(filePath);
+  const typePath = resolveTypePathFromFrontmatter(schema, parsed.frontmatter);
+  const typeDef = typePath ? getTypeDefByPath(schema, typePath) : undefined;
+  if (!typeDef) {
+    return { file: filePath, issue, action: 'failed', message: 'Could not resolve note type' };
+  }
+
+  const section = findBodySectionByTitle(typeDef.bodySections, title);
+  if (!section) {
+    return {
+      file: filePath,
+      issue,
+      action: 'skipped',
+      message: `Section "${title}" no longer declared in schema`,
+    };
+  }
+
+  // Idempotency: skip if the heading is already present at its declared level.
+  if (bodyHasSectionHeading(parsed.body, section.level ?? level, title)) {
+    return {
+      file: filePath,
+      issue,
+      action: 'skipped',
+      message: `Section "${title}" already present`,
+    };
+  }
+
+  // Append just this section (without its children — children get their own
+  // issues/fixes), using the canonical scaffold.
+  const sectionScaffold = generateBodySections([{ ...section, children: undefined }]);
+  const existing = parsed.body.replace(/\s*$/, '');
+  const newBody = existing.length > 0
+    ? `${existing}\n\n${sectionScaffold}`
+    : sectionScaffold;
+
+  const order = typeDef.fieldOrder;
   if (!isDryRunEnabled()) {
     await writeNote(filePath, parsed.frontmatter, newBody, order);
   }
@@ -429,6 +526,10 @@ async function applyFix(
 
     if (issue.code === 'unlinked-mention') {
       return await applyUnlinkedMentionFix(schema, filePath, issue);
+    }
+
+    if (issue.code === 'missing-body-section') {
+      return await applyBodySectionFix(schema, filePath, issue);
     }
 
     if (issue.code === 'frontmatter-key-casing') {
@@ -1499,6 +1600,24 @@ export async function runAutoFix(
           console.log(chalk.red(`    ✗ Failed to rename ${issue.field}: ${fixResult.message}`));
           failed++;
         }
+      } else if (issue.code === 'missing-body-section') {
+        // Append the canonical heading scaffold for a declared body section.
+        const fixResult = await applyFix(schema, result.path, issue);
+        if (fixResult.action === 'fixed') {
+          const title = (issue.meta?.['title'] as string | undefined) ?? '';
+          console.log(chalk.cyan(`  ${result.relativePath}`));
+          console.log(chalk.green(`    ✓ Added body section: ${title}`));
+          fixed++;
+        } else if (fixResult.action === 'skipped') {
+          console.log(chalk.cyan(`  ${result.relativePath}`));
+          console.log(chalk.yellow(`    ⚠ ${fixResult.message}`));
+          skipped++;
+          registerManualReview(manualReviewNeeded, result.relativePath, issue);
+        } else {
+          console.log(chalk.cyan(`  ${result.relativePath}`));
+          console.log(chalk.red(`    ✗ Failed to add body section: ${fixResult.message}`));
+          failed++;
+        }
       } else if (issue.code === 'missing-successor') {
         // Spawn the missing recurrence successor (same engine as the fast path).
         const fixResult = await applyMissingSuccessorFix(schema, vaultDir, result.path, issue);
@@ -1703,6 +1822,8 @@ async function handleInteractiveFix(
       return handleKeyCasingFix(schema, result, issue);
     case 'unlinked-mention':
       return handleUnlinkedMentionFix(schema, result, issue);
+    case 'missing-body-section':
+      return handleBodySectionFix(schema, result, issue);
     case 'missing-successor':
       return handleMissingSuccessorFix(context, result, issue);
     default:
@@ -3368,6 +3489,25 @@ async function handleUnlinkedMentionFix(
     console.log(chalk.red(`    ✗ Failed: ${fixResult.message}`));
     return 'failed';
   }
+}
+
+/**
+ * Handle a missing body section interactively (#510): confirm, then append the
+ * canonical heading scaffold.
+ */
+async function handleBodySectionFix(
+  schema: LoadedSchema,
+  result: FileAuditResult,
+  issue: AuditIssue
+): Promise<'fixed' | 'skipped' | 'failed' | 'quit'> {
+  const title = (issue.meta?.['title'] as string | undefined) ?? '';
+  return confirmAndApplyFix(
+    schema,
+    result,
+    issue,
+    `    → Add body section "${title}"?`,
+    `Added body section: ${title}`
+  );
 }
 
 /**

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -65,7 +65,11 @@ export type IssueCode =
   // Task system (#107): a recurrence rule that is broken at the config level —
   // a non-date offset base, a malformed trigger, or a template that doesn't
   // exist. Deterministic config error; NEVER auto-fixable.
-  | 'invalid-recurrence';
+  | 'invalid-recurrence'
+  // Body validation (#510): a heading section declared in the type's
+  // `body_sections` is missing from the note body (or present at the wrong
+  // heading level). Auto-fixable: --fix appends the canonical heading scaffold.
+  | 'missing-body-section';
 
 /**
  * A single audit issue.

--- a/tests/ts/commands/audit-fix.pty.test.ts
+++ b/tests/ts/commands/audit-fix.pty.test.ts
@@ -396,6 +396,10 @@ tags:
   - good
   - 42
 ---
+## Steps
+- [ ] Step 1
+
+## Notes
 `,
       };
 
@@ -449,6 +453,10 @@ type: task
 status: backlog
 parent: "[[Self Task]]"
 ---
+## Steps
+- [ ] Step 1
+
+## Notes
 `,
       };
 
@@ -459,6 +467,10 @@ type: task
 status: backlog
 parent: "[[Self Task]]"
 ---
+## Steps
+- [ ] Step 1
+
+## Notes
 `,
       };
 

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -2489,6 +2489,10 @@ priority: medium
 type: task
 status: backlog
 ---
+## Steps
+- [ ] Step 1
+
+## Notes
 `
       );
 
@@ -2498,6 +2502,7 @@ status: backlog
 type: milestone
 status: in-flight
 ---
+## Tasks
 `
       );
 

--- a/tests/ts/fixtures/setup.ts
+++ b/tests/ts/fixtures/setup.ts
@@ -117,6 +117,7 @@ deadline: "2024-01-15"
 type: milestone
 status: in-flight
 ---
+## Tasks
 `
   );
 
@@ -126,6 +127,7 @@ status: in-flight
 type: milestone
 status: settled
 ---
+## Tasks
 `
   );
 

--- a/tests/ts/lib/audit-body-sections.test.ts
+++ b/tests/ts/lib/audit-body-sections.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, writeFile, rm, readFile, mkdtemp } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadSchema } from '../../../src/lib/schema.js';
+import { runAudit } from '../../../src/lib/audit/detection.js';
+import { runAutoFix } from '../../../src/lib/audit/fix.js';
+import { detectMissingBodySections } from '../../../src/lib/audit/body-sections.js';
+import type { BodySection, Schema } from '../../../src/types/schema.js';
+
+// ---------------------------------------------------------------------------
+// Unit tests on the pure detector (no filesystem)
+// ---------------------------------------------------------------------------
+
+const SECTIONS: BodySection[] = [
+  { title: 'Steps to Reproduce', level: 2, content_type: 'bullets' },
+  { title: 'Expected Behavior', level: 2, content_type: 'paragraphs' },
+];
+
+describe('body-sections: detectMissingBodySections', () => {
+  it('flags a missing declared section', () => {
+    const body = '## Steps to Reproduce\n- one\n';
+    const issues = detectMissingBodySections(body, SECTIONS);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.code).toBe('missing-body-section');
+    expect(issues[0]!.message).toContain('Expected Behavior');
+    expect(issues[0]!.autoFixable).toBe(true);
+    expect(issues[0]!.inBody).toBe(true);
+  });
+
+  it('does not flag when all sections are present', () => {
+    const body = '## Steps to Reproduce\n- one\n\n## Expected Behavior\n\nIt should work.\n';
+    const issues = detectMissingBodySections(body, SECTIONS);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('tolerates trailing whitespace and ATX closing hashes', () => {
+    const body = '## Steps to Reproduce  \n\n## Expected Behavior ##\n';
+    const issues = detectMissingBodySections(body, SECTIONS);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('flags all sections for an empty body', () => {
+    const issues = detectMissingBodySections('', SECTIONS);
+    expect(issues.map((i) => i.meta?.['title'])).toEqual([
+      'Steps to Reproduce',
+      'Expected Behavior',
+    ]);
+  });
+
+  it('does not count a heading inside a fenced code block as present', () => {
+    const body = '```\n## Steps to Reproduce\n```\n\n## Expected Behavior\n\nok\n';
+    const issues = detectMissingBodySections(body, SECTIONS);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.meta?.['title']).toBe('Steps to Reproduce');
+  });
+
+  it('flags a heading present at the wrong level and records the line', () => {
+    // "## Steps to Reproduce" declared, but the body only has it at level 3.
+    const body = '### Steps to Reproduce\n- one\n\n## Expected Behavior\n\nok\n';
+    const issues = detectMissingBodySections(body, SECTIONS);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.meta?.['wrongLevel']).toBe(true);
+    expect(issues[0]!.lineNumber).toBe(1);
+  });
+
+  it('recurses into nested child sections', () => {
+    const nested: BodySection[] = [
+      {
+        title: 'Plan',
+        level: 2,
+        children: [{ title: 'Risks', level: 3, content_type: 'bullets' }],
+      },
+    ];
+    const body = '## Plan\n\nA plan.\n';
+    const issues = detectMissingBodySections(body, nested);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.meta?.['title']).toBe('Risks');
+    expect(issues[0]!.meta?.['level']).toBe(3);
+  });
+
+  it('returns nothing when the type declares no body sections', () => {
+    expect(detectMissingBodySections('anything', [])).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end audit + fix on a real vault
+// ---------------------------------------------------------------------------
+
+const SCHEMA: Schema = {
+  version: 2,
+  types: {
+    meta: { fields: {} },
+    bug: {
+      extends: 'meta',
+      output_dir: 'Bugs',
+      fields: { type: { value: 'bug' } },
+      field_order: ['type'],
+      body_sections: [
+        { title: 'Steps to Reproduce', level: 2, content_type: 'bullets' },
+        { title: 'Expected Behavior', level: 2, content_type: 'paragraphs' },
+      ],
+    },
+    note: {
+      extends: 'meta',
+      output_dir: 'Notes',
+      fields: { type: { value: 'note' } },
+      field_order: ['type'],
+    },
+  },
+};
+
+describe('body-sections: end-to-end audit + fix', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-body-sections-'));
+    await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+    await writeFile(join(vaultDir, '.bwrb', 'schema.json'), JSON.stringify(SCHEMA, null, 2));
+    await mkdir(join(vaultDir, 'Bugs'), { recursive: true });
+    await mkdir(join(vaultDir, 'Notes'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('detects a missing body section', async () => {
+    await writeFile(
+      join(vaultDir, 'Bugs', 'Crash.md'),
+      `---\ntype: bug\n---\n## Steps to Reproduce\n- click\n`
+    );
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false });
+    const bug = results.find((r) => r.relativePath === 'Bugs/Crash.md');
+    const missing = bug?.issues.filter((i) => i.code === 'missing-body-section') ?? [];
+    expect(missing).toHaveLength(1);
+    expect(missing[0]!.meta?.['title']).toBe('Expected Behavior');
+  });
+
+  it('does not flag a note whose type declares no body sections', async () => {
+    await writeFile(join(vaultDir, 'Notes', 'Daily.md'), `---\ntype: note\n---\nFree text.\n`);
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false });
+    const daily = results.find((r) => r.relativePath === 'Notes/Daily.md');
+    expect(daily?.issues.some((i) => i.code === 'missing-body-section')).toBeFalsy();
+  });
+
+  it('auto-fixes by appending the missing heading scaffold, and is idempotent', async () => {
+    await writeFile(
+      join(vaultDir, 'Bugs', 'Crash.md'),
+      `---\ntype: bug\n---\n## Steps to Reproduce\n- click\n`
+    );
+    const schema = await loadSchema(vaultDir);
+
+    const results = await runAudit(schema, vaultDir, { strict: false });
+    await runAutoFix(results, schema, vaultDir, { dryRun: false });
+
+    const after = await readFile(join(vaultDir, 'Bugs', 'Crash.md'), 'utf-8');
+    expect(after).toContain('## Expected Behavior');
+    // Existing content is preserved.
+    expect(after).toContain('## Steps to Reproduce');
+    expect(after).toContain('- click');
+
+    // Re-auditing should now find nothing, and a second fix is a no-op.
+    const results2 = await runAudit(schema, vaultDir, { strict: false });
+    const bug2 = results2.find((r) => r.relativePath === 'Bugs/Crash.md');
+    expect(bug2?.issues.some((i) => i.code === 'missing-body-section')).toBeFalsy();
+
+    await runAutoFix(results2, schema, vaultDir, { dryRun: false });
+    const after2 = await readFile(join(vaultDir, 'Bugs', 'Crash.md'), 'utf-8');
+    // No duplicate heading appended.
+    expect(after2.match(/## Expected Behavior/g)).toHaveLength(1);
+  });
+
+  it('dry-run does not write', async () => {
+    const original = `---\ntype: bug\n---\n## Steps to Reproduce\n- click\n`;
+    await writeFile(join(vaultDir, 'Bugs', 'Crash.md'), original);
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false });
+    await runAutoFix(results, schema, vaultDir, { dryRun: true });
+    const after = await readFile(join(vaultDir, 'Bugs', 'Crash.md'), 'utf-8');
+    expect(after).toBe(original);
+  });
+
+  it('only-filter scopes the run to missing-body-section issues', async () => {
+    await writeFile(join(vaultDir, 'Bugs', 'Crash.md'), `---\ntype: bug\n---\n`);
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'missing-body-section',
+    });
+    for (const r of results) {
+      for (const i of r.issues) {
+        expect(i.code).toBe('missing-body-section');
+      }
+    }
+  });
+
+  it('ignore-filter suppresses missing-body-section issues', async () => {
+    await writeFile(join(vaultDir, 'Bugs', 'Crash.md'), `---\ntype: bug\n---\n`);
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      ignoreIssue: 'missing-body-section',
+    });
+    const bug = results.find((r) => r.relativePath === 'Bugs/Crash.md');
+    expect(bug?.issues.some((i) => i.code === 'missing-body-section')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## What

Adds a new `missing-body-section` audit detection that validates the markdown **body**, closing the long-standing gap where `bwrb audit` only checked frontmatter.

For each heading declared in a type's [`body_sections`](docs-site/src/content/docs/reference/commands/audit.md) (including nested `children`), the note body must contain a matching ATX heading at the declared level. Trailing whitespace and ATX closing hashes (`## Title ##`) are tolerated. A heading present at the **wrong level** is flagged (with `lineNumber`).

## Why

The schema heavily enforces YAML frontmatter, but `new`/`edit` only *scaffold* body headings — nothing re-checks that a user didn't later delete or rename `## Steps to Reproduce`. This re-validates that structure at audit time, exactly the distinct ask in #510.

## Scope

- **In:** required heading presence/structure (the issue author's "distinct part").
- **Out:** body wikilink validation — that overlaps with the existing `unlinked-mention` (#600) / `frequent-unlinked-term` (#601) detections, and the issue author asked to coordinate the link half there rather than duplicate it. Also out: body *content* validation (whether bullets/checkboxes are filled in), which would be noisy.

## Flag-only vs auto-fixable

**Auto-fixable.** Appending a declared heading is safe, deterministic, and additive: `--fix` appends the missing section using the *same* `generateBodySections` scaffold that `new`/`edit` emit, so it never deletes or rewrites prose. It is idempotent (a re-run finds the now-present heading and does nothing — no duplicates). Both interactive `--fix` and `--fix --auto --execute` are wired up.

## Infra reused / overlap avoided

- Reuses `maskNonProse` (#600) so a `## Heading` inside a code block or link doesn't count as satisfying a section.
- Reuses the single per-file body read shared with `unlinked-mention` (no extra read).
- Reuses `generateBodySections` (the `new`/`edit` scaffold) for the fix, so output is identical to freshly-created notes.
- No overlap with relation-field stale-reference/malformed-wikilink checks (those are frontmatter; this is headings).

## Tests

New `tests/ts/lib/audit-body-sections.test.ts`: pure-detector unit tests (missing/present/wrong-level/nested/empty-body/code-fence-masking) + end-to-end audit+fix (detect, append-and-idempotent, dry-run no-write, `--only`/`--ignore` scoping). Updated shared task/milestone fixtures to include their declared headings so the test vault stays genuinely valid.

## Gates

`pnpm qa`, `pnpm knip`, `pnpm docs:build` all pass.

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)