### PR TITLE
fix(query): canonicalize aliases in under() subtree queries

### DIFF
--- a/docs-site/src/content/docs/concepts/hierarchical-scope.md
+++ b/docs-site/src/content/docs/concepts/hierarchical-scope.md
@@ -109,12 +109,12 @@ Collapsing `scope` + `context` into a single context tree removes the redundancy
 - **Transitive queries.** "Everything in the career domain" is a single `under(context, '[[career]]')`, not an OR over every leaf.
 - **Contexts are first-class notes.** Because they're real notes, they get `unlinked-mention` audit coverage, backlinks, and graph presence for free, and aliases (see [Schema](/concepts/schema/)) help with all of those. Rich contexts (Builder, with its own content) and label-like contexts (PKM) cost the same.
 
-:::caution[Use the canonical note name in `under()` targets and `context` relations]
-Aliases help backlinks, unlinked-mention detection, and audit coverage on context notes, but they do **not** apply to `under()`. The `under` operator (and the `context` relation it dereferences) matches wikilink targets **literally** — it does not yet canonicalize aliases. So a task whose `context` points at an *alias* of a context note silently drops out of altitude queries.
+:::note[`under()` is alias-aware]
+Aliases (see [Schema](/concepts/schema/)) work transparently with `under()`. The operator canonicalizes aliases on **both sides** before walking the tree — the same alias resolution that powers `bwrb open <alias>`.
 
-Concretely, if `Builder` has an alias `BuilderProject`, then a task with `context: "[[BuilderProject]]"` will **not** be returned by `under(context, '[[Builder]]')` or `under(context, '[[career]]')` — the alias is never resolved back to `Builder`, so the tree walk never reaches it. Always reference context notes by their **canonical note name** in `under()` targets and in any leaf `context` relation.
+Concretely, if `Builder` has an alias `BuilderProject`, then a task with `context: "[[BuilderProject]]"` **is** returned by `under(context, '[[Builder]]')` and `under(context, '[[career]]')` — the alias resolves back to `Builder`, so the tree walk reaches it. Passing the alias as the query node works too: `under(context, '[[BuilderProject]]')` resolves to `Builder` and walks its whole subtree. You can use either the canonical name or an alias in `under()` targets and in leaf `context` relations.
 
-This is a known limitation; a follow-up issue will track making `under()` alias-aware.
+Ambiguous aliases (the same alias declared on more than one note) are the one exception: they are **not** auto-resolved, so they match nothing rather than silently picking a winner. Disambiguate by renaming the alias or referencing the canonical note name.
 :::
 - **Validation for free.** A task pointing at a non-existent context is flagged by the existing relation-source audit (see [Validation and Audit](/concepts/validation-and-audit/)), exactly like any other broken relation.
 

--- a/docs-site/src/content/docs/reference/targeting.md
+++ b/docs-site/src/content/docs/reference/targeting.md
@@ -123,8 +123,16 @@ Notes:
 - **Resolution scope.** `under` resolves relation targets and their ancestors
   across the **whole vault**, so the target notes do not need to share the
   filtered type.
-- **Robustness.** A dangling (unresolvable) relation target simply doesn't
-  match; a malformed `parent` cycle is walked safely and never loops forever.
+- **Alias-aware.** `under` canonicalizes aliases (see
+  [Schema](/concepts/schema/)) on **both sides** — an aliased relation value (`context: "[[BuilderProject]]"` where
+  `BuilderProject` is an alias of `Builder`) and an aliased query node
+  (`under(context, '[[BuilderProject]]')`) both resolve to the canonical note,
+  using the same resolution as `bwrb open <alias>`. An ambiguous alias (declared
+  on more than one note) is **not** auto-resolved — it matches nothing rather
+  than silently picking a winner.
+- **Robustness.** A dangling (unresolvable) relation target — including a
+  dangling alias — simply doesn't match; a malformed `parent` cycle is walked
+  safely and never loops forever.
 
 For the full pattern — modelling life domains and projects as a `parent` tree of
 context notes and collapsing a redundant `scope` field into it — see

