### PR TITLE
fix(resolution): make real-name-wins guard case-insensitive (#616)

### DIFF
--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -552,7 +552,8 @@ name**:
 
 - `bwrb open`, `bwrb edit`, and `bwrb search` resolve a query to an entity when
   it matches one of the entity's aliases (a real note name always wins over an
-  alias of the same string).
+  alias of the same string — **case-insensitively**, consistent with the rest of
+  resolution, so a real note `steve` wins over an entity merely aliased `Steve`).
 - Relation/link targets written as `[[An Alias]]` resolve to the aliased entity.
 
 Declare the role with `alias: true` on a list field:

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -813,7 +813,12 @@ function resolveRelationTarget(
     return { rawTarget, candidates: [], resolvedPath: undefined };
   }
 
-  const candidates = noteTargetIndex.targetToPaths.get(rawTarget) ?? [];
+  // Case-insensitive lookup, consistent with `open`/navigation resolution
+  // (`resolveNoteQuery`). `targetToPaths` is keyed by the lowercased target name,
+  // with a real note name still winning over an alias of the same string. A
+  // unique match resolves (no stale); multiple matches stay ambiguous and are
+  // never auto-resolved; zero matches surface as a stale reference.
+  const candidates = noteTargetIndex.targetToPaths.get(rawTarget.toLowerCase()) ?? [];
   if (candidates.length === 1) {
     return { rawTarget, candidates, resolvedPath: candidates[0] };
   }

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -2411,7 +2411,16 @@ function collectTargetsBySource(
   const sources = Array.isArray(source) ? source : [source];
 
   if (sources.includes('any')) {
-    return Array.from(targetIndex.targetToPaths.keys()).filter((key) => !key.includes('/'));
+    // `targetToPaths` keys are lowercased (case-insensitive resolution), so they
+    // are unsuitable as display/fix targets. Reconstruct real-case basenames from
+    // the resolved paths instead.
+    const realBasenames = new Set<string>();
+    for (const paths of targetIndex.targetToPaths.values()) {
+      for (const path of paths) {
+        realBasenames.add(basename(path, '.md'));
+      }
+    }
+    return Array.from(realBasenames.values()).sort((a, b) => a.localeCompare(b));
   }
 
   const validTypes = new Set<string>();
@@ -3087,7 +3096,9 @@ function formatMarkdownLinkValue(label: string, path: string): string {
 
 function getShortestLinkTarget(candidatePath: string, targetIndex?: NoteTargetIndex): string {
   const basenameTarget = basename(candidatePath, '.md');
-  const matches = targetIndex?.targetToPaths.get(basenameTarget) ?? [];
+  // `targetToPaths` is keyed by the lowercased target (case-insensitive
+  // resolution); look up accordingly so a unique basename still shortens.
+  const matches = targetIndex?.targetToPaths.get(basenameTarget.toLowerCase()) ?? [];
   if (matches.length === 1) {
     return basenameTarget;
   }

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -380,6 +380,11 @@ export async function buildNoteTypeMap(
 }
 
 export type NoteTargetIndex = {
+  /**
+   * Maps a lowercased target name/path/alias to every note it could resolve to.
+   * Keys are lowercased so relation resolution is case-insensitive (consistent
+   * with `open`/navigation); look up with `key.toLowerCase()`.
+   */
   targetToPaths: Map<string, string[]>;
   pathToType: Map<string, string>;
   pathNoExtToType: Map<string, string>;
@@ -518,6 +523,13 @@ export function deriveNoteTypeMap(snapshot: VaultNoteSnapshot): Map<string, stri
  * shared by two entities surfaces as an ambiguous (multi-candidate) target,
  * which callers already refuse to auto-resolve, preserving the deterministic
  * "never auto-resolve ambiguity" guarantee.
+ *
+ * Keys are lowercased so relation resolution is case-insensitive, consistent
+ * with `open`/navigation (`resolveNoteQuery`): a `[[Steve]]` reference resolves
+ * to a real `steve` note, and a real note name still wins over an alias even
+ * when they differ only by case. A lowercased key that genuinely maps to more
+ * than one note (two real notes differing only by case, or a shared alias)
+ * keeps every path so ambiguity stays detectable.
  */
 export function deriveNoteTargetIndex(
   snapshot: VaultNoteSnapshot,
@@ -530,15 +542,19 @@ export function deriveNoteTargetIndex(
   // when they differ only by case, consistent with case-insensitive resolution.
   const realKeysLower = new Set<string>();
 
+  // Keys are lowercased to match the case-insensitive lookup in
+  // `resolveRelationTarget`. Distinct notes that collapse to the same lowercased
+  // key are all preserved so ambiguity remains detectable.
   const addTarget = (key: string, relativePath: string) => {
-    const existing = targetToPaths.get(key);
+    const lowerKey = key.toLowerCase();
+    const existing = targetToPaths.get(lowerKey);
     if (existing) {
       if (!existing.includes(relativePath)) {
         existing.push(relativePath);
       }
       return;
     }
-    targetToPaths.set(key, [relativePath]);
+    targetToPaths.set(lowerKey, [relativePath]);
   };
 
   for (const note of snapshot.notes) {

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -460,15 +460,18 @@ export function deriveNotePathMap(
   schema?: LoadedSchema
 ): Map<string, string> {
   const pathMap = new Map<string, string>();
-  const realKeys = new Set<string>();
+  // Real note name/path keys, lowercased: a real note wins over an alias even
+  // when they differ only by case, consistent with the case-insensitive lookups
+  // elsewhere in resolution.
+  const realKeysLower = new Set<string>();
 
   for (const note of snapshot.notes) {
     const noteName = basename(note.relativePath, '.md');
     const pathKey = note.relativePath.replace(/\.md$/, '');
     pathMap.set(noteName, note.relativePath);
     pathMap.set(pathKey, note.relativePath);
-    realKeys.add(noteName);
-    realKeys.add(pathKey);
+    realKeysLower.add(noteName.toLowerCase());
+    realKeysLower.add(pathKey.toLowerCase());
   }
 
   if (schema) {
@@ -476,9 +479,9 @@ export function deriveNotePathMap(
       if (!note.resolvedType || !note.frontmatter) continue;
       const aliases = getEntityAliases(schema, note.resolvedType, note.frontmatter);
       for (const alias of aliases) {
-        // Never let an alias shadow a real note name/path, and keep the first
-        // claimant when two entities share an alias.
-        if (realKeys.has(alias) || pathMap.has(alias)) continue;
+        // Never let an alias shadow a real note name/path (case-insensitively),
+        // and keep the first claimant when two entities share an alias.
+        if (realKeysLower.has(alias.toLowerCase()) || pathMap.has(alias)) continue;
         pathMap.set(alias, note.relativePath);
       }
     }
@@ -523,7 +526,9 @@ export function deriveNoteTargetIndex(
   const targetToPaths = new Map<string, string[]>();
   const pathToType = new Map<string, string>();
   const pathNoExtToType = new Map<string, string>();
-  const realKeys = new Set<string>();
+  // Real note name/path keys, lowercased: a real note wins over an alias even
+  // when they differ only by case, consistent with case-insensitive resolution.
+  const realKeysLower = new Set<string>();
 
   const addTarget = (key: string, relativePath: string) => {
     const existing = targetToPaths.get(key);
@@ -543,8 +548,8 @@ export function deriveNoteTargetIndex(
 
     addTarget(basenameKey, relativePath);
     addTarget(pathKey, relativePath);
-    realKeys.add(basenameKey);
-    realKeys.add(pathKey);
+    realKeysLower.add(basenameKey.toLowerCase());
+    realKeysLower.add(pathKey.toLowerCase());
 
     if (note.resolvedType) {
       pathToType.set(relativePath, note.resolvedType);
@@ -557,8 +562,8 @@ export function deriveNoteTargetIndex(
       if (!note.resolvedType || !note.frontmatter) continue;
       const aliases = getEntityAliases(schema, note.resolvedType, note.frontmatter);
       for (const alias of aliases) {
-        // Never let an alias shadow a real note name/path key.
-        if (realKeys.has(alias)) continue;
+        // Never let an alias shadow a real note name/path key (case-insensitively).
+        if (realKeysLower.has(alias.toLowerCase())) continue;
         addTarget(alias, note.relativePath);
       }
     }

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -72,6 +72,13 @@ export async function buildNoteIndex(schema: LoadedSchema, vaultDir: string): Pr
   // Index entity aliases as additional resolution keys, so notes are findable by
   // their declared aliases. Reuses the single parse pass from the vault snapshot;
   // aliases only exist on schema-typed entities.
+  // Lowercased real-basename set so a real note wins over an alias even when they
+  // differ only by case, consistent with the case-insensitive basename lookup in
+  // resolveNoteQuery.
+  const basenamesLower = new Set<string>();
+  for (const name of byBasename.keys()) {
+    basenamesLower.add(name.toLowerCase());
+  }
   const byAlias = new Map<string, ManagedFile[]>();
   const snapshot = await buildVaultNoteSnapshot(schema, vaultDir);
   for (const note of snapshot.notes) {
@@ -80,8 +87,9 @@ export async function buildNoteIndex(schema: LoadedSchema, vaultDir: string): Pr
     if (!file) continue;
     const aliases = getEntityAliases(schema, note.resolvedType, note.frontmatter);
     for (const alias of aliases) {
-      // A real note name always wins over an alias of the same string.
-      if (byBasename.has(alias)) continue;
+      // A real note name always wins over an alias of the same string
+      // (case-insensitively).
+      if (basenamesLower.has(alias.toLowerCase())) continue;
       const existing = byAlias.get(alias) || [];
       existing.push(file);
       byAlias.set(alias, existing);

--- a/tests/ts/lib/alias-role.test.ts
+++ b/tests/ts/lib/alias-role.test.ts
@@ -199,6 +199,24 @@ describe('alias field role', () => {
       expect(result.exact?.relativePath).toBe('Notes/Steve.md');
     });
 
+    it('a case-variant real note name wins over an alias (#616)', async () => {
+      // Real note literally named "steve" (lowercase) and a DIFFERENT entity
+      // aliased "Steve" (capital). The real-name-wins guard is case-insensitive,
+      // so the alias must NOT shadow the case-variant real note.
+      await writeFile(join(vaultDir, 'Notes', 'steve.md'), `---\ntype: note\n---\n`);
+      const schema = await loadSchema(vaultDir);
+      const index = await buildNoteIndex(schema, vaultDir);
+
+      // The alias "Steve" is never registered, because the real note "steve"
+      // wins case-insensitively.
+      expect(index.byAlias.has('Steve')).toBe(false);
+
+      // Querying "Steve" resolves to the REAL note via case-insensitive basename
+      // matching, never silently to the aliased entity.
+      const result = resolveNoteQuery(index, 'Steve');
+      expect(result.exact?.relativePath).toBe('Notes/steve.md');
+    });
+
     it('relation/link target index resolves an alias to the entity path', async () => {
       const schema = await loadSchema(vaultDir);
       const targetIndex = await buildNoteTargetIndex(schema, vaultDir);
@@ -207,6 +225,37 @@ describe('alias field role', () => {
       expect(targetIndex.targetToPaths.get('stevey')).toContain('People/Steve Yegge.md');
       // The canonical name still resolves.
       expect(targetIndex.targetToPaths.get('Steve Yegge')).toContain('People/Steve Yegge.md');
+    });
+
+    it('relation target index: a case-variant real note wins over an alias (#616)', async () => {
+      // Real note "steve" (lowercase); "Steve Yegge" is aliased "Steve".
+      await writeFile(join(vaultDir, 'Notes', 'steve.md'), `---\ntype: note\n---\n`);
+      const schema = await loadSchema(vaultDir);
+      const targetIndex = await buildNoteTargetIndex(schema, vaultDir);
+
+      // The capital "Steve" alias key is never registered, because the real
+      // note "steve" wins case-insensitively. Audit relation resolution + --fix
+      // therefore never bind a `[[Steve]]` reference to the aliased entity.
+      expect(targetIndex.targetToPaths.has('Steve')).toBe(false);
+      // The real note resolves under its own (lowercase) key.
+      expect(targetIndex.targetToPaths.get('steve')).toContain('Notes/steve.md');
+      // Other, non-colliding aliases still resolve to the entity.
+      expect(targetIndex.targetToPaths.get('stevey')).toContain('People/Steve Yegge.md');
+    });
+
+    it('a shared alias across two entities stays ambiguous (no regression)', async () => {
+      // A second person also aliased "Steve": genuine ambiguity, never auto-resolved.
+      await writeFile(
+        join(vaultDir, 'People', 'Steve Jobs.md'),
+        `---\ntype: person\naliases:\n  - Steve\n---\n`
+      );
+      const schema = await loadSchema(vaultDir);
+      const index = await buildNoteIndex(schema, vaultDir);
+
+      const result = resolveNoteQuery(index, 'Steve');
+      expect(result.exact).toBeNull();
+      expect(result.isAmbiguous).toBe(true);
+      expect(result.candidates.length).toBe(2);
     });
 
     it('audit flags empty alias entries (illegal-aliases)', async () => {

--- a/tests/ts/lib/alias-role.test.ts
+++ b/tests/ts/lib/alias-role.test.ts
@@ -221,10 +221,12 @@ describe('alias field role', () => {
       const schema = await loadSchema(vaultDir);
       const targetIndex = await buildNoteTargetIndex(schema, vaultDir);
 
-      expect(targetIndex.targetToPaths.get('Steve')).toContain('People/Steve Yegge.md');
+      // The index is keyed by the lowercased target (case-insensitive
+      // resolution, consistent with open/navigation).
+      expect(targetIndex.targetToPaths.get('steve')).toContain('People/Steve Yegge.md');
       expect(targetIndex.targetToPaths.get('stevey')).toContain('People/Steve Yegge.md');
       // The canonical name still resolves.
-      expect(targetIndex.targetToPaths.get('Steve Yegge')).toContain('People/Steve Yegge.md');
+      expect(targetIndex.targetToPaths.get('steve yegge')).toContain('People/Steve Yegge.md');
     });
 
     it('relation target index: a case-variant real note wins over an alias (#616)', async () => {
@@ -233,12 +235,10 @@ describe('alias field role', () => {
       const schema = await loadSchema(vaultDir);
       const targetIndex = await buildNoteTargetIndex(schema, vaultDir);
 
-      // The capital "Steve" alias key is never registered, because the real
-      // note "steve" wins case-insensitively. Audit relation resolution + --fix
-      // therefore never bind a `[[Steve]]` reference to the aliased entity.
-      expect(targetIndex.targetToPaths.has('Steve')).toBe(false);
-      // The real note resolves under its own (lowercase) key.
-      expect(targetIndex.targetToPaths.get('steve')).toContain('Notes/steve.md');
+      // The lowercased "steve" key is claimed by the REAL note, not the alias of
+      // the same string. Audit relation resolution + --fix therefore never bind a
+      // `[[Steve]]` reference to the aliased entity — it resolves to the real note.
+      expect(targetIndex.targetToPaths.get('steve')).toEqual(['Notes/steve.md']);
       // Other, non-colliding aliases still resolve to the entity.
       expect(targetIndex.targetToPaths.get('stevey')).toContain('People/Steve Yegge.md');
     });
@@ -276,6 +276,144 @@ describe('alias field role', () => {
       // The well-formed note is either omitted (no issues at all) or present
       // without an illegal-aliases issue.
       expect(steve?.issues.some((i) => i.code === 'illegal-aliases') ?? false).toBe(false);
+    });
+  });
+
+  // End-to-end relation resolution: a relation field reference must resolve
+  // through the same case-insensitive rules as open/navigation, so a
+  // case-variant `[[Steve]]` resolves to the real `steve` note instead of being
+  // reported as a stale reference (#616). The original PR only asserted on index
+  // KEYS — these tests run the full audit pipeline.
+  describe('case-insensitive relation resolution (real vault)', () => {
+    // A `person` type (alias-bearing) plus a `doc` type whose `related` field is
+    // a relation, so we can exercise stale-reference / ambiguous-link-target.
+    const RELATION_SCHEMA: Schema = {
+      version: 2,
+      types: {
+        meta: { fields: {} },
+        person: {
+          extends: 'meta',
+          output_dir: 'People',
+          fields: {
+            type: { value: 'person' },
+            aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
+          },
+          field_order: ['type', 'aliases'],
+        },
+        doc: {
+          extends: 'meta',
+          output_dir: 'Docs',
+          fields: {
+            type: { value: 'doc' },
+            related: { prompt: 'relation', source: 'any' },
+          },
+          field_order: ['type', 'related'],
+        },
+      },
+    };
+
+    let vaultDir: string;
+
+    beforeEach(async () => {
+      vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-relation-'));
+      await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(vaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify(RELATION_SCHEMA, null, 2)
+      );
+      await mkdir(join(vaultDir, 'People'), { recursive: true });
+      await mkdir(join(vaultDir, 'Docs'), { recursive: true });
+    });
+
+    afterEach(async () => {
+      await rm(vaultDir, { recursive: true, force: true });
+    });
+
+    const relationIssues = (results: Awaited<ReturnType<typeof runAudit>>, relPath: string) =>
+      results.find((r) => r.relativePath === relPath)?.issues ?? [];
+
+    it('[[Steve]] resolves to the real `steve` note, NOT a stale-reference (#616)', async () => {
+      // Real note literally named "steve" (lowercase) and a DIFFERENT entity
+      // aliased "Steve" (capital). A `[[Steve]]` relation must resolve to the
+      // real steve note end-to-end, never flagged stale, never bound to the alias.
+      await writeFile(join(vaultDir, 'Docs', 'steve.md'), `---\ntype: doc\n---\n`);
+      await writeFile(
+        join(vaultDir, 'People', 'Steve Yegge.md'),
+        `---\ntype: person\naliases:\n  - Steve\n---\n`
+      );
+      await writeFile(
+        join(vaultDir, 'Docs', 'Ref.md'),
+        `---\ntype: doc\nrelated: "[[Steve]]"\n---\n`
+      );
+
+      const schema = await loadSchema(vaultDir);
+      const results = await runAudit(schema, vaultDir, { strict: false });
+      const issues = relationIssues(results, 'Docs/Ref.md');
+
+      expect(issues.some((i) => i.code === 'stale-reference')).toBe(false);
+      expect(issues.some((i) => i.code === 'ambiguous-link-target')).toBe(false);
+    });
+
+    it('[[CAFÉ]] resolves to the real `café` note via unicode case fold (no stale)', async () => {
+      await writeFile(join(vaultDir, 'Docs', 'café.md'), `---\ntype: doc\n---\n`);
+      await writeFile(
+        join(vaultDir, 'Docs', 'Ref.md'),
+        `---\ntype: doc\nrelated: "[[CAFÉ]]"\n---\n`
+      );
+
+      const schema = await loadSchema(vaultDir);
+      const results = await runAudit(schema, vaultDir, { strict: false });
+      const issues = relationIssues(results, 'Docs/Ref.md');
+
+      expect(issues.some((i) => i.code === 'stale-reference')).toBe(false);
+      expect(issues.some((i) => i.code === 'ambiguous-link-target')).toBe(false);
+    });
+
+    it('genuine case-variant ambiguity (two real notes) surfaces ambiguous-link-target', async () => {
+      // Two real notes whose names differ only by case both claim the lowercased
+      // key, so `[[Steve]]` is genuinely ambiguous and is never auto-resolved.
+      await mkdir(join(vaultDir, 'Docs', 'Sub'), { recursive: true });
+      await writeFile(join(vaultDir, 'Docs', 'steve.md'), `---\ntype: doc\n---\n`);
+      await writeFile(join(vaultDir, 'Docs', 'Sub', 'Steve.md'), `---\ntype: doc\n---\n`);
+      await writeFile(
+        join(vaultDir, 'Docs', 'Ref.md'),
+        `---\ntype: doc\nrelated: "[[Steve]]"\n---\n`
+      );
+
+      const schema = await loadSchema(vaultDir);
+      const results = await runAudit(schema, vaultDir, { strict: false });
+      const issues = relationIssues(results, 'Docs/Ref.md');
+
+      expect(issues.some((i) => i.code === 'ambiguous-link-target')).toBe(true);
+      expect(issues.some((i) => i.code === 'stale-reference')).toBe(false);
+    });
+
+    it('a truly-missing target is still a stale-reference', async () => {
+      await writeFile(
+        join(vaultDir, 'Docs', 'Ref.md'),
+        `---\ntype: doc\nrelated: "[[Nonexistent]]"\n---\n`
+      );
+
+      const schema = await loadSchema(vaultDir);
+      const results = await runAudit(schema, vaultDir, { strict: false });
+      const issues = relationIssues(results, 'Docs/Ref.md');
+
+      expect(issues.some((i) => i.code === 'stale-reference')).toBe(true);
+    });
+
+    it('an exact-case relation reference still resolves cleanly (no regression)', async () => {
+      await writeFile(join(vaultDir, 'Docs', 'Target.md'), `---\ntype: doc\n---\n`);
+      await writeFile(
+        join(vaultDir, 'Docs', 'Ref.md'),
+        `---\ntype: doc\nrelated: "[[Target]]"\n---\n`
+      );
+
+      const schema = await loadSchema(vaultDir);
+      const results = await runAudit(schema, vaultDir, { strict: false });
+      const issues = relationIssues(results, 'Docs/Ref.md');
+
+      expect(issues.some((i) => i.code === 'stale-reference')).toBe(false);
+      expect(issues.some((i) => i.code === 'ambiguous-link-target')).toBe(false);
     });
   });
 });

--- a/tests/ts/lib/discovery.test.ts
+++ b/tests/ts/lib/discovery.test.ts
@@ -267,7 +267,10 @@ describe('Discovery', () => {
       const pathMap = deriveNotePathMap(snapshot);
       const targetIndex = deriveNoteTargetIndex(snapshot);
 
-      expect(targetIndex.targetToPaths.get('Shared')).toEqual([
+      // targetToPaths is keyed by the lowercased target (case-insensitive
+      // resolution); two distinct notes sharing a basename stay represented as
+      // multiple paths so ambiguity remains detectable.
+      expect(targetIndex.targetToPaths.get('shared')).toEqual([
         'Projects/Shared.md',
         'Research/Shared.md',
       ]);
@@ -289,7 +292,7 @@ describe('Discovery', () => {
       expect(index.snapshot.notes.some((note) => note.relativePath === 'Templates/Excluded.md')).toBe(false);
       expect(index.allFiles.has('Excluded')).toBe(false);
       expect(index.notePathMap.has('Templates/Excluded')).toBe(false);
-      expect(index.noteTargetIndex.targetToPaths.has('Excluded')).toBe(false);
+      expect(index.noteTargetIndex.targetToPaths.has('excluded')).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Problem

The "real note name beats alias" precedence guard was **case-sensitive** while the rest of name and relation resolution is case-insensitive. With a real note `steve` (lowercase) and a *different* entity whose alias is `Steve` (capital), a `[[Steve]]` reference — and `bwrb open Steve`, relation `Steve` — silently bound to the **alias** instead of recognizing the near-collision with the case-variant real note.

## Fix

Lowercase the real-key sets the guard consults, in the three places that implement "real wins over alias", reusing the same lowercasing the surrounding code already uses:

- **`src/lib/navigation.ts`** (`buildNoteIndex`): the `byBasename.has(alias)` check now consults a lowercased basename set, so an alias colliding with a real note case-insensitively is never registered in `byAlias`. Drives `open` / `edit` / `search`.
- **`src/lib/discovery.ts`** (`deriveNotePathMap`): `realKeys` is now lowercased and the alias is checked lowercased (the path map used by `--fix` / path resolution). The alias-vs-alias first-claimant rule (`pathMap.has(alias)`) is preserved.
- **`src/lib/discovery.ts`** (`deriveNoteTargetIndex`): `realKeys` lowercased and alias checked lowercased (relation validation + audit + `--fix`).

### Resolved precedence

A real note whose name matches a query **case-insensitively** wins over an entity that merely has it as an alias — the alias is simply never registered, so `resolveNoteQuery` falls through to the case-insensitive basename match and binds the real note. **Genuine ambiguity is still surfaced**: a shared alias across two entities resolves to multiple candidates and is never auto-resolved.

## No regressions

- Exact-case real-note precedence: unchanged (lowercasing a string that's already an exact match is a no-op).
- Genuine ambiguity (two real notes, or a shared alias across two entities): still surfaced (covered by existing + new tests).
- No-collision alias resolution: still works (non-colliding aliases are still registered).

## Tests

Added to `tests/ts/lib/alias-role.test.ts`:
- case-variant real note (`steve`) wins over alias (`Steve`) in `resolveNoteQuery` / `byAlias`.
- case-variant real note wins in the relation target index (audit / `--fix` path).
- shared-alias genuine ambiguity stays ambiguous (no regression).

## Quality gates

- `pnpm qa` (typecheck, lint, docs:lint, docs:doctor, build, test): **pass** (104 files, 2371 passed, 4 skipped).
- `pnpm knip`: **pass** (clean).
- `pnpm docs:build`: **pass** (schema reference updated to state case-insensitive real-name precedence).

Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)