### PR TITLE
fix(audit): single-report numeric date-list elements (#641)

### DIFF
--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -86,6 +86,8 @@ Note: built-in fields written by `bwrb new` (currently `id` and `name`) are alwa
 Invalid option values inside list fields are reported as `invalid-option` with `listIndex` metadata, not a separate issue code.
 For a [`date`](/reference/schema/) field with `multiple: true` (a list of dates), each element is validated against the field's granularity and an invalid element is reported as `invalid-date-format` with `listIndex` metadata identifying the offending value. List elements are reported for manual correction (not auto-fixed); only scalar date values are auto-normalized.
 
+A **numeric** date element (e.g. an unquoted `2026`, which YAML parses as a number) is treated exactly like a numeric scalar date: it is owned by the date check, so it is reported **once** — as `invalid-date-format` when it isn't a valid date for the field's granularity, or as `wrong-scalar-type` ("should be quoted as a string") when it *is* a valid date. It is never additionally reported as `invalid-list-element`. This matches scalar date handling and what `bwrb new`/`bwrb edit` accept on write.
+
 An empty or whitespace-only date value is treated as **unset**, not as an invalid date — the same convention every optional field follows (an empty optional field never produces a format/type issue). So an optional `date` field stored as `""` produces no `invalid-date-format` issue, matching what `bwrb new`/`bwrb edit` accept on write. An empty **required** date is reported once as [`empty-string-required`](#issue-codes) (consistent with every other required field), and an empty **element** inside a date list is reported once as `invalid-list-element` — never additionally as `invalid-date-format`.
 
 ## Examples

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -579,10 +579,14 @@ export async function auditFile(
               }),
             autoFixable: listIndex === undefined && Boolean(normalization),
           });
-        } else if (typeof element === 'number' && listIndex === undefined) {
-          // Valid scalar date stored as a YAML number — should be quoted as a
-          // string. A numeric element inside a list is instead reported (and
-          // coerced) by checkListElementIntegrity, so don't double-report here.
+        } else if (typeof element === 'number') {
+          // A valid date stored as a YAML number — should be quoted as a string.
+          // This is true for both scalar dates and list elements: the date check
+          // owns every numeric element of a date field (just as create/edit
+          // validates numeric elements as dates), so `checkListElementIntegrity`
+          // skips numeric date elements and we report exactly one issue per bad
+          // element (#641). For scalar dates the field-level auto-fixer can quote
+          // the value; a list element is surfaced for a manual fix.
           issues.push({
             severity: 'error',
             code: 'wrong-scalar-type',
@@ -590,7 +594,8 @@ export async function auditFile(
             field: fieldName,
             value: element,
             expected: 'string',
-            autoFixable: true,
+            ...(listIndex !== undefined && { listIndex }),
+            autoFixable: listIndex === undefined,
           });
         }
       };
