### PR TITLE
fix(discover): exit 2 for an unreadable root directory

### DIFF
--- a/docs-site/src/content/docs/reference/commands/schema.md
+++ b/docs-site/src/content/docs/reference/commands/schema.md
@@ -298,7 +298,7 @@ The `data` object has this shape:
   "root": "/abs/path/scanned",
   "totalFiles": 4,
   "filesWithFrontmatter": 3,
-  "unreadable": [],                 // { file, error } for files skipped (never fatal)
+  "unreadable": [],                 // { file, error } for skipped files AND nested unreadable subdirs (never fatal)
   "schemaPresent": true,            // whether a schema was loaded for drift
   "fields": [
     {
@@ -336,6 +336,13 @@ Value-types are coarse, frontmatter-shaped buckets: `string`, `number`,
 |------|---------|
 | `0` | Report produced (including for non-conforming data) |
 | `2` | Real error (for example, the path is missing or unreadable) |
+
+A scanned **root** that exists but whose contents cannot be listed (for example
+a directory with `chmod 000`) is a real error and exits `2` — it is never
+reported as "0 files". By contrast, an unreadable **nested** subdirectory found
+mid-walk is recoverable: the rest of the tree is still scanned (exit `0`) and the
+locked subdirectory is surfaced in the `unreadable` list rather than silently
+dropped.
 
 ---
 

--- a/src/commands/schema/discover.ts
+++ b/src/commands/schema/discover.ts
@@ -111,7 +111,15 @@ Examples:
         }
       }
 
