### PR TITLE
feat(audit): validate body wikilinks and relative file/image links (#652)

### DIFF
--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -79,6 +79,9 @@ Delete semantics in repair mode:
 | `unlinked-mention` | A known entity's name or [registered alias](/reference/schema/#alias) appears in body prose as plain text but is not wikilinked (warning; exact/alias matches auto-fixable, fuzzy/ambiguous matches flag-only — see below) |
 | `frequent-unlinked-term` | A proper-noun-ish term mentioned frequently across the vault that has **no note yet** (warning; **advisory heuristic, never auto-fixable** — see below) |
 | `missing-body-section` | A heading section declared in the type's [`body_sections`](/reference/schema/) is missing from the note body, or present at the wrong heading level (warning; **auto-fixable** — `--fix` appends the canonical heading scaffold — see below) |
+| `broken-body-wikilink` | A well-formed `[[wikilink]]` in the note **body** whose target resolves to **no note** via the alias-aware, case-insensitive note index (warning; **flag-only** — offers a "did you mean?" hint but never auto-links — see below) |
+| `malformed-body-wikilink` | Wikilink bracket syntax in the body that is broken — an empty target (`[[]]`/`[[ ]]`) or an unclosed `[[` (warning; **flag-only**) |
+| `broken-body-file-link` | A relative markdown file/image link in the body — `[text](path.md)` / `![alt](img.png)` — whose target does not exist on disk (warning; **flag-only**) |
 | `missing-successor` | A [recurring](/automation/task-system/) note satisfies its trigger (e.g. `status = done`) but its chain field (`next`) is empty — a successor was never spawned (e.g. completed outside bwrb). Warning; **auto-fixable** (`--fix` spawns it, identical to the fast path) |
 | `invalid-recurrence` | A [recurrence](/automation/task-system/) rule is broken at the config level — a malformed trigger, a non-date offset base, or a template that doesn't exist (error; **never auto-fixable** — a config error gets the same safety net as data) |
 
@@ -278,7 +281,7 @@ What it checks:
 - A heading written inside a fenced code block, inline code, or a link does **not** satisfy the requirement — the same [body masking](#unlinked-mention-semantics-web-integrity) used by `unlinked-mention` is applied, so only real prose headings count.
 - If a heading with the right title exists but at the **wrong level**, it is still flagged (with the offending `lineNumber`), and the fix appends a correctly-leveled heading rather than rewriting yours.
 
-What it does **not** check: it validates heading *presence/structure* only — not whether the body content under a section is filled in (bullets, checkboxes, paragraph counts). It also does not validate body wikilinks; that is the job of [`unlinked-mention`](#unlinked-mention-semantics-web-integrity) and [`frequent-unlinked-term`](#frequent-unlinked-term-semantics-open-world-nudge), which scan body links and never overlap with this structural check.
+What it does **not** check: it validates heading *presence/structure* only — not whether the body content under a section is filled in (bullets, checkboxes, paragraph counts). It also does not validate body links; that is the job of the [body-link checks](#body-link-validation-semantics-link-integrity) (`broken-body-wikilink`, `malformed-body-wikilink`, `broken-body-file-link`), which never overlap with this structural check.
 
 **Auto-fixable.** Adding a declared heading is a safe, deterministic, **additive** repair — `--fix` appends the missing section using the *same* scaffold `bwrb new`/`bwrb edit` emit (heading + the section's `content_type` placeholder), so it never deletes or rewrites existing prose. It is idempotent: a re-run finds the now-present heading and does nothing (no duplicate headings). Types that declare no `body_sections` are never flagged.
 
@@ -291,6 +294,33 @@ bwrb audit --fix --auto --execute --all
 
 # Suppress the check
 bwrb audit --ignore missing-body-section
+```
+
+### Body-link validation semantics (link integrity)
+
+The body-link checks validate the actual **links written in a note's markdown body** — the link-integrity counterpart to `missing-body-section`'s structure check. They are all **flag-only**: bwrb reports the problem (often with a suggestion) but never edits body prose links, because the intended target can't be known safely.
+
+There are three codes:
+
+- **`broken-body-wikilink`** — a *well-formed* `[[Target]]` (also `[[Target|display]]`, `[[Target#heading]]`, and embeds `![[Target]]`) whose target resolves to **no note**. Resolution uses the same alias-aware, case-insensitive [note index](/reference/schema/#alias) that relation fields use: a link written as `[[an alias]]` or `[[REALNOTE]]` resolves wherever the note's name or a [registered alias](/reference/schema/#alias) does. When a near-named note exists, a flag-only *"did you mean?"* hint is offered. An **ambiguous** body wikilink (its text matches more than one note) is **not** flagged — it is still a working Obsidian link (Obsidian resolves by proximity); ambiguity is only an error in *relation fields*, which is a separate frontmatter check.
+- **`malformed-body-wikilink`** — bracket syntax that looks like a wikilink but is broken: an empty/whitespace-only target (`[[]]`, `[[ ]]`) or an unclosed `[[` with no matching `]]`.
+- **`broken-body-file-link`** — a markdown file or image link, `[text](path)` / `![alt](path)`, whose **relative** target does not exist on disk. The path is resolved relative to the note's own directory (a leading `/` is treated as the vault root, Obsidian-style), with percent-encoding (e.g. `%20`) decoded for the existence check. **External targets are never checked**: URLs with a scheme (`https:`, `mailto:`, `tel:`…), protocol-relative `//host` links, and pure in-page anchors (`#section`).
+
+All three respect code context: links written inside **fenced code blocks** or **inline code** are masked out and never flagged. Reported issues carry the offending `lineNumber` and the raw link `value`.
+
+**Relationship to `unlinked-mention`.** These checks are the inverse of [`unlinked-mention`](#unlinked-mention-semantics-web-integrity) and never overlap with it:
+
+- `unlinked-mention` flags a **known entity's name appearing as plain text** that *should* be a wikilink (it masks out existing `[[...]]` before scanning).
+- `broken-body-wikilink` flags an **actual `[[...]]` link that points nowhere** (it looks *only* at existing wikilinks).
+
+They are also disjoint from `frequent-unlinked-term` (an open-world plain-text heuristic) and from the relation-field checks (`stale-reference`, `malformed-wikilink`, `ambiguous-link-target`), which validate **frontmatter** values only.
+
+```bash
+# Report broken body wikilinks only
+bwrb audit --only broken-body-wikilink
+
+# Suppress broken file/image link checks
+bwrb audit --ignore broken-body-file-link
 ```
 
 ### Non-interactive mode

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -126,6 +126,12 @@ Issue Types:
                         with no note yet (advisory heuristic; never auto-fixed)
   missing-body-section  Heading section declared in the type's body_sections is
                         missing from the note body (auto-fixable: appends it)
+  broken-body-wikilink  A [[wikilink]] in the body resolves to no note
+                        (flag-only; offers a "did you mean?" hint)
+  malformed-body-wikilink Broken wikilink bracket syntax in the body ([[]] /
+                        unclosed [[) (flag-only)
+  broken-body-file-link A relative [text](path)/![alt](img) link in the body
+                        whose target doesn't exist on disk (flag-only)
 
 Type Resolution:
   Audit resolves each file's type from its frontmatter 'type' field.

--- a/src/lib/audit/body-links.ts
+++ b/src/lib/audit/body-links.ts
@@ -41,7 +41,7 @@
  */
 
 import { existsSync } from 'fs';
-import { isAbsolute, resolve } from 'path';
+import { basename, isAbsolute, resolve } from 'path';
 import type { NoteTargetIndex } from '../discovery.js';
 import { levenshteinDistance } from '../levenshtein.js';
 import type { AuditIssue } from './types.js';
@@ -100,11 +100,19 @@ function fuzzyNoteSuggestions(target: string, index: NoteTargetIndex): string[] 
   if (target.length < FUZZY_MIN_LENGTH) return [];
   const lower = target.toLowerCase();
   const scored: Array<{ name: string; distance: number }> = [];
-  for (const key of index.targetToPaths.keys()) {
+  for (const [key, paths] of index.targetToPaths) {
     if (key.length < FUZZY_MIN_LENGTH) continue;
     const dist = levenshteinDistance(lower, key);
     if (dist === 0) continue;
-    if (dist <= FUZZY_MAX_DISTANCE) scored.push({ name: key, distance: dist });
+    if (dist <= FUZZY_MAX_DISTANCE) {
+      // `targetToPaths` keys are lowercased; surface the canonical-case basename
+      // (reconstructed from the resolved note path) so the "did you mean?" hint
+      // shows `RealNote` rather than the index key `realnote`. Fall back to the
+      // key if no path is recorded (shouldn't happen for real notes).
+      const firstPath = paths[0];
+      const name = firstPath ? basename(firstPath, '.md') : key;
+      scored.push({ name, distance: dist });
+    }
   }
   scored.sort((a, b) => a.distance - b.distance || a.name.localeCompare(b.name, 'en'));
   return scored.slice(0, FUZZY_MAX_SUGGESTIONS).map((s) => s.name);

--- a/src/lib/audit/body-links.ts
+++ b/src/lib/audit/body-links.ts
@@ -1,0 +1,326 @@
+/**
+ * Body-LINK validation (#652) — the link-integrity half of #510.
+ *
+ * #510 shipped `missing-body-section` (heading structure). This module covers the
+ * other half: validating actual LINKS written in a note's markdown body.
+ *
+ * Three checks, all flag-only (we never auto-edit body prose links here — see the
+ * trust-model note on each):
+ *
+ *  - `broken-body-wikilink`: a well-formed `[[Target]]` (or `[[Target|alias]]`,
+ *    `[[Target#heading]]`) in the body whose Target resolves to NO note via the
+ *    alias-aware, case-insensitive note-target index (#266/#636). Flag-only: we
+ *    cannot know the intended target, so we never auto-link. A fuzzy "did you
+ *    mean?" hint is offered when a near-named note exists.
+ *  - `malformed-body-wikilink`: bracket syntax that looks like a wikilink but is
+ *    broken — `[[]]`, `[[ ]]` (empty/whitespace target), or an unclosed `[[`.
+ *    Flag-only: malformed body syntax is ambiguous to repair safely.
+ *  - `broken-body-file-link`: a markdown file/image link `[text](path)` /
+ *    `![alt](path)` whose RELATIVE target does not exist on disk (resolved
+ *    relative to the note's own directory). External URLs (`http(s)://`,
+ *    `mailto:`, protocol-relative `//`), in-page anchors (`#section`), and
+ *    Obsidian-style absolute vault paths are intentionally NOT checked here.
+ *    Flag-only.
+ *
+ * Overlap avoidance (deliberate, see #652):
+ *  - `unlinked-mention` (#600) flags KNOWN entity names appearing as PLAIN TEXT
+ *    that are NOT wikilinked. This module is the inverse: it flags actual
+ *    `[[...]]` links that point NOWHERE. The two never fire on the same span —
+ *    unlinked-mention masks out existing wikilinks before scanning; this module
+ *    only looks at existing wikilinks.
+ *  - `frequent-unlinked-term` (#601) is an open-world plain-text heuristic — also
+ *    disjoint.
+ *  - Relation-field `stale-reference`/`malformed-wikilink`/`ambiguous-link-target`
+ *    validate FRONTMATTER values only (body stale-reference was explicitly
+ *    deferred). This module validates the BODY only. No overlap.
+ *
+ * Code handling: links written inside fenced code blocks or inline code are NOT
+ * flagged. We mask code spans (via `maskCodeSpans`) before scanning, preserving
+ * offsets/line numbers, then read the link text back from the ORIGINAL body at
+ * the matched offsets so the reported value is the real link.
+ */
+
+import { existsSync } from 'fs';
+import { isAbsolute, resolve } from 'path';
+import type { NoteTargetIndex } from '../discovery.js';
+import { levenshteinDistance } from '../levenshtein.js';
+import type { AuditIssue } from './types.js';
+import { maskCodeSpans } from './unlinked-mention.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Max Levenshtein distance for a "did you mean?" hint on a broken wikilink. */
+const FUZZY_MAX_DISTANCE = 2;
+/** A broken target must be at least this long to bother fuzzy-suggesting. */
+const FUZZY_MIN_LENGTH = 4;
+/** Cap on how many "did you mean?" suggestions to list. */
+const FUZZY_MAX_SUGGESTIONS = 3;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Compute 1-based line number for a character offset. */
+function lineNumberAt(text: string, offset: number): number {
+  let line = 1;
+  for (let i = 0; i < offset && i < text.length; i++) {
+    if (text[i] === '\n') line++;
+  }
+  return line;
+}
+
+/**
+ * Whether a markdown-link destination is an external/non-file target we must not
+ * check on disk: a URL with a scheme (`https:`, `mailto:`, `tel:`, …), a
+ * protocol-relative `//host`, or a pure in-page anchor (`#section`).
+ */
+function isNonFileTarget(dest: string): boolean {
+  if (dest.startsWith('#')) return true;
+  if (dest.startsWith('//')) return true;
+  // scheme:rest — RFC3986-ish scheme (letter then letters/digits/+-.)
+  return /^[a-z][a-z0-9+.-]*:/i.test(dest);
+}
+
+/**
+ * Resolve the directory of a note from its vault-relative path, returning the
+ * directory portion (vault-relative). E.g. "Bugs/Crash.md" -> "Bugs".
+ */
+function noteDir(selfRelativePath: string): string {
+  const idx = selfRelativePath.lastIndexOf('/');
+  return idx === -1 ? '' : selfRelativePath.slice(0, idx);
+}
+
+/**
+ * Offer up to {@link FUZZY_MAX_SUGGESTIONS} note names that are a near match to a
+ * broken wikilink target, as a flag-only "did you mean?" hint.
+ */
+function fuzzyNoteSuggestions(target: string, index: NoteTargetIndex): string[] {
+  if (target.length < FUZZY_MIN_LENGTH) return [];
+  const lower = target.toLowerCase();
+  const scored: Array<{ name: string; distance: number }> = [];
+  for (const key of index.targetToPaths.keys()) {
+    if (key.length < FUZZY_MIN_LENGTH) continue;
+    const dist = levenshteinDistance(lower, key);
+    if (dist === 0) continue;
+    if (dist <= FUZZY_MAX_DISTANCE) scored.push({ name: key, distance: dist });
+  }
+  scored.sort((a, b) => a.distance - b.distance || a.name.localeCompare(b.name, 'en'));
+  return scored.slice(0, FUZZY_MAX_SUGGESTIONS).map((s) => s.name);
+}
+
+// ============================================================================
+// Wikilink detection (broken + malformed)
+// ============================================================================
+
+/**
+ * Match well-formed body wikilinks: `[[Target]]`, `[[Target|display]]`,
+ * `[[Target#heading]]`, `[[Target#heading|display]]`. The target is everything
+ * up to the first `#` (heading) or `|` (display alias). An embed `![[...]]` is
+ * matched too (the leading `!` is outside the capture and ignored).
+ */
+const WIKILINK_RE = /\[\[([^\]\n]*?)\]\]/g;
+
+/**
+ * Match an opening `[[` that is never closed on the same construct — used only to
+ * catch unclosed malformed wikilinks. Applied after well-formed ones are masked.
+ */
+const UNCLOSED_WIKILINK_RE = /\[\[(?![^\]\n]*\]\])/g;
+
+/**
+ * Extract the resolvable target (note name/path) from a wikilink inner string,
+ * stripping a `#heading` and/or `|display` suffix. Returns the trimmed target.
+ */
+function wikilinkTarget(inner: string): string {
+  let t = inner;
+  const pipe = t.indexOf('|');
+  if (pipe !== -1) t = t.slice(0, pipe);
+  const hash = t.indexOf('#');
+  if (hash !== -1) t = t.slice(0, hash);
+  return t.trim();
+}
+
+/**
+ * Detect broken and malformed wikilinks in a note body.
+ *
+ * @param body  Markdown body (frontmatter already stripped).
+ * @param index Alias-aware, case-insensitive note-target index.
+ */
+export function detectBodyWikilinks(
+  body: string,
+  index: NoteTargetIndex | undefined
+): AuditIssue[] {
+  const issues: AuditIssue[] = [];
+  // Mask code (but NOT links) so links inside code fences / inline code are
+  // ignored, while offsets into the original body stay accurate.
+  const masked = maskCodeSpans(body);
+
+  let m: RegExpExecArray | null;
+  WIKILINK_RE.lastIndex = 0;
+  while ((m = WIKILINK_RE.exec(masked)) !== null) {
+    const inner = m[1] ?? '';
+    const start = m.index;
+    const line = lineNumberAt(body, start);
+    const target = wikilinkTarget(inner);
+
+    // Malformed: empty/whitespace-only target (`[[]]`, `[[ ]]`, `[[|x]]`,
+    // `[[#h]]`).
+    if (target.length === 0) {
+      issues.push({
+        severity: 'warning',
+        code: 'malformed-body-wikilink',
+        message: `Malformed wikilink on line ${line}: '${m[0]}' has an empty target`,
+        value: m[0],
+        autoFixable: false,
+        inBody: true,
+        lineNumber: line,
+        suggestion: 'Empty wikilink target — fill in or remove the link',
+        meta: { offset: start, reason: 'empty-target' },
+      });
+      continue;
+    }
+
+    // Broken: resolves to no note via the alias-aware index.
+    const candidates = index?.targetToPaths.get(target.toLowerCase()) ?? [];
+    if (candidates.length === 0) {
+      const suggestions = index ? fuzzyNoteSuggestions(target, index) : [];
+      issues.push({
+        severity: 'warning',
+        code: 'broken-body-wikilink',
+        message: `Broken wikilink on line ${line}: '[[${target}]]' resolves to no note`,
+        value: m[0],
+        autoFixable: false,
+        inBody: true,
+        lineNumber: line,
+        targetName: target,
+        ...(suggestions.length > 0 ? { similarFiles: suggestions } : {}),
+        suggestion:
+          suggestions.length > 0
+            ? `Did you mean ${suggestions.map((s) => `[[${s}]]`).join(' or ')}? (not auto-linked)`
+            : 'Create the note or fix the link target (not auto-linked)',
+        meta: { offset: start, target },
+      });
+    }
+    // Resolving to >= 1 note is fine here — a single match is valid, and an
+    // ambiguous (multi-match) body wikilink is still a working Obsidian link
+    // (Obsidian resolves by proximity), so we do not flag it. Ambiguity in
+    // RELATION FIELDS is a separate, frontmatter-only concern.
+  }
+
+  // Unclosed `[[` with no closing `]]` on the same line/construct. Mask the
+  // well-formed wikilinks first so we don't re-flag their opening brackets.
+  const withoutWellFormed = masked.replace(WIKILINK_RE, (mm) => mm.replace(/[^\n]/g, ' '));
+  UNCLOSED_WIKILINK_RE.lastIndex = 0;
+  while ((m = UNCLOSED_WIKILINK_RE.exec(withoutWellFormed)) !== null) {
+    const start = m.index;
+    const line = lineNumberAt(body, start);
+    issues.push({
+      severity: 'warning',
+      code: 'malformed-body-wikilink',
+      message: `Malformed wikilink on line ${line}: unclosed '[[' (missing ']]')`,
+      value: '[[',
+      autoFixable: false,
+      inBody: true,
+      lineNumber: line,
+      suggestion: 'Unclosed wikilink — add the closing ]] or remove the [[',
+      meta: { offset: start, reason: 'unclosed' },
+    });
+  }
+
+  return issues;
+}
+
+// ============================================================================
+// Markdown file/image link detection (broken relative path)
+// ============================================================================
+
+/**
+ * Match markdown links and images: `[text](dest)` and `![alt](dest)`. The
+ * destination capture stops at the first whitespace so an optional `"title"`
+ * after the URL is excluded, and at the closing paren.
+ */
+const MD_LINK_RE = /!?\[[^\]\n]*\]\(\s*([^)\s]+)[^)]*\)/g;
+
+/**
+ * Detect markdown file/image links in the body whose RELATIVE target does not
+ * exist on disk. External URLs and in-page anchors are skipped.
+ *
+ * @param body     Markdown body (frontmatter already stripped).
+ * @param selfPath Vault-relative path of the note (for resolving relative dests).
+ * @param vaultDir Absolute vault root, for on-disk existence checks.
+ */
+export function detectBodyFileLinks(
+  body: string,
+  selfPath: string,
+  vaultDir: string
+): AuditIssue[] {
+  const issues: AuditIssue[] = [];
+  const masked = maskCodeSpans(body);
+  const dir = noteDir(selfPath);
+
+  let m: RegExpExecArray | null;
+  MD_LINK_RE.lastIndex = 0;
+  while ((m = MD_LINK_RE.exec(masked)) !== null) {
+    const rawDest = m[1] ?? '';
+    const start = m.index;
+    const line = lineNumberAt(body, start);
+
+    // Decode percent-encoding (e.g. spaces as %20) for the existence check;
+    // leave the reported value as the author wrote it.
+    let dest = rawDest;
+    try {
+      dest = decodeURIComponent(rawDest);
+    } catch {
+      // Malformed escape — fall back to the raw destination.
+    }
+
+    // Strip a trailing in-page anchor (`file.md#section`).
+    const hashIdx = dest.indexOf('#');
+    const filePart = hashIdx === -1 ? dest : dest.slice(0, hashIdx);
+    if (filePart.length === 0) continue;
+
+    // Skip external/non-file targets.
+    if (isNonFileTarget(dest)) continue;
+
+    // Resolve the on-disk path: absolute dests are treated as vault-absolute
+    // (Obsidian style: leading "/" is the vault root); otherwise relative to the
+    // note's own directory.
+    const absPath = isAbsolute(filePart)
+      ? resolve(vaultDir, `.${filePart}`)
+      : resolve(vaultDir, dir, filePart);
+
+    if (existsSync(absPath)) continue;
+
+    const isImage = m[0].startsWith('!');
+    issues.push({
+      severity: 'warning',
+      code: 'broken-body-file-link',
+      message: `Broken ${isImage ? 'image' : 'file'} link on line ${line}: '${rawDest}' does not exist on disk`,
+      value: rawDest,
+      autoFixable: false,
+      inBody: true,
+      lineNumber: line,
+      targetName: rawDest,
+      suggestion: 'Fix the path or restore the missing file (not auto-fixed)',
+      meta: { offset: start, dest: rawDest, isImage },
+    });
+  }
+
+  return issues;
+}
+
+/**
+ * Convenience: run all body-link detections for a single note body.
+ */
+export function detectBodyLinks(
+  body: string,
+  selfPath: string,
+  vaultDir: string,
+  index: NoteTargetIndex | undefined
+): AuditIssue[] {
+  return [
+    ...detectBodyWikilinks(body, index),
+    ...detectBodyFileLinks(body, selfPath, vaultDir),
+  ];
+}

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -46,6 +46,7 @@ import {
   type FileAuditResult,
   type ManagedFile,
   type AuditRunOptions,
+  type IssueCode,
   ALLOWED_NATIVE_FIELDS,
 } from './types.js';
 import { isBwrbBuiltinFrontmatterField } from '../frontmatter/systemFields.js';
@@ -91,6 +92,8 @@ import {
 import { FrequentTermAccumulator } from './frequent-unlinked-term.js';
 // Import body-section validation (#510)
 import { detectMissingBodySections } from './body-sections.js';
+// Import body-link validation (#652)
+import { detectBodyLinks } from './body-links.js';
 import { parseNote } from '../frontmatter.js';
 
 /**
@@ -263,7 +266,7 @@ export async function runAudit(
  */
 export async function auditFile(
   schema: LoadedSchema,
-  _vaultDir: string,
+  vaultDir: string,
   file: ManagedFile,
   options: AuditRunOptions,
   noteIndex?: import('../discovery.js').VaultNoteIndex,
@@ -699,7 +702,7 @@ export async function auditFile(
     issues.push(
       ...(await checkRecurrenceIssues(
         schema,
-        _vaultDir,
+        vaultDir,
         resolvedTypePath,
         frontmatter,
         wantInvalidRecurrence,
@@ -749,7 +752,20 @@ export async function auditFile(
     options.ignoreIssue !== 'missing-body-section' &&
     (options.onlyIssue === undefined || options.onlyIssue === 'missing-body-section');
 
-  if (wantsUnlinkedMention || wantsBodySections) {
+  // Body-link validation (#652): broken/malformed body wikilinks + broken
+  // relative file/image links. Distinct from unlinked-mention (plain-text
+  // mentions) and frontmatter relation checks. Runs whenever any of its codes is
+  // in scope.
+  const bodyLinkCodes: IssueCode[] = [
+    'broken-body-wikilink',
+    'malformed-body-wikilink',
+    'broken-body-file-link',
+  ];
+  const wantsBodyLinks =
+    (options.ignoreIssue === undefined || !bodyLinkCodes.includes(options.ignoreIssue)) &&
+    (options.onlyIssue === undefined || bodyLinkCodes.includes(options.onlyIssue));
+
+  if (wantsUnlinkedMention || wantsBodySections || wantsBodyLinks) {
     try {
       const { body } = await parseNote(file.path);
       const hasBody = Boolean(body && body.trim().length > 0);
@@ -764,6 +780,21 @@ export async function auditFile(
       // body-section validation runs even when the body is blank.
       if (wantsBodySections) {
         issues.push(...detectMissingBodySections(body ?? '', typeDef.bodySections));
+      }
+
+      // Body-link validation only matters when there is a body to scan.
+      if (wantsBodyLinks && hasBody) {
+        const bodyLinkIssues = detectBodyLinks(
+          body,
+          file.relativePath,
+          vaultDir,
+          noteIndex?.noteTargetIndex
+        ).filter(
+          (issue) =>
+            (options.onlyIssue === undefined || issue.code === options.onlyIssue) &&
+            issue.code !== options.ignoreIssue
+        );
+        issues.push(...bodyLinkIssues);
       }
     } catch {
       // If the body can't be parsed, skip body-level detections for this file.

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -756,14 +756,19 @@ export async function auditFile(
   // relative file/image links. Distinct from unlinked-mention (plain-text
   // mentions) and frontmatter relation checks. Runs whenever any of its codes is
   // in scope.
+  //
+  // The gate intentionally depends on `--only` (onlyIssue) but NOT on `--ignore`
+  // (ignoreIssue): the three body-link codes share one detection pass, so
+  // ignoring a single code must not skip the whole block — otherwise the other
+  // two codes would be silently dropped. Per-code `--ignore` filtering happens on
+  // the produced issues below (`issue.code !== options.ignoreIssue`).
   const bodyLinkCodes: IssueCode[] = [
     'broken-body-wikilink',
     'malformed-body-wikilink',
     'broken-body-file-link',
   ];
   const wantsBodyLinks =
-    (options.ignoreIssue === undefined || !bodyLinkCodes.includes(options.ignoreIssue)) &&
-    (options.onlyIssue === undefined || bodyLinkCodes.includes(options.onlyIssue));
+    options.onlyIssue === undefined || bodyLinkCodes.includes(options.onlyIssue);
 
   if (wantsUnlinkedMention || wantsBodySections || wantsBodyLinks) {
     try {

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -69,7 +69,19 @@ export type IssueCode =
   // Body validation (#510): a heading section declared in the type's
   // `body_sections` is missing from the note body (or present at the wrong
   // heading level). Auto-fixable: --fix appends the canonical heading scaffold.
-  | 'missing-body-section';
+  | 'missing-body-section'
+  // Body link validation (#652): a well-formed `[[Target]]` in the body whose
+  // target resolves to NO note via the alias-aware note-target index. Distinct
+  // from `unlinked-mention` (which flags plain-text mentions of KNOWN entities).
+  // Flag-only: we can't know the intended target, so we never auto-link.
+  | 'broken-body-wikilink'
+  // Body link validation (#652): bracket syntax that looks like a wikilink but is
+  // broken — empty `[[]]`/`[[ ]]` target, or an unclosed `[[`. Flag-only.
+  | 'malformed-body-wikilink'
+  // Body link validation (#652): a markdown file/image link `[t](path)` /
+  // `![a](img)` whose relative target doesn't exist on disk (resolved relative to
+  // the note's directory). External URLs / anchors are not checked. Flag-only.
+  | 'broken-body-file-link';
 
 /**
  * A single audit issue.

--- a/src/lib/audit/unlinked-mention.ts
+++ b/src/lib/audit/unlinked-mention.ts
@@ -190,12 +190,17 @@ function blankOut(text: string): string {
 }
 
 /**
- * Mask regions of the body where a literal name match must NOT be flagged:
- * fenced code blocks, inline code, existing wikilinks, markdown links, and bare
- * URLs. Returns a string of identical length/line structure with those regions
- * blanked to spaces.
+ * Mask ONLY code regions (fenced code blocks + inline code spans), leaving links
+ * and prose intact. Returns a string of identical length/line structure with the
+ * code regions blanked to spaces so character offsets and line numbers stay
+ * accurate.
+ *
+ * This is the shared primitive behind {@link maskNonProse}. It is exported for
+ * body-LINK validation (#652), which must still SEE wikilinks/markdown links
+ * (they are exactly what it inspects) but must NOT flag links written inside
+ * code fences or inline code.
  */
-export function maskNonProse(body: string): string {
+export function maskCodeSpans(body: string): string {
   let masked = body;
 
   const maskPattern = (pattern: RegExp): void => {
@@ -208,6 +213,25 @@ export function maskNonProse(body: string): string {
   maskPattern(/^[ \t]*(```|~~~)[\s\S]*$/gm);
   // Inline code spans.
   maskPattern(/`[^`\n]+`/g);
+
+  return masked;
+}
+
+/**
+ * Mask regions of the body where a literal name match must NOT be flagged:
+ * fenced code blocks, inline code, existing wikilinks, markdown links, and bare
+ * URLs. Returns a string of identical length/line structure with those regions
+ * blanked to spaces.
+ */
+export function maskNonProse(body: string): string {
+  // Reuse the shared code-span masking, then additionally blank out links/URLs
+  // (which body-link validation deliberately keeps visible).
+  let masked = maskCodeSpans(body);
+
+  const maskPattern = (pattern: RegExp): void => {
+    masked = masked.replace(pattern, (m) => blankOut(m));
+  };
+
   // Existing wikilinks (including display-aliased form).
   maskPattern(/\[\[[^\]]*\]\]/g);
   // Markdown links/images: keep the visible text out of scope entirely so we

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -1684,9 +1684,9 @@ milestone: "[[Non Existent Milestone]]"
       expect(staleIssue.inBody).toBe(false);
     });
 
-    it('should NOT detect stale reference in body content (v1.0 scope is frontmatter only)', async () => {
-      // Body content link validation is deferred to v2.0
-      // Per product scope, v1.0 only validates frontmatter relation fields
+    it('should not report a broken body wikilink as a frontmatter stale-reference (#652)', async () => {
+      // Body link validation (#652) uses its own `broken-body-wikilink` code;
+      // frontmatter-only `stale-reference` must never fire on a body link.
       await writeFile(
         join(tempVaultDir, 'Ideas', 'Body Links.md'),
         `---
@@ -1702,10 +1702,12 @@ This idea references [[Non Existent Note]] which doesn't exist.
 
       const result = await runCLI(['audit', 'idea', '--output', 'json'], tempVaultDir);
 
-      // Should pass with no issues - body links are not validated in v1.0
-      expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout);
-      expect(output.files.length).toBe(0); // No files with issues
+      const file = output.files.find((f: { path: string }) => f.path.includes('Body Links.md'));
+      expect(file).toBeDefined();
+      // The body link is flagged as broken-body-wikilink, NOT stale-reference.
+      expect(file.issues.some((i: { code: string }) => i.code === 'broken-body-wikilink')).toBe(true);
+      expect(file.issues.some((i: { code: string }) => i.code === 'stale-reference')).toBe(false);
     });
 
     it('should not report stale reference for existing file', async () => {
@@ -1772,8 +1774,7 @@ milestone: "[[Q1 Relase]]"
       expect(staleIssue.similarFiles.some((f: string) => f.includes('Q1 Release'))).toBe(true);
     });
 
-    it('should NOT report body wikilinks even with multiple stale references (v1.0 scope)', async () => {
-      // Body content link validation is deferred to v2.0
+    it('should report every broken body wikilink (#652)', async () => {
       await writeFile(
         join(tempVaultDir, 'Ideas', 'Multiple Links.md'),
         `---
@@ -1789,14 +1790,17 @@ Second link: [[Missing Two]]
 
       const result = await runCLI(['audit', 'idea', '--output', 'json'], tempVaultDir);
 
-      // Should pass with no issues - body links are not validated in v1.0
-      expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout);
-      expect(output.files.length).toBe(0);
+      const file = output.files.find((f: { path: string }) => f.path.includes('Multiple Links.md'));
+      expect(file).toBeDefined();
+      const broken = file.issues.filter((i: { code: string }) => i.code === 'broken-body-wikilink');
+      expect(broken).toHaveLength(2);
     });
 
-    it('should NOT report body wikilinks with aliases and headings (v1.0 scope)', async () => {
-      // Body content link validation is deferred to v2.0
+    it('should resolve broken body wikilinks past aliases and headings (#652)', async () => {
+      // The target is missing regardless of `|alias` / `#heading` suffixes, so all
+      // three are flagged as broken-body-wikilink (the suffixes are stripped for
+      // resolution).
       await writeFile(
         join(tempVaultDir, 'Ideas', 'Complex Links.md'),
         `---
@@ -1813,10 +1817,12 @@ Link with both: [[Missing Note#Section|Alias]]
 
       const result = await runCLI(['audit', 'idea', '--output', 'json'], tempVaultDir);
 
-      // Should pass with no issues - body links are not validated in v1.0
-      expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout);
-      expect(output.files.length).toBe(0);
+      const file = output.files.find((f: { path: string }) => f.path.includes('Complex Links.md'));
+      expect(file).toBeDefined();
+      const broken = file.issues.filter((i: { code: string }) => i.code === 'broken-body-wikilink');
+      expect(broken).toHaveLength(3);
+      expect(broken.every((i: { targetName: string }) => i.targetName === 'Missing Note')).toBe(true);
     });
   });
 

--- a/tests/ts/lib/audit-body-links.test.ts
+++ b/tests/ts/lib/audit-body-links.test.ts
@@ -62,10 +62,14 @@ describe('body-links: detectBodyWikilinks', () => {
     expect(issues[0]!.targetName).toBe('Nope');
   });
 
-  it('offers a fuzzy "did you mean?" hint for a near-named note', () => {
+  it('offers a fuzzy "did you mean?" hint with the canonical-case filename', () => {
     const issues = detectBodyWikilinks('[[RealNotee]]', index);
     expect(issues).toHaveLength(1);
-    expect(issues[0]!.similarFiles).toContain('realnote');
+    // The hint must surface the real-case basename ('RealNote'), not the
+    // lowercased index key ('realnote').
+    expect(issues[0]!.similarFiles).toContain('RealNote');
+    expect(issues[0]!.similarFiles).not.toContain('realnote');
+    expect(issues[0]!.suggestion).toContain('[[RealNote]]');
     expect(issues[0]!.suggestion).toContain('Did you mean');
   });
 
@@ -268,4 +272,73 @@ describe('body-links: end-to-end audit', () => {
     const src = results.find((r) => r.relativePath === 'Notes/Source.md');
     expect(src?.issues.some((i) => i.code === 'broken-body-file-link')).toBeFalsy();
   });
+
+  // ---------------------------------------------------------------------------
+  // #680 regression: a Source note containing ALL THREE body-link issue codes.
+  // `--ignore <one body-link code>` must suppress ONLY that code; the other two
+  // must STILL report (they share one detection pass, so the bug was the outer
+  // gate skipping the whole block when any one code was ignored).
+  // ---------------------------------------------------------------------------
+  const ALL_THREE: Array<
+    'broken-body-wikilink' | 'malformed-body-wikilink' | 'broken-body-file-link'
+  > = ['broken-body-wikilink', 'malformed-body-wikilink', 'broken-body-file-link'];
+
+  async function writeSourceWithAllThree() {
+    // [[Ghost]] -> broken-body-wikilink; [[]] -> malformed-body-wikilink;
+    // [doc](missing.md) -> broken-body-file-link.
+    await writeFile(
+      join(vaultDir, 'Notes', 'Source.md'),
+      `---\ntype: note\n---\nBroken [[Ghost]].\nMalformed [[]].\nFile [doc](missing.md).\n`
+    );
+  }
+
+  it('sanity: an unfiltered run reports all three body-link codes', async () => {
+    await writeSourceWithAllThree();
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false });
+    const src = results.find((r) => r.relativePath === 'Notes/Source.md');
+    const codes = new Set(src?.issues.map((i) => i.code) ?? []);
+    for (const code of ALL_THREE) {
+      expect(codes.has(code)).toBe(true);
+    }
+  });
+
+  for (const ignored of ALL_THREE) {
+    it(`--ignore ${ignored} suppresses only that code; the other two still report`, async () => {
+      await writeSourceWithAllThree();
+      const schema = await loadSchema(vaultDir);
+      const results = await runAudit(schema, vaultDir, {
+        strict: false,
+        ignoreIssue: ignored,
+      });
+      const src = results.find((r) => r.relativePath === 'Notes/Source.md');
+      const codes = new Set(src?.issues.map((i) => i.code) ?? []);
+
+      // The ignored code is gone.
+      expect(codes.has(ignored)).toBe(false);
+      // The other two body-link codes STILL report.
+      for (const code of ALL_THREE) {
+        if (code === ignored) continue;
+        expect(codes.has(code)).toBe(true);
+      }
+    });
+  }
+
+  for (const only of ALL_THREE) {
+    it(`--only ${only} runs body links and reports just that code`, async () => {
+      await writeSourceWithAllThree();
+      const schema = await loadSchema(vaultDir);
+      const results = await runAudit(schema, vaultDir, {
+        strict: false,
+        onlyIssue: only,
+      });
+      const src = results.find((r) => r.relativePath === 'Notes/Source.md');
+      const codes = src?.issues.map((i) => i.code) ?? [];
+
+      expect(codes.length).toBeGreaterThan(0);
+      for (const code of codes) {
+        expect(code).toBe(only);
+      }
+    });
+  }
 });

--- a/tests/ts/lib/audit-body-links.test.ts
+++ b/tests/ts/lib/audit-body-links.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, writeFile, rm, mkdtemp } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadSchema } from '../../../src/lib/schema.js';
+import { runAudit } from '../../../src/lib/audit/detection.js';
+import {
+  detectBodyWikilinks,
+  detectBodyFileLinks,
+} from '../../../src/lib/audit/body-links.js';
+import { deriveNoteTargetIndex } from '../../../src/lib/discovery.js';
+import type { VaultNoteSnapshot } from '../../../src/lib/discovery.js';
+import type { Schema } from '../../../src/types/schema.js';
+
+// ---------------------------------------------------------------------------
+// Unit tests on the pure wikilink detector (no filesystem)
+// ---------------------------------------------------------------------------
+
+/** Build a tiny note-target index from a list of vault-relative note paths. */
+function indexFor(paths: string[]) {
+  const snapshot: VaultNoteSnapshot = {
+    notes: paths.map((relativePath) => ({ relativePath, path: relativePath })),
+  };
+  return deriveNoteTargetIndex(snapshot);
+}
+
+describe('body-links: detectBodyWikilinks', () => {
+  const index = indexFor(['Notes/RealNote.md', 'People/Steve Yegge.md']);
+
+  it('flags a wikilink that resolves to no note', () => {
+    const issues = detectBodyWikilinks('See [[Nonexistent]] for more.', index);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.code).toBe('broken-body-wikilink');
+    expect(issues[0]!.autoFixable).toBe(false);
+    expect(issues[0]!.inBody).toBe(true);
+    expect(issues[0]!.lineNumber).toBe(1);
+    expect(issues[0]!.targetName).toBe('Nonexistent');
+  });
+
+  it('does not flag a valid wikilink', () => {
+    const issues = detectBodyWikilinks('Refer to [[RealNote]].', index);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('resolves case-insensitively', () => {
+    const issues = detectBodyWikilinks('[[realnote]] and [[REALNOTE]]', index);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('resolves a display-aliased and heading-suffixed wikilink', () => {
+    const issues = detectBodyWikilinks(
+      '[[RealNote|some text]] and [[RealNote#A Heading]]',
+      index
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it('flags a broken wikilink that has a display alias', () => {
+    const issues = detectBodyWikilinks('[[Nope|display]]', index);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.code).toBe('broken-body-wikilink');
+    expect(issues[0]!.targetName).toBe('Nope');
+  });
+
+  it('offers a fuzzy "did you mean?" hint for a near-named note', () => {
+    const issues = detectBodyWikilinks('[[RealNotee]]', index);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.similarFiles).toContain('realnote');
+    expect(issues[0]!.suggestion).toContain('Did you mean');
+  });
+
+  it('flags an empty wikilink target as malformed', () => {
+    const empty = detectBodyWikilinks('[[]]', index);
+    expect(empty).toHaveLength(1);
+    expect(empty[0]!.code).toBe('malformed-body-wikilink');
+
+    const whitespace = detectBodyWikilinks('[[   ]]', index);
+    expect(whitespace).toHaveLength(1);
+    expect(whitespace[0]!.code).toBe('malformed-body-wikilink');
+  });
+
+  it('flags an unclosed wikilink', () => {
+    const issues = detectBodyWikilinks('A [[Dangling link here\n', index);
+    expect(issues.some((i) => i.code === 'malformed-body-wikilink')).toBe(true);
+  });
+
+  it('does not flag wikilinks inside a fenced code block', () => {
+    const body = '```\n[[Nonexistent]]\n[[]]\n```\nDone.';
+    expect(detectBodyWikilinks(body, index)).toHaveLength(0);
+  });
+
+  it('does not flag wikilinks inside inline code', () => {
+    const body = 'Use `[[Nonexistent]]` syntax.';
+    expect(detectBodyWikilinks(body, index)).toHaveLength(0);
+  });
+
+  it('reports the correct line number', () => {
+    const body = 'line 1\nline 2\n[[Nonexistent]]\n';
+    const issues = detectBodyWikilinks(body, index);
+    expect(issues[0]!.lineNumber).toBe(3);
+  });
+
+  it('does not flag an ambiguous (multi-match) wikilink as broken', () => {
+    // Two notes collapse to the same lowercased key -> ambiguous but valid.
+    const ambiguousIndex = indexFor(['A/Topic.md', 'B/topic.md']);
+    const issues = detectBodyWikilinks('[[Topic]]', ambiguousIndex);
+    expect(issues.some((i) => i.code === 'broken-body-wikilink')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests on the pure file/image link detector (real temp files)
+// ---------------------------------------------------------------------------
+
+describe('body-links: detectBodyFileLinks', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-body-links-'));
+    await mkdir(join(vaultDir, 'Notes', 'assets'), { recursive: true });
+    await writeFile(join(vaultDir, 'Notes', 'exists.md'), 'x');
+    await writeFile(join(vaultDir, 'Notes', 'assets', 'pic.png'), 'x');
+  });
+
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('flags a broken relative file link', () => {
+    const issues = detectBodyFileLinks(
+      'See [doc](missing.md).',
+      'Notes/Source.md',
+      vaultDir
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.code).toBe('broken-body-file-link');
+    expect(issues[0]!.autoFixable).toBe(false);
+  });
+
+  it('flags a broken relative image link', () => {
+    const issues = detectBodyFileLinks(
+      '![alt](missing.png)',
+      'Notes/Source.md',
+      vaultDir
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.code).toBe('broken-body-file-link');
+    expect(issues[0]!.meta?.['isImage']).toBe(true);
+  });
+
+  it('does not flag a valid relative file link', () => {
+    const issues = detectBodyFileLinks(
+      '[doc](exists.md) and ![pic](assets/pic.png)',
+      'Notes/Source.md',
+      vaultDir
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it('does not flag external URLs', () => {
+    const body =
+      '[site](https://example.com) [m](mailto:a@b.com) [a](#section) [p](//cdn.example.com/x.png)';
+    expect(detectBodyFileLinks(body, 'Notes/Source.md', vaultDir)).toHaveLength(0);
+  });
+
+  it('does not flag file links inside a fenced code block', () => {
+    const body = '```\n[doc](missing.md)\n```';
+    expect(detectBodyFileLinks(body, 'Notes/Source.md', vaultDir)).toHaveLength(0);
+  });
+
+  it('handles percent-encoded spaces in the path', () => {
+    return writeFile(join(vaultDir, 'Notes', 'a b.md'), 'x').then(() => {
+      const issues = detectBodyFileLinks(
+        '[doc](a%20b.md)',
+        'Notes/Source.md',
+        vaultDir
+      );
+      expect(issues).toHaveLength(0);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end audit on a real vault
+// ---------------------------------------------------------------------------
+
+const SCHEMA: Schema = {
+  version: 2,
+  types: {
+    meta: { fields: {} },
+    note: {
+      extends: 'meta',
+      output_dir: 'Notes',
+      fields: { type: { value: 'note' } },
+      field_order: ['type'],
+    },
+  },
+};
+
+describe('body-links: end-to-end audit', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-body-links-e2e-'));
+    await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+    await writeFile(
+      join(vaultDir, '.bwrb', 'schema.json'),
+      JSON.stringify(SCHEMA, null, 2)
+    );
+    await mkdir(join(vaultDir, 'Notes'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('flags broken body wikilinks and file links across a real run', async () => {
+    await writeFile(
+      join(vaultDir, 'Notes', 'Real.md'),
+      `---\ntype: note\n---\nI exist.\n`
+    );
+    await writeFile(
+      join(vaultDir, 'Notes', 'Source.md'),
+      `---\ntype: note\n---\nGood [[Real]]. Bad [[Ghost]].\nBroken [doc](missing.md).\nExternal [x](https://example.com).\n`
+    );
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false });
+    const src = results.find((r) => r.relativePath === 'Notes/Source.md');
+
+    const broken = src?.issues.filter((i) => i.code === 'broken-body-wikilink') ?? [];
+    expect(broken).toHaveLength(1);
+    expect(broken[0]!.targetName).toBe('Ghost');
+
+    const fileLinks = src?.issues.filter((i) => i.code === 'broken-body-file-link') ?? [];
+    expect(fileLinks).toHaveLength(1);
+
+    // Valid [[Real]] and external URL produced no findings.
+    expect(src?.issues.some((i) => i.value === '[[Real]]')).toBeFalsy();
+  });
+
+  it('only-filter scopes the run to broken-body-wikilink', async () => {
+    await writeFile(
+      join(vaultDir, 'Notes', 'Source.md'),
+      `---\ntype: note\n---\n[[Ghost]] and [doc](missing.md)\n`
+    );
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'broken-body-wikilink',
+    });
+    for (const r of results) {
+      for (const i of r.issues) {
+        expect(i.code).toBe('broken-body-wikilink');
+      }
+    }
+  });
+
+  it('ignore-filter suppresses broken-body-file-link', async () => {
+    await writeFile(
+      join(vaultDir, 'Notes', 'Source.md'),
+      `---\ntype: note\n---\n[doc](missing.md)\n`
+    );
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      ignoreIssue: 'broken-body-file-link',
+    });
+    const src = results.find((r) => r.relativePath === 'Notes/Source.md');
+    expect(src?.issues.some((i) => i.code === 'broken-body-file-link')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Closes #652

Implements the link-integrity half of #510. The heading half (`missing-body-section`) already shipped; this adds NEW audit checks for actual LINKS written in a note's markdown body. All three are **flag-only** (we never auto-edit body prose links).

## New checks

| Code | What it flags | Fixable |
|------|----------------|---------|
| `broken-body-wikilink` | A well-formed `[[Target]]` (also `[[T\|alias]]`, `[[T#heading]]`, `![[T]]`) whose target resolves to **no note** | flag-only (offers a "did you mean?" hint) |
| `malformed-body-wikilink` | Empty `[[]]`/`[[ ]]` target, or an unclosed `[[` | flag-only |
| `broken-body-file-link` | `[text](path)` / `![alt](img)` whose **relative** target doesn't exist on disk | flag-only |

## How it works

- **Resolution reuse**: broken-wikilink resolution uses the existing alias-aware, case-insensitive `deriveNoteTargetIndex` / `targetToPaths` (#266/#636) — the same index relation fields use. So `[[an alias]]` / `[[REALNOTE]]` resolve wherever the note's name or a registered alias does.
- **Ambiguity**: a body wikilink whose text matches >1 note is NOT flagged (it still resolves in Obsidian by proximity); ambiguity remains a frontmatter-only relation concern.
- **Relative file links**: resolved relative to the note's own directory (leading `/` = vault root, Obsidian-style), with `%20` decoding for existence checks. External URLs (`https:`, `mailto:`…), protocol-relative `//host`, and in-page `#anchor` targets are skipped.
- **Code handling**: factored a shared `maskCodeSpans()` out of `maskNonProse` so these checks still SEE links while masking fenced code blocks + inline code (links inside code are never flagged).
- Hooks into the single shared body read in `detection.ts`; respects `--only`/`--ignore`/`--path`/`--output json`.

## Overlap avoidance

Inverse of `unlinked-mention` (#600, plain-text mentions of KNOWN entities) — these flag actual `[[...]]` links pointing NOWHERE; the two never fire on the same span. Disjoint from `frequent-unlinked-term` (#601) and the frontmatter-only relation checks.

## Tests / docs

- New `tests/ts/lib/audit-body-links.test.ts` (21 cases) + updated 3 `audit.test.ts` cases that encoded the now-superseded "body links deferred to v2.0" assumption.
- Documented in the audit reference with a new "Body-link validation semantics" section.
- `pnpm qa` (2413 passed), `pnpm knip`, `pnpm docs:build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)