### PR TITLE
fix(schema): surface "did you mean a type?" for unknown CLI types

### DIFF
--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -9,6 +9,7 @@ import { Command } from 'commander';
 import {
   loadSchema,
   getTypeDefByPath,
+  formatUnknownTypeError,
 } from '../lib/schema.js';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts } from '../lib/command.js';
@@ -309,7 +310,7 @@ Examples:
       if (typePath) {
         const typeDef = getTypeDefByPath(schema, typePath);
         if (!typeDef) {
-          const error = `Unknown type: ${typePath}`;
+          const error = formatUnknownTypeError(schema, typePath);
           if (jsonMode) {
             printJson(jsonError(error, { code: ExitCodes.VALIDATION_ERROR }));
             printError(error);

--- a/src/commands/bulk.ts
+++ b/src/commands/bulk.ts
@@ -17,6 +17,7 @@ import {
   getTypeFamilies,
   getOptionsForField,
   resolveTypeFromFrontmatter,
+  formatUnknownTypeError,
 } from '../lib/schema.js';
 import { discoverManagedFiles } from '../lib/discovery.js';
 import { parseNote } from '../lib/frontmatter.js';
@@ -235,7 +236,7 @@ Examples:
       if (typePath) {
         const typeDef = getTypeDefByPath(schema, typePath);
         if (!typeDef) {
-          const error = `Unknown type: ${typePath}`;
+          const error = formatUnknownTypeError(schema, typePath);
           if (jsonMode) {
             printJson(jsonError(error));
             process.exit(ExitCodes.VALIDATION_ERROR);

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -9,7 +9,7 @@ import {
   listDashboards,
 } from '../lib/dashboard.js';
 import { resolveTargets, type TargetingOptions } from '../lib/targeting.js';
-import { loadSchema, getTypeDefByPath } from '../lib/schema.js';
+import { loadSchema, getTypeDefByPath, formatUnknownTypeError } from '../lib/schema.js';
 import { setDefaultDashboard } from '../lib/schema-writer.js';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts } from '../lib/command.js';
@@ -471,7 +471,7 @@ Examples:
       if (options.type) {
         const typeDef = getTypeDefByPath(schema, options.type);
         if (!typeDef) {
-          const error = `Unknown type: ${options.type}`;
+          const error = formatUnknownTypeError(schema, options.type);
           if (jsonMode) {
             printJson(jsonError(error));
             process.exit(ExitCodes.VALIDATION_ERROR);
@@ -770,7 +770,7 @@ Examples:
       if (options.type) {
         const typeDef = getTypeDefByPath(schema, options.type);
         if (!typeDef) {
-          const error = `Unknown type: ${options.type}`;
+          const error = formatUnknownTypeError(schema, options.type);
           if (jsonMode) {
             printJson(jsonError(error));
             process.exit(ExitCodes.VALIDATION_ERROR);

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -10,7 +10,7 @@ import { basename, isAbsolute, relative } from 'path';
 import fs from 'fs/promises';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts, resolveGlobalPickerMode } from '../lib/command.js';
-import { loadSchema, getTypeDefByPath } from '../lib/schema.js';
+import { loadSchema, getTypeDefByPath, formatUnknownTypeError } from '../lib/schema.js';
 import { configurePromptMode, printError, printSuccess } from '../lib/prompt.js';
 import { printJson, jsonSuccess, jsonError, ExitCodes, exitWithResolutionError } from '../lib/output.js';
 import { buildNoteIndex, type ManagedFile } from '../lib/navigation.js';
@@ -128,7 +128,7 @@ Examples:
       if (options.type) {
         const typeDef = getTypeDefByPath(schema, options.type);
         if (!typeDef) {
-          const error = `Unknown type: ${options.type}`;
+          const error = formatUnknownTypeError(schema, options.type);
           if (jsonMode) {
             printJson(jsonError(error));
             process.exit(ExitCodes.VALIDATION_ERROR);

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -6,6 +6,7 @@ import {
   loadSchema,
   getTypeDefByPath,
   getAllFieldsForType,
+  formatUnknownTypeError,
 } from '../lib/schema.js';
 import {
   buildParentMap,
@@ -276,7 +277,7 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
       if (targeting.type) {
         const typeDef = getTypeDefByPath(schema, targeting.type);
         if (!typeDef) {
-          const error = `Unknown type: ${targeting.type}`;
+          const error = formatUnknownTypeError(schema, targeting.type);
           if (jsonMode) {
             printJson(jsonError(error));
             process.exit(ExitCodes.VALIDATION_ERROR);

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { relative } from 'path';
-import { loadSchema, getTypeDefByPath } from '../lib/schema.js';
+import { loadSchema, getTypeDefByPath, formatUnknownTypeError } from '../lib/schema.js';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts } from '../lib/command.js';
 import { configurePromptMode, promptSelection, printError } from '../lib/prompt.js';
@@ -147,7 +147,7 @@ Template management:
 
       const typeDef = getTypeDefByPath(schema, resolvedPath);
       if (!typeDef) {
-        printError(`Unknown type: ${resolvedPath}`);
+        printError(formatUnknownTypeError(schema, resolvedPath));
         process.exit(1);
       }
 

--- a/src/commands/new/json-mode.ts
+++ b/src/commands/new/json-mode.ts
@@ -8,6 +8,7 @@ import {
   getFieldsForType,
   getFrontmatterOrder,
   getTypeDefByPath,
+  formatUnknownTypeError,
 } from '../../lib/schema.js';
 import {
   applyDefaults,
@@ -40,7 +41,7 @@ export async function createNoteFromJson(
 ): Promise<NoteCreationResult> {
   const typeDef = getTypeDefByPath(schema, typePath);
   if (!typeDef) {
-    throwJsonError(jsonError(`Unknown type: ${typePath}`), ExitCodes.VALIDATION_ERROR);
+    throwJsonError(jsonError(formatUnknownTypeError(schema, typePath)), ExitCodes.VALIDATION_ERROR);
   }
 
   const ownership = await resolveJsonOwnership(schema, vaultDir, typePath, typeDef, ownershipOptions);

--- a/src/commands/recent.ts
+++ b/src/commands/recent.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { basename, relative } from 'path';
 import { stat } from 'fs/promises';
 import chalk from 'chalk';
-import { loadSchema, getTypeDefByPath } from '../lib/schema.js';
+import { loadSchema, getTypeDefByPath, formatUnknownTypeError } from '../lib/schema.js';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts } from '../lib/command.js';
 import { printError } from '../lib/prompt.js';
@@ -146,7 +146,7 @@ Examples:
       if (targeting.type) {
         const typeDef = getTypeDefByPath(schema, targeting.type);
         if (!typeDef) {
-          const error = `Unknown type: ${targeting.type}`;
+          const error = formatUnknownTypeError(schema, targeting.type);
           if (jsonMode) {
             printJson(jsonError(error));
             process.exit(ExitCodes.VALIDATION_ERROR);

--- a/src/commands/schema/helpers/output.ts
+++ b/src/commands/schema/helpers/output.ts
@@ -18,6 +18,7 @@ import {
   getFieldOrderForOrigin,
   getFieldOrderForTrait,
   getOutputDir,
+  formatUnknownTypeError,
 } from '../../../lib/schema.js';
 import { printError } from '../../../lib/prompt.js';
 import { printJson, jsonError, ExitCodes } from '../../../lib/output.js';
@@ -53,7 +54,7 @@ export function outputSchemaJson(schema: LoadedSchema): void {
 export function outputTypeDetailsJson(schema: LoadedSchema, typePath: string): void {
   const typeDef = getTypeDefByPath(schema, typePath);
   if (!typeDef) {
-    printJson(jsonError(`Unknown type: ${typePath}`));
+    printJson(jsonError(formatUnknownTypeError(schema, typePath)));
     process.exit(ExitCodes.VALIDATION_ERROR);
   }
 
@@ -309,7 +310,7 @@ export function showTypeDetails(schema: LoadedSchema, typePath: string): void {
   const context = getTtyContext();
   const typeDef = getTypeDefByPath(schema, typePath);
   if (!typeDef) {
-    printError(`Unknown type: ${typePath}`);
+    printError(formatUnknownTypeError(schema, typePath));
     process.exit(1);
   }
 

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -11,7 +11,7 @@ import { readFile } from 'fs/promises';
 import { basename } from 'path';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts, resolveGlobalPickerMode } from '../lib/command.js';
-import { loadSchema, getTypeDefByPath } from '../lib/schema.js';
+import { loadSchema, getTypeDefByPath, formatUnknownTypeError } from '../lib/schema.js';
 import { configurePromptMode, printError, printSuccess } from '../lib/prompt.js';
 import { printJson, jsonSuccess, jsonError, ExitCodes, exitWithResolutionError, warnDeprecated, type SearchOutputFormat } from '../lib/output.js';
 import { openNote, resolveAppMode } from './open.js';
@@ -368,7 +368,7 @@ async function handleContentSearch(
   if (options.type) {
     const typeDef = getTypeDefByPath(schema, options.type);
     if (!typeDef) {
-      const error = `Unknown type: ${options.type}`;
+      const error = formatUnknownTypeError(schema, options.type);
       if (jsonMode) {
         printJson(jsonError(error));
         process.exit(ExitCodes.VALIDATION_ERROR);

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -982,15 +982,8 @@ export function getEntityAliases(
 }
 
 // ============================================================================
-// Source Type Resolution (for dynamic fields)
+// Unknown Type Suggestions ("did you mean a type?")
 // ============================================================================
-
-/**
- * Result of resolving a source type name.
- */
-export type SourceTypeResolution =
-  | { success: true; typeName: string }
-  | { success: false; error: string; suggestions?: string[] };
 
 /**
  * Find close matches for a string within a list of candidates.
@@ -1012,70 +1005,53 @@ function findCloseMatches(target: string, candidates: string[], maxDistance: num
   return matches.map(m => m.candidate);
 }
 
-
-
 /**
- * Resolve a source type name with helpful error messages.
- * 
- * This function validates that a source type exists and provides
- * actionable error messages when it doesn't, including:
- * - Detecting enum value confusion (e.g., "person" being an enum value, not a type)
- * - Suggesting similar type names for typos
- * - Listing available types when no close match is found
+ * Suggest the closest concrete type name for a (likely-misspelled) type name.
+ *
+ * Used to surface a "Did you mean 'X'?" hint when a user supplies an unknown
+ * type on the CLI (`--type`, a positional type arg, etc.). Mirrors the
+ * field/option typo-suggestion behavior used elsewhere:
+ * - Returns undefined for an exact match (nothing to suggest) or when no
+ *   candidate is within a sensible edit-distance threshold.
+ * - The threshold scales with the input length (so short type names like
+ *   `ide`→`idea` still match) but is capped so wildly-different input
+ *   (`completely-unknown`) yields no bogus suggestion.
+ *
+ * Returns only the single closest match to keep the hint focused and
+ * consistent with `suggestFieldName`.
  */
-export function resolveSourceType(
+export function suggestTypeName(
   schema: LoadedSchema,
-  source: string
-): SourceTypeResolution {
-  // Direct match - source is a valid type
-  if (schema.types.has(source)) {
-    return { success: true, typeName: source };
-  }
+  typeName: string
+): string | undefined {
+  if (schema.types.has(typeName)) return undefined;
 
   const availableTypes = getConcreteTypeNames(schema);
+  // Threshold: at most 3 edits, but never more than 60% of the input length so
+  // very short inputs don't match unrelated types and long gibberish is rejected.
+  const maxDistance = Math.min(3, Math.ceil(typeName.length * 0.6));
+  const matches = findCloseMatches(typeName, availableTypes, maxDistance);
+  return matches[0];
+}
 
-  // Check for old path format (e.g., "note/task" or "foo/bar")
-  // V2 uses flat type names, not paths
-  if (source.includes('/')) {
-    const parts = source.split('/');
-    const lastPart = parts[parts.length - 1] ?? '';
-    
-    // Check if the last segment is a valid type
-    if (lastPart && schema.types.has(lastPart)) {
-      return {
-        success: false,
-        error: `Source "${source}" uses path format which is no longer supported.\n` +
-          `Use just the type name: "${lastPart}"`,
-        suggestions: [lastPart],
-      };
-    }
-    
-    // Neither segment is valid - generic path format error
-    return {
-      success: false,
-      error: `Source "${source}" uses path format which is not supported.\n` +
-        `Available types: ${availableTypes.join(', ')}`,
-    };
-  }
-
-  // Check for typos using fuzzy matching
-  const closeMatches = findCloseMatches(source, availableTypes, 3);
-
-  if (closeMatches.length > 0) {
-    return {
-      success: false,
-      error: `Source type "${source}" does not exist.\n` +
-        `Did you mean: ${closeMatches.join(', ')}?`,
-      suggestions: closeMatches,
-    };
-  }
-
-  // No close match - list all available types
-  return {
-    success: false,
-    error: `Source type "${source}" does not exist.\n` +
-      `Available types: ${availableTypes.join(', ')}`,
-  };
+/**
+ * Build the standard "Unknown type" error message, appending a
+ * "Did you mean 'X'?" hint when a close match exists.
+ *
+ * This is the single shared formatter used by every command that accepts a
+ * type name (`list`/`recent`/`search`/`audit`/`bulk`/`dashboard`/`new`/
+ * `schema list`/`edit`). Keeping the `Unknown type: <name>` prefix preserves
+ * the existing message shape (and JSON error payload), only adding the
+ * suggestion — so valid types are unaffected and JSON consumers get the hint
+ * inline in the error string.
+ */
+export function formatUnknownTypeError(
+  schema: LoadedSchema,
+  typeName: string
+): string {
+  const suggestion = suggestTypeName(schema, typeName);
+  const base = `Unknown type: ${typeName}`;
+  return suggestion ? `${base}. Did you mean '${suggestion}'?` : base;
 }
 
 // ============================================================================

--- a/tests/ts/commands/recent.test.ts
+++ b/tests/ts/commands/recent.test.ts
@@ -96,6 +96,28 @@ describe('recent command', () => {
       expect(result.exitCode).not.toBe(0);
       expect(result.stderr).toContain('Unknown type: nonsense');
     });
+
+    it('suggests a close match for a misspelled type', async () => {
+      // 'taks' is a transposition of the real type 'task'
+      const result = await runCLI(['recent', '--type', 'taks'], vaultDir);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('Unknown type: taks');
+      expect(result.stderr).toContain("Did you mean 'task'?");
+    });
+
+    it('does not suggest for a wildly-unknown type', async () => {
+      const result = await runCLI(['recent', '--type', 'nonsense'], vaultDir);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).not.toContain('Did you mean');
+    });
+
+    it('includes the suggestion in the JSON error payload', async () => {
+      const result = await runCLI(['recent', '--type', 'taks', '--output', 'json'], vaultDir);
+      expect(result.exitCode).not.toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.error).toContain('Unknown type: taks');
+      expect(json.error).toContain("Did you mean 'task'?");
+    });
   });
 
   describe('--output json', () => {

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -173,6 +173,22 @@ describe('schema command', () => {
       expect(result.stdout).toContain('Own fields:');
     });
 
+    it('should suggest a close match for a misspelled type', async () => {
+      const result = await runCLI(['schema', 'list', 'type', 'taks'], vaultDir);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('Unknown type: taks');
+      expect(result.stderr).toContain("Did you mean 'task'?");
+    });
+
+    it('should not suggest for a wildly-unknown type', async () => {
+      const result = await runCLI(['schema', 'list', 'type', 'nonsense'], vaultDir);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('Unknown type: nonsense');
+      expect(result.stderr).not.toContain('Did you mean');
+    });
+
     it('should ignore schema snapshot when showing type details in JSON', async () => {
       const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-type-snapshot-ignore-'));
       await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });

--- a/tests/ts/lib/schema.test.ts
+++ b/tests/ts/lib/schema.test.ts
@@ -22,7 +22,8 @@ import {
   getPluralName,
   computeDefaultOutputDir,
   getType,
-  resolveSourceType,
+  suggestTypeName,
+  formatUnknownTypeError,
   getFieldsByOrigin,
   getFieldOrderForOrigin,
   getAllOwnFieldNames,
@@ -573,81 +574,40 @@ describe('schema', () => {
     });
   });
 
-  describe('resolveSourceType', () => {
-    it('should return success for valid type names', () => {
-      const result = resolveSourceType(schema, 'idea');
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.typeName).toBe('idea');
-      }
+  describe('suggestTypeName', () => {
+    it('returns undefined for a valid type name (nothing to suggest)', () => {
+      expect(suggestTypeName(schema, 'idea')).toBeUndefined();
+      expect(suggestTypeName(schema, 'task')).toBeUndefined();
     });
 
-    it('should return success for nested type names', () => {
-      const result = resolveSourceType(schema, 'task');
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.typeName).toBe('task');
-      }
+    it('suggests the closest type for a typo', () => {
+      // 'ide' is one edit from 'idea'
+      expect(suggestTypeName(schema, 'ide')).toBe('idea');
+      // 'taks' is a transposition of 'task'
+      expect(suggestTypeName(schema, 'taks')).toBe('task');
     });
 
-    it('should report unknown type for unrecognized values', () => {
-      // 'raw' is not a type name
-      const result = resolveSourceType(schema, 'raw');
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toContain('does not exist');
-      }
+    it('returns undefined when no candidate is close enough', () => {
+      expect(suggestTypeName(schema, 'completely-unknown-type')).toBeUndefined();
     });
 
-    it('should report path format error for slash-containing names with valid last segment', () => {
-      // 'objective/task' has 'task' as valid type - suggest using just the type name
-      const result = resolveSourceType(schema, 'objective/task');
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toContain('uses path format');
-        expect(result.error).toContain('Use just the type name: "task"');
-        expect(result.suggestions).toContain('task');
-      }
+    it('does not over-suggest for very short unrelated input', () => {
+      // 'low' is not a type name and not within threshold of any type
+      expect(suggestTypeName(schema, 'low')).toBeUndefined();
+    });
+  });
+
+  describe('formatUnknownTypeError', () => {
+    it('includes a "Did you mean" hint when there is a close match', () => {
+      const msg = formatUnknownTypeError(schema, 'taks');
+      expect(msg).toContain('Unknown type: taks');
+      expect(msg).toContain("Did you mean 'task'?");
     });
 
-    it('should report path format error for invalid path format names', () => {
-      const result = resolveSourceType(schema, 'foo/bar');
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toContain('uses path format');
-        expect(result.error).toContain('Available types:');
-      }
-    });
-
-    it('should suggest similar type names for typos', () => {
-      // 'ide' is close to 'idea'
-      const result = resolveSourceType(schema, 'ide');
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toContain('does not exist');
-        expect(result.error).toContain('Did you mean:');
-        expect(result.suggestions).toContain('idea');
-      }
-    });
-
-    it('should list available types when no close match exists', () => {
-      const result = resolveSourceType(schema, 'completely-unknown-type');
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toContain('does not exist');
-        expect(result.error).toContain('Available types:');
-        // Should not have suggestions for very different names
-        expect(result.suggestions).toBeUndefined();
-      }
-    });
-
-    it('should report unknown for short unrecognized values', () => {
-      // 'low' is not a type name
-      const result = resolveSourceType(schema, 'low');
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error).toContain('does not exist');
-      }
+    it('omits the hint when there is no close match', () => {
+      const msg = formatUnknownTypeError(schema, 'completely-unknown-type');
+      expect(msg).toBe('Unknown type: completely-unknown-type');
+      expect(msg).not.toContain('Did you mean');
     });
   });
 


### PR DESCRIPTION
## What

`resolveSourceType` / `findCloseMatches` in `src/lib/schema.ts` provided a "did you mean &lt;type&gt;?" suggestion for misspelled type names but had **zero production callers** (only unit tests). Every command that accepts a type name reported a bare `Unknown type: X` with no suggestion — inconsistent with the typo hints already shown for fields and options.

This wires the capability into the single shared type-validation error path.

## How

- Add `suggestTypeName()` and `formatUnknownTypeError()` to `schema.ts`, reusing the existing `findCloseMatches()` / `levenshteinDistance()` (no fork). The formatter keeps the `Unknown type: X` prefix — so the `--output json` error payload shape is unchanged — and appends `Did you mean 'Y'?` only when there's a close match within a length-scaled edit-distance threshold (`min(3, ceil(len*0.6))`).
- Replace the duplicated `Unknown type: X` literal across every command that takes a type name: `list`, `recent`, `search`, `audit`, `bulk`, `dashboard` (new + edit), `new` (interactive + JSON), `schema list type`, and `edit`. Suggestion surfaces in both text (stderr) and JSON modes.
- Remove the now-redundant `resolveSourceType()` / `SourceTypeResolution` dead path — the capability is preserved via the new helpers, and knip stays clean.

Valid types are unaffected; wildly-unknown input gets a clean `Unknown type: X` with no bogus suggestion.

## Tests

- Unit: `suggestTypeName` / `formatUnknownTypeError` (migrated from the old `resolveSourceType` suite) — close match, no-match, short-input, JSON-shape.
- CLI integration (`recent`): close-match suggestion in stderr, no suggestion for wildly-unknown, suggestion present in the JSON error payload.
- CLI integration (`schema list type`): close-match suggestion + no-suggestion cases.

## Quality gates

- `pnpm qa` ✅ (typecheck, lint, docs:lint, docs:doctor, build, 2368 tests pass)
- `pnpm knip` ✅ clean

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)