### PR TITLE
fix(schema): reconcile schema.schema.json with the Zod/loader contract (#626)

### DIFF
--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -4,7 +4,9 @@
   "title": "Bowerbird Schema",
   "description": "Schema for defining types, fields, and configuration for markdown vaults",
   "type": "object",
-  "required": ["types"],
+  "required": [
+    "types"
+  ],
   "additionalProperties": false,
   "properties": {
     "$schema": {
@@ -23,6 +25,13 @@
     "config": {
       "$ref": "#/definitions/config"
     },
+    "traits": {
+      "type": "object",
+      "description": "Reusable field bundles composed into types via each type's `traits` array. Composition (`also-has`) alongside `extends` inheritance (`is-a`). Optional; schemas without traits are unchanged.",
+      "additionalProperties": {
+        "$ref": "#/definitions/trait"
+      }
+    },
     "types": {
       "type": "object",
       "description": "Type definitions with inheritance support",
@@ -35,6 +44,52 @@
     }
   },
   "definitions": {
+    "trait": {
+      "type": "object",
+      "description": "A reusable bundle of fields composed into a type. Traits are flat: they carry only fields (and an optional description, plus an optional recurrence block) and cannot extend types or compose other traits.",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this trait bundles and when to use it. Surfaced by `bwrb schema list`."
+        },
+        "fields": {
+          "type": "object",
+          "description": "Field definitions contributed by this trait",
+          "additionalProperties": {
+            "$ref": "#/definitions/frontmatterField"
+          }
+        },
+        "recurrence": {
+          "$ref": "#/definitions/recurrence"
+        }
+      }
+    },
+    "recurrence": {
+      "type": "object",
+      "description": "Event-driven, spawn-on-transition recurrence (#107). When a field transitions into a value (e.g. status enters done), spawn a successor note from a template, offsetting the successor's date field from a predecessor date field. No cron, no daemon, no LLM.",
+      "additionalProperties": false,
+      "required": [
+        "on"
+      ],
+      "properties": {
+        "on": {
+          "type": "string",
+          "description": "Trigger transition, written as `<field> = <value>` (e.g. \"status = done\"). The successor is spawned when the trigger field transitions INTO this value."
+        },
+        "template": {
+          "type": "string",
+          "description": "Template to spawn the successor from. Defaults to the completed note's type default template (a task begets a task). A named template can spawn a different type (finish \"draft\" -> spawn \"review\")."
+        },
+        "set": {
+          "type": "object",
+          "description": "Field-offset assignments for the successor. Each value is a field-offset expression `<dateField> <+|-> <duration>` (e.g. \"deadline + 7d\"). The base must be a date field on the predecessor. Transition-time offsets and calendar-anchored bases are not supported.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "config": {
       "type": "object",
       "description": "Vault-wide configuration options",
@@ -42,7 +97,10 @@
       "properties": {
         "link_format": {
           "type": "string",
-          "enum": ["wikilink", "markdown"],
+          "enum": [
+            "wikilink",
+            "markdown"
+          ],
           "default": "wikilink",
           "description": "Link format for relation fields: wikilink (\"[[Note]]\") or markdown (\"[Note](Note.md)\")"
         },
@@ -56,7 +114,12 @@
         },
         "open_with": {
           "type": "string",
-          "enum": ["system", "editor", "visual", "obsidian"],
+          "enum": [
+            "system",
+            "editor",
+            "visual",
+            "obsidian"
+          ],
           "default": "system",
           "description": "Default behavior for --open flag"
         },
@@ -66,23 +129,29 @@
         },
         "default_dashboard": {
           "type": "string",
-          "description": "Default dashboard to run when `bwrb dashboard` is called without arguments"
+          "description": "Dashboard to run when `bwrb dashboard` is called without arguments"
         },
         "excluded_directories": {
           "type": "array",
-          "items": { "type": "string" },
-          "description": "Vault-root-relative directory prefixes excluded from all discovery/targeting"
+          "items": {
+            "type": "string"
+          },
+          "description": "Vault-root-relative directory prefixes excluded from all discovery/targeting operations (e.g., \"Archive\", \"Templates\")"
         },
         "date_format": {
           "type": "string",
           "default": "YYYY-MM-DD",
-          "description": "Display/parse format for date fields (YYYY, MM, DD tokens), e.g. MM/DD/YYYY"
+          "description": "Date format for date fields (YYYY, MM, DD tokens), e.g. YYYY-MM-DD (default), MM/DD/YYYY, DD-MM-YYYY"
         },
         "date_granularity": {
           "type": "string",
-          "enum": ["day", "month", "year"],
+          "enum": [
+            "day",
+            "month",
+            "year"
+          ],
           "default": "day",
-          "description": "Default coarsest date precision for all date fields; per-field `granularity` overrides it"
+          "description": "Default coarsest date precision allowed for all date fields (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Per-field `granularity` overrides this default."
         }
       }
     },
@@ -93,40 +162,57 @@
       "properties": {
         "ignored_directories": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Directories to skip during audit"
         },
         "allowed_extra_fields": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Extra frontmatter fields that are allowed without warning"
         }
       }
     },
     "typeNode": {
       "type": "object",
-      "description": "Type definition with inheritance support",
+      "description": "Type definition with inheritance support. Flat v2 model: `extends` for is-a inheritance, `traits` for also-has composition, `fields` (not `frontmatter`) for field definitions. All properties are optional.",
       "additionalProperties": false,
       "properties": {
         "extends": {
           "type": "string",
-          "description": "Parent type name (implicit 'meta' if not specified)"
+          "description": "Parent type name (implicit 'meta' if not specified). Single-parent is-a inheritance."
+        },
+        "traits": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Trait names composed into this type (composition alongside `extends`). Precedence: own fields > traits > inherited; later traits in the array win over earlier ones."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this type is for and when to use it. Surfaced by `bwrb schema list`."
         },
         "fields": {
           "type": "object",
-          "description": "Field definitions (merged with ancestors at load time)",
+          "description": "Field definitions, merged with ancestors and traits at load time",
           "additionalProperties": {
-            "$ref": "#/definitions/field"
+            "$ref": "#/definitions/frontmatterField"
           }
         },
         "field_order": {
           "type": "array",
-          "items": { "type": "string" },
-          "description": "Explicit field ordering (optional - defaults to definition order)"
+          "items": {
+            "type": "string"
+          },
+          "description": "Explicit field ordering (optional; defaults to definition order)"
         },
         "body_sections": {
           "type": "array",
-          "description": "Body section definitions",
+          "description": "Body section definitions generated after frontmatter",
           "items": {
             "$ref": "#/definitions/bodySection"
           }
@@ -137,7 +223,7 @@
         },
         "output_dir": {
           "type": "string",
-          "description": "Output directory (computed from hierarchy if not specified)"
+          "description": "Directory path relative to vault root where files of this type are created (computed from hierarchy if not specified)"
         },
         "filename": {
           "type": "string",
@@ -145,40 +231,89 @@
         },
         "plural": {
           "type": "string",
-          "description": "Custom plural form for folder naming (e.g., 'research' instead of 'researches')"
+          "description": "Custom plural form for folder naming (e.g., 'research' instead of 'researches'). Auto-pluralized if not specified."
         }
       }
     },
