### PR TITLE
fix(discovery): index notes in nested subdirs under a type's output_dir (#619)

### DIFF
--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -71,11 +71,41 @@ Types define categories of notes. Each type has a name (the object key) and a de
 | `extends` | string | `"meta"` | Parent type name (single-inheritance) |
 | `traits` | array | — | Trait names composed into this type (see [Traits](#traits)) |
 | `description` | string | — | What this type is for and when to use it. Surfaced by `bwrb schema list` |
+| `output_dir` | string | auto | Vault-relative folder where this type's notes live (e.g., `"Objectives/Tasks"`). See [Output directories](#output-directories) |
 | `fields` | object | `{}` | Field definitions |
 | `field_order` | array | — | Order of fields in frontmatter |
 | `body_sections` | array | — | Body structure after frontmatter |
 | `recursive` | boolean | `false` | Whether type can contain instances of itself |
 | `plural` | string | auto | Custom plural for folder naming (e.g., `"research"` instead of `"researchs"`) |
+
+### Output directories
+
+Each type's `output_dir` is the folder its notes live in. `bwrb new` creates notes
+directly in `output_dir`, but discovery (`bwrb list`, `bwrb search`, and
+`search --fuzzy`) treats `output_dir` as a **subtree**: notes filed in nested
+subfolders are discovered and associated with that type too.
+
+For a `people` type with `output_dir: "People"`, all of these are discovered as
+`people` notes:
+
+```
+People/Ada Lovelace.md          # direct child
+People/Historical/Ada Lovelace.md   # nested subdir
+People/Historical/Mathematicians/Ada.md   # deeply nested
+```
+
+Boundaries are respected so notes are never misassigned:
+
+- A nested folder that is itself another type's `output_dir` (e.g. `Objectives/Tasks`
+  under `Objectives`) belongs to that more specific type, not the parent.
+- Owned-note subfolders (see [Owned relations](#owned-relations)) keep their owned
+  child type and ownership metadata.
+- Hidden/system folders (`.bwrb`, anything starting with `.`) and paths excluded by
+  `config.excluded_directories`, `.gitignore`, or `.bwrbignore` are never indexed.
+
+A nested note whose declared `type` does not match the folder it sits in is still
+discoverable, but `bwrb audit` reports it as `wrong-directory` — discovery and the
+audit's directory check use the same subtree rule.
 
 ### Inheritance
 

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -756,36 +756,118 @@ export async function collectFilesForType(
 }
 
 /**
- * Collect files from a pooled (flat) directory.
+ * Boundaries that stop a recursive pooled scan from crossing into a subtree
+ * that belongs to a *different* type's discovery path.
+ *
+ * - `claimedDirs`: relative paths that are another concrete type's `output_dir`.
+ *   Those notes are assigned to that type by its own pooled scan, so we must not
+ *   claim them here (avoids misassigning a nested type's notes to the parent).
+ * - `ownedFieldFolders`: owned-field folder basenames (e.g. `research`). Owned
+ *   notes live under `<owner>/<field>/` and are collected (with ownership
+ *   metadata and the correct child type) by `collectOwnedFiles`. We must not
+ *   descend into those folders here or we'd double-count them under the wrong
+ *   type.
+ */
+export interface PooledScanBoundaries {
+  claimedDirs: Set<string>;
+  ownedFieldFolders: Set<string>;
+}
+
+/**
+ * Compute the subtree boundaries for a recursive pooled scan of `typeName`.
+ *
+ * Other types' output directories that are nested *under* this type's output
+ * directory are excluded so each note is claimed by the most specific type. The
+ * type's own output_dir is never treated as a boundary against itself.
+ */
+function getPooledScanBoundaries(
+  schema: LoadedSchema,
+  typeName: string
+): PooledScanBoundaries {
+  const selfDir = (getOutputDirFromSchema(schema, typeName) ?? '').replace(/\/$/, '');
+
+  const claimedDirs = new Set<string>();
+  for (const other of getConcreteTypeNames(schema)) {
+    if (other === typeName) continue;
+    const dir = getOutputDirFromSchema(schema, other);
+    if (!dir) continue;
+    const normalized = dir.replace(/\/$/, '');
+    if (normalized && normalized !== selfDir) {
+      claimedDirs.add(normalized);
+    }
+  }
+
+  const ownedFieldFolders = new Set<string>();
+  for (const [, ownedFields] of schema.ownership.owns) {
+    for (const field of ownedFields as OwnedFieldInfo[]) {
+      if (field.fieldName) ownedFieldFolders.add(field.fieldName);
+    }
+  }
+
+  return { claimedDirs, ownedFieldFolders };
+}
+
+/**
+ * Collect files from a type's output directory.
+ *
+ * Recurses into nested subdirectories so that notes filed in subfolders under a
+ * type's `output_dir` (e.g. `People/Sub/X.md` for a `people` type rooted at
+ * `People`) are discovered and associated with that type — consistent with how
+ * `audit`'s wrong-directory check already treats a subdirectory of `output_dir`
+ * as a correct location.
+ *
+ * Recursion stops at `boundaries` so notes belonging to a more specific nested
+ * type, or owned notes living in owner folders, are not misassigned here.
  */
 export async function collectPooledFiles(
   vaultDir: string,
   outputDir: string,
   expectedType: string,
   excluded: Set<string>,
-  ignoreMatcher: Ignore | null
+  ignoreMatcher: Ignore | null,
+  boundaries?: PooledScanBoundaries
 ): Promise<ManagedFile[]> {
   const normalizedOutputDir = outputDir.replace(/\/$/, '');
-  const fullDir = join(vaultDir, normalizedOutputDir);
-  if (!existsSync(fullDir)) return [];
+  const rootDir = join(vaultDir, normalizedOutputDir);
+  if (!existsSync(rootDir)) return [];
 
   if (shouldExcludePath(normalizedOutputDir, excluded, ignoreMatcher, true)) return [];
 
+  const claimedDirs = boundaries?.claimedDirs ?? new Set<string>();
+  const ownedFieldFolders = boundaries?.ownedFieldFolders ?? new Set<string>();
   const files: ManagedFile[] = [];
-  const entries = await readdir(fullDir, { withFileTypes: true });
 
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+  const walk = async (dir: string, relDir: string): Promise<void> => {
+    const entries = await readdir(dir, { withFileTypes: true });
 
-    const relativePath = join(normalizedOutputDir, entry.name);
-    if (shouldExcludePath(relativePath, excluded, ignoreMatcher)) continue;
+    for (const entry of entries) {
+      const entryRel = join(relDir, entry.name);
 
-    files.push({
-      path: join(fullDir, entry.name),
-      relativePath,
-      expectedType,
-    });
-  }
+      if (entry.isDirectory()) {
+        // Never descend into hidden/system directories.
+        if (entry.name.startsWith('.')) continue;
+        // Stop at another type's output directory (it owns its own notes).
+        if (claimedDirs.has(entryRel)) continue;
+        // Stop at owned-field folders (owned notes are collected elsewhere with
+        // their correct child type and ownership metadata).
+        if (ownedFieldFolders.has(entry.name)) continue;
+        if (shouldExcludePath(entryRel, excluded, ignoreMatcher, true)) continue;
+        await walk(join(dir, entry.name), entryRel);
+        continue;
+      }
+
+      if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+      if (shouldExcludePath(entryRel, excluded, ignoreMatcher)) continue;
+
+      files.push({
+        path: join(dir, entry.name),
+        relativePath: entryRel,
+        expectedType,
+      });
+    }
+  };
+
+  await walk(rootDir, normalizedOutputDir);
 
   // Sort for deterministic ordering across platforms
   return files.sort(stablePathCompare);
@@ -901,13 +983,23 @@ async function collectFilesForTypeWithOwnership(
   const excluded = getExcludedDirectories(schema);
   const ignoreMatcher = await loadIgnoreMatcher(vaultDir, excluded);
 
-  // Collect files in the type's output_dir (non-owned notes)
+  // Collect files in the type's output_dir (non-owned notes), recursing into
+  // nested subdirectories while skipping subtrees owned by other types or
+  // ownership folders.
   const outputDir = getOutputDirFromSchema(schema, typeName);
   if (outputDir) {
-    const typeFiles = await collectPooledFiles(vaultDir, outputDir, typeName, excluded, ignoreMatcher);
+    const boundaries = getPooledScanBoundaries(schema, typeName);
+    const typeFiles = await collectPooledFiles(
+      vaultDir,
+      outputDir,
+      typeName,
+      excluded,
+      ignoreMatcher,
+      boundaries
+    );
     files.push(...typeFiles);
   }
-  
+
   // If this type can be owned, also collect owned instances
   if (canTypeBeOwned(schema, typeName)) {
     // Find all owner types and collect owned files from each
@@ -921,9 +1013,19 @@ async function collectFilesForTypeWithOwnership(
       }
     }
   }
-  
+
+  // Dedupe by path, preferring entries that carry ownership metadata so an owned
+  // note is never represented by a plain pooled entry with the wrong type.
+  const byPath = new Map<string, ManagedFile>();
+  for (const file of files) {
+    const existing = byPath.get(file.relativePath);
+    if (!existing || (!existing.ownership && file.ownership)) {
+      byPath.set(file.relativePath, file);
+    }
+  }
+
   // Sort for deterministic ordering across platforms
-  return files.sort(stablePathCompare);
+  return Array.from(byPath.values()).sort(stablePathCompare);
 }
 
 // ============================================================================

--- a/tests/ts/commands/search.test.ts
+++ b/tests/ts/commands/search.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { createTestVault, cleanupTestVault, runCLI } from '../fixtures/setup.js';
-import { writeFile } from 'fs/promises';
+import { writeFile, mkdir } from 'fs/promises';
 import { join } from 'path';
 
 describe('search command', () => {
@@ -227,8 +227,7 @@ status: backlog
 
     it('should exclude unmanaged files in gitignored directories', async () => {
       // Create an unmanaged file outside type directories
-      const { mkdir } = await import('fs/promises');
-      await mkdir(join(tempVaultDir, 'Drafts'), { recursive: true });
+        await mkdir(join(tempVaultDir, 'Drafts'), { recursive: true });
       await writeFile(join(tempVaultDir, 'Drafts', 'WIP Note.md'), `---
 title: WIP Note
 ---
@@ -247,8 +246,7 @@ Work in progress
 
     it('should find unmanaged files NOT in gitignored directories', async () => {
       // Create an unmanaged file outside type directories
-      const { mkdir } = await import('fs/promises');
-      await mkdir(join(tempVaultDir, 'Notes'), { recursive: true });
+        await mkdir(join(tempVaultDir, 'Notes'), { recursive: true });
       await writeFile(join(tempVaultDir, 'Notes', 'Random Note.md'), `---
 title: Random Note
 ---
@@ -652,5 +650,86 @@ Some content
         expect(json.error).toContain('Unknown function: missingFn');
       });
     });
+  });
+});
+
+describe('nested subdir discovery (#619)', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  it('lists a note in a nested subdir under output_dir with the parent type', async () => {
+    await mkdir(join(vaultDir, 'Ideas', 'Sub'), { recursive: true });
+    await writeFile(
+      join(vaultDir, 'Ideas', 'Sub', 'Nested Idea.md'),
+      '---\ntype: idea\nstatus: raw\n---\n'
+    );
+
+    const result = await runCLI(['list', '--type', 'idea', '--output', 'paths'], vaultDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Ideas/Sub/Nested Idea.md');
+  });
+
+  it('finds a nested note via plain search', async () => {
+    await mkdir(join(vaultDir, 'Ideas', 'Sub'), { recursive: true });
+    await writeFile(
+      join(vaultDir, 'Ideas', 'Sub', 'Nested Idea.md'),
+      '---\ntype: idea\nstatus: raw\n---\n'
+    );
+
+    const result = await runCLI(
+      ['search', 'Nested Idea', '--output', 'paths'],
+      vaultDir
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('Ideas/Sub/Nested Idea.md');
+  });
+
+  it('finds a deeply nested note via fuzzy search', async () => {
+    await mkdir(join(vaultDir, 'Ideas', 'A', 'B'), { recursive: true });
+    await writeFile(
+      join(vaultDir, 'Ideas', 'A', 'B', 'Deeply Nested Idea.md'),
+      '---\ntype: idea\nstatus: raw\n---\n'
+    );
+
+    const result = await runCLI(
+      ['search', 'Deeply Nestd Idea', '--fuzzy', '--output', 'json'],
+      vaultDir
+    );
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(true);
+    expect(json.data.some((d: { name: string }) => d.name === 'Deeply Nested Idea')).toBe(true);
+  });
+
+  it('does not misassign a nested note under one type to another type', async () => {
+    // A nested idea under Ideas must not show up when listing tasks.
+    await mkdir(join(vaultDir, 'Ideas', 'Sub'), { recursive: true });
+    await writeFile(
+      join(vaultDir, 'Ideas', 'Sub', 'Nested Idea.md'),
+      '---\ntype: idea\nstatus: raw\n---\n'
+    );
+
+    const tasks = await runCLI(['list', '--type', 'task', '--output', 'paths'], vaultDir);
+    expect(tasks.exitCode).toBe(0);
+    expect(tasks.stdout).not.toContain('Nested Idea');
+  });
+
+  it('excludes hidden subdirectories under a type output_dir', async () => {
+    await mkdir(join(vaultDir, 'Ideas', '.hidden'), { recursive: true });
+    await writeFile(
+      join(vaultDir, 'Ideas', '.hidden', 'Secret Idea.md'),
+      '---\ntype: idea\nstatus: raw\n---\n'
+    );
+
+    const result = await runCLI(['list', '--type', 'idea', '--output', 'paths'], vaultDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('Secret Idea');
   });
 });

--- a/tests/ts/lib/discovery.test.ts
+++ b/tests/ts/lib/discovery.test.ts
@@ -627,10 +627,112 @@ describe('Discovery', () => {
 
     it('should not have duplicates', async () => {
       const files = await discoverFilesForNavigation(schema, vaultDir);
-      
+
       const paths = files.map(f => f.relativePath);
       const uniquePaths = new Set(paths);
       expect(paths.length).toBe(uniquePaths.size);
+    });
+  });
+
+  describe('nested subdirectories under output_dir (#619)', () => {
+    it('indexes notes in a nested subdir and assigns the parent type', async () => {
+      await mkdir(join(vaultDir, 'Ideas', 'Sub'), { recursive: true });
+      await writeFile(
+        join(vaultDir, 'Ideas', 'Sub', 'Nested Idea.md'),
+        '---\ntype: idea\nstatus: raw\n---\n'
+      );
+
+      const files = await collectFilesForType(schema, vaultDir, 'idea');
+      const nested = files.find(f => f.relativePath === 'Ideas/Sub/Nested Idea.md');
+
+      expect(nested).toBeDefined();
+      expect(nested!.expectedType).toBe('idea');
+    });
+
+    it('indexes deeply nested notes (2+ levels)', async () => {
+      await mkdir(join(vaultDir, 'Ideas', 'A', 'B'), { recursive: true });
+      await writeFile(
+        join(vaultDir, 'Ideas', 'A', 'B', 'Deep Idea.md'),
+        '---\ntype: idea\nstatus: raw\n---\n'
+      );
+
+      const files = await collectFilesForType(schema, vaultDir, 'idea');
+      const deep = files.find(f => f.relativePath === 'Ideas/A/B/Deep Idea.md');
+
+      expect(deep).toBeDefined();
+      expect(deep!.expectedType).toBe('idea');
+    });
+
+    it('makes nested notes discoverable for navigation', async () => {
+      await mkdir(join(vaultDir, 'Ideas', 'Sub'), { recursive: true });
+      await writeFile(
+        join(vaultDir, 'Ideas', 'Sub', 'Nested Idea.md'),
+        '---\ntype: idea\nstatus: raw\n---\n'
+      );
+
+      const files = await discoverFilesForNavigation(schema, vaultDir);
+      const paths = files.map(f => f.relativePath);
+      expect(paths).toContain('Ideas/Sub/Nested Idea.md');
+    });
+
+    it('does not misassign a nested note from another type subtree', async () => {
+      // Objectives is the `objective` output_dir; Objectives/Tasks belongs to `task`.
+      // A note nested directly under Objectives is an `objective`, while one nested
+      // under Objectives/Tasks must stay a `task` (not bleed up to `objective`).
+      await mkdir(join(vaultDir, 'Objectives', 'Tasks', 'Sub'), { recursive: true });
+      await writeFile(
+        join(vaultDir, 'Objectives', 'Tasks', 'Sub', 'Nested Task.md'),
+        '---\ntype: task\nstatus: backlog\n---\n'
+      );
+
+      const objectiveFiles = await collectFilesForType(schema, vaultDir, 'objective');
+      const taskFiles = await collectFilesForType(schema, vaultDir, 'task');
+
+      // `task` is a descendant of `objective`, so the nested task IS reachable via
+      // the objective family, but it must carry the `task` type, never `objective`.
+      const viaObjective = objectiveFiles.find(
+        f => f.relativePath === 'Objectives/Tasks/Sub/Nested Task.md'
+      );
+      const viaTask = taskFiles.find(
+        f => f.relativePath === 'Objectives/Tasks/Sub/Nested Task.md'
+      );
+
+      expect(viaTask).toBeDefined();
+      expect(viaTask!.expectedType).toBe('task');
+      if (viaObjective) {
+        expect(viaObjective.expectedType).toBe('task');
+      }
+
+      // A type that is NOT a parent of task must never see the nested task.
+      const ideaFiles = await collectFilesForType(schema, vaultDir, 'idea');
+      expect(
+        ideaFiles.some(f => f.relativePath === 'Objectives/Tasks/Sub/Nested Task.md')
+      ).toBe(false);
+    });
+
+    it('excludes hidden subdirectories under a type output_dir', async () => {
+      await mkdir(join(vaultDir, 'Ideas', '.hidden'), { recursive: true });
+      await writeFile(
+        join(vaultDir, 'Ideas', '.hidden', 'Secret.md'),
+        '---\ntype: idea\n---\n'
+      );
+
+      const excluded = getExcludedDirectories(schema);
+      const gitignore = await loadGitignore(vaultDir);
+      const files = await collectPooledFiles(vaultDir, 'Ideas', 'idea', excluded, gitignore, {
+        claimedDirs: new Set(),
+        ownedFieldFolders: new Set(),
+      });
+      const paths = files.map(f => f.relativePath);
+
+      expect(paths.some(p => p.includes('.hidden'))).toBe(false);
+    });
+
+    it('does not double-count notes in a nested type output_dir', async () => {
+      const files = await discoverAllTypeFiles(schema, vaultDir);
+      const paths = files.map(f => f.relativePath);
+      const unique = new Set(paths);
+      expect(paths.length).toBe(unique.size);
     });
   });
 });


