### PR TITLE
perf(query): single vault pass for under() + validate relation-field arg

### DIFF
--- a/docs-site/src/content/docs/reference/targeting.md
+++ b/docs-site/src/content/docs/reference/targeting.md
@@ -117,7 +117,11 @@ Notes:
   career. (`under(field, '[[X]]')` ≡ `field = [[X]]` OR `field` points to a
   descendant of `X`.)
 - **Any relation field.** The first argument is the field to dereference —
-  `under(milestone, '[[Q2]]')`, `under(owner, '[[Platform]]')`, etc.
+  `under(milestone, '[[Q2]]')`, `under(owner, '[[Platform]]')`, etc. When
+  `--type` is set, the first argument is validated against the schema: an unknown
+  field, or a field that is not a relation, is flagged up front (e.g.
+  `under() expects a relation field, but 'status' is a 'select' field`) rather
+  than silently matching nothing.
 - **Multi-valued fields.** If the relation holds a list, the note matches when
   **any** target is under the node.
 - **Resolution scope.** `under` resolves relation targets and their ancestors

--- a/src/lib/expression-validation.ts
+++ b/src/lib/expression-validation.ts
@@ -10,6 +10,7 @@ import type { Expression, BinaryExpression, UnaryExpression, CallExpression, Ide
 import { parseExpression } from './expression.js';
 import type { LoadedSchema } from '../types/schema.js';
 import { getFieldsForType, getAllFieldsForType, getFieldOptions } from './schema.js';
+import type { Field } from '../types/schema.js';
 import { validateSelectOptionValue, suggestFieldName } from './validation.js';
 import { normalizeWhereExpression } from './where-normalize.js';
 import { FRONTMATTER_IDENTIFIER } from './where-constants.js';
@@ -113,6 +114,55 @@ export function extractFieldComparisons(expr: Expression): FieldComparison[] {
 
   walk(expr);
   return comparisons;
+}
+
+/**
+ * Extract the field-name references passed as the FIRST argument to `under(...)`.
+ *
+ * `under(field, '[[Node]]')` dereferences a relation FIELD (arg 0) and walks the
+ * target's ancestor chain; arg 1 is a node string, NOT a field. We collect only
+ * arg 0 so it can be validated against the schema (must exist, must be a relation
+ * field). The node string is deliberately ignored here.
+ */
+function extractUnderFieldRefs(expr: Expression): string[] {
+  const fields: string[] = [];
+
+  function walk(node: Expression): void {
+    switch (node.type) {
+      case 'BinaryExpression': {
+        const binary = node as BinaryExpression;
+        if (binary.operator === '&&' || binary.operator === '||') {
+          walk(binary.left);
+          walk(binary.right);
+        }
+        break;
+      }
+      case 'UnaryExpression': {
+        walk((node as UnaryExpression).argument);
+        break;
+      }
+      case 'CallExpression': {
+        const call = node as CallExpression;
+        const callee = call.callee as Identifier;
+        if (callee?.type === 'Identifier' && callee.name === 'under') {
+          const [arg1] = call.arguments;
+          // Only the first argument is a field reference; the second is a node.
+          const fieldName = arg1 ? getFieldName(arg1) : null;
+          if (fieldName) fields.push(fieldName);
+        }
+        // `under` is never nested inside another call's args in practice, but
+        // walk any call arguments that are themselves logical/call expressions
+        // so a future `... && under(...)` inside a call still gets validated.
+        for (const arg of call.arguments) {
+          walk(arg);
+        }
+        break;
+      }
+    }
+  }
+
+  walk(expr);
+  return fields;
 }
 
 /**
@@ -247,6 +297,22 @@ export function validateWhereExpressions(
     try {
       const normalized = normalizeWhereExpression(exprString, allFieldNames);
       const expr = parseExpression(normalized);
+
+      // Validate the FIRST argument of any `under(field, '[[Node]]')` call: it
+      // must be a known field on the type, and a relation-typed field (since
+      // `under` dereferences a relation). The node string (arg 2) is not a field
+      // and is not validated here.
+      for (const underField of extractUnderFieldRefs(expr)) {
+        const underError = validateUnderFieldRef(
+          exprString,
+          underField,
+          typeName,
+          allowedFields,
+          fields
+        );
+        if (underError) errors.push(underError);
+      }
+
       const comparisons = extractFieldComparisons(expr);
 
       for (const comparison of comparisons) {
@@ -301,6 +367,56 @@ export function validateWhereExpressions(
 }
 
 /**
+ * Validate the first argument of an `under(field, ...)` call.
+ *
+ * Returns an error when:
+ * - the field is unknown for the type (consistent with how other field
+ *   references are flagged when `--type` is known), or
+ * - the field exists but is not a relation field (so `under` would have nothing
+ *   to dereference).
+ *
+ * Returns null when the field is a valid relation field, or when the field
+ * definition isn't available to inspect (e.g. inherited/synthetic fields whose
+ * `prompt` we can't see) — we only flag what we can verify, to avoid breaking
+ * valid usage.
+ */
+function validateUnderFieldRef(
+  expression: string,
+  fieldName: string,
+  typeName: string,
+  allowedFields: Set<string>,
+  fields: Record<string, Field>
+): WhereValidationError | null {
+  // Unknown field for this type.
+  if (!allowedFields.has(fieldName)) {
+    const fieldList = Array.from(allowedFields);
+    const suggestion = suggestFieldName(fieldName, fieldList);
+    return {
+      expression,
+      field: fieldName,
+      value: '',
+      message: `Unknown field '${fieldName}' for type '${typeName}' in under()`,
+      validOptions: fieldList,
+      ...(suggestion && { suggestion }),
+    };
+  }
+
+  // Known field — verify it's a relation field when we can see its definition.
+  const field = fields[fieldName];
+  if (field && field.prompt !== 'relation') {
+    return {
+      expression,
+      field: fieldName,
+      value: '',
+      message: `under() expects a relation field, but '${fieldName}' is a '${field.prompt ?? 'non-relation'}' field on type '${typeName}'`,
+      validOptions: [],
+    };
+  }
+
+  return null;
+}
+
+/**
  * Validate a single field value against its options.
  */
 function validateFieldValue(
@@ -330,8 +446,10 @@ export function formatWhereValidationErrors(errors: WhereValidationError[]): str
 
   if (errors.length === 1) {
     const err = errors[0]!;
-    let msg = `Error: ${err.message}.\n`;
-    msg += `  Valid options: ${err.validOptions.join(', ')}`;
+    let msg = `Error: ${err.message}.`;
+    if (err.validOptions.length > 0) {
+      msg += `\n  Valid options: ${err.validOptions.join(', ')}`;
+    }
     if (err.suggestion) {
       msg += `\n  Did you mean '${err.suggestion}'?`;
     }
@@ -341,7 +459,9 @@ export function formatWhereValidationErrors(errors: WhereValidationError[]): str
   const lines: string[] = ['Expression validation errors:'];
   for (const err of errors) {
     let line = `  - ${err.message}`;
-    if (err.validOptions.length <= 5) {
+    if (err.validOptions.length === 0) {
+      // No options to suggest (e.g. a relation-field-type error).
+    } else if (err.validOptions.length <= 5) {
       line += `. Valid options: ${err.validOptions.join(', ')}`;
     } else {
       line += `. Valid options: ${err.validOptions.slice(0, 5).join(', ')}... (${err.validOptions.length} total)`;

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -9,8 +9,7 @@ import {
 import { matchesExpression, buildEvalContext, type HierarchyData } from './expression.js';
 import { collectFrontmatterKeys, normalizeWhereExpressions } from './where-normalize.js';
 import { extractLinkTarget } from './links.js';
-import { buildVaultNoteSnapshot, discoverManagedFiles } from './discovery.js';
-import { parseNote } from './frontmatter.js';
+import { buildVaultNoteSnapshot, type VaultNoteSnapshot } from './discovery.js';
 
 /**
  * Validate that a field name is valid for a type.
@@ -132,41 +131,49 @@ function addParentRelationship(
  * Needed by `under`, which walks the ancestor chain of a relation target that
  * usually lives outside the (type-)filtered candidate set. Relationships
  * already present from the candidate pass are preserved.
+ *
+ * Performance: this builds the parent map AND the alias map from a SINGLE vault
+ * snapshot. `buildVaultNoteSnapshot` walks the vault once and parses every note
+ * once (resolving each note's type in the same pass), and both maps are derived
+ * from that one snapshot. Previously this re-parsed the vault twice per `under`
+ * query — once via `discoverManagedFiles` + `parseNote`, and again inside
+ * `buildVaultAliasMap`'s own snapshot pass.
  */
 async function augmentHierarchyDataFromVault(
   hierarchyData: HierarchyData,
-  options: Pick<FrontmatterFilterOptions, 'schema'> & { vaultDir: string }
+  options: Pick<FrontmatterFilterOptions, 'schema'> & {
+    vaultDir: string;
+    /** Optional pre-built snapshot to reuse instead of walking the vault again. */
+    snapshot?: VaultNoteSnapshot;
+  }
 ): Promise<void> {
   if (!options.schema) return;
 
-  const managedFiles = await discoverManagedFiles(options.schema, options.vaultDir);
+  const snapshot =
+    options.snapshot ?? (await buildVaultNoteSnapshot(options.schema, options.vaultDir));
   const hierarchyFieldCache = new Map<string, string[]>();
 
-  for (const managed of managedFiles) {
-    let frontmatter: Record<string, unknown>;
-    try {
-      ({ frontmatter } = await parseNote(managed.path));
-    } catch {
-      continue;
-    }
+  for (const note of snapshot.notes) {
+    if (!note.frontmatter) continue;
     addParentRelationship(
-      { path: managed.path, frontmatter },
+      { path: note.path, frontmatter: note.frontmatter },
       hierarchyData.parentMap,
       hierarchyData.childrenMap,
       // Resolve each note's own type from frontmatter for the full-vault pass.
-      options.schema ? { schema: options.schema } : {},
+      { schema: options.schema },
       hierarchyFieldCache
     );
   }
 
-  // Build the alias -> canonical-note map so `under` can canonicalize aliased
-  // relation targets and aliased query nodes (see HierarchyData.aliasMap).
-  hierarchyData.aliasMap = await buildVaultAliasMap(options.schema, options.vaultDir);
+  // Build the alias -> canonical-note map from the SAME snapshot so `under` can
+  // canonicalize aliased relation targets and aliased query nodes (see
+  // HierarchyData.aliasMap) without re-reading the vault.
+  hierarchyData.aliasMap = buildVaultAliasMap(options.schema, snapshot);
 }
 
 /**
  * Build a map from each declared alias to the canonical note name it resolves
- * to, over the entire vault. Reuses the same alias index that drives navigation
+ * to, from a vault snapshot. Reuses the same alias index that drives navigation
  * (`getEntityAliases` from #266) so `under` canonicalizes aliases identically to
  * `bwrb open <alias>`.
  *
@@ -178,12 +185,10 @@ async function augmentHierarchyDataFromVault(
  *   data loss, and silently picking a winner is exactly the footgun this guards
  *   against, so an ambiguous alias resolves to nothing (no match, no crash).
  */
-async function buildVaultAliasMap(
+function buildVaultAliasMap(
   schema: LoadedSchema,
-  vaultDir: string
-): Promise<Map<string, string>> {
-  const snapshot = await buildVaultNoteSnapshot(schema, vaultDir);
-
+  snapshot: VaultNoteSnapshot
+): Map<string, string> {
   // Real note names always win over aliases.
   const realNames = new Set<string>();
   for (const note of snapshot.notes) {

--- a/tests/ts/lib/expression-validation.test.ts
+++ b/tests/ts/lib/expression-validation.test.ts
@@ -291,6 +291,77 @@ describe('expression-validation', () => {
       // Should not throw, just skip unparseable expressions
       expect(result.valid).toBe(true);
     });
+
+    describe('under() first-argument validation', () => {
+      it('passes for a valid relation field', () => {
+        // task.milestone is a relation field.
+        const result = validateWhereExpressions(
+          ["under(milestone, '[[career]]')"],
+          schema,
+          'task'
+        );
+        expect(result.valid).toBe(true);
+        expect(result.errors).toHaveLength(0);
+      });
+
+      it('passes for the relation field `parent`', () => {
+        const result = validateWhereExpressions(
+          ["under(parent, '[[career]]')"],
+          schema,
+          'task'
+        );
+        expect(result.valid).toBe(true);
+      });
+
+      it('flags an unknown field passed to under()', () => {
+        const result = validateWhereExpressions(
+          ["under(nope, '[[career]]')"],
+          schema,
+          'task'
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]!.field).toBe('nope');
+        expect(result.errors[0]!.message).toContain('Unknown field');
+        expect(result.errors[0]!.message).toContain('under()');
+      });
+
+      it('flags a known non-relation field passed to under()', () => {
+        // task.status is a select field, not a relation.
+        const result = validateWhereExpressions(
+          ["under(status, '[[career]]')"],
+          schema,
+          'task'
+        );
+        expect(result.valid).toBe(false);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]!.field).toBe('status');
+        expect(result.errors[0]!.message).toContain('expects a relation field');
+        expect(result.errors[0]!.message).toContain("'select'");
+      });
+
+      it('does not validate the node (second) argument as a field', () => {
+        // 'nope' here is a node string, not a field — only `milestone` is checked.
+        const result = validateWhereExpressions(
+          ["under(milestone, '[[nope]]')"],
+          schema,
+          'task'
+        );
+        expect(result.valid).toBe(true);
+      });
+
+      it('validates under() combined with other clauses', () => {
+        const result = validateWhereExpressions(
+          ["status == 'backlog' && under(status, '[[career]]')"],
+          schema,
+          'task'
+        );
+        expect(result.valid).toBe(false);
+        expect(
+          result.errors.some(e => e.message.includes('expects a relation field'))
+        ).toBe(true);
+      });
+    });
   });
 
   describe('formatWhereValidationErrors', () => {

--- a/tests/ts/lib/query.test.ts
+++ b/tests/ts/lib/query.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { join } from 'path';
 import { writeFile, rm } from 'fs/promises';
 import {
@@ -6,6 +6,7 @@ import {
   applyFrontmatterFilters,
   type FileWithFrontmatter,
 } from '../../../src/lib/query.js';
+import * as discovery from '../../../src/lib/discovery.js';
 import { loadSchema } from '../../../src/lib/schema.js';
 import { createTestVault, cleanupTestVault } from '../fixtures/setup.js';
 import type { Schema } from '../../../src/types/schema.js';
@@ -279,6 +280,33 @@ describe('query', () => {
           typePath: 'task',
         });
         expect(underResult).toHaveLength(1);
+      });
+
+      it('parses the vault exactly once (parent + alias maps share one snapshot)', async () => {
+        // Regression for #634: the full-vault augmentation used to walk + parse
+        // the vault twice per `under` query (once for the parent map via
+        // discoverManagedFiles + parseNote, once for the alias map via its own
+        // buildVaultNoteSnapshot). Both maps now come from a SINGLE snapshot.
+        const snapshotSpy = vi.spyOn(discovery, 'buildVaultNoteSnapshot');
+        try {
+          const files = makeFiles([
+            { path: 'Objectives/Tasks/Leaf.md', fm: { type: 'task', status: 'backlog', milestone: '"[[Vercel]]"' } },
+          ]);
+
+          const result = await applyFrontmatterFilters(files, {
+            whereExpressions: ["under(milestone, '[[career]]')"],
+            vaultDir,
+            schema,
+            typePath: 'task',
+          });
+
+          // Behavior unchanged: still matches the deep-descendant relation target.
+          expect(result).toHaveLength(1);
+          // And the vault snapshot was built exactly once for the query.
+          expect(snapshotSpy).toHaveBeenCalledTimes(1);
+        } finally {
+          snapshotSpy.mockRestore();
+        }
       });
 
       it('does not match (and does not crash) on a dangling relation target', async () => {


### PR DESCRIPTION
Closes #634

Two follow-ups to the `under(field, '[[Node]]')` query operator (from #602, alias-aware via #636).

## 1. Perf — one vault pass instead of two

When a `--where` expression uses `under`, `augmentHierarchyDataFromVault` (`src/lib/query.ts`) needs the full vault's parent chains (relation targets usually live outside the type-filtered candidate set). Previously this read/parsed the entire vault **twice per query**:

- once via `discoverManagedFiles` + `parseNote` (per managed file) to build the parent map, and
- again inside `buildVaultAliasMap`, which ran its **own** `buildVaultNoteSnapshot` pass to build the alias map.

`buildVaultNoteSnapshot` already walks the vault, parses every note, and resolves each note's type in a single pass. `augmentHierarchyDataFromVault` now builds **one** snapshot and derives **both** the parent map and the alias map from it. `buildVaultAliasMap` became a pure (sync) function taking that snapshot. Net: an `under` query reads/parses the vault **once** (was 2×).

Behavior is identical — same #602/#636 semantics. A new test spies on `buildVaultNoteSnapshot` and asserts it's called exactly once for an `under` query while results are unchanged.

(Cross-invocation caching is intentionally **not** added — each `bwrb` run is a fresh process; the goal was eliminating redundant passes *within* a run.)

## 2. Validation — flag under()'s first argument

`expression-validation.ts` now validates the **first** argument of `under(...)` against the schema when `--type` is known (consistent with existing field validation, which only runs with a type context). The second argument is a node string and is deliberately **not** treated as a field.

- Unknown field → `Unknown field 'nope' for type 'task' in under()` (with a did-you-mean suggestion when close)
- Known but non-relation field → `under() expects a relation field, but 'status' is a 'select' field on type 'task'`
- Valid relation field (`milestone`, `parent`, …) → no error

The error formatter was tweaked to omit the "Valid options:" line when there are none (the relation-type error has no option list).

## Tests
- `tests/ts/lib/query.test.ts`: single-snapshot spy test (parses vault once, results unchanged); existing `under()` tests still pass.
- `tests/ts/lib/expression-validation.test.ts`: valid relation field, `parent`, unknown field, non-relation field, node-arg-not-validated, and `under` combined with other clauses.

## Docs
Small note in `reference/targeting.md` describing the new first-arg validation.

## Gates
- `pnpm qa` — pass (105 files, 2427 passed / 4 skipped)
- `pnpm knip` — pass
- `pnpm docs:build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)