@@ -1159,6 +1164,16 @@ function checkListElementIntegrity(
       }
 
       if (typeof item !== 'string') {
+        // Numeric elements of a date field are owned by the date check
+        // (checkDateElement): a number in a date field is a date candidate, not a
+        // structural wrong-type. It is reported once there — as invalid-date-format
+        // when it isn't a valid date, or wrong-scalar-type ("quote it") when it is.
+        // Skipping here keeps each bad element single-reported and aligns date
+        // lists with scalar dates and the create/edit path (#641).
+        if (field.prompt === 'date' && typeof item === 'number') {
+          return;
+        }
+
         const canCoerce = typeof item === 'number' || typeof item === 'boolean';
         issues.push({
           severity: 'warning',

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -3749,6 +3749,110 @@ effort: "3"
       expect(issues[0].value).toBe('2026');
     });
 
+    // #641: a numeric or empty-string element of a multiple date field must be
+    // reported exactly once, consistent with scalar dates and the create/edit
+    // path. The date check owns numeric elements (a number in a date field is a
+    // date candidate, not a structural wrong-type); checkListElementIntegrity
+    // owns null/empty/nested/non-numeric-wrong-type. The two must not both fire
+    // for the same element.
+    async function auditAllIssues(filename: string, body: string, field = 'dates') {
+      await writeFile(join(tempVaultDir, 'Logs', filename), body);
+      const result = await runCLI(['audit', 'log', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(result.stdout);
+      const file = output.files.find((f: { path: string }) => f.path.includes(filename));
+      const issues: { code: string; field?: string; listIndex?: number; value?: unknown }[] =
+        file?.issues ?? [];
+      return issues.filter((i) => i.field === field || i.field === undefined);
+    }
+
+    it('reports an invalid numeric date-list element once as invalid-date-format (#641)', async () => {
+      // At day granularity, numeric 2026 and 5 are not valid dates. Each must be
+      // reported once as invalid-date-format and NOT also as invalid-list-element.
+      const issues = await auditAllIssues(
+        'NumericInvalid.md',
+        `---\ntype: log\ndates:\n  - "2026-01-01"\n  - 2026\n  - 5\n---\n`
+      );
+      const dateIssues = issues.filter((i) => i.code === 'invalid-date-format');
+      const listIssues = issues.filter((i) => i.code === 'invalid-list-element');
+      expect(dateIssues.map((i) => i.listIndex).sort()).toEqual([1, 2]);
+      expect(listIssues).toHaveLength(0);
+    });
+
+    it('reports a valid numeric date-list element once as wrong-scalar-type (#641)', async () => {
+      // At year granularity a numeric 2026 IS a valid date; it should be quoted as
+      // a string. Reported once as wrong-scalar-type (matching scalar dates), not
+      // as invalid-list-element and not as invalid-date-format.
+      const yearSchema = {
+        version: 2,
+        types: {
+          log: {
+            output_dir: 'Logs',
+            fields: {
+              type: { value: 'log' },
+              years: { prompt: 'date' as const, multiple: true, granularity: 'year' as const },
+            },
+          },
+        },
+      };
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify(yearSchema, null, 2)
+      );
+      await writeFile(
+        join(tempVaultDir, 'Logs', 'NumericValid.md'),
+        `---\ntype: log\nyears:\n  - 2026\n---\n`
+      );
+      const result = await runCLI(['audit', 'log', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(result.stdout);
+      const file = output.files.find((f: { path: string }) => f.path.includes('NumericValid.md'));
+      const issues: { code: string; listIndex?: number; value?: unknown }[] = file?.issues ?? [];
+      const wrongScalar = issues.filter((i) => i.code === 'wrong-scalar-type');
+      const listIssues = issues.filter((i) => i.code === 'invalid-list-element');
+      const dateIssues = issues.filter((i) => i.code === 'invalid-date-format');
+      expect(wrongScalar).toHaveLength(1);
+      expect(wrongScalar[0].listIndex).toBe(0);
+      expect(wrongScalar[0].value).toBe(2026);
+      expect(listIssues).toHaveLength(0);
+      expect(dateIssues).toHaveLength(0);
+    });
+
+    it('reports an empty-string date-list element once as invalid-list-element (#641)', async () => {
+      const issues = await auditAllIssues(
+        'EmptyElement.md',
+        `---\ntype: log\ndates:\n  - "2026-01-01"\n  - ""\n  - "2026-02-01"\n---\n`
+      );
+      const dateIssues = issues.filter((i) => i.code === 'invalid-date-format');
+      const listIssues = issues.filter((i) => i.code === 'invalid-list-element');
+      expect(dateIssues).toHaveLength(0);
+      expect(listIssues).toHaveLength(1);
+      expect(listIssues[0].listIndex).toBe(1);
+    });
+
+    it('reports an invalid date-string element once as invalid-date-format (#641)', async () => {
+      const issues = await auditAllIssues(
+        'InvalidString.md',
+        `---\ntype: log\ndates:\n  - "2026-01-01"\n  - not-a-date\n---\n`
+      );
+      const dateIssues = issues.filter((i) => i.code === 'invalid-date-format');
+      const listIssues = issues.filter((i) => i.code === 'invalid-list-element');
+      expect(dateIssues).toHaveLength(1);
+      expect(dateIssues[0].listIndex).toBe(1);
+      expect(listIssues).toHaveLength(0);
+    });
+
+    it('reports no issues for an all-valid string date list (#641)', async () => {
+      const issues = await auditAllIssues(
+        'AllValid.md',
+        `---\ntype: log\ndates:\n  - "2026-01-01"\n  - "2026-02-01"\n---\n`
+      );
+      const dateIssues = issues.filter((i) => i.code === 'invalid-date-format');
+      const listIssues = issues.filter((i) => i.code === 'invalid-list-element');
+      const wrongScalar = issues.filter((i) => i.code === 'wrong-scalar-type');
+      expect(dateIssues).toHaveLength(0);
+      expect(listIssues).toHaveLength(0);
+      expect(wrongScalar).toHaveLength(0);
+    });
+
     it('does not regress scalar (single-value) date validation', async () => {
       // Scalar date assigned to a multiple field still gets validated and the
       // existing scalar code path is unaffected.


### PR DESCRIPTION
## Summary

Fixes the remaining double-report in the audit path for `multiple: true` date fields. A **numeric** element of a date list was being reported by BOTH the date check (`invalid-date-format`) and the structural list-integrity check (`invalid-list-element`). The empty-string half of #641 was already resolved by #614.

## What still double-reported after #614

- **Numeric element that isn't a valid date** (e.g. `5`, or `2026` at day granularity): `invalid-date-format` + `invalid-list-element` (wrong-type). The date check only early-returned on non-string/non-number, so numbers fell through.
- **Numeric element that IS a valid date** (e.g. `2026` at year granularity): single-reported, but with the *wrong* code (`invalid-list-element` wrong-type) — inconsistent with scalar dates, which report `wrong-scalar-type` ("quote it"), and with create/edit, which accepts it as a valid date.

## Fix — one check owns each failure mode

The date check owns every numeric element of a date field (a number in a date field is a date candidate, not a structural wrong-type), consistent with scalar dates and `bwrb new`/`bwrb edit`:

- Numeric element → reported once: `invalid-date-format` when not a valid date, else `wrong-scalar-type` ("should be quoted as a string"). `checkDateElement` now emits `wrong-scalar-type` with a `listIndex` for valid numeric list elements (previously scalar-only).
- `checkListElementIntegrity` skips numeric elements in date fields, so it no longer also flags them.
- Empty-string elements stay single (`invalid-list-element`, #614); invalid date strings stay single (`invalid-date-format`).

## Tests

Added five `#641` cases to the `#593` suite: invalid numeric → one `invalid-date-format`; valid numeric → one `wrong-scalar-type`; empty string → one `invalid-list-element`; invalid string → one `invalid-date-format`; all-valid → none. Existing #593/#614 tests unchanged and green.

## Quality gates

- `pnpm qa` — pass (2381 tests)
- `pnpm knip` — pass
- `pnpm docs:build` — pass (docs updated to describe numeric-element handling)

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)