### PR DESCRIPTION
## Summary

Notes filed in nested subdirectories under a type's `output_dir` (e.g. `People/Sub/X.md` for a `people` type rooted at `People`) were invisible to `bwrb list`, plain `bwrb search`, and `search --fuzzy`. This makes them discoverable with correct type association.

## Root cause

`buildNoteIndex` → `discoverFilesForNavigation` → `discoverAllTypeFiles` → `collectPooledFiles` read only the **direct children** of each type's `output_dir` (non-recursive `readdir`, `entry.isFile()` only). Nested notes then fell into a gap:

- the non-recursive pooled scan never saw them, and
- the recursive *unmanaged* scan filtered them out, because `isInTypeOutputDir` already treats any path under a type dir (including subtrees) as "in a type directory".

So nested notes were neither managed nor unmanaged — invisible everywhere. Fuzzy correctly reuses the shared index, so the gap was consistent across all three commands.

## Design decision

`audit`'s `wrong-directory` check **already** treats a subdirectory of `output_dir` as a correct location (`actualDir === expectedDir || actualDir.startsWith(expectedDir + '/')`). Discovery was simply lagging behind that semantics. The fix aligns them:

- A nested note under a type's `output_dir` is **indexed and assigned to that type** (option (a) from the issue's design question).
- A nested note whose declared `type` doesn't match its folder is still discoverable, but `audit` continues to flag it `wrong-directory`. Discovery and audit now use the same subtree rule (discoverable **and** flagged, never hidden).