--- a/src/lib/expression.ts
+++ b/src/lib/expression.ts
@@ -25,6 +25,16 @@ export interface HierarchyData {
   parentMap: Map<string, string>;
   /** Map from note name to set of child note names */
   childrenMap: Map<string, Set<string>>;
+  /**
+   * Optional map from a declared alias to the canonical note name it resolves
+   * to. Used by `under` to canonicalize aliased relation targets and aliased
+   * query nodes before walking the parent chain, so aliases never silently
+   * drop out of subtree queries. Built from the same alias index that drives
+   * navigation (`getEntityAliases`). Ambiguous aliases (claimed by more than
+   * one note) are intentionally omitted, so they resolve to nothing rather than
+   * silently picking one note's subtree.
+   */
+  aliasMap?: Map<string, string>;
 }
 
 /**
@@ -397,9 +407,21 @@ const FUNCTIONS: Record<string, FunctionImpl> = {
    * matches notes whose `context` is `[[career]]` itself OR any descendant of
    * career. For multi-valued relation fields, matches if ANY target is under
    * the node.
+   *
+   * Aliases are canonicalized on BOTH sides via `hierarchyData.aliasMap`: an
+   * aliased relation target (e.g. `[[BuilderProject]]`, an alias of `Builder`)
+   * resolves to its canonical note so its ancestor chain is walked, and an
+   * aliased query node resolves to the canonical note so subtree matching works.
+   * This makes `under` consistent with `bwrb open <alias>`. A dangling alias
+   * (claimed by no note) or an ambiguous alias (claimed by several) is left
+   * as-is, so it simply fails to match rather than crashing or guessing.
    */
   under: (args, context) => {
-    const targetNode = extractNoteNameFromArg(String(args[1] ?? ''));
+    const aliasMap = context.hierarchyData?.aliasMap;
+    const targetNode = canonicalizeAlias(
+      extractNoteNameFromArg(String(args[1] ?? '')),
+      aliasMap
+    );
     if (!targetNode || !context.hierarchyData) return false;
 
     // Resolve the relation field value(s) to note names. extractLinkTargets
@@ -408,7 +430,9 @@ const FUNCTIONS: Record<string, FunctionImpl> = {
     if (relationTargets.length === 0) return false;
 
     const parentMap = context.hierarchyData.parentMap;
-    for (const relationTarget of relationTargets) {
+    for (const rawTarget of relationTargets) {
+      const relationTarget = canonicalizeAlias(rawTarget, aliasMap);
+      if (!relationTarget) continue;
       // Inclusive of the direct target (depth 0).
       if (relationTarget === targetNode) return true;
       // Otherwise walk the target's own ancestor chain.
@@ -419,6 +443,23 @@ const FUNCTIONS: Record<string, FunctionImpl> = {
     return false;
   },
 };
+
+/**
+ * Resolve a note name through the alias map, if present.
+ *
+ * If `name` is a declared alias that unambiguously resolves to a canonical note,
+ * return that canonical name; otherwise return `name` unchanged. A real note
+ * name always wins over an alias (the alias map never contains keys that shadow
+ * real notes), so canonical names pass through untouched.
+ */
+function canonicalizeAlias(
+  name: string | null,
+  aliasMap: Map<string, string> | undefined
+): string | null {
+  if (!name) return name;
+  if (!aliasMap) return name;
+  return aliasMap.get(name) ?? name;
+}
 
 /**
  * Walk a parent chain starting from `start`, returning true if `target` is

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1,10 +1,15 @@
 import { basename } from 'path';
 import type { LoadedSchema } from '../types/schema.js';
-import { getAllFieldsForType, getType, resolveTypeFromFrontmatter } from './schema.js';
+import {
+  getAllFieldsForType,
+  getEntityAliases,
+  getType,
+  resolveTypeFromFrontmatter,
+} from './schema.js';
 import { matchesExpression, buildEvalContext, type HierarchyData } from './expression.js';
 import { collectFrontmatterKeys, normalizeWhereExpressions } from './where-normalize.js';
 import { extractLinkTarget } from './links.js';
-import { discoverManagedFiles } from './discovery.js';
+import { buildVaultNoteSnapshot, discoverManagedFiles } from './discovery.js';
 import { parseNote } from './frontmatter.js';
 
 /**
@@ -153,6 +158,63 @@ async function augmentHierarchyDataFromVault(
       hierarchyFieldCache
     );
   }
+
+  // Build the alias -> canonical-note map so `under` can canonicalize aliased
+  // relation targets and aliased query nodes (see HierarchyData.aliasMap).
+  hierarchyData.aliasMap = await buildVaultAliasMap(options.schema, options.vaultDir);
+}
+
+/**
+ * Build a map from each declared alias to the canonical note name it resolves
+ * to, over the entire vault. Reuses the same alias index that drives navigation
+ * (`getEntityAliases` from #266) so `under` canonicalizes aliases identically to
+ * `bwrb open <alias>`.
+ *
+ * Trust model (consistent with navigation's alias resolution and
+ * `deriveNotePathMap`):
+ * - An alias never shadows a real note name.
+ * - An alias claimed by more than one note is AMBIGUOUS and is dropped from the
+ *   map entirely. Resolving it to one note's subtree would reintroduce silent
+ *   data loss, and silently picking a winner is exactly the footgun this guards
+ *   against, so an ambiguous alias resolves to nothing (no match, no crash).
+ */
+async function buildVaultAliasMap(
+  schema: LoadedSchema,
+  vaultDir: string
+): Promise<Map<string, string>> {
+  const snapshot = await buildVaultNoteSnapshot(schema, vaultDir);
+
+  // Real note names always win over aliases.
+  const realNames = new Set<string>();
+  for (const note of snapshot.notes) {
+    realNames.add(basename(note.relativePath, '.md'));
+  }
+
+  // First pass: count how many notes claim each (non-shadowed) alias.
+  const claims = new Map<string, string[]>();
+  for (const note of snapshot.notes) {
+    if (!note.resolvedType || !note.frontmatter) continue;
+    const canonical = basename(note.relativePath, '.md');
+    const aliases = getEntityAliases(schema, note.resolvedType, note.frontmatter);
+    for (const alias of aliases) {
+      if (realNames.has(alias)) continue; // never shadow a real note
+      const existing = claims.get(alias);
+      if (existing) {
+        if (!existing.includes(canonical)) existing.push(canonical);
+      } else {
+        claims.set(alias, [canonical]);
+      }
+    }
+  }
+
+  // Second pass: keep only unambiguous aliases.
+  const aliasMap = new Map<string, string>();
+  for (const [alias, canonicals] of claims) {
+    if (canonicals.length === 1) {
+      aliasMap.set(alias, canonicals[0]!);
+    }
+  }
+  return aliasMap;
 }
 
 function resolveHierarchyType(

--- a/tests/ts/commands/hierarchical-scope.test.ts
+++ b/tests/ts/commands/hierarchical-scope.test.ts
@@ -256,3 +256,180 @@ describe('#554 hierarchical scope — contexts as notes + under()', () => {
     expect(descendants.stdout).not.toContain('PKM.md');
   });
 });
+
+/**
+ * Guard test for #636 — "under() does not canonicalize aliases".
+ *
+ * Aliases are a field role (#266): a context note can declare alternate names.
+ * Before #636, `under()` matched wikilink targets literally, so a task using an
+ * aliased context (e.g. context: [[BuilderProject]] where BuilderProject is an
+ * alias of Builder) silently dropped out of every subtree query. This locks in
+ * that aliases are canonicalized on BOTH the relation value and the query node.
+ */
+describe('#636 under() canonicalizes aliases', () => {
+  let vaultDir: string;
+
+  const SCHEMA = {
+    version: 2,
+    types: {
+      entity: {
+        output_dir: 'Entities',
+        fields: { type: { value: 'entity' } },
+        field_order: ['type'],
+      },
+      context: {
+        extends: 'entity',
+        output_dir: 'Contexts',
+        recursive: true,
+        fields: {
+          type: { value: 'context' },
+          parent: { prompt: 'relation', source: 'context', format: 'quoted-wikilink' },
+          aliases: { prompt: 'list', alias: true, list_format: 'yaml-array', default: [] },
+        },
+        field_order: ['type', 'parent', 'aliases'],
+      },
+      task: {
+        output_dir: 'Tasks',
+        fields: {
+          type: { value: 'task' },
+          status: {
+            prompt: 'select',
+            options: ['backlog', 'active', 'done'],
+            default: 'backlog',
+            required: true,
+          },
+          context: { prompt: 'relation', source: 'context', format: 'quoted-wikilink' },
+        },
+        field_order: ['type', 'status', 'context'],
+      },
+    },
+    audit: { ignored_directories: [] },
+  };
+
+  const writeNote = async (rel: string, frontmatter: string[]) => {
+    const path = join(vaultDir, rel);
+    await mkdir(join(path, '..'), { recursive: true });
+    await writeFile(path, ['---', ...frontmatter, '---', ''].join('\n'));
+  };
+
+  beforeAll(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-636-'));
+    await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+    await writeFile(join(vaultDir, '.bwrb', 'schema.json'), JSON.stringify(SCHEMA, null, 2));
+
+    // career (alias: careerAlias)
+    //   └── Builder (alias: BuilderProject)
+    //         └── Vercel
+    await writeNote('Contexts/career.md', [
+      'type: context',
+      'aliases:',
+      '  - careerAlias',
+    ]);
+    await writeNote('Contexts/Builder.md', [
+      'type: context',
+      'parent: "[[career]]"',
+      'aliases:',
+      '  - BuilderProject',
+    ]);
+    await writeNote('Contexts/Vercel.md', ['type: context', 'parent: "[[Builder]]"']);
+
+    // Two notes claim the same alias 'Dup' -> ambiguous.
+    await writeNote('Contexts/Alpha.md', [
+      'type: context',
+      'aliases:',
+      '  - Dup',
+    ]);
+    await writeNote('Contexts/Beta.md', [
+      'type: context',
+      'aliases:',
+      '  - Dup',
+    ]);
+
+    // Task uses the ALIAS as its context value.
+    await writeNote('Tasks/Aliased context task.md', [
+      'type: task',
+      'status: active',
+      'context: "[[BuilderProject]]"',
+    ]);
+    // Task uses the canonical leaf.
+    await writeNote('Tasks/Canonical leaf task.md', [
+      'type: task',
+      'status: active',
+      'context: "[[Vercel]]"',
+    ]);
+    // Task pointing at the ambiguous alias.
+    await writeNote('Tasks/Ambiguous alias task.md', [
+      'type: task',
+      'status: active',
+      'context: "[[Dup]]"',
+    ]);
+  });
+
+  afterAll(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('matches an aliased relation target against a canonical ancestor', async () => {
+    // context: [[BuilderProject]] (alias of Builder) IS under career.
+    const result = await runCLI(
+      ['list', 'task', '--where', "under(context, '[[career]]')", '--output', 'paths'],
+      vaultDir
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Aliased context task.md');
+    expect(result.stdout).toContain('Canonical leaf task.md');
+  });
+
+  it('resolves an aliased query node to its canonical note and walks its subtree', async () => {
+    // under(context, '[[BuilderProject]]') must behave like '[[Builder]]':
+    // both the aliased-context task and the Vercel-leaf task (Vercel is under
+    // Builder) are returned.
+    const result = await runCLI(
+      ['list', 'task', '--where', "under(context, '[[BuilderProject]]')", '--output', 'paths'],
+      vaultDir
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Aliased context task.md');
+    expect(result.stdout).toContain('Canonical leaf task.md');
+  });
+
+  it('canonicalizes an aliased query node that is an ancestor', async () => {
+    const result = await runCLI(
+      ['list', 'task', '--where', "under(context, '[[careerAlias]]')", '--output', 'paths'],
+      vaultDir
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Aliased context task.md');
+    expect(result.stdout).toContain('Canonical leaf task.md');
+  });
+
+  it('does not resolve an ambiguous alias to a subtree (no silent winner)', async () => {
+    // 'Dup' is claimed by both Alpha and Beta, so it is dropped from the alias
+    // map. The Dup task must NOT be reachable via either claimant's subtree —
+    // the engine refuses to silently pick a winner. (A literal Dup-vs-Dup self
+    // match would still pass under(context, '[[Dup]]'); the guarantee under test
+    // is that no canonicalization to Alpha/Beta happens.)
+    const viaAlpha = await runCLI(
+      ['list', 'task', '--where', "under(context, '[[Alpha]]')", '--output', 'paths'],
+      vaultDir
+    );
+    expect(viaAlpha.exitCode).toBe(0);
+    expect(viaAlpha.stdout).not.toContain('Ambiguous alias task.md');
+
+    const viaBeta = await runCLI(
+      ['list', 'task', '--where', "under(context, '[[Beta]]')", '--output', 'paths'],
+      vaultDir
+    );
+    expect(viaBeta.exitCode).toBe(0);
+    expect(viaBeta.stdout).not.toContain('Ambiguous alias task.md');
+  });
+
+  it('does not crash on a dangling alias', async () => {
+    const result = await runCLI(
+      ['list', 'task', '--where', "under(context, '[[GhostAlias]]')", '--output', 'paths'],
+      vaultDir
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('Aliased context task.md');
+  });
+}, 30000);

--- a/tests/ts/lib/expression.test.ts
+++ b/tests/ts/lib/expression.test.ts
@@ -476,6 +476,82 @@ describe('expression', () => {
         expect(matchesExpression("isDescendantOf('[[career]]')", ctx)).toBe(false);
         expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(true);
       });
+
+      describe('alias canonicalization (#636)', () => {
+        // Builder has alias 'BuilderProject'; career has alias 'careerAlias'.
+        // 'Dup' is an ambiguous alias claimed by two notes -> dropped.
+        const aliasMap = new Map([
+          ['BuilderProject', 'Builder'],
+          ['careerAlias', 'career'],
+        ]);
+
+        const makeAliasedNote = (relationValue: unknown): EvalContext => ({
+          frontmatter: { context: relationValue },
+          file: { name: 'Some Task', path: 'Tasks/Some Task.md', folder: 'Tasks', ext: '.md' },
+          hierarchyData: {
+            parentMap: contextParentMap,
+            childrenMap: contextChildrenMap,
+            aliasMap,
+          },
+        });
+
+        it('matches an aliased relation target against a canonical ancestor', () => {
+          // context: [[BuilderProject]] (alias of Builder) IS under career.
+          const ctx = makeAliasedNote('[[BuilderProject]]');
+          expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(true);
+        });
+
+        it('resolves an aliased query node to its canonical note and walks its subtree', () => {
+          // under(context, '[[BuilderProject]]') should behave like '[[Builder]]'.
+          const ctx = makeAliasedNote('[[Vercel]]');
+          expect(matchesExpression("under(context, '[[BuilderProject]]')", ctx)).toBe(true);
+        });
+
+        it('matches an aliased relation target as the inclusive direct target', () => {
+          // context: [[BuilderProject]] resolves to Builder; query node Builder.
+          const ctx = makeAliasedNote('[[BuilderProject]]');
+          expect(matchesExpression("under(context, '[[Builder]]')", ctx)).toBe(true);
+        });
+
+        it('matches when both sides are aliases of the same canonical note', () => {
+          const ctx = makeAliasedNote('[[BuilderProject]]');
+          expect(matchesExpression("under(context, '[[BuilderProject]]')", ctx)).toBe(true);
+        });
+
+        it('handles mixed alias + canonical multi-valued relation targets', () => {
+          const ctx = makeAliasedNote(['[[personal]]', '[[BuilderProject]]']);
+          expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(true);
+        });
+
+        it('canonicalizes an aliased query node that is itself an ancestor', () => {
+          // careerAlias -> career; Builder is under career.
+          const ctx = makeAliasedNote('[[Builder]]');
+          expect(matchesExpression("under(context, '[[careerAlias]]')", ctx)).toBe(true);
+        });
+
+        it('does not match / crash on a dangling alias (claimed by no note)', () => {
+          // 'GhostAlias' is not in the alias map -> left as-is -> no match.
+          const ctx = makeAliasedNote('[[GhostAlias]]');
+          expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(false);
+        });
+
+        it('does not resolve an ambiguous alias to a subtree (no silent winner)', () => {
+          // The query layer drops ambiguous aliases, so 'Dup' never reaches the
+          // alias map. It stays literal: it is NOT canonicalized into any note's
+          // subtree, so it does not appear under a canonical ancestor.
+          const ctx = makeAliasedNote('[[Dup]]');
+          expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(false);
+          // A literal Dup-vs-Dup still matches as the inclusive direct target;
+          // the guarantee is only that no subtree walking happens for it.
+          expect(matchesExpression("under(context, '[[OtherCanonical]]')", ctx)).toBe(false);
+        });
+
+        it('leaves canonical names untouched when an alias map is present', () => {
+          const ctx = makeAliasedNote('[[Vercel]]');
+          expect(matchesExpression("under(context, '[[career]]')", ctx)).toBe(true);
+          expect(matchesExpression("under(context, '[[personal]]')", ctx)).toBe(false);
+        });
+      });
     });
 
     describe('hierarchy functions composability', () => {


### PR DESCRIPTION
## Summary

`under(field, '[[Node]]')` matched wikilink targets **literally** with no alias canonicalization, a silent data-loss footgun directly under the hierarchical-scope pattern (#554):

- A task with `context: [[BuilderProject]]` (where `BuilderProject` is an alias of `Builder`) was **invisible** to `under(context, '[[Builder]]')` and `under(context, '[[career]]')`.
- `under(context, '[[BuilderProject]]')` returned only that note and did **not** walk Builder's subtree.

`under` now **canonicalizes aliases on both sides** before walking the parent chain:

1. **Relation value(s)** — an aliased target resolves to its canonical note so its ancestor chain is walked.
2. **Query node** — an aliased argument resolves to the canonical note so subtree matching works.

## How

- Reuses the **#266 alias index** (`getEntityAliases`) — the same resolution that powers `bwrb open <alias>`. No forked alias logic.
- The alias→canonical map is built over the whole vault inside the existing `augmentHierarchyDataFromVault` pass (`src/lib/query.ts`) and threaded through `HierarchyData.aliasMap`. Canonicalization happens in `under` (`src/lib/expression.ts`) via a small `canonicalizeAlias` helper.

## Ambiguity & trust model

Consistent with navigation's alias resolution and `deriveNotePathMap`:
- An alias **never shadows** a real note name.
- An **ambiguous** alias (claimed by more than one note) is **dropped from the map** — it resolves to nothing rather than silently picking a winner, since auto-picking would reintroduce the exact data-loss this fixes.
- Dangling aliases and `parent` cycles remain safe (no match, no crash).

## Tests

Unit (`expression.test.ts`) and end-to-end CLI (`hierarchical-scope.test.ts`): aliased relation target under canonical ancestor, aliased query node walking its subtree, aliased ancestor query node, mixed alias + canonical multi-valued targets, dangling alias, ambiguous alias (no silent winner). Existing non-alias `under()` behavior unchanged.

## Docs

- `concepts/hierarchical-scope.md`: replaced the #554 `:::caution` (which documented the alias drop-out as a known limitation) with a `:::note` documenting the new alias-aware behavior.
- `reference/targeting.md`: added an "Alias-aware" bullet to the `under()` notes.

## Gates

`pnpm qa` ✅ · `pnpm knip` ✅ · `pnpm docs:build` ✅

Closes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)