-    "field": {
+    "frontmatterField": {
       "type": "object",
-      "description": "Field definition for type frontmatter",
       "additionalProperties": false,
       "properties": {
+        "value": {
+          "type": "string",
+          "description": "Static value (use $NOW for current datetime, $TODAY for date)"
+        },
         "prompt": {
           "type": "string",
-          "enum": ["text", "select", "list", "date", "relation", "boolean", "number"],
-          "description": "Prompt type (how the field is collected)"
+          "enum": [
+            "text",
+            "select",
+            "relation",
+            "list",
+            "date",
+            "boolean",
+            "number"
+          ],
+          "description": "Type of prompt: text (free text), select (from enum), relation (from vault query), list (comma-separated list), date (date picker), boolean (yes/no), number (numeric input)"
         },
         "granularity": {
           "type": "string",
-          "enum": ["day", "month", "year"],
-          "description": "Coarsest date precision allowed for date fields (day=full YYYY-MM-DD, month=YYYY-MM, year=YYYY); overrides config.date_granularity"
+          "enum": [
+            "day",
+            "month",
+            "year"
+          ],
+          "description": "Coarsest date precision allowed for this `date` field, finer is always allowed (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Overrides the global config.date_granularity for this field."
         },
-        "value": {
+        "label": {
           "type": "string",
-          "description": "Static value (no prompting)"
+          "description": "Label shown to user for input prompts (the imperative prompt text, e.g. \"Select status\"). Distinct from `description`, which explains what the field is for."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this field is for and when to use it. Surfaced by `bwrb schema list`; distinct from `label`."
         },
         "options": {
           "type": "array",
-          "items": { "type": "string" },
-          "description": "Inline options for select prompts"
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "The option value stored in frontmatter"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "What this option means / when to choose it"
+                  }
+                }
+              }
+            ]
+          },
+          "description": "Allowed values for select fields (inline options). Each entry is a bare value or a { value, description } pair that documents what the option means."
         },
         "source": {
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ],
-          "description": "Type name(s) for relation prompts"
+          "description": "Type name(s) for relation prompts. When a relation's value is ambiguous because two notes share a name, path-qualify the link (e.g. `[[contexts/Betson]]`); see the search command docs for the shortest-unambiguous-form rule.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         },
         "filter": {
           "type": "object",
@@ -187,39 +322,51 @@
             "$ref": "#/definitions/filterCondition"
           }
         },