## The fix

`collectPooledFiles` now recurses into nested subdirectories, stopping at boundaries so nothing is misassigned or double-counted:

- **Another type's `output_dir`** nested below (e.g. `Objectives/Tasks` under `Objectives`) is skipped — that type's own scan claims it (most-specific type wins).
- **Owned-note folders** are skipped during the pooled walk; owned notes keep their owned child type + ownership metadata via `collectOwnedFiles`. Entries are deduped by path in `collectFilesForTypeWithOwnership`, preferring the ownership-bearing entry.
- **Hidden/system dirs** (`.bwrb`, anything starting with `.`) and `config.excluded_directories` / `.gitignore` / `.bwrbignore` exclusions are honored exactly as before.

## Avoiding regressions

- Misassignment: boundary set = other concrete types' `output_dir`s + owned-field folder names; cross-type isolation covered by tests.
- Hidden dirs: explicit `entry.name.startsWith('.')` skip in the recursive walk + existing `shouldExcludePath`.
- Double-count: dedupe by `relativePath` (ownership entry preferred); `discoverAllTypeFiles` dedupe unchanged.
- Perf: still one bounded walk per type subtree; boundaries prune sibling-type subtrees.

## Tests

- `tests/ts/lib/discovery.test.ts` — nested + deeply-nested association, navigation discovery, cross-type non-misassignment, hidden-dir exclusion, no double-count.
- `tests/ts/commands/search.test.ts` — `list --type`, plain `search`, `search --fuzzy` on nested/deeply-nested notes; cross-type isolation; hidden-dir exclusion.

## Docs

Documented `output_dir` subtree discovery semantics (with boundaries and the audit relationship) in `reference/schema.md`.

## Quality gates

- `pnpm qa` ✅ (typecheck, lint, docs:lint, docs:doctor, build, 2345 tests pass / 4 skipped)
- `pnpm knip` ✅
- `pnpm docs:build` ✅

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)