### PR TITLE
feat(recent): add recent command for recently modified notes

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -70,6 +70,7 @@ export default defineConfig({
 								{ slug: 'reference/commands/edit' },
 								{ slug: 'reference/commands/delete' },
 								{ slug: 'reference/commands/list' },
+								{ slug: 'reference/commands/recent' },
 								{ slug: 'reference/commands/open' },
 								{ slug: 'reference/commands/search' },
 								{ slug: 'reference/commands/schema' },

--- a/docs-site/src/content/docs/reference/commands/recent.md
+++ b/docs-site/src/content/docs/reference/commands/recent.md
@@ -1,0 +1,114 @@
+---
+title: bwrb recent
+description: List recently modified notes, most-recent first
+---
+
+List recently modified notes, ordered by file modification time (most-recent
+first). This is thin sugar over [`bwrb list`](/reference/commands/list/) for the
+common "what did I touch lately?" query.
+
+## Synopsis
+
+```bash
+bwrb recent [options] [positional]
+```
+
+The positional argument is auto-detected as type, path (contains `/`), or where
+expression (contains operators) — the same smart detection used by `list`.
+
+## Recency source
+
+`recent` orders notes by their **file modification time (mtime)** from the
+filesystem. This is deterministic, requires no frontmatter convention, and is
+the "useful half" of a recency command (recently *modified* notes). It does not
+track an action log of edits made via the CLI — use git history for that.
+
+There is no frontmatter fallback: every file on disk has an mtime, so the source
+is always available.
+
+## Options
+
+### Targeting
+
+| Option | Description |
+|--------|-------------|
+| `-t, --type <type>` | Filter by type path (e.g., `idea`, `objective/task`) |
+| `-p, --path <glob>` | Filter by file path glob (e.g., `Projects/**`, `Ideas/`) |
+| `-w, --where <expr>` | Filter with expression (repeatable, ANDed together) |
+| `-b, --body <query>` | Filter by body content search |
+
+### Output
+
+| Option | Description |
+|--------|-------------|
+| `--limit <n>` | Show only the first `n` notes (default `20`) |
+| `--output <format>` | Output format: `text`, `paths`, `link`, `json` |
+
+## Output Formats
+
+| Format | Description |
+|--------|-------------|
+| `text` | `NAME` / `MODIFIED` table (default) |
+| `paths` | Vault-relative file paths |
+| `link` | Wikilinks (`[[Note Name]]`) |
+| `json` | Full JSON data including the modification timestamp |
+
+## Examples
+
+```bash
+# 20 most recently modified notes
+bwrb recent
+
+# Only the 5 most recent
+bwrb recent --limit 5
+
+# Most recently modified tasks
+bwrb recent --type task
+
+# Recently modified notes under a folder
+bwrb recent --path "Projects/**"
+
+# Machine-readable output
+bwrb recent --output paths
+bwrb recent --output json
+```
+
+## JSON output
+
+Each entry includes `_path`, `_name`, an ISO-8601 `_modified` timestamp (the
+mtime used for ordering), and the note's frontmatter spread in — consistent with
+`bwrb list --output json` plus the `_modified` field.
+
+```bash
+bwrb recent --type idea --limit 2 --output json
+```
+
+```json
+[
+  {
+    "_path": "Ideas/Another Idea.md",
+    "_name": "Another Idea",
+    "_modified": "2026-06-20T14:31:07.000Z",
+    "type": "idea",
+    "status": "backlog",
+    "priority": "high"
+  },
+  {
+    "_path": "Ideas/Sample Idea.md",
+    "_name": "Sample Idea",
+    "_modified": "2026-06-19T09:12:44.000Z",
+    "type": "idea",
+    "status": "raw",
+    "priority": "medium"
+  }
+]
+```
+
+Notes with identical modification times are ordered alphabetically by name so
+output is deterministic.
+
+## Equivalent `list` query
+
+`recent` is a convenience wrapper. The closest hand-written equivalent is a
+listing sorted by mtime, descending, with a limit — `recent` adds the `_modified`
+field and a sensible default limit on top.

--- a/src/commands/recent.ts
+++ b/src/commands/recent.ts
@@ -1,0 +1,309 @@
+import { Command } from 'commander';
+import { basename, relative } from 'path';
+import { stat } from 'fs/promises';
+import chalk from 'chalk';
+import { loadSchema, getTypeDefByPath } from '../lib/schema.js';
+import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
+import { getGlobalOpts } from '../lib/command.js';
+import { printError } from '../lib/prompt.js';
+import {
+  printJson,
+  jsonError,
+  ExitCodes,
+  exitWithResolutionError,
+  type ListOutputFormat,
+} from '../lib/output.js';
+import { UserCancelledError } from '../lib/errors.js';
+import {
+  resolveTargets,
+  parsePositionalArg,
+  hasAnyTargeting,
+  formatTargetingSummary,
+  type TargetingOptions,
+} from '../lib/targeting.js';
+import { getTtyContext } from '../lib/tty/context.js';
+import { renderTable } from '../lib/tty/table.js';
+
+/**
+ * Default number of recently-modified notes to show when --limit is omitted.
+ */
+const DEFAULT_RECENT_LIMIT = 20;
+
+interface RecentCommandOptions {
+  type?: string;
+  path?: string;
+  body?: string;
+  where?: string[];
+  limit?: string;
+  output?: string;
+}
+
+/**
+ * Resolve the output format from the --output flag. `recent` shares the
+ * list output contract but only supports the formats that make sense for a
+ * flat, recency-ordered listing (no tree).
+ */
+function resolveRecentOutputFormat(value: string | undefined): ListOutputFormat {
+  if (!value) return 'default';
+  if (value === 'text') return 'default';
+  const valid: ListOutputFormat[] = ['default', 'paths', 'link', 'json'];
+  if (valid.includes(value as ListOutputFormat)) {
+    return value as ListOutputFormat;
+  }
+  return 'default';
+}
+
+function parseRecentLimit(value: string | undefined, jsonMode: boolean): number {
+  if (value === undefined) return DEFAULT_RECENT_LIMIT;
+
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit <= 0) {
+    const error = 'Invalid --limit value: must be a positive integer';
+    if (jsonMode) {
+      printJson(jsonError(error));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    printError(error);
+    process.exit(1);
+  }
+
+  return limit;
+}
+
+/**
+ * The recency source for `recent` is the file modification time (mtime) from
+ * the filesystem. This is deterministic, requires no frontmatter convention,
+ * and matches the scoping decision on issue #68 ("recently *modified* notes").
+ */
+interface RecentFile {
+  path: string;
+  frontmatter: Record<string, unknown>;
+  mtimeMs: number;
+}
+
+export const recentCommand = new Command('recent')
+  .description('List recently modified notes (most-recent first)')
+  .addHelpText('after', `
+Recency source:
+  Notes are ordered by file modification time (mtime), most-recent first.
+  This is sugar over 'list' for the common "what did I touch lately?" query.
+
+Targeting Selectors (compose via AND):
+  --type <type>        Filter by type (e.g., task, objective/milestone)
+  --path <glob>        Filter by file path (e.g., Projects/**, Ideas/)
+  --where <expr>       Filter by frontmatter expression (can repeat)
+  --body <query>       Filter by body content (uses ripgrep)
+  --limit <n>          Show only the first n notes (default ${DEFAULT_RECENT_LIMIT})
+
+Examples:
+  bwrb recent
+  bwrb recent --limit 5
+  bwrb recent --type task
+  bwrb recent --type task --limit 10
+  bwrb recent --output json
+  bwrb recent --output paths
+  bwrb recent --path "Projects/**"`)
+  .argument('[positional]', 'Smart positional: type, path (contains /), or where expression (contains =<>~)')
+  .option('-t, --type <type>', 'Filter by type path (e.g., idea, objective/task)')
+  .option('-p, --path <glob>', 'Filter by file path glob (e.g., Projects/**, Ideas/)')
+  .option('-b, --body <query>', 'Filter by body content search')
+  .option('-w, --where <expression...>', 'Filter with expression (multiple are ANDed)')
+  .option('--limit <n>', `Limit output to the first n notes (default ${DEFAULT_RECENT_LIMIT})`)
+  .option('--output <format>', 'Output format: text (default), paths, link, json')
+  .action(async (positional: string | undefined, options: RecentCommandOptions, cmd: Command) => {
+    const outputFormat = resolveRecentOutputFormat(options.output);
+    const jsonMode = outputFormat === 'json';
+
+    try {
+      const globalOpts = getGlobalOpts(cmd);
+      const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
+      if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
+      const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
+      const schema = await loadSchema(vaultDir);
+
+      // Build targeting options from flags
+      const targeting: TargetingOptions = {};
+      if (options.type) targeting.type = options.type;
+      if (options.path) targeting.path = options.path;
+      if (options.where) targeting.where = options.where;
+      if (options.body) targeting.body = options.body;
+
+      // Handle smart positional detection (mirrors `list`)
+      if (positional) {
+        const positionalResult = parsePositionalArg(positional, schema, targeting);
+        if (positionalResult.error) {
+          if (jsonMode) {
+            printJson(jsonError(positionalResult.error));
+            process.exit(ExitCodes.VALIDATION_ERROR);
+          }
+          printError(positionalResult.error);
+          process.exit(1);
+        }
+        Object.assign(targeting, positionalResult.options);
+      }
+
+      // Validate type if specified
+      if (targeting.type) {
+        const typeDef = getTypeDefByPath(schema, targeting.type);
+        if (!typeDef) {
+          const error = `Unknown type: ${targeting.type}`;
+          if (jsonMode) {
+            printJson(jsonError(error));
+            process.exit(ExitCodes.VALIDATION_ERROR);
+          }
+          printError(error);
+          process.exit(1);
+        }
+        targeting.type = typeDef.name;
+      }
+
+      const limit = parseRecentLimit(options.limit, jsonMode);
+
+      // Reuse list's discovery + targeting infrastructure
+      const targetResult = await resolveTargets(targeting, schema, vaultDir);
+
+      if (targetResult.error) {
+        exitWithResolutionError(targetResult.error, targetResult.files, jsonMode);
+      }
+
+      // Stat files for mtime (the recency source). Skip files that can't be
+      // stat'd (e.g. removed mid-scan) rather than failing the whole command.
+      const withMtime: RecentFile[] = [];
+      for (const file of targetResult.files) {
+        try {
+          const stats = await stat(file.path);
+          withMtime.push({
+            path: file.path,
+            frontmatter: file.frontmatter,
+            mtimeMs: stats.mtimeMs,
+          });
+        } catch {
+          // Skip unreadable files
+        }
+      }
+
+      // Sort most-recent first; ties break alphabetically by note name for
+      // deterministic output.
+      withMtime.sort((a, b) => {
+        if (b.mtimeMs !== a.mtimeMs) return b.mtimeMs - a.mtimeMs;
+        return basename(a.path, '.md').localeCompare(basename(b.path, '.md'));
+      });
+
+      const limited = withMtime.slice(0, limit);
+
+      // No results
+      if (limited.length === 0) {
+        if (jsonMode) {
+          console.log(JSON.stringify([], null, 2));
+        } else if (outputFormat === 'default') {
+          // Only the human-facing default output prints a message; the
+          // machine-facing formats (paths/link) stay silent like `list`.
+          if (hasAnyTargeting(targeting)) {
+            console.log(`No notes found matching: ${formatTargetingSummary(targeting)}`);
+          } else {
+            console.log('No notes found.');
+          }
+        }
+        return;
+      }
+
+      switch (outputFormat) {
+        case 'json': {
+          const jsonOutput = limited.map(({ path, frontmatter, mtimeMs }) => ({
+            _path: relative(vaultDir, path),
+            _name: basename(path, '.md'),
+            _modified: new Date(mtimeMs).toISOString(),
+            ...frontmatter,
+          }));
+          console.log(JSON.stringify(jsonOutput, null, 2));
+          return;
+        }
+
+        case 'paths': {
+          for (const { path } of limited) {
+            console.log(relative(vaultDir, path));
+          }
+          return;
+        }
+
+        case 'link': {
+          for (const { path } of limited) {
+            console.log(`[[${basename(path, '.md')}]]`);
+          }
+          return;
+        }
+
+        default: {
+          printRecentTable(limited);
+          return;
+        }
+      }
+    } catch (err) {
+      if (err instanceof UserCancelledError) {
+        if (jsonMode) {
+          printJson(jsonError('Cancelled', { code: ExitCodes.VALIDATION_ERROR }));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        console.log('Cancelled.');
+        process.exit(1);
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      if (jsonMode) {
+        printJson(jsonError(message));
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+      printError(message);
+      process.exit(1);
+    }
+  });
+
+/**
+ * Format a timestamp for the default (human) table output.
+ * Uses the local-timezone date and time, second precision dropped.
+ */
+function formatModified(mtimeMs: number): string {
+  const d = new Date(mtimeMs);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  const date = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  const time = `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  return `${date} ${time}`;
+}
+
+/**
+ * Render the default table: NAME + MODIFIED columns.
+ */
+function printRecentTable(files: RecentFile[]): void {
+  const context = getTtyContext();
+  const headerStyle = context.colorEnabled ? (text: string) => chalk.gray(text) : null;
+
+  const columns = [
+    {
+      key: 'primary',
+      title: 'NAME',
+      minWidth: 12,
+      weight: 2,
+      priority: 0,
+      canDrop: false,
+      ...(headerStyle ? { style: headerStyle } : {}),
+    },
+    {
+      key: 'modified',
+      title: 'MODIFIED',
+      minWidth: 16,
+      weight: 1,
+      priority: 1,
+      canDrop: true,
+      ...(headerStyle ? { style: headerStyle } : {}),
+    },
+  ];
+
+  const rows = files.map(({ path, mtimeMs }) => ({
+    primary: basename(path, '.md'),
+    modified: formatModified(mtimeMs),
+  }));
+
+  const lines = renderTable({ columns, rows, context });
+  for (const line of lines) {
+    console.log(line);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { newCommand } from './commands/new.js';
 import { editCommand } from './commands/edit.js';
 import { deleteCommand } from './commands/delete.js';
 import { listCommand } from './commands/list.js';
+import { recentCommand } from './commands/recent.js';
 import { openCommand } from './commands/open.js';
 import { searchCommand } from './commands/search.js';
 import { schemaCommand } from './commands/schema/index.js';
@@ -61,6 +62,7 @@ if (completionsIndex !== -1) {
 
   // Query operations
   program.addCommand(listCommand);
+  program.addCommand(recentCommand);
   program.addCommand(openCommand);
   program.addCommand(searchCommand);
 

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -241,8 +241,9 @@ export async function getPathCompletions(
  */
 const COMMANDS = [
   'new',
-  'edit', 
+  'edit',
   'list',
+  'recent',
   'open',
   'search',
   'audit',
@@ -269,6 +270,7 @@ const COMMAND_OPTIONS: Record<string, string[]> = {
   new: ['--type', '-t', '--vault', '--non-interactive', '--template', '--json', '--help'],
   edit: ['--type', '-t', '--path', '-p', '--where', '-w', '--id', '--body', '-b', '--picker', '--json', '--output', '--open', '--app', '--vault', '--non-interactive', '--help'],
   list: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--text', '--id', '--fields', '--sort', '--desc', '--limit', '--count', '--output', '-o', '--vault', '--non-interactive', '--json', '--help'],
+  recent: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--limit', '--output', '--vault', '--non-interactive', '--help'],
   open: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--app', '--vault', '--non-interactive', '--help'],
   search: ['--type', '-t', '--path', '-p', '--where', '-w', '--text', '--all', '-a', '--wikilink', '--vault', '--non-interactive', '--help'],
   audit: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--text', '--all', '-a', '--strict', '--only', '--ignore', '--output', '--fix', '--auto', '--dry-run', '--execute', '--allow-field', '--vault', '--non-interactive', '--help'],

--- a/tests/ts/commands/help.contract.test.ts
+++ b/tests/ts/commands/help.contract.test.ts
@@ -28,6 +28,7 @@ describe('help output contract snapshots', () => {
       'edit',
       'delete',
       'list',
+      'recent',
       'open',
       'search',
       'schema',

--- a/tests/ts/commands/recent.test.ts
+++ b/tests/ts/commands/recent.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFile, utimes, mkdir } from 'fs/promises';
+import { join } from 'path';
+import { createTestVault, cleanupTestVault, runCLI } from '../fixtures/setup.js';
+
+/**
+ * Set the mtime of a file to a fixed point in time.
+ * `seconds` is an absolute epoch-seconds value; larger = more recent.
+ */
+async function setMtime(path: string, seconds: number): Promise<void> {
+  const when = new Date(seconds * 1000);
+  await utimes(path, when, when);
+}
+
+describe('recent command', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  describe('ordering by mtime', () => {
+    it('lists notes most-recent first by file mtime', async () => {
+      // Base epoch (2024-01-01ish), spaced an hour apart
+      const base = 1_700_000_000;
+      await setMtime(join(vaultDir, 'Ideas', 'Sample Idea.md'), base + 100);
+      await setMtime(join(vaultDir, 'Ideas', 'Another Idea.md'), base + 300);
+      await setMtime(join(vaultDir, 'Objectives/Tasks', 'Sample Task.md'), base + 200);
+
+      const result = await runCLI(['recent', '--output', 'paths'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout.trim().split('\n');
+      // Most recent (Another Idea, +300) first, then Sample Task (+200),
+      // then Sample Idea (+100). Milestones use whatever mtime they have
+      // (created during vault setup, likely older or newer — we only assert
+      // the relative order of the three we control).
+      const idxAnother = lines.indexOf('Ideas/Another Idea.md');
+      const idxTask = lines.indexOf('Objectives/Tasks/Sample Task.md');
+      const idxSample = lines.indexOf('Ideas/Sample Idea.md');
+      expect(idxAnother).toBeGreaterThanOrEqual(0);
+      expect(idxAnother).toBeLessThan(idxTask);
+      expect(idxTask).toBeLessThan(idxSample);
+    });
+
+    it('breaks mtime ties alphabetically by note name', async () => {
+      const tie = 1_700_000_500;
+      await setMtime(join(vaultDir, 'Ideas', 'Sample Idea.md'), tie);
+      await setMtime(join(vaultDir, 'Ideas', 'Another Idea.md'), tie);
+      // Push everything else older so the tied pair sorts first
+      await setMtime(join(vaultDir, 'Objectives/Tasks', 'Sample Task.md'), tie - 1000);
+      await setMtime(join(vaultDir, 'Objectives/Milestones', 'Active Milestone.md'), tie - 1000);
+      await setMtime(join(vaultDir, 'Objectives/Milestones', 'Settled Milestone.md'), tie - 1000);
+
+      const result = await runCLI(['recent', '--output', 'paths', '--limit', '2'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout.trim().split('\n');
+      // Same mtime -> alphabetical: "Another Idea" before "Sample Idea"
+      expect(lines).toEqual(['Ideas/Another Idea.md', 'Ideas/Sample Idea.md']);
+    });
+  });
+
+  describe('--limit', () => {
+    it('caps the number of results', async () => {
+      const result = await runCLI(['recent', '--output', 'paths', '--limit', '2'], vaultDir);
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout.trim().split('\n').filter(Boolean);
+      expect(lines).toHaveLength(2);
+    });
+
+    it('rejects a non-positive limit', async () => {
+      const result = await runCLI(['recent', '--limit', '0'], vaultDir);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('Invalid --limit value');
+    });
+  });
+
+  describe('--type filtering', () => {
+    it('only includes notes of the given type', async () => {
+      const result = await runCLI(['recent', '--type', 'idea', '--output', 'paths'], vaultDir);
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout.trim().split('\n').filter(Boolean);
+      expect(lines).toContain('Ideas/Sample Idea.md');
+      expect(lines).toContain('Ideas/Another Idea.md');
+      expect(lines.some(l => l.includes('Task'))).toBe(false);
+      expect(lines.some(l => l.includes('Milestone'))).toBe(false);
+    });
+
+    it('errors on an unknown type', async () => {
+      const result = await runCLI(['recent', '--type', 'nonsense'], vaultDir);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('Unknown type: nonsense');
+    });
+  });
+
+  describe('--output json', () => {
+    it('emits an array with _path, _name, _modified, and frontmatter', async () => {
+      // Make "Another Idea" decisively the most recent of the ideas.
+      await setMtime(join(vaultDir, 'Ideas', 'Sample Idea.md'), 1_700_000_000);
+      await setMtime(join(vaultDir, 'Ideas', 'Another Idea.md'), 1_700_009_999);
+
+      const result = await runCLI(['recent', '--type', 'idea', '--output', 'json'], vaultDir);
+      expect(result.exitCode).toBe(0);
+
+      const parsed = JSON.parse(result.stdout);
+      expect(Array.isArray(parsed)).toBe(true);
+      const first = parsed[0];
+      expect(first._name).toBe('Another Idea');
+      expect(first._path).toBe('Ideas/Another Idea.md');
+      expect(typeof first._modified).toBe('string');
+      // _modified is an ISO timestamp
+      expect(() => new Date(first._modified).toISOString()).not.toThrow();
+      // frontmatter is spread in
+      expect(first.type).toBe('idea');
+    });
+
+    it('emits an empty array for an empty result set', async () => {
+      const result = await runCLI(
+        ['recent', '--path', 'NoSuchDir/**', '--output', 'json'],
+        vaultDir
+      );
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual([]);
+    });
+  });
+
+  describe('default output', () => {
+    it('shows a NAME / MODIFIED table', async () => {
+      const result = await runCLI(['recent', '--type', 'idea'], vaultDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('NAME');
+      expect(result.stdout).toContain('MODIFIED');
+      expect(result.stdout).toContain('Sample Idea');
+    });
+  });
+
+  describe('empty vault', () => {
+    it('reports no notes found', async () => {
+      const emptyVault = await createTestVault();
+      // Remove all managed notes by pointing recent at a type with no notes
+      // is covered above; here we exercise the genuinely-empty path filter.
+      const result = await runCLI(
+        ['recent', '--path', 'DoesNotExist/**', '--output', 'paths'],
+        emptyVault
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('');
+      await cleanupTestVault(emptyVault);
+    });
+
+    it('handles a vault with no managed notes at all', async () => {
+      // Build a minimal vault with a schema but no notes.
+      const { mkdtemp } = await import('fs/promises');
+      const { tmpdir } = await import('os');
+      const bare = await mkdtemp(join(tmpdir(), 'bwrb-recent-empty-'));
+      await mkdir(join(bare, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(bare, '.bwrb', 'schema.json'),
+        JSON.stringify({ version: 1, types: { idea: { plural: 'Ideas' } } }, null, 2)
+      );
+
+      const result = await runCLI(['recent'], bare);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('No notes found');
+      await cleanupTestVault(bare);
+    });
+  });
+});

--- a/tests/ts/helpers/help.ts
+++ b/tests/ts/helpers/help.ts
@@ -3,6 +3,7 @@ const CANONICAL_HELP_COMMAND_ORDER = [
   'edit',
   'delete',
   'list',
+  'recent',
   'open',
   'search',
   'schema',


### PR DESCRIPTION
## Summary

Adds `bwrb recent`, a command that lists recently modified notes most-recent first. It is thin sugar over the existing `list` infrastructure, as scoped in the issue discussion ("the useful half is recently *modified* notes").

```
bwrb recent [--limit N] [--type T] [--path G] [--where E] [--body Q] [--output text|paths|link|json]
```

## Recency source

Ordering is by **file modification time (mtime)** from the filesystem. This is deterministic, needs no frontmatter convention, and every file has an mtime so there is no missing-value fallback to handle. The CLI-action-log half ("notes touched *via* the CLI") is intentionally out of scope per the issue — that is redundant with git history.

- Default limit: **20**
- mtime ties break **alphabetically by note name** for deterministic output

## Reuse of `list` infrastructure

- Discovery + targeting (`--type`, `--path`, `--where`, `--body`, smart positional, type validation) all go through the shared `resolveTargets` / `parsePositionalArg` from `src/lib/targeting.ts`.
- Output follows the `list` contract: `text` (NAME/MODIFIED table via the shared `renderTable`), `paths`, `link`, and `json`.
- JSON shape matches `list --output json` plus an ISO `_modified` field:

```json
[
  {
    "_path": "Ideas/Another Idea.md",
    "_name": "Another Idea",
    "_modified": "2026-06-20T14:31:07.000Z",
    "type": "idea",
    "status": "backlog"
  }
]
```

## Wiring

- Registered in `src/index.ts` (Query operations group, after `list`).
- Shell completion: added to `COMMANDS` and `COMMAND_OPTIONS` in `src/lib/completion.ts`.
- Contract tests updated: `tests/ts/helpers/help.ts` (canonical order) and `tests/ts/commands/help.contract.test.ts`.
- Docs: new `docs-site/.../reference/commands/recent.md` + sidebar entry in `docs-site/astro.config.mjs`.

## Tests

New `tests/ts/commands/recent.test.ts` covers most-recent-first ordering (via controlled mtimes), `--limit` capping + validation, `--type` filtering + unknown-type error, `json`/`paths`/default output shapes, mtime ties, and empty results (empty array in JSON, silent in paths, message in default).

## Quality gates

- `pnpm qa` — pass (104 files, 2320 passed / 4 skipped)
- `pnpm knip` — pass (clean)
- `pnpm docs:build` — pass

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)