### PR TITLE
fix(template): type boolean/number template default prompts

### DIFF
--- a/src/lib/field-prompt.ts
+++ b/src/lib/field-prompt.ts
@@ -148,11 +148,11 @@ export async function promptField(
 
     case 'boolean':
       if (opts.mode === 'create') return promptBooleanFieldCreate(label);
-      return promptTextOrDateTemplate(label, opts);
+      return promptBooleanTemplate(label, opts);
 
     case 'number':
       if (opts.mode === 'create') return promptNumberFieldCreate(label, field);
-      return promptTextOrDateTemplate(label, opts);
+      return promptNumberTemplate(label, opts);
 
     default:
       if (opts.mode === 'create') return field.default;
@@ -348,9 +348,8 @@ async function promptNumberFieldCreate(label: string, field: Field): Promise<unk
 }
 
 /**
- * The shared text/date/default branch for the template modes. In template-default
- * mode `boolean`/`number` fields also land here (raw text prompt for the default),
- * matching the historical template behavior.
+ * The shared text/date branch for the template modes (raw text prompt for the
+ * default, honoring `(skip)` / `(keep)` / `(clear)` semantics).
  */
 async function promptTextOrDateTemplate(
   label: string,
@@ -366,6 +365,74 @@ async function promptTextOrDateTemplate(
   if (!input.trim()) return opts.currentValue;
   if (input.toLowerCase() === 'clear') return CLEAR;
   return input.trim();
+}
+
+/**
+ * Prompt for a `boolean` template default. Stores a real boolean value (not a
+ * string) while honoring the mode's `(skip)` / `(keep)` / `(clear)` semantics:
+ *
+ * - `template-default`: a `(skip)` / `true` / `false` selection. `(skip)`
+ *   returns `undefined` (no default stored).
+ * - `template-edit`: a `(keep)` / `(clear)` / `true` / `false` selection.
+ *   `(keep)` returns the current value, `(clear)` returns {@link CLEAR}.
+ */
+async function promptBooleanTemplate(
+  label: string,
+  opts: Extract<FieldPromptOptions, { mode: 'template-default' } | { mode: 'template-edit' }>
+): Promise<unknown> {
+  if (opts.mode === 'template-default') {
+    const selected = await promptSelection(`Default ${label}:`, ['(skip)', 'true', 'false']);
+    if (selected === null) throw new UserCancelledError();
+    if (selected === '(skip)') return undefined;
+    return selected === 'true';
+  }
+
+  const selected = await promptSelection(`New ${label}:`, ['(keep)', '(clear)', 'true', 'false']);
+  if (selected === null) throw new UserCancelledError();
+  if (selected === '(keep)') return opts.currentValue;
+  if (selected === '(clear)') return CLEAR;
+  return selected === 'true';
+}
+
+/**
+ * Prompt for a `number` template default. Validates input and re-prompts on an
+ * invalid number, storing a real number value (not a string) while honoring the
+ * mode's `(skip)` / `(keep)` / `(clear)` semantics:
+ *
+ * - `template-default`: an empty input skips (returns `undefined`).
+ * - `template-edit`: an empty input keeps the current value; `clear` returns
+ *   {@link CLEAR}.
+ */
+async function promptNumberTemplate(
+  label: string,
+  opts: Extract<FieldPromptOptions, { mode: 'template-default' } | { mode: 'template-edit' }>
+): Promise<unknown> {
+  while (true) {
+    if (opts.mode === 'template-default') {
+      const input = await promptInput(`Default ${label} (or Enter to skip)`);
+      if (input === null) throw new UserCancelledError();
+      const trimmed = input.trim();
+      if (!trimmed) return undefined;
+      const parsed = parseFloat(trimmed);
+      if (Number.isNaN(parsed)) {
+        printWarning(`Invalid number: "${input}". Please enter a valid number.`);
+        continue;
+      }
+      return parsed;
+    }
+
+    const input = await promptInput(`New ${label} (Enter to keep, "clear" to remove)`);
+    if (input === null) throw new UserCancelledError();
+    const trimmed = input.trim();
+    if (!trimmed) return opts.currentValue;
+    if (trimmed.toLowerCase() === 'clear') return CLEAR;
+    const parsed = parseFloat(trimmed);
+    if (Number.isNaN(parsed)) {
+      printWarning(`Invalid number: "${input}". Please enter a valid number.`);
+      continue;
+    }
+    return parsed;
+  }
 }
 
 function formatUniqueRelationValues(

--- a/tests/ts/commands/template.pty.test.ts
+++ b/tests/ts/commands/template.pty.test.ts
@@ -33,6 +33,21 @@ defaults:
 `,
 };
 
+const TYPED_DEFAULTS_IDEA_TEMPLATE: TempVaultFile = {
+  path: '.bwrb/templates/idea/typed.md',
+  content: `---
+type: template
+template-for: idea
+description: Idea template with typed defaults
+defaults:
+  effort: 3
+  archived: false
+---
+
+# {title}
+`,
+};
+
 const RELATION_MULTIPLE_SCHEMA = {
   version: 2,
   config: {
@@ -211,12 +226,115 @@ describePty('template command PTY tests', () => {
       );
     }, 30000);
 
+    it('should store typed boolean/number defaults and skip via confirm/validation', async () => {
+      await withTempVault(
+        ['template', 'new', 'idea'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Template name', 10000);
+          await proc.typeAndEnter('typed-defaults');
+
+          await proc.waitFor('Description', 5000);
+          await proc.typeAndEnter('Typed boolean/number defaults');
+
+          await proc.waitFor('Set default values', 5000);
+          proc.write('y');
+
+          // status (select) - skip
+          await proc.waitFor('status', 5000);
+          proc.write('1');
+
+          // priority (select) - skip
+          await proc.waitFor('priority', 5000);
+          proc.write('1');
+
+          // labels (multi-select) - skip
+          await proc.waitFor('labels', 5000);
+          proc.write('\r');
+
+          // effort (number) - invalid first, then a real number
+          await proc.waitFor('Default effort', 5000);
+          await proc.typeAndEnter('not-a-number');
+          await proc.waitFor('Invalid number', 5000);
+          await proc.typeAndEnter('5');
+
+          // archived (boolean) - confirm-style selection: pick "true"
+          await proc.waitFor('Default archived', 5000);
+          await proc.waitForStable(150, 2000);
+          proc.write('2'); // options: (skip)=1, true=2, false=3
+
+          await proc.waitFor('Force prompting', 5000);
+          proc.write('n');
+
+          await proc.waitFor('Custom filename', 5000);
+          proc.write('n');
+
+          await proc.waitFor('Created:', 10000);
+
+          const templatePath = join(vaultPath, '.bwrb/templates/idea', 'typed-defaults.md');
+          const content = await readFile(templatePath, 'utf-8');
+          const frontmatter = parseFrontmatter(content);
+          const defaults = frontmatter.defaults as Record<string, unknown>;
+          // Real number, not a string
+          expect(defaults.effort).toBe(5);
+          // Real boolean, not a string
+          expect(defaults.archived).toBe(true);
+        },
+        { schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should omit boolean/number defaults when skipped', async () => {
+      await withTempVault(
+        ['template', 'new', 'idea'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Template name', 10000);
+          await proc.typeAndEnter('skip-typed');
+
+          await proc.waitFor('Description', 5000);
+          await proc.typeAndEnter('Skip typed defaults');
+
+          await proc.waitFor('Set default values', 5000);
+          proc.write('y');
+
+          await proc.waitFor('status', 5000);
+          proc.write('1');
+          await proc.waitFor('priority', 5000);
+          proc.write('1');
+          await proc.waitFor('labels', 5000);
+          proc.write('\r');
+
+          // effort (number) - Enter to skip
+          await proc.waitFor('Default effort', 5000);
+          proc.write('\r');
+
+          // archived (boolean) - (skip) is the highlighted first option
+          await proc.waitFor('Default archived', 5000);
+          await proc.waitForStable(150, 2000);
+          proc.write('1'); // (skip)
+
+          // No defaults set -> no Force prompting question
+          await proc.waitFor('Custom filename', 5000);
+          proc.write('n');
+
+          await proc.waitFor('Created:', 10000);
+
+          const templatePath = join(vaultPath, '.bwrb/templates/idea', 'skip-typed.md');
+          const content = await readFile(templatePath, 'utf-8');
+          const frontmatter = parseFrontmatter(content);
+          const defaults = (frontmatter.defaults as Record<string, unknown>) ?? {};
+          expect(defaults.effort).toBeUndefined();
+          expect(defaults.archived).toBeUndefined();
+        },
+        { schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
     it('should cancel cleanly on Ctrl+C', async () => {
       await withTempVault(
         ['template', 'new', 'idea'],
         async (proc, vaultPath) => {
           await proc.waitFor('Template name', 10000);
-          
+
           // Cancel with Ctrl+C
           proc.write('\x03');
 
@@ -371,6 +489,148 @@ describePty('template command PTY tests', () => {
         { files: [DEFAULT_IDEA_TEMPLATE], schema: TEST_SCHEMA }
       );
     }, 15000);
+
+    it('should keep boolean/number defaults via (keep)', async () => {
+      await withTempVault(
+        ['template', 'edit', 'idea', 'typed'],
+        async (proc, vaultPath) => {
+          const templatePath = join(vaultPath, '.bwrb/templates/idea/typed.md');
+
+          await proc.waitFor('Current description:', 10000);
+          proc.write('\r');
+
+          await proc.waitFor('Edit default values', 5000);
+          proc.write('y');
+
+          // status (select) - keep
+          await proc.waitFor('New status', 5000);
+          proc.write('1'); // (keep)
+          // priority (select) - keep
+          await proc.waitFor('New priority', 5000);
+          proc.write('1'); // (keep)
+          // labels (multi relation? select multiple) - keep
+          await proc.waitFor('New labels', 5000);
+          proc.write('1'); // (keep)
+
+          // effort (number) - Enter keeps current
+          await proc.waitFor('New effort', 5000);
+          proc.write('\r');
+
+          // archived (boolean) - (keep)
+          await proc.waitFor('New archived', 5000);
+          await proc.waitForStable(150, 2000);
+          proc.write('1'); // (keep)
+
+          await proc.waitFor('Edit prompt-fields', 5000);
+          proc.write('n');
+          await proc.waitFor('Edit filename pattern', 5000);
+          proc.write('n');
+          await proc.waitFor('Edit body', 5000);
+          proc.write('n');
+          await proc.waitFor('Updated:', 5000);
+
+          const content = await readFile(templatePath, 'utf-8');
+          const frontmatter = parseFrontmatter(content);
+          const defaults = frontmatter.defaults as Record<string, unknown>;
+          expect(defaults.effort).toBe(3);
+          expect(defaults.archived).toBe(false);
+        },
+        { files: [TYPED_DEFAULTS_IDEA_TEMPLATE], schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should change and clear boolean/number defaults with typed values', async () => {
+      await withTempVault(
+        ['template', 'edit', 'idea', 'typed'],
+        async (proc, vaultPath) => {
+          const templatePath = join(vaultPath, '.bwrb/templates/idea/typed.md');
+
+          await proc.waitFor('Current description:', 10000);
+          proc.write('\r');
+
+          await proc.waitFor('Edit default values', 5000);
+          proc.write('y');
+
+          await proc.waitFor('New status', 5000);
+          proc.write('1'); // keep
+          await proc.waitFor('New priority', 5000);
+          proc.write('1'); // keep
+          await proc.waitFor('New labels', 5000);
+          proc.write('1'); // keep
+
+          // effort (number) - change to a real number (invalid first, then valid)
+          await proc.waitFor('New effort', 5000);
+          await proc.typeAndEnter('nope');
+          await proc.waitFor('Invalid number', 5000);
+          await proc.typeAndEnter('8');
+
+          // archived (boolean) - clear it
+          await proc.waitFor('New archived', 5000);
+          await proc.waitForStable(150, 2000);
+          proc.write('2'); // (clear): (keep)=1, (clear)=2, true=3, false=4
+
+          await proc.waitFor('Edit prompt-fields', 5000);
+          proc.write('n');
+          await proc.waitFor('Edit filename pattern', 5000);
+          proc.write('n');
+          await proc.waitFor('Edit body', 5000);
+          proc.write('n');
+          await proc.waitFor('Updated:', 5000);
+
+          const content = await readFile(templatePath, 'utf-8');
+          const frontmatter = parseFrontmatter(content);
+          const defaults = frontmatter.defaults as Record<string, unknown>;
+          expect(defaults.effort).toBe(8);
+          expect(defaults.archived).toBeUndefined();
+        },
+        { files: [TYPED_DEFAULTS_IDEA_TEMPLATE], schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should set a new boolean default via confirm-style selection', async () => {
+      await withTempVault(
+        ['template', 'edit', 'idea', 'typed'],
+        async (proc, vaultPath) => {
+          const templatePath = join(vaultPath, '.bwrb/templates/idea/typed.md');
+
+          await proc.waitFor('Current description:', 10000);
+          proc.write('\r');
+
+          await proc.waitFor('Edit default values', 5000);
+          proc.write('y');
+
+          await proc.waitFor('New status', 5000);
+          proc.write('1');
+          await proc.waitFor('New priority', 5000);
+          proc.write('1');
+          await proc.waitFor('New labels', 5000);
+          proc.write('1');
+
+          await proc.waitFor('New effort', 5000);
+          proc.write('\r'); // keep
+
+          // archived: change false -> true
+          await proc.waitFor('New archived', 5000);
+          await proc.waitForStable(150, 2000);
+          proc.write('3'); // true: (keep)=1, (clear)=2, true=3, false=4
+
+          await proc.waitFor('Edit prompt-fields', 5000);
+          proc.write('n');
+          await proc.waitFor('Edit filename pattern', 5000);
+          proc.write('n');
+          await proc.waitFor('Edit body', 5000);
+          proc.write('n');
+          await proc.waitFor('Updated:', 5000);
+
+          const content = await readFile(templatePath, 'utf-8');
+          const frontmatter = parseFrontmatter(content);
+          const defaults = frontmatter.defaults as Record<string, unknown>;
+          expect(defaults.archived).toBe(true);
+          expect(defaults.effort).toBe(3);
+        },
+        { files: [TYPED_DEFAULTS_IDEA_TEMPLATE], schema: TEST_SCHEMA }
+      );
+    }, 30000);
 
     it('should allow setting empty array defaults for multiple relation fields', async () => {
       await withTempVault(

--- a/tests/ts/commands/template.test.ts
+++ b/tests/ts/commands/template.test.ts
@@ -132,6 +132,43 @@ Body
     });
   });
 
+  describe('typed boolean/number defaults downstream', () => {
+    it('produces a correctly-typed note that passes audit', async () => {
+      // Template stores a real number and boolean default (as #648 ensures the
+      // interactive prompts do). A note created from it must have boolean/number
+      // frontmatter (not strings) and pass audit.
+      await writeFile(
+        join(vaultDir, '.bwrb/templates/idea', 'typed.md'),
+        `---
+type: template
+template-for: idea
+description: Typed defaults
+defaults:
+  effort: 5
+  archived: true
+---
+
+# {title}
+`
+      );
+
+      const create = await runCLI(
+        ['new', 'idea', '--json', '{"name": "Typed Defaults Note"}', '--template', 'typed'],
+        vaultDir
+      );
+      expect(create.exitCode).toBe(0);
+      const output = JSON.parse(create.stdout);
+
+      const content = await readFile(join(vaultDir, output.path), 'utf-8');
+      // Real number and boolean, not quoted strings.
+      expect(content).toMatch(/^effort: 5$/m);
+      expect(content).toMatch(/^archived: true$/m);
+
+      const audit = await runCLI(['audit', '--path', output.path], vaultDir);
+      expect(audit.exitCode).toBe(0);
+    });
+  });
+
   describe('template validate', () => {
     it('should validate all templates', async () => {
       const result = await runCLI(['template', 'validate'], vaultDir);


### PR DESCRIPTION
## Summary

Fixes #648. In the `template new` (template-default) and `template edit` (template-edit) flows, `boolean` and `number` field defaults fell through to a raw-text input instead of the proper boolean-confirm / number-validated prompt used by the `new` create flow. As a result, template defaults for those types were stored as strings and weren't validated at prompt time.

## What changed

`src/lib/field-prompt.ts`: `boolean` and `number` now route through dedicated template prompts in **both** template modes, replacing the shared `promptTextOrDateTemplate` raw-text path for these types:

- **boolean** → `promptBooleanTemplate`: a confirm-style selection (`(skip)`/`true`/`false` in template-default; `(keep)`/`(clear)`/`true`/`false` in template-edit) that stores a real boolean.
- **number** → `promptNumberTemplate`: numeric validation with re-prompt on invalid input, storing a real number. Empty input means skip (template-default) or keep (template-edit); `clear` removes.

Mode semantics are preserved exactly: prompt strings keep the `Default X:` / `New X:` conventions and the `(skip)` / `(keep)` / `(clear)` sentinels. All other field types and the entire create flow are unchanged.

Because stored defaults now carry the correct type, `bwrb new --template` produces correctly-typed frontmatter (e.g. `effort: 5`, `archived: true`) that passes `bwrb audit`.

## Tests

- `template new`: typed boolean/number defaults stored as real boolean/number; number re-prompts on invalid input; both omitted when skipped.
- `template edit`: keep (retains current), clear (removes), and change (new typed value) for boolean and number.
- Downstream: a note created from a typed template has boolean/number frontmatter and passes `bwrb audit`.
- Existing template PTY suite still passes (21 tests).

`pnpm qa` (104 files, 2365 passed) and `pnpm knip` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)