### PR TITLE
test: harden real-CLI harness against parallel-load flake (#643)

### DIFF
--- a/tests/ts/commands/non-interactive-create-edit.test.ts
+++ b/tests/ts/commands/non-interactive-create-edit.test.ts
@@ -52,13 +52,13 @@ describe('global --non-interactive create/edit flows', () => {
 
   it('requires explicit inputs for dashboard and template editing flows', async () => {
     const dashboardSeed = await runCLI(['dashboard', 'new', 'triage', '--json', '{"type":"idea"}'], vaultDir);
-    expect(dashboardSeed.exitCode).toBe(0);
+    expect(dashboardSeed.exitCode, `dashboard seed stderr: ${dashboardSeed.stderr}`).toBe(0);
 
     const templateSeed = await runCLI(
       ['template', 'new', 'idea', '--json', '{"name":"triage-template","body":"# Body"}'],
       vaultDir
     );
-    expect(templateSeed.exitCode).toBe(0);
+    expect(templateSeed.exitCode, `template seed stderr: ${templateSeed.stderr}`).toBe(0);
 
     const dashboardEdit = await runCLI(['--non-interactive', 'dashboard', 'edit', 'triage'], vaultDir);
     expect(dashboardEdit.exitCode).not.toBe(0);

--- a/tests/ts/commands/non-interactive-destructive.test.ts
+++ b/tests/ts/commands/non-interactive-destructive.test.ts
@@ -51,13 +51,13 @@ describe('global --non-interactive destructive flows', () => {
 
   it('requires --force for dashboard and template delete when non-interactive is set', async () => {
     const dashboardSeed = await runCLI(['dashboard', 'new', 'triage', '--json', '{"type":"idea"}'], vaultDir);
-    expect(dashboardSeed.exitCode).toBe(0);
+    expect(dashboardSeed.exitCode, `dashboard seed stderr: ${dashboardSeed.stderr}`).toBe(0);
 
     const templateSeed = await runCLI(
       ['template', 'new', 'idea', '--json', '{"name":"triage-template","body":"# Body"}'],
       vaultDir
     );
-    expect(templateSeed.exitCode).toBe(0);
+    expect(templateSeed.exitCode, `template seed stderr: ${templateSeed.stderr}`).toBe(0);
 
     const dashboardDelete = await runCLI(['--non-interactive', 'dashboard', 'delete', 'triage'], vaultDir);
     expect(dashboardDelete.exitCode).not.toBe(0);

--- a/tests/ts/fixtures/setup.ts
+++ b/tests/ts/fixtures/setup.ts
@@ -278,10 +278,117 @@ export interface CLIResult {
 export interface RunCLIOptions {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
+  /**
+   * Hard wall-clock budget for a single spawn before it is killed and the
+   * attempt is treated as a transient failure. Defaults to RUN_CLI_TIMEOUT_MS.
+   *
+   * The real CLI is launched via `tsx`, which pays a non-trivial cold-start
+   * cost per process. Under heavy parallel load (many concurrent vitest forks
+   * each spawning their own `tsx`), that cold start can balloon well past a
+   * second. This budget is deliberately generous so that contention shows up
+   * as a slow-but-successful run rather than a flaky failure.
+   */
+  timeoutMs?: number;
+  /**
+   * Number of times to re-attempt a spawn that fails transiently (spawn
+   * error such as EAGAIN/ENOMEM, or our own per-spawn timeout). Defaults to
+   * RUN_CLI_RETRIES. A non-zero exit code from the CLI itself is NOT retried
+   * here — that is the CLI's own behavior and is what tests assert on.
+   */
+  retries?: number;
+}
+
+/**
+ * Per-spawn wall-clock budget. Generous on purpose: `tsx` cold start under
+ * heavy parallel load (15+ concurrent forks) can take several seconds, and a
+ * too-tight budget is the root cause of the historical seed-step flake
+ * (vitest aborting the test, SIGTERM-ing the in-flight spawn, surfacing as
+ * "exitCode 1, expected 0"). Override per call via RunCLIOptions.timeoutMs.
+ */
+const RUN_CLI_TIMEOUT_MS = Number(process.env.BWRB_TEST_CLI_TIMEOUT_MS) || 30_000;
+
+/**
+ * Default number of retries for transient spawn failures (spawn errors or the
+ * per-spawn timeout). CLI non-zero exits are never retried.
+ */
+const RUN_CLI_RETRIES = 2;
+
+class TransientSpawnError extends Error {}
+
+function spawnOnce(
+  cliCommand: string,
+  cliArgs: string[],
+  cwd: string,
+  mergedEnv: Record<string, string>,
+  stdin: string | undefined,
+  timeoutMs: number
+): Promise<CLIResult> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(cliCommand, cliArgs, {
+      cwd,
+      env: mergedEnv,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      proc.kill('SIGKILL');
+      reject(
+        new TransientSpawnError(
+          `runCLI spawn exceeded ${timeoutMs}ms: ${cliCommand} ${cliArgs.join(' ')}`
+        )
+      );
+    }, timeoutMs);
+
+    proc.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    // Without this handler a failed spawn (e.g. EAGAIN/ENOMEM under load)
+    // would leave the promise pending forever, surfacing as an opaque vitest
+    // worker timeout rather than a diagnosable, retryable failure.
+    proc.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new TransientSpawnError(`runCLI spawn failed: ${err.message}`));
+    });
+
+    if (stdin) {
+      proc.stdin.write(stdin);
+      proc.stdin.end();
+    }
+
+    proc.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        exitCode: code ?? 0,
+      });
+    });
+  });
 }
 
 /**
  * Run the bwrb CLI with arguments and capture output.
+ *
+ * The CLI is spawned as a real subprocess (`tsx src/index.ts`, or `node
+ * dist/index.js` when BWRB_TEST_DIST=1). To stay reliable under heavy parallel
+ * load this helper applies a generous per-spawn timeout and retries only
+ * *transient* spawn failures (spawn errors or timeouts). A non-zero CLI exit
+ * code is returned as-is so tests can assert on it.
+ *
  * @param args CLI arguments (e.g., ['list', 'idea', '--status=raw'])
  * @param vaultDir Optional vault directory (passed via --vault)
  * @param stdin Optional stdin input for interactive commands
@@ -293,7 +400,12 @@ export async function runCLI(
   options: RunCLIOptions = {}
 ): Promise<CLIResult> {
   const fullArgs = vaultDir ? ['--vault', vaultDir, ...args] : args;
-  const { cwd = PROJECT_ROOT, env = {} } = options;
+  const {
+    cwd = PROJECT_ROOT,
+    env = {},
+    timeoutMs = RUN_CLI_TIMEOUT_MS,
+    retries = RUN_CLI_RETRIES,
+  } = options;
 
   const cliCommand = USE_DIST ? 'node' : TSX_BIN;
   const cliArgs = USE_DIST ? [CLI_PATH, ...fullArgs] : [CLI_SRC_PATH, ...fullArgs];
@@ -313,34 +425,25 @@ export async function runCLI(
     mergedEnv.NO_COLOR = '1';
   }
 
-  return new Promise((resolve) => {
-    const proc = spawn(cliCommand, cliArgs, {
-      cwd,
-      env: mergedEnv,
-    });
-
-    let stdout = '';
-    let stderr = '';
-
-    proc.stdout.on('data', (data) => {
-      stdout += data.toString();
-    });
-
-    proc.stderr.on('data', (data) => {
-      stderr += data.toString();
-    });
-
-    if (stdin) {
-      proc.stdin.write(stdin);
-      proc.stdin.end();
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await spawnOnce(cliCommand, cliArgs, cwd, mergedEnv, stdin, timeoutMs);
+    } catch (err) {
+      if (!(err instanceof TransientSpawnError)) throw err;
+      lastError = err;
+      // Small backoff lets transient contention (CPU/fork pressure) ease.
+      if (attempt < retries) {
+        await new Promise((resolve) => setTimeout(resolve, 100 * (attempt + 1)));
+      }
     }
+  }
 
-    proc.on('close', (code) => {
-      resolve({
-        stdout: stdout.trim(),
-        stderr: stderr.trim(),
-        exitCode: code ?? 0,
-      });
-    });
-  });
+  // Surface the transient failure clearly so future flakes are diagnosable
+  // instead of masquerading as a bare "exitCode 1".
+  throw new Error(
+    `runCLI failed after ${retries + 1} attempt(s): ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`
+  );
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,15 @@ export default defineConfig({
     maxConcurrency: 5,
     // Retry flaky tests once before failing - handles CPU contention gracefully
     retry: 1,
+    // Real-CLI suites spawn `tsx` subprocesses (see tests/ts/fixtures/setup.ts),
+    // and some tests fire several sequential spawns in one test/hook. Under heavy
+    // parallel load (many concurrent forks each cold-starting `tsx`) those spawns
+    // can take several seconds each. The default 5s timeout was too tight and was
+    // the root cause of the seed-step flake (#643): vitest aborted the test,
+    // SIGTERM-ed the in-flight spawn, and it surfaced as "exitCode 1, expected 0".
+    // These budgets are generous so contention shows up as slow-but-green.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

Fixes the intermittent SEED-step failures in the non-interactive destructive/create-edit suites that only appeared under heavy parallel load (many concurrent `tsx` spawns).

Closes #643

## Root cause (with evidence)

The two suites failed with `expected 1 to be +0` at their seed steps (`dashboard new` / `template new`). Reproduced reliably by running both process-spawning suites together (they pass in isolation):

```
→ Test timed out in 5000ms.
→ expected 1 to be +0 // Object.is equality
 ❯ non-interactive-create-edit.test.ts:55:36  expect(dashboardSeed.exitCode).toBe(0);
```

The `exitCode 1` was a **secondary artifact of a timeout**, not a real CLI failure:

- The CLI is spawned as a real subprocess via `tsx src/index.ts` — one cold start per `runCLI` call.
- The seed tests fire several sequential `tsx` spawns in a single test. Under fork contention each cold start takes ~1.5–2s, so the test exceeded the **default 5000ms `testTimeout`**.
- When vitest aborts the test it SIGTERM-s the in-flight `tsx`, which resolves with `exitCode 1` → the confusing "seed step exit 1".

Proof: a probe that ran 12 sequential `dashboard new` spawns under the same load with a 60s timeout returned exit 0 every time. Re-running the two suites with `--testTimeout=30000` made them pass reliably; with the default 5s they failed every time.

(The earlier `relative-paths` worker timeout was the same contention, made worse by `runCLI` having no `proc.on('error')` handler — a failed spawn left the promise pending forever.)

## Fix

- **vitest.config.ts**: raise `testTimeout`/`hookTimeout` to 30s — the real fix. Contention now shows up as slow-but-green instead of an aborted test masquerading as exit 1.
- **tests/ts/fixtures/setup.ts** (`runCLI`, used by 29 test files): add a per-spawn wall-clock timeout, a `proc.on('error')` handler (so a failed spawn fails fast and diagnosably instead of hanging), and a bounded retry for **transient spawn failures only** (spawn errors / our timeout). A non-zero CLI exit is returned as-is, so the assertions under test are untouched.
- **Both seed tests**: surface the seed command's stderr in the assertion message so any future flake is immediately diagnosable.

No test assertions were weakened — only setup/seed robustness and timeouts changed.

## Verification

- Targeted suites (+ `relative-paths`) under parallel load: **5/5 runs green** (31 tests each).
- Full `pnpm test` (104 files, max parallel): **3/3 runs green** (2320 passed, 4 skipped).
- `pnpm qa`: pass (typecheck, lint, docs:lint, docs:doctor, build, full test).
- `pnpm knip`: pass (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)