### PR TITLE
fix(audit): treat empty optional date as unset, not invalid (#614)

### DIFF
--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -86,6 +86,8 @@ Note: built-in fields written by `bwrb new` (currently `id` and `name`) are alwa
 Invalid option values inside list fields are reported as `invalid-option` with `listIndex` metadata, not a separate issue code.
 For a [`date`](/reference/schema/) field with `multiple: true` (a list of dates), each element is validated against the field's granularity and an invalid element is reported as `invalid-date-format` with `listIndex` metadata identifying the offending value. List elements are reported for manual correction (not auto-fixed); only scalar date values are auto-normalized.
 
+An empty or whitespace-only date value is treated as **unset**, not as an invalid date — the same convention every optional field follows (an empty optional field never produces a format/type issue). So an optional `date` field stored as `""` produces no `invalid-date-format` issue, matching what `bwrb new`/`bwrb edit` accept on write. An empty **required** date is reported once as [`empty-string-required`](#issue-codes) (consistent with every other required field), and an empty **element** inside a date list is reported once as `invalid-list-element` — never additionally as `invalid-date-format`.
+
 ## Examples
 
 ### Basic Auditing

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -538,6 +538,14 @@ export async function auditFile(
       const checkDateElement = (element: unknown, listIndex?: number) => {
         if (typeof element !== 'string' && typeof element !== 'number') return;
 
+        // An empty/blank string is "unset", not an invalid date. This mirrors the
+        // write path (validateFrontmatter treats `''` as no value) and how other
+        // optional fields behave (e.g. empty selects are skipped). A *required*
+        // empty date is reported once as `empty-string-required`; an empty list
+        // element is reported once as `invalid-list-element`. Skipping here keeps
+        // write and audit in agreement and avoids double-reporting (#614).
+        if (typeof element === 'string' && element.trim().length === 0) return;
+
         // A bare year (e.g. 2026) is parsed as a number by YAML; treat it as a
         // partial date string for validation.
         const dateStr = String(element);

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -3304,6 +3304,155 @@ deadline: 2026/1/2
       expect(dateIssue.meta).toMatchObject({ normalized: '2026-01-02' });
     });
 
+    it('should not flag an empty optional date as invalid-date-format (#614)', async () => {
+      // Repro for #614: the write path accepts an empty-string optional date and
+      // stores `deadline: ""`. Audit must agree and treat it as "unset" rather
+      // than reporting an invalid date format.
+      await mkdir(join(tempVaultDir, 'Objectives/Tasks'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, 'Objectives/Tasks', 'Empty Deadline.md'),
+        `---
+type: task
+status: backlog
+deadline: ""
+---
+`
+      );
+
+      const result = await runCLI(['audit', 'task', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(result.stdout);
+      const file = output.files.find((f: { path: string }) => f.path.includes('Empty Deadline.md'));
+
+      if (file) {
+        const dateIssue = file.issues.find((i: { code: string }) => i.code === 'invalid-date-format');
+        expect(dateIssue).toBeUndefined();
+      }
+    });
+
+    it('should not flag a blank (whitespace) optional date as invalid-date-format', async () => {
+      await mkdir(join(tempVaultDir, 'Objectives/Tasks'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, 'Objectives/Tasks', 'Blank Deadline.md'),
+        `---
+type: task
+status: backlog
+deadline: "   "
+---
+`
+      );
+
+      const result = await runCLI(['audit', 'task', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(result.stdout);
+      const file = output.files.find((f: { path: string }) => f.path.includes('Blank Deadline.md'));
+
+      if (file) {
+        const dateIssue = file.issues.find((i: { code: string }) => i.code === 'invalid-date-format');
+        expect(dateIssue).toBeUndefined();
+      }
+    });
+
+    it('should still flag a non-empty malformed optional date', async () => {
+      await mkdir(join(tempVaultDir, 'Objectives/Tasks'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, 'Objectives/Tasks', 'Garbage Deadline.md'),
+        `---
+type: task
+status: backlog
+deadline: "not-a-date"
+---
+`
+      );
+
+      const result = await runCLI(['audit', 'task', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(result.stdout);
+      const file = output.files.find((f: { path: string }) => f.path.includes('Garbage Deadline.md'));
+      expect(file).toBeDefined();
+      const dateIssue = file.issues.find((i: { code: string }) => i.code === 'invalid-date-format');
+      expect(dateIssue).toBeDefined();
+    });
+
+    it('should report an empty required date once as empty-string-required, not invalid-date-format', async () => {
+      // A required empty date should follow the same "missing required" path as
+      // any other required field — exactly one issue, and not a bogus format
+      // error.
+      const schema = {
+        ...TEST_SCHEMA,
+        types: {
+          ...TEST_SCHEMA.types,
+          dated: {
+            output_dir: 'Dated',
+            fields: {
+              type: { value: 'dated' },
+              when: { prompt: 'date', required: true },
+            },
+            field_order: ['type', 'when'],
+          },
+        },
+      };
+      await writeFile(join(tempVaultDir, '.bwrb', 'schema.json'), JSON.stringify(schema, null, 2));
+      await mkdir(join(tempVaultDir, 'Dated'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, 'Dated', 'No When.md'),
+        `---
+type: dated
+when: ""
+---
+`
+      );
+
+      const result = await runCLI(['audit', 'dated', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(result.stdout);
+      const file = output.files.find((f: { path: string }) => f.path.includes('No When.md'));
+      expect(file).toBeDefined();
+      const emptyRequired = file.issues.filter((i: { code: string }) => i.code === 'empty-string-required');
+      const dateIssues = file.issues.filter((i: { code: string }) => i.code === 'invalid-date-format');
+      expect(emptyRequired).toHaveLength(1);
+      expect(dateIssues).toHaveLength(0);
+    });
+
+    it('should report an empty element in a date list once (as invalid-list-element, not invalid-date-format)', async () => {
+      // Coordinates with #640/#641: empty list elements are surfaced by the list
+      // integrity checker. The per-element date check must skip them so they are
+      // not double-reported as invalid-date-format.
+      const schema = {
+        ...TEST_SCHEMA,
+        types: {
+          ...TEST_SCHEMA.types,
+          dated: {
+            output_dir: 'Dated',
+            fields: {
+              type: { value: 'dated' },
+              dates: { prompt: 'date', multiple: true },
+            },
+            field_order: ['type', 'dates'],
+          },
+        },
+      };
+      await writeFile(join(tempVaultDir, '.bwrb', 'schema.json'), JSON.stringify(schema, null, 2));
+      await mkdir(join(tempVaultDir, 'Dated'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, 'Dated', 'Date List.md'),
+        `---
+type: dated
+dates:
+  - "2026-01-01"
+  - ""
+  - "2026-02-01"
+---
+`
+      );
+
+      const result = await runCLI(['audit', 'dated', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(result.stdout);
+      const file = output.files.find((f: { path: string }) => f.path.includes('Date List.md'));
+      expect(file).toBeDefined();
+      const dateIssues = file.issues.filter((i: { code: string }) => i.code === 'invalid-date-format');
+      expect(dateIssues).toHaveLength(0);
+      const listIssues = file.issues.filter((i: { code: string }) => i.code === 'invalid-list-element');
+      expect(listIssues).toHaveLength(1);
+      expect(listIssues[0].listIndex).toBe(1);
+    });
+
     it('should detect empty required values as empty-string-required', async () => {
       await writeFile(
         join(tempVaultDir, 'Ideas', 'Empty Status.md'),


### PR DESCRIPTION
## Problem

`bwrb new`/`bwrb edit` accept an empty-string value for an optional date field and store `deadline: ""`, but `bwrb audit` then reported `Invalid date for deadline: must be YYYY-MM-DD`. Write and audit disagreed for empty strings.

Repro:
```
bwrb new task --json '{"name":"x","deadline":""}'
bwrb audit task   # => Invalid date for deadline (before this fix)
```

## Convention found + canonical rule

An **empty string in an optional field is "unset"** everywhere in the codebase:
- Write path: `validateFrontmatter` computes `hasValue = value !== '' && ...`, so empty strings skip all type/option/date validation (the value is still stored as `""`, same as other optional fields).
- Audit: optional empty text/number/select fields produce no issue (e.g. the select-option check explicitly `continue`s on a blank string).

Dates were the lone exception: the per-element date checker in `src/lib/audit/detection.ts` did not skip blank strings, so an empty date got flagged as `invalid-date-format`.

**Canonical rule (now applied to dates too):** an empty or whitespace-only date value is treated as unset, not as an invalid date. Fixed on the **audit side** (the write side already agreed).

This keeps all three cases consistent and double-report-free:
- **Optional empty date** → no issue (matches write; the #614 repro).
- **Required empty date** → reported once as `empty-string-required` — the same path as every other required field, not a bogus format error.
- **Empty element in a `multiple` date list** → reported once as `invalid-list-element` (coordinates with #640/#641), never additionally as `invalid-date-format`. This also removes a latent double-report that existed before.

Non-empty malformed dates are unaffected and still flagged.

## Tests

Added to `tests/ts/commands/audit.test.ts`:
- empty optional date → audit clean (core repro)
- blank/whitespace optional date → clean
- non-empty malformed optional date → still flagged
- required empty date → exactly one `empty-string-required`, zero `invalid-date-format`
- empty element in a date list → exactly one `invalid-list-element`, zero `invalid-date-format`

## Docs

Updated the audit reference (`docs-site/.../reference/commands/audit.md`) to document the empty-date-is-unset rule. `pnpm docs:build` passes.

## Quality gates

- `pnpm qa` ✅ (2350 passed)
- `pnpm knip` ✅
- `pnpm docs:build` ✅
- Verified the end-to-end CLI repro: `new` writes `deadline: ""`, `audit` reports `No issues found`.

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)