-        "required": {
-          "type": "boolean",
-          "description": "Whether the field is required"
-        },
-        "default": {
-          "oneOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ],
-          "description": "Default value"
-        },
-        "list_format": {
-          "type": "string",
-          "enum": ["yaml-array", "comma-separated"],
-          "description": "How list values are formatted in YAML"
-        },
-        "label": {
-          "type": "string",
-          "description": "Prompt label override"
-        },
         "multiple": {
           "type": "boolean",
-          "description": "Whether this field can hold multiple values (for context fields)"
+          "description": "Whether this field can hold multiple values"
         },
         "owned": {
           "type": "boolean",
           "description": "Whether children referenced by this field are owned (colocate with parent)"
+        },
+        "alias": {
+          "type": "boolean",
+          "description": "Field role: marks this field as holding the entity's aliases (alternate names). bwrb consults aliases during name resolution and linking, so an entity is findable by its aliases wherever it is findable by its name. The value must be an array of non-empty, unique strings (Obsidian `aliases` format)."
+        },
+        "default": {
+          "description": "Default value if user skips the prompt",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether this field is required (user cannot skip)"
+        },
+        "list_format": {
+          "type": "string",
+          "enum": [
+            "yaml-array",
+            "comma-separated"
+          ],
+          "description": "For list fields, how to format the list"
         }
       }
     },
     "bodySection": {
       "type": "object",
-      "required": ["title"],
+      "required": [
+        "title"
+      ],
       "additionalProperties": false,
       "properties": {
         "title": {
@@ -235,13 +382,21 @@
         },
         "content_type": {
           "type": "string",
-          "enum": ["none", "paragraphs", "bullets", "checkboxes"],
+          "enum": [
+            "none",
+            "paragraphs",
+            "bullets",
+            "checkboxes"
+          ],
           "default": "none",
           "description": "Type of content placeholder to add"
         },
         "prompt": {
           "type": "string",
-          "enum": ["none", "list"],
+          "enum": [
+            "none",
+            "list"
+          ],
           "description": "If set, prompts user for initial content during creation"
         },
         "prompt_label": {
@@ -271,12 +426,16 @@
         },
         "in": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Field must be one of these values"
         },
         "not_in": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Field must not be one of these values"
         }
       }

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -24,7 +24,7 @@ my-vault/
 
 ```json
 {
-  "$schema": "https://bwrb.dev/schema.schema.json",
+  "$schema": "https://bwrb.dev/schema.json",
   "version": 2,
   "schemaVersion": "1.0.0",
   "traits": { ... },
@@ -717,7 +717,7 @@ Add `$schema` to your schema file for editor autocomplete and validation:
 
 ```json
 {
-  "$schema": "https://bwrb.dev/schema.schema.json",
+  "$schema": "https://bwrb.dev/schema.json",
   "types": { ... }
 }
 ```
@@ -737,7 +737,7 @@ If the URL isn't reachable, configure the schema manually in `.vscode/settings.j
 }
 ```
 
-Or reference a local copy of `schema.schema.json` from the bwrb repository.
+Or reference a local copy of `schema.schema.json` (shipped with the `bwrb` package) from the bwrb repository.
 
 ### Neovim
 
@@ -750,7 +750,7 @@ require('lspconfig').jsonls.setup({
       schemas = {
         {
           fileMatch = { "*/.bwrb/schema.json" },
-          url = "https://bwrb.dev/schema.schema.json"
+          url = "https://bwrb.dev/schema.json"
         }
       }
     }
@@ -766,7 +766,7 @@ A full schema demonstrating inheritance, relations, body sections, and config:
 
 ```json
 {
-  "$schema": "https://bwrb.dev/schema.schema.json",
+  "$schema": "https://bwrb.dev/schema.json",
   "version": 2,
   "schemaVersion": "1.0.0",
   

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "files": [
     "dist/**",
+    "schema.schema.json",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -117,9 +117,21 @@
           "type": "string",
           "description": "Dashboard to run when `bwrb dashboard` is called without arguments"
         },
+        "excluded_directories": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Vault-root-relative directory prefixes excluded from all discovery/targeting operations (e.g., \"Archive\", \"Templates\")"
+        },
         "date_format": {
           "type": "string",
-          "description": "Date format for date fields (defaults to YYYY-MM-DD)"
+          "default": "YYYY-MM-DD",
+          "description": "Date format for date fields (YYYY, MM, DD tokens), e.g. YYYY-MM-DD (default), MM/DD/YYYY, DD-MM-YYYY"
+        },
+        "date_granularity": {
+          "type": "string",
+          "enum": ["day", "month", "year"],
+          "default": "day",
+          "description": "Default coarsest date precision allowed for all date fields (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Per-field `granularity` overrides this default."
         }
       }
     },