-      const report = await buildDiscoverReport(root, { schema });
+      // buildDiscoverReport throws if the scanned ROOT directory is unreadable
+      // (its contents cannot be listed even though the path exists). Surface a
+      // clear IO error rather than silently reporting "0 files".
+      let report;
+      try {
+        report = await buildDiscoverReport(root, { schema });
+      } catch {
+        throw new Error(`Path not found or unreadable: ${root}`);
+      }
 
       if (jsonMode) {
         printJson(jsonSuccess({ data: report }));

--- a/src/lib/discover.ts
+++ b/src/lib/discover.ts
@@ -149,7 +149,12 @@ export interface DiscoverReport {
   totalFiles: number;
   /** Files that had a (non-empty) frontmatter block. */
   filesWithFrontmatter: number;
-  /** Files that could not be parsed (path + reason). Never fatal. */
+  /**
+   * Paths that could not be read and were skipped (path + reason). Never fatal.
+   * Includes individual files that failed to parse and NESTED subdirectories
+   * that could not be listed mid-walk. (An unreadable scanned ROOT is a hard
+   * error and never reaches a report.)
+   */
   unreadable: Array<{ file: string; error: string }>;
   /** Whether a schema was found and loaded for drift detection. */
   schemaPresent: boolean;
@@ -163,29 +168,69 @@ export interface DiscoverReport {
 // File walking
 // ============================================================================
 
+/** Result of walking a folder for Markdown files. */
+interface MarkdownWalkResult {
+  /** Absolute paths of every `.md` file found, sorted. */
+  files: string[];
+  /**
+   * Nested directories that could not be read mid-walk (path + reason). The
+   * scanned ROOT is never recorded here — an unreadable root is a hard error
+   * raised by the caller of {@link collectMarkdownFiles}, not a recoverable
+   * skip. These are surfaced (not silently dropped) but do not abort the scan.
+   */
+  unreadableDirs: Array<{ dir: string; error: string }>;
+}
+
 /**
  * Recursively collect `.md` files under `dir`. Hidden directories (`.git`,
  * `.bwrb`, …) are skipped. Standalone helper so discover can run on an
  * arbitrary folder without the vault's schema-aware discovery machinery.
+ *
+ * The ROOT directory being unreadable is a hard error: `readdir` throws and
+ * the error propagates to the caller (which maps it to a non-zero exit). An
+ * unreadable NESTED subdirectory is recoverable — it is recorded in
+ * `unreadableDirs` and the rest of the tree is still scanned, so one locked
+ * subfolder does not make the whole run silently report "0 files".
+ *
+ * @param isRoot whether `dir` is the originally scanned root (default true).
+ *   Recursive calls pass `false` so their failures are recorded, not thrown.
  */
-async function collectMarkdownFiles(dir: string): Promise<string[]> {
-  const results: string[] = [];
+async function collectMarkdownFiles(
+  dir: string,
+  isRoot = true
+): Promise<MarkdownWalkResult> {
+  const files: string[] = [];
+  const unreadableDirs: Array<{ dir: string; error: string }> = [];
+
   let entries;
   try {
     entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return results;
+  } catch (err) {
+    // Root unreadable → hard error (exit 2). Nested → record and skip.
+    if (isRoot) throw err;
+    unreadableDirs.push({
+      dir,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { files, unreadableDirs };
   }
+
   for (const entry of entries) {
     if (entry.name.startsWith('.')) continue;
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
-      results.push(...(await collectMarkdownFiles(full)));
+      const nested = await collectMarkdownFiles(full, false);
+      files.push(...nested.files);
+      unreadableDirs.push(...nested.unreadableDirs);
     } else if (entry.isFile() && entry.name.endsWith('.md')) {
-      results.push(full);
+      files.push(full);
     }
   }
-  return results.sort((a, b) => a.localeCompare(b));
+
+  return {
+    files: files.sort((a, b) => a.localeCompare(b)),
+    unreadableDirs,
+  };
 }
 
 // ============================================================================
@@ -275,10 +320,15 @@ export async function buildDiscoverReport(
   options: BuildReportOptions = {}
 ): Promise<DiscoverReport> {
   const { schema } = options;
-  const files = await collectMarkdownFiles(root);
+  // An unreadable ROOT throws here and propagates to the command layer, which
+  // maps it to a non-zero (IO_ERROR) exit. Nested unreadable dirs are returned
+  // and surfaced below rather than aborting the scan.
+  const { files, unreadableDirs } = await collectMarkdownFiles(root);
 
   const accumulators = new Map<string, FieldAccumulator>();
-  const unreadable: Array<{ file: string; error: string }> = [];
+  const unreadable: Array<{ file: string; error: string }> = unreadableDirs.map(
+    (d) => ({ file: relative(root, d.dir), error: d.error })
+  );
   let filesWithFrontmatter = 0;
 
   const schemaInfo = schema ? collateSchemaFields(schema) : undefined;

--- a/tests/ts/commands/schema-discover.test.ts
+++ b/tests/ts/commands/schema-discover.test.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { mkdtemp, mkdir, writeFile, rm, chmod } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCLI } from '../fixtures/setup.js';
+
+/**
+ * `chmod 000` is a no-op for the root user (root bypasses permission bits), so
+ * permission-based tests must be skipped when the suite runs as root (common in
+ * CI containers). `process.getuid` is undefined on Windows; treat that as
+ * "cannot test permissions" and skip too.
+ */
+const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+const skipIfNoPerms = isRoot ? it.skip : it;
 
 /**
  * `schema discover` is DESCRIPTIVE — it reports frontmatter facts and never
@@ -245,6 +254,59 @@ describe('schema discover', () => {
       const parsed = JSON.parse(result.stdout) as { success: boolean; error: string };
       expect(parsed.success).toBe(false);
       expect(parsed.error).toContain('not found');
+    });
+
+    skipIfNoPerms('exits non-zero for an unreadable ROOT directory (#639)', async () => {
+      const locked = join(dir, 'locked');
+      await mkdir(locked, { recursive: true });
+      await writeFile(join(locked, 'n.md'), `---\nk: v\n---\n`);
+      await chmod(locked, 0o000);
+      try {
+        const result = await runCLI(['schema', 'discover', locked]);
+        // Must NOT silently report "0 markdown file(s)" with exit 0.
+        expect(result.exitCode).toBe(2);
+        expect(result.stdout).not.toContain('0 markdown file(s)');
+      } finally {
+        // Restore perms so afterEach cleanup can remove the dir.
+        await chmod(locked, 0o755);
+      }
+    });
+
+    skipIfNoPerms('reports an error as JSON for an unreadable ROOT in json mode (#639)', async () => {
+      const locked = join(dir, 'locked');
+      await mkdir(locked, { recursive: true });
+      await writeFile(join(locked, 'n.md'), `---\nk: v\n---\n`);
+      await chmod(locked, 0o000);
+      try {
+        const result = await runCLI(['schema', 'discover', locked, '--output', 'json']);
+        expect(result.exitCode).toBe(2);
+        const parsed = JSON.parse(result.stdout) as { success: boolean; error: string };
+        expect(parsed.success).toBe(false);
+        expect(parsed.error).toContain('unreadable');
+      } finally {
+        await chmod(locked, 0o755);
+      }
+    });
+
+    skipIfNoPerms('surfaces an unreadable NESTED subdir without aborting the scan (#639)', async () => {
+      // Readable root with one readable note and one locked subdirectory.
+      await writeNote('readable.md', `---\ntype: idea\n---\n`);
+      const lockedSub = join(dir, 'locked-sub');
+      await mkdir(lockedSub, { recursive: true });
+      await writeFile(join(lockedSub, 'hidden.md'), `---\nsecret: yes\n---\n`);
+      await chmod(lockedSub, 0o000);
+      try {
+        const result = await runCLI(['schema', 'discover', dir, '--output', 'json']);
+        // The scan succeeds (exit 0) and still reports the readable file...
+        expect(result.exitCode).toBe(0);
+        const data = parseJson(result.stdout);
+        expect(data.totalFiles).toBe(1);
+        expect(field(data, 'type')).toBeDefined();
+        // ...but the locked subdir is surfaced, not silently dropped.
+        expect(data.unreadable.some((u) => u.file === 'locked-sub')).toBe(true);
+      } finally {
+        await chmod(lockedSub, 0o755);
+      }
     });
 
     it('classifies dates, lists, and booleans distinctly', async () => {


### PR DESCRIPTION
## Summary

`bwrb schema discover` silently reported `0 markdown file(s)` and exited `0` when the scanned **root** directory existed but its contents were unreadable (e.g. `chmod 000`). `collectMarkdownFiles` caught and swallowed the `readdir` error, returning an empty file list. The documented contract reserves exit `2` (`IO_ERROR`) for missing/unreadable paths.

Repro (now fixed):
```
mkdir locked && printf -- '---\nk: v\n---' > locked/n.md && chmod 000 locked
bwrb schema discover ./locked   # before: "0 markdown file(s)", exit 0  →  now: exit 2
```

## What changed

- **`src/lib/discover.ts`** — `collectMarkdownFiles` now distinguishes the root call from recursive calls (`isRoot` flag). An unreadable **root** throws (propagated to the command layer); an unreadable **nested** subdir found mid-walk is recorded in a `unreadableDirs` list and surfaced in the report's existing `unreadable[]` mechanism, without aborting the scan. This keeps one locked subfolder from making a whole run silently report "0 files", while a locked root is a hard error.
- **`src/commands/schema/discover.ts`** — wraps `buildDiscoverReport` so a root-walk failure maps to a clear `Path not found or unreadable: <root>` message and exit `2` (text + JSON error payload).
- **Tests** — CLI tests for the unreadable-root case (text + `--output json`) and the nested-unreadable case (surfaced, not silently `0`). Permission tests skip when running as root (where `chmod 000` is ignored) and restore perms before cleanup.
- **Docs** — `schema discover` reference now documents the root-vs-nested distinction and notes that nested unreadable subdirs appear in `unreadable[]`.

## Distinction

- **Root unreadable** → hard error, exit `2`.
- **Nested subdir unreadable mid-walk** → recoverable, exit `0`, surfaced in `unreadable[]` (consistent with how malformed files are already reported).

## Quality gates

- `pnpm qa` — pass (typecheck, lint, docs:lint, docs:doctor, build, test; 2388 passed / 4 skipped).
- `pnpm knip` — pass.
- `pnpm docs:build` — pass.

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)