### PR TITLE
fix(recurrence): disambiguate cross-type successor names vault-globally

### DIFF
--- a/docs-site/src/content/docs/automation/task-system.md
+++ b/docs-site/src/content/docs/automation/task-system.md
@@ -83,6 +83,16 @@ spawn a `review`:
 The audit validates that the referenced template exists (a rule pointing at a deleted
 template is a deterministic error — see below).
 
+**Successor naming.** The successor carries the predecessor's name so the chain reads
+naturally, but bwrb wikilinks are **name-based** (`[[Chapter One]]` resolves by basename
+across every directory). So the spawned successor's basename is guaranteed **unique across
+the whole vault**: if the carried name is already taken anywhere, bwrb appends ` 2`, ` 3`,
+… A same-type successor in a busy directory and a **cross-type** successor (finish a
+`draft` → spawn a `review`) are handled the same way — finishing `drafts/Chapter One.md`
+spawns `reviews/Chapter One 2.md`, not `reviews/Chapter One.md`, so the predecessor's
+`next` and the successor's `prev` resolve unambiguously to the right notes (a type whose
+template defines a filename pattern disambiguates via that pattern instead).
+
 ### The `next` field does three jobs
 
 A single `next` relation field collapses three requirements into one mechanism:

--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -33,6 +33,8 @@ import { formatValue } from './vault.js';
 import { getFilenamePattern } from './template.js';
 import { createNoteFromJson } from '../commands/new/json-mode.js';
 import { findDefaultTemplateWithInheritance } from './template.js';
+import { buildNoteIndex } from './navigation.js';
+import type { NoteIndex } from './navigation.js';
 import type { NoteCreationResult } from '../commands/new/types.js';
 
 /**
@@ -400,16 +402,33 @@ async function resolveSuccessorTemplate(
  *
  * If the spawn type (or its template) defines a filename pattern, that pattern
  * disambiguates the filename (commonly via a date), so the carried-forward name
- * is returned unchanged. Otherwise the successor would be filed as
- * `<name>.md` — identical to the predecessor — so we suffix ` 2`, ` 3`, ...
- * against the spawn type's output directory until a free name is found.
+ * is returned unchanged. Otherwise the successor would be filed as `<name>.md` —
+ * and we must guarantee its basename is UNIQUE across the whole vault, not just
+ * the spawn type's own output dir, then suffix ` 2`, ` 3`, ... until it is.
+ *
+ * Why vault-global, not per-output-dir (#632): bwrb wikilinks are NAME-based, so
+ * `[[Chapter One]]` resolves by BASENAME across every directory. Same-type
+ * recurrence collides inside one dir (caught by the dir check), but a CROSS-TYPE
+ * successor (e.g. finish a `draft` → spawn a `review`) lands in a DIFFERENT dir
+ * yet keeps the predecessor's exact basename. The per-dir check never sees that
+ * clash, so the predecessor's `next: [[Chapter One]]` then resolves ambiguously
+ * to BOTH notes — `bwrb audit` reports a self-reference and a relation
+ * type-mismatch. Enforcing global basename uniqueness (consistent with how
+ * name-based links resolve) makes the spawned successor's basename distinct, so
+ * `next`/`prev` resolve unambiguously to the right notes.
+ *
+ * The vault note index (`byBasename`) is the authority for "exists anywhere";
+ * we additionally check the spawn type's output dir on disk as a belt-and-
+ * suspenders for any note the index excludes (it shares the same discovery rules
+ * as the rest of the CLI, so in practice they agree).
  */
 function resolveSuccessorName(
   schema: LoadedSchema,
   vaultDir: string,
   spawnType: string,
   template: import('../types/schema.js').Template | null,
-  baseName: string
+  baseName: string,
+  noteIndex: NoteIndex
 ): string {
   const typeDef = getType(schema, spawnType);
   const pattern = typeDef ? getFilenamePattern(template, typeDef) : null;
@@ -420,7 +439,11 @@ function resolveSuccessorName(
   const outputDir = getOutputDir(schema, spawnType);
   const dir = outputDir ? join(vaultDir, outputDir) : vaultDir;
 
-  const exists = (name: string): boolean => existsSync(join(dir, `${name}.md`));
+  // A name is taken if it collides with ANY existing note's basename anywhere in
+  // the vault (name-based-link uniqueness) OR with a file already on disk in the
+  // spawn type's output dir.
+  const exists = (name: string): boolean =>
+    noteIndex.byBasename.has(name) || existsSync(join(dir, `${name}.md`));
   if (!exists(baseName)) return baseName;
 
   let counter = 2;
@@ -469,15 +492,25 @@ export async function prepareSuccessor(
   // throws a clear, deterministic error for a missing/partial/unparseable base.
   const offsetFields = computeOffsetFields(schema, typeName, predecessor);
 
-  // Resolve a successor name that won't collide with the predecessor's filename.
+  // Resolve a successor name whose basename is UNIQUE across the whole vault.
   // When the spawn type uses a filename pattern, the pattern disambiguates (so we
-  // keep the carried-forward name); otherwise we suffix a counter against the
-  // spawn type's output directory.
+  // keep the carried-forward name); otherwise we suffix a counter until no
+  // existing note shares the basename. Vault-global (not per-output-dir) so a
+  // cross-type successor doesn't reuse the predecessor's basename and break
+  // name-based `next`/`prev` resolution (#632).
   const carriedName =
     typeof predecessor['name'] === 'string' && predecessor['name'].trim() !== ''
       ? (predecessor['name'] as string)
       : predecessorName;
-  const successorName = resolveSuccessorName(schema, vaultDir, spawnType, template, carriedName);
+  const noteIndex = await buildNoteIndex(schema, vaultDir);
+  const successorName = resolveSuccessorName(
+    schema,
+    vaultDir,
+    spawnType,
+    template,
+    carriedName,
+    noteIndex
+  );
 
   const input = buildSuccessorInput(
     schema,

--- a/tests/ts/lib/recurrence.test.ts
+++ b/tests/ts/lib/recurrence.test.ts
@@ -734,6 +734,237 @@ status: open
   });
 });
 