@@ -140,96 +152,58 @@
         }
       }
     },
-    "typeDefinition": {
-      "type": "object",
-      "required": ["output_dir", "frontmatter"],
-      "additionalProperties": false,
-      "properties": {
-        "output_dir": {
-          "type": "string",
-          "description": "Directory path relative to vault root where files of this type are created"
-        },
-        "filename": {
-          "type": "string",
-          "description": "Filename pattern"
-        },
-        "frontmatter": {
-          "type": "object",
-          "description": "Frontmatter field definitions in order",
-          "additionalProperties": {
-            "$ref": "#/definitions/frontmatterField"
-          }
-        },
-        "frontmatter_order": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "Order of frontmatter fields (keys from frontmatter object)"
-        },
-        "body_sections": {
-          "type": "array",
-          "description": "Body sections to generate after frontmatter",
-          "items": {
-            "$ref": "#/definitions/bodySection"
-          }
-        }
-      }
-    },
     "typeNode": {
       "type": "object",
-      "description": "Recursive type family or leaf definition",
+      "description": "Type definition with inheritance support. Flat v2 model: `extends` for is-a inheritance, `traits` for also-has composition, `fields` (not `frontmatter`) for field definitions. All properties are optional.",
       "additionalProperties": false,
       "properties": {
-        "subtypes": {
-          "type": "object",
-          "description": "Nested subtype map",
-          "additionalProperties": {
-            "$ref": "#/definitions/typeNode"
-          }
-        },
-        "output_dir": { "type": "string" },
-        "filename": { "type": "string", "description": "Filename pattern" },
-        "frontmatter": {
-          "$ref": "#/definitions/typeDefinition/properties/frontmatter"
-        },
-        "frontmatter_order": { "type": "array", "items": { "type": "string" } },
-        "body_sections": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/bodySection" }
-        },
-        "plural": {
-          "type": "string",
-          "description": "Custom plural form for folder naming (e.g., 'research' instead of 'researches')"
-        },
         "extends": {
           "type": "string",
-          "description": "Parent type name (v2 inheritance model)"
+          "description": "Parent type name (implicit 'meta' if not specified). Single-parent is-a inheritance."
         },
         "traits": {
           "type": "array",
           "items": { "type": "string" },
           "description": "Trait names composed into this type (composition alongside `extends`). Precedence: own fields > traits > inherited; later traits in the array win over earlier ones."
         },
-        "fields": {
-          "type": "object",
-          "description": "Field definitions (v2 model, replaces frontmatter)",
-          "additionalProperties": {
-            "$ref": "#/definitions/frontmatterField"
-          }
-        },
-        "field_order": { "type": "array", "items": { "type": "string" }, "description": "Field ordering (v2 model)" },
         "description": {
           "type": "string",
           "description": "Human-readable description of what this type is for and when to use it. Surfaced by `bwrb schema list`."
         },
-        "recursive": { "type": "boolean", "description": "Whether this type can contain instances of itself" }
-      },
-      "anyOf": [
-        { "required": ["subtypes"] },
-        { "required": ["output_dir", "frontmatter"] },
-        { "required": ["extends"] },
-        { "required": ["fields"] },
-        { "required": ["traits"] }
-      ]
+        "fields": {
+          "type": "object",
+          "description": "Field definitions, merged with ancestors and traits at load time",
+          "additionalProperties": {
+            "$ref": "#/definitions/frontmatterField"
+          }
+        },
+        "field_order": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Explicit field ordering (optional; defaults to definition order)"
+        },
+        "body_sections": {
+          "type": "array",
+          "description": "Body section definitions generated after frontmatter",
+          "items": { "$ref": "#/definitions/bodySection" }
+        },
+        "recursive": {
+          "type": "boolean",
+          "description": "Whether this type can contain instances of itself"
+        },
+        "output_dir": {
+          "type": "string",
+          "description": "Directory path relative to vault root where files of this type are created (computed from hierarchy if not specified)"
+        },
+        "filename": {
+          "type": "string",
+          "description": "Filename pattern"
+        },
+        "plural": {
+          "type": "string",
+          "description": "Custom plural form for folder naming (e.g., 'research' instead of 'researches'). Auto-pluralized if not specified."
+        }
+      }
     },
     "frontmatterField": {
       "type": "object",
@@ -243,6 +217,11 @@
           "type": "string",
           "enum": ["text", "select", "relation", "list", "date", "boolean", "number"],
           "description": "Type of prompt: text (free text), select (from enum), relation (from vault query), list (comma-separated list), date (date picker), boolean (yes/no), number (numeric input)"
+        },
+        "granularity": {
+          "type": "string",
+          "enum": ["day", "month", "year"],
+          "description": "Coarsest date precision allowed for this `date` field, finer is always allowed (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Overrides the global config.date_granularity for this field."
         },
         "label": {
           "type": "string",

--- a/tests/fixtures/vault/.bwrb/schema.json
+++ b/tests/fixtures/vault/.bwrb/schema.json
@@ -23,8 +23,7 @@
         "milestone": {
           "prompt": "relation",
           "source": "milestone",
-          "filter": { "status": { "not_in": ["settled"] } },
-          "format": "quoted-wikilink"
+          "filter": { "status": { "not_in": ["settled"] } }
         },
         "creation-date": { "value": "$NOW" },
         "deadline": { "prompt": "date", "label": "Deadline (YYYY-MM-DD)" },

--- a/tests/ts/lib/schema-schema-drift.test.ts
+++ b/tests/ts/lib/schema-schema-drift.test.ts
@@ -2,15 +2,119 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { readFile } from 'node:fs/promises';
 
 /**
- * Regression guard for Issue #247.
- * Ensures `schema.schema.json` matches runtime Zod behavior for key fields.
+ * Minimal, dependency-free JSON Schema (draft-07 subset) validator.
+ *
+ * `schema.schema.json` only uses a small slice of draft-07: `type`,
+ * `properties`, `additionalProperties` (bool or schema), `required`, `enum`,
+ * `items`, `anyOf`/`oneOf`, and local `$ref`. A bespoke validator keeps this
+ * drift guard free of runtime dependencies while still mechanically checking
+ * that real vault schemas satisfy (and that legacy shapes are rejected by) the
+ * published JSON Schema.
+ */
+function makeValidator(root: any) {
+  const resolveRef = (ref: string): any => {
+    if (!ref.startsWith('#/')) throw new Error(`unsupported $ref: ${ref}`);
+    let node = root;
+    for (const seg of ref.slice(2).split('/')) {
+      node = node[seg];
+      if (node === undefined) throw new Error(`unresolved $ref: ${ref}`);
+    }
+    return node;
+  };
+
+  const typeOf = (v: unknown): string => {
+    if (v === null) return 'null';
+    if (Array.isArray(v)) return 'array';
+    if (Number.isInteger(v)) return 'integer';
+    return typeof v;
+  };
+
+  const matchesType = (expected: string, v: unknown): boolean => {
+    const actual = typeOf(v);
+    if (expected === 'number') return actual === 'number' || actual === 'integer';
+    if (expected === 'integer') return actual === 'integer';
+    return actual === expected;
+  };
+
+  const check = (schema: any, value: unknown, path: string, errors: string[]): void => {
+    if (schema.$ref) {
+      check(resolveRef(schema.$ref), value, path, errors);
+      return;
+    }
+    if (schema.anyOf) {
+      const ok = schema.anyOf.some((s: any) => {
+        const sub: string[] = [];
+        check(s, value, path, sub);
+        return sub.length === 0;
+      });
+      if (!ok) errors.push(`${path}: did not match anyOf`);
+      return;
+    }
+    if (schema.oneOf) {
+      const matches = schema.oneOf.filter((s: any) => {
+        const sub: string[] = [];
+        check(s, value, path, sub);
+        return sub.length === 0;
+      });
+      if (matches.length !== 1) errors.push(`${path}: matched ${matches.length} oneOf branches`);
+      return;
+    }
+    if (schema.type && !matchesType(schema.type, value)) {
+      errors.push(`${path}: expected ${schema.type}, got ${typeOf(value)}`);
+      return;
+    }
+    if (schema.enum && !schema.enum.includes(value as never)) {
+      errors.push(`${path}: ${JSON.stringify(value)} not in enum`);
+    }
+    if (schema.type === 'object' && typeOf(value) === 'object') {
+      const obj = value as Record<string, unknown>;
+      for (const req of schema.required ?? []) {
+        if (!(req in obj)) errors.push(`${path}: missing required "${req}"`);
+      }
+      for (const [k, v] of Object.entries(obj)) {
+        const propSchema = schema.properties?.[k];
+        if (propSchema) {
+          check(propSchema, v, `${path}/${k}`, errors);
+        } else if (schema.additionalProperties === false) {
+          errors.push(`${path}: additional property "${k}" not allowed`);
+        } else if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+          check(schema.additionalProperties, v, `${path}/${k}`, errors);
+        }
+      }
+    }
+    if (schema.type === 'array' && Array.isArray(value) && schema.items) {
+      value.forEach((item, i) => check(schema.items, item, `${path}[${i}]`, errors));
+    }
+  };
+
+  return (value: unknown): { ok: boolean; errors: string[] } => {
+    const errors: string[] = [];
+    check(root, value, '#', errors);
+    return { ok: errors.length === 0, errors };
+  };
+}
+
+/**
+ * Regression guard for Issues #247 and #626.
+ *
+ * `schema.schema.json` is the hand-maintained JSON Schema users point their
+ * editor's JSON LSP at. It is NOT generated from the Zod schema, so it can
+ * silently drift from the real runtime contract in `src/types/schema.ts` /
+ * `src/lib/schema.ts`. These guards mechanically assert the two agree on the
+ * points #626 raised (type definitions use `fields`, not `frontmatter`;
+ * `config.date_granularity` and field-level `granularity` exist) and, more
+ * generally, that a real `fields`-based vault schema validates against it.
  */
 describe('schema.schema.json drift guards', () => {
   let metaSchema: any;
+  let docsSchema: any;
 
   beforeAll(async () => {
     const schemaUrl = new URL('../../../schema.schema.json', import.meta.url);
     metaSchema = JSON.parse(await readFile(schemaUrl, 'utf-8'));
+    // The published copy users actually fetch from the docs site.
+    const docsUrl = new URL('../../../docs-site/public/schema.json', import.meta.url);
+    docsSchema = JSON.parse(await readFile(docsUrl, 'utf-8'));
   });
 
   it('includes config.open_with system option and default', () => {
@@ -31,6 +135,22 @@ describe('schema.schema.json drift guards', () => {
 
     expect(configProps.date_format).toBeDefined();
     expect(configProps.date_format.type).toBe('string');
+  });
+
+  // --- #626: config.date_granularity must exist (Zod ConfigSchema.date_granularity) ---
+  it('exposes config.date_granularity with the day/month/year enum (#626)', () => {
+    const granularity = metaSchema.definitions.config.properties.date_granularity;
+    expect(granularity).toBeDefined();
+    expect(granularity.type).toBe('string');
+    expect(granularity.enum).toEqual(expect.arrayContaining(['day', 'month', 'year']));
+  });
+
+  // --- #626: field-level granularity must exist (Zod FieldSchema.granularity) ---
+  it('exposes field-level granularity with the day/month/year enum (#626)', () => {
+    const granularity = metaSchema.definitions.frontmatterField.properties.granularity;
+    expect(granularity).toBeDefined();
+    expect(granularity.type).toBe('string');
+    expect(granularity.enum).toEqual(expect.arrayContaining(['day', 'month', 'year']));
   });
 
   it('allows array forms for relation field.source and field.default', () => {
@@ -82,19 +202,6 @@ describe('schema.schema.json drift guards', () => {
     expect(trait.properties.description).toBeDefined();
   });
 
-  it('lets a type compose traits via a string array', () => {
-    const traitsProp = metaSchema.definitions.typeNode.properties.traits;
-    expect(traitsProp).toBeDefined();
-    expect(traitsProp.type).toBe('array');
-    expect(traitsProp.items.type).toBe('string');
-
-    // A type may be defined with traits alone (no extends/fields/subtypes).
-    const anyOf = metaSchema.definitions.typeNode.anyOf;
-    expect(anyOf).toEqual(
-      expect.arrayContaining([{ required: ['traits'] }])
-    );
-  });
-
   it('exposes a recurrence block on the trait definition (#107)', () => {
     const trait = metaSchema.definitions.trait;
     expect(trait.properties.recurrence).toBeDefined();
@@ -110,13 +217,128 @@ describe('schema.schema.json drift guards', () => {
     expect(recurrence.properties.set.additionalProperties.type).toBe('string');
   });
 
-  it('includes filename on type definitions', () => {
-    const typeDefProps = metaSchema.definitions.typeDefinition.properties;
-    expect(typeDefProps.filename).toBeDefined();
-    expect(typeDefProps.filename.type).toBe('string');
+  // --- #626 core: type definitions use the flat v2 `fields` contract ---
+  describe('type definitions match the flat v2 loader contract (#626)', () => {
+    it('a type composes traits via a string array', () => {
+      const traitsProp = metaSchema.definitions.typeNode.properties.traits;
+      expect(traitsProp).toBeDefined();
+      expect(traitsProp.type).toBe('array');
+      expect(traitsProp.items.type).toBe('string');
+    });
 
+    it('typeNode exposes `fields` (not the legacy `frontmatter`) keyed by field defs', () => {
+      const props = metaSchema.definitions.typeNode.properties;
+      expect(props.fields).toBeDefined();
+      expect(props.fields.additionalProperties.$ref).toBe('#/definitions/frontmatterField');
+      // The loader reads `fields`; the legacy `frontmatter` shape must be gone.
+      expect(props.frontmatter).toBeUndefined();
+      expect(props.frontmatter_order).toBeUndefined();
+      expect(props.subtypes).toBeUndefined();
+    });
+
+    it('does NOT mark `frontmatter`/`output_dir` as required anywhere (#626)', () => {
+      // The old typeDefinition demanded ["output_dir", "frontmatter"]; the Zod
+      // TypeSchema requires neither (all properties optional).
+      expect(metaSchema.definitions.typeDefinition).toBeUndefined();
+      const typeNode = metaSchema.definitions.typeNode;
+      const required = typeNode.required ?? [];
+      expect(required).not.toContain('frontmatter');
+      // No anyOf branch may demand the legacy frontmatter pairing.
+      const anyOf = typeNode.anyOf ?? [];
+      for (const branch of anyOf) {
+        expect(branch.required ?? []).not.toContain('frontmatter');
+      }
+    });
+
+    it('typeNode carries the full flat v2 property set from the Zod TypeSchema', () => {
+      const props = metaSchema.definitions.typeNode.properties;
+      for (const key of [
+        'extends',
+        'traits',
+        'description',
+        'fields',
+        'field_order',
+        'body_sections',
+        'recursive',
+        'output_dir',
+        'filename',
+        'plural',
+      ]) {
+        expect(props[key], `typeNode missing v2 property "${key}"`).toBeDefined();
+      }
+    });
+  });
+
+  it('includes filename on type definitions', () => {
     const typeNodeProps = metaSchema.definitions.typeNode.properties;
     expect(typeNodeProps.filename).toBeDefined();
     expect(typeNodeProps.filename.type).toBe('string');
+  });
+
+  // --- The published docs-site copy must not drift from the root schema ---
+  it('docs-site/public/schema.json matches schema.schema.json (modulo $id)', () => {
+    const stripId = (s: any) => {
+      const { $id, ...rest } = s;
+      return rest;
+    };
+    expect(stripId(docsSchema)).toEqual(stripId(metaSchema));
+  });
+
+  // --- End-to-end: a real fields-based vault schema validates against the JSON Schema ---
+  describe('real vault schemas validate against the JSON Schema', () => {
+    let validate: ReturnType<typeof makeValidator>;
+
+    beforeAll(() => {
+      validate = makeValidator(metaSchema);
+    });
+
+    it('the test fixture schema (uses `fields`) validates', async () => {
+      const fixtureUrl = new URL(
+        '../../fixtures/vault/.bwrb/schema.json',
+        import.meta.url
+      );
+      const fixture = JSON.parse(await readFile(fixtureUrl, 'utf-8'));
+      const { ok, errors } = validate(fixture);
+      if (!ok) {
+        throw new Error(
+          'fixture schema failed JSON-Schema validation:\n' + errors.join('\n')
+        );
+      }
+      expect(ok).toBe(true);
+    });
+
+    it('a fields-based schema with date_granularity/granularity validates (#626)', () => {
+      const valid = {
+        version: 2,
+        config: { date_granularity: 'day' },
+        types: {
+          task: {
+            output_dir: 'Tasks',
+            fields: {
+              status: { prompt: 'select', options: ['todo', 'done'] },
+              due: { prompt: 'date', granularity: 'month' },
+            },
+          },
+        },
+      };
+      const { ok, errors } = validate(valid);
+      expect(errors).toEqual([]);
+      expect(ok).toBe(true);
+    });
+
+    it('rejects the legacy `frontmatter`-based type shape (#626)', () => {
+      // The shape the OLD schema *demanded* — `frontmatter` instead of `fields` —
+      // must now be rejected (additionalProperties: false on typeNode).
+      const legacy = {
+        version: 2,
+        types: {
+          task: {
+            output_dir: 'Tasks',
+            frontmatter: { status: { prompt: 'text' } },
+          },
+        },
+      };
+      expect(validate(legacy).ok).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`schema.schema.json` — the hand-maintained JSON Schema users point their editor's JSON LSP at — had drifted from the real runtime contract (`src/types/schema.ts` Zod schemas / `src/lib/schema.ts` loader). This reconciles it.

### Drift found and fixed in `schema.schema.json`
- **`frontmatter` → `fields`**: the type definition demanded the legacy `frontmatter` key and required `["output_dir", "frontmatter"]`, but the v2 loader reads `fields`. Removed the dead `typeDefinition` definition and rewrote `typeNode` to the flat v2 shape (`extends`/`traits`/`description`/`fields`/`field_order`/`body_sections`/`recursive`/`output_dir`/`filename`/`plural`), dropping `frontmatter`, `frontmatter_order`, and `subtypes`. Nothing is required (matches the all-optional Zod `TypeSchema`).
- **`config.date_granularity`** (day/month/year): existed in Zod, missing from JSON Schema. Added.
- **field-level `granularity`** (day/month/year): existed in Zod, missing from JSON Schema. Added.
- **`config.excluded_directories`** and a **`date_format` default**: also missing. Added.

### Second drifted copy reconciled
`docs-site/public/schema.json` (the file actually served at bwrb.dev) had drifted the *opposite* way: it had the flat v2 model + granularity but was missing `traits`/`recurrence`/`alias`/option-objects. Synced it to be content-identical to the root schema (modulo `$id`) so both URLs serve one correct schema.

### Drift-guard test strengthened
`tests/ts/lib/schema-schema-drift.test.ts` now mechanically asserts:
- `typeNode` uses `fields` (not `frontmatter`); legacy `frontmatter`/`frontmatter_order`/`subtypes`/`typeDefinition` are gone; no `frontmatter` requirement anywhere.
- `config.date_granularity` and field-level `granularity` exist with the day/month/year enum.
- `typeNode` carries the full v2 property set.
- The docs-site copy stays content-identical to the root (modulo `$id`).
- A small dependency-free draft-07 validator confirms the real `fields`-based fixture schema **validates**, a fields-based schema using `date_granularity`/`granularity` validates, and the old `frontmatter` shape is **rejected**.

### Also
- Removed an orphan `format` key from the vault test fixture (not in the Zod field contract; silently stripped at load — surfaced by the new validator).
- Shipped `schema.schema.json` in the npm package `files` (the docs reference `node_modules/bwrb/schema.schema.json`).
- Aligned the docs' remote `$schema` URL examples with the published `https://bwrb.dev/schema.json` (what `bwrb init` writes and what is actually served).

## Verification
- `pnpm qa` (typecheck, lint, docs:lint, docs:doctor, build, test): **pass** — 2359 passed / 4 skipped.
- `pnpm knip`: **pass**.
- `pnpm docs:build`: **pass**.

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)