+describe('recurrence: cross-type naming (#632)', () => {
+  // A `draft` whose completion (status -> done) spawns a `review` via a NAMED
+  // template that targets a DIFFERENT type. Both types carry the `next`/`prev`
+  // chain (their `source` accepts both draft and review). bwrb wikilinks are
+  // name-based, so the spawned review must NOT reuse the draft's basename or the
+  // chain links resolve ambiguously.
+  const CROSS_SCHEMA: Schema = {
+    version: 2,
+    traits: {
+      chained: {
+        description: 'Forward/back chain across draft and review',
+        fields: {
+          next: { prompt: 'relation', source: ['draft', 'review'] },
+          prev: { prompt: 'relation', source: ['draft', 'review'] },
+        },
+      },
+      spawnsReview: {
+        description: 'On completion, spawn a review via a cross-type template',
+        recurrence: {
+          on: 'status = done',
+          template: 'spawn-review',
+          set: { due: 'due + 3d' },
+        },
+      },
+    },
+    types: {
+      draft: {
+        output_dir: 'drafts',
+        traits: ['chained', 'spawnsReview'],
+        fields: {
+          name: { prompt: 'text', required: true },
+          status: { prompt: 'select', options: ['todo', 'doing', 'done'], default: 'todo' },
+          due: { prompt: 'date' },
+        },
+      },
+      review: {
+        output_dir: 'reviews',
+        traits: ['chained'],
+        fields: {
+          name: { prompt: 'text', required: true },
+          status: { prompt: 'select', options: ['todo', 'doing', 'done'], default: 'todo' },
+          due: { prompt: 'date' },
+        },
+      },
+    },
+  };
+
+  async function writeReviewTemplate(vaultDir: string): Promise<void> {
+    const dir = join(vaultDir, '.bwrb', 'templates', 'review');
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, 'spawn-review.md'),
+      `---
+type: template
+template-for: review
+name: spawn-review
+defaults:
+  status: todo
+---
+
+# {name}
+`
+    );
+  }
+
+  async function listDir(vaultDir: string, sub: string): Promise<string[]> {
+    const dir = join(vaultDir, sub);
+    if (!existsSync(dir)) return [];
+    return (await readdir(dir)).filter((f) => f.endsWith('.md')).sort();
+  }
+
+  let vaultDir: string;
+  beforeEach(async () => {
+    vaultDir = await setupVault(CROSS_SCHEMA);
+    await writeReviewTemplate(vaultDir);
+    await mkdir(join(vaultDir, 'drafts'), { recursive: true });
+    await mkdir(join(vaultDir, 'reviews'), { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('spawns a review with a UNIQUE basename (not the draft name) and audits clean', async () => {
+    const draftPath = join(vaultDir, 'drafts', 'Chapter One.md');
+    await writeFile(
+      draftPath,
+      `---
+type: draft
+name: Chapter One
+status: doing
+due: 2026-04-01
+---
+
+# Chapter One
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, draftPath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+
+    // The review landed in reviews/ with a DISTINCT basename (suffix), not
+    // `reviews/Chapter One.md` (which would clash by name with the draft).
+    const drafts = await listDir(vaultDir, 'drafts');
+    const reviews = await listDir(vaultDir, 'reviews');
+    expect(drafts).toEqual(['Chapter One.md']);
+    expect(reviews).toHaveLength(1);
+    const reviewName = reviews[0]!.replace(/\.md$/, '');
+    expect(reviewName).not.toBe('Chapter One');
+    expect(reviewName.startsWith('Chapter One')).toBe(true); // carried name + suffix
+
+    // Offset applied to the spawned review.
+    const succFm = await readFrontmatter(join(vaultDir, 'reviews', reviews[0]!));
+    expect(succFm['due']).toBe('2026-04-04');
+
+    // `bwrb audit` is CLEAN of the name-collision symptoms (#632): no
+    // self-reference, no relation type-mismatch, no unlinked-mention.
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const issues = results.flatMap((r) => r.issues);
+    expect(issues.some((i) => i.code === 'self-reference')).toBe(false);
+    expect(issues.some((i) => i.code === 'type-mismatch')).toBe(false);
+    expect(issues.some((i) => i.code === 'unlinked-mention')).toBe(false);
+    expect(issues.some((i) => i.code === 'ambiguous-link-target')).toBe(false);
+  });
+
+  it('next/prev resolve to the correct DISTINCT notes', async () => {
+    const draftPath = join(vaultDir, 'drafts', 'Chapter One.md');
+    await writeFile(
+      draftPath,
+      `---
+type: draft
+name: Chapter One
+status: doing
+due: 2026-04-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, draftPath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+
+    const reviews = await listDir(vaultDir, 'reviews');
+    const reviewName = reviews[0]!.replace(/\.md$/, '');
+
+    // Predecessor's `next` points at the review's UNIQUE name; the review's
+    // `prev` points back at the draft. They are different basenames.
+    const draftFm = await readFrontmatter(draftPath);
+    const reviewFm = await readFrontmatter(join(vaultDir, 'reviews', reviews[0]!));
+    expect(String(draftFm['next'])).toContain(reviewName);
+    expect(String(reviewFm['prev'])).toContain('Chapter One');
+    expect(String(draftFm['next'])).not.toContain('[[Chapter One]]');
+  });
+
+  it('is idempotent: re-completing the draft does NOT spawn a duplicate review', async () => {
+    const draftPath = join(vaultDir, 'drafts', 'Chapter One.md');
+    await writeFile(
+      draftPath,
+      `---
+type: draft
+name: Chapter One
+status: doing
+due: 2026-04-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, draftPath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+    expect(await listDir(vaultDir, 'reviews')).toHaveLength(1);
+
+    await editNoteFromJson(
+      schema,
+      vaultDir,
+      draftPath,
+      JSON.stringify({ status: 'done', due: '2026-04-01' }),
+      { jsonMode: false }
+    );
+    expect(await listDir(vaultDir, 'reviews')).toHaveLength(1);
+  });
+
+  it('a chain of cross-type spawns stays unambiguous (distinct basenames, audit clean)', async () => {
+    // Pre-seed a review that already carries the base name, forcing the spawned
+    // review to climb past the first suffix and proving global-basename scope.
+    await writeFile(
+      join(vaultDir, 'reviews', 'Chapter One 2.md'),
+      `---
+type: review
+name: Chapter One 2
+status: todo
+due: 2026-01-01
+---
+`
+    );
+    const draftPath = join(vaultDir, 'drafts', 'Chapter One.md');
+    await writeFile(
+      draftPath,
+      `---
+type: draft
+name: Chapter One
+status: doing
+due: 2026-04-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, draftPath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+
+    const reviews = await listDir(vaultDir, 'reviews');
+    // Existing `Chapter One 2` is untouched; the spawn climbs to `Chapter One 3`.
+    expect(reviews).toContain('Chapter One 2.md');
+    expect(reviews).toContain('Chapter One 3.md');
+
+    // Every basename across the vault is unique → no ambiguous resolution.
+    const allBasenames = [
+      ...(await listDir(vaultDir, 'drafts')),
+      ...(await listDir(vaultDir, 'reviews')),
+    ].map((f) => f.replace(/\.md$/, ''));
+    expect(new Set(allBasenames).size).toBe(allBasenames.length);
+
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const issues = results.flatMap((r) => r.issues);
+    expect(issues.some((i) => i.code === 'self-reference')).toBe(false);
+    expect(issues.some((i) => i.code === 'type-mismatch')).toBe(false);
+  });
+});
+
 describe('recurrence: multi-spawn template (#630)', () => {
   let vaultDir: string;
   afterEach(async () => {


### PR DESCRIPTION
## Summary

Cross-type recurrence (#107) — a recurrence rule whose `template` targets a **different** type than the predecessor (e.g. finish a `draft` → spawn a `review`) — reused the predecessor's **exact basename**, filed in the spawn type's directory (`reviews/Chapter One.md` alongside `drafts/Chapter One.md`).

`resolveSuccessorName` only checked for filename collisions within the spawn type's **own output dir**, so it never saw the cross-directory clash and never disambiguated.

### Why same-name broke (name-based links)

bwrb wikilinks resolve by **basename across every directory**. With two notes named `Chapter One`, the predecessor's `next: [[Chapter One]]` resolved to **both** notes:
- `self-reference` — the ambiguous `next` matched the predecessor itself.
- `type-mismatch` — `prev expects draft but Chapter One is review` (ambiguous basename hit the wrong-typed note).
- `unlinked-mention` warning.

No data corruption (links byte-clean, spawn atomic) — purely a name-based-linking collision.

### The fix + collision scope

`resolveSuccessorName` now enforces **vault-global basename uniqueness** via the existing vault note index (`buildNoteIndex` → `byBasename`), suffixing ` 2`, ` 3`, … until the basename is free **anywhere** in the vault. The output-dir on-disk check is kept as a belt-and-suspenders.

I chose **vault-global** scope (not predecessor-only) because that is exactly the invariant name-based links require to resolve unambiguously — the same authority the rest of the CLI uses to resolve `[[...]]`. Predecessor-only would fix the immediate symptom but still allow a successor to collide with some *other* same-named note and reintroduce ambiguity.

- **Same-type recurrence** is unaffected: the predecessor already occupies the basename in-dir, so it still suffixes (` 2`) exactly as before.
- **Filename-pattern types** still disambiguate via their pattern (early return preserved).
- **Idempotency + atomicity (#107)** preserved — naming happens inside the existing `prepareSuccessor` phase, before any mutation.

## Tests

Added a `recurrence: cross-type naming (#632)` suite: `draft` done → `review` successor gets a unique basename (not the predecessor's); `next`/`prev` resolve to distinct notes; `bwrb audit` clean (no self-reference / type-mismatch / ambiguous-link-target / unlinked-mention); idempotent re-completion spawns no duplicate; a pre-seeded `Chapter One 2` forces the spawn to climb to `Chapter One 3`, proving global scope. Existing same-type suite still green.

## Quality gates

- `pnpm qa` — pass (2392 passed, 4 skipped; typecheck + lint + docs:lint + docs:doctor + build + test).
- `pnpm knip` — clean.
- `pnpm docs:build` — clean (docs updated: task-system successor-naming note).

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)