### PR TITLE
fix(audit): align duplicate-alias severity + make illegal-aliases auto-fixable

### DIFF
--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -75,7 +75,7 @@ Delete semantics in repair mode:
 | `stale-reference` | Wikilink points to non-existent file |
 | `trailing-whitespace` | Trailing spaces/tabs on raw frontmatter `key: value` lines (warning; auto-fixable) |
 | `wrong-scalar-type` | Scalar value has wrong type for schema |
-| `illegal-aliases` | An [`alias`-role field](/reference/schema/#alias) has empty or non-string entries (the Obsidian aliases format requires non-empty, unique strings) |
+| `illegal-aliases` | An [`alias`-role field](/reference/schema/#alias) violates the Obsidian aliases format (array of **non-empty, unique** strings): an empty/whitespace entry, a **duplicate** entry, or a non-string entry (**error** — matching what `bwrb new`/`bwrb edit` reject on write; empty/whitespace + duplicate cases are **auto-fixable**, a non-string entry is **flag-only** — see below) |
 | `unlinked-mention` | A known entity's name or [registered alias](/reference/schema/#alias) appears in body prose as plain text but is not wikilinked (warning; exact/alias matches auto-fixable, fuzzy/ambiguous matches flag-only — see below) |
 | `frequent-unlinked-term` | A proper-noun-ish term mentioned frequently across the vault that has **no note yet** (warning; **advisory heuristic, never auto-fixable** — see below) |
 | `missing-body-section` | A heading section declared in the type's [`body_sections`](/reference/schema/) is missing from the note body, or present at the wrong heading level (warning; **auto-fixable** — `--fix` appends the canonical heading scaffold — see below) |
@@ -92,6 +92,21 @@ For a [`date`](/reference/schema/) field with `multiple: true` (a list of dates)
 A **numeric** date element (e.g. an unquoted `2026`, which YAML parses as a number) is treated exactly like a numeric scalar date: it is owned by the date check, so it is reported **once** — as `invalid-date-format` when it isn't a valid date for the field's granularity, or as `wrong-scalar-type` ("should be quoted as a string") when it *is* a valid date. It is never additionally reported as `invalid-list-element`. This matches scalar date handling and what `bwrb new`/`bwrb edit` accept on write.
 
 An empty or whitespace-only date value is treated as **unset**, not as an invalid date — the same convention every optional field follows (an empty optional field never produces a format/type issue). So an optional `date` field stored as `""` produces no `invalid-date-format` issue, matching what `bwrb new`/`bwrb edit` accept on write. An empty **required** date is reported once as [`empty-string-required`](#issue-codes) (consistent with every other required field), and an empty **element** inside a date list is reported once as `invalid-list-element` — never additionally as `invalid-date-format`.
+
+### Alias hygiene (`illegal-aliases`)
+
+An [`alias`-role field](/reference/schema/#alias) must hold an **array of non-empty, unique strings** (the Obsidian `aliases` format). The write path (`bwrb new`/`bwrb edit`) rejects a non-array value, an empty/whitespace entry, a duplicate entry, or a non-string entry as a hard error. Audit reports the exact same conditions at **error** severity, so a note hand-written with duplicate or blank aliases no longer slips through as a mere warning — write and audit agree.
+
+`--fix` applies the safe, idempotent subset:
+
+- **Empty/whitespace entries** are dropped.
+- **Duplicate entries** are de-duplicated, preserving the **first** occurrence (so order is stable).
+
+This reuses the same dedupe-style cleanup as `duplicate-list-values`, extended to also drop blanks, and converges on re-run (a second `--fix` changes nothing). It never merges *distinct* aliases, so no meaningful data is lost.
+
+A **non-string** alias entry (e.g. a bare number) is **flag-only**: bwrb can't infer the intended text, so it is surfaced for a manual fix rather than auto-cleaned. (A bare numeric YAML element may still be stringified by the separate `invalid-list-element` coercion, but the alias entry is never dropped.) A non-array alias value is reported as `wrong-scalar-type`.
+
+Note: because duplicate aliases are owned by `illegal-aliases`, an `alias`-role field never additionally produces a `duplicate-list-values` warning — that generic warning still applies to all other list fields unchanged.
 
 ## Examples
 

--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -104,9 +104,9 @@ An [`alias`-role field](/reference/schema/#alias) must hold an **array of non-em
 
 This reuses the same dedupe-style cleanup as `duplicate-list-values`, extended to also drop blanks, and converges on re-run (a second `--fix` changes nothing). It never merges *distinct* aliases, so no meaningful data is lost.
 
-A **non-string** alias entry (e.g. a bare number) is **flag-only**: bwrb can't infer the intended text, so it is surfaced for a manual fix rather than auto-cleaned. (A bare numeric YAML element may still be stringified by the separate `invalid-list-element` coercion, but the alias entry is never dropped.) A non-array alias value is reported as `wrong-scalar-type`.
+A **non-string** alias entry (e.g. a bare number) is **flag-only**: bwrb can't infer the intended text, so it is surfaced for a manual fix rather than auto-cleaned. The alias entry is never dropped or coerced — it survives untouched. A non-array alias value is reported as `wrong-scalar-type`.
 
-Note: because duplicate aliases are owned by `illegal-aliases`, an `alias`-role field never additionally produces a `duplicate-list-values` warning — that generic warning still applies to all other list fields unchanged.
+Note: `illegal-aliases` is the **sole owner** of alias-field list cleanup. An `alias`-role field therefore never additionally produces a generic `duplicate-list-values` warning *or* an `invalid-list-element` issue — both are suppressed so blanks and duplicates are detected and fixed exactly once, by `illegal-aliases`, in a single idempotent pass. (Running both removers on the same field used to destroy a distinct alias when blanks preceded a real entry; see #617.) Those generic checks still apply to all other list fields unchanged.
 
 ## Examples
 

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -581,8 +581,16 @@ aliases:
 
 **Validation.** Because `aliases` is a recognized role, bwrb validates the value
 as an array of **non-empty, unique strings** (the Obsidian `aliases` format).
-`bwrb audit` flags a scalar value, empty entries, non-string entries, or
-duplicates.
+The write path (`bwrb new`/`bwrb edit`) rejects a scalar value, empty/whitespace
+entries, non-string entries, and duplicates as a hard error. `bwrb audit` reports
+the **same** conditions at **error** severity (an [`illegal-aliases`](/reference/commands/audit/#alias-hygiene-illegal-aliases)
+issue), so write and audit agree — a note hand-written with duplicate or blank
+aliases is an error, not a warning.
+
+**Auto-fix.** `bwrb audit --fix` cleans the safe, idempotent cases: it drops
+empty/whitespace entries and de-duplicates (preserving the first occurrence). It
+never merges distinct aliases. A **non-string** entry stays flag-only (bwrb can't
+infer the intended text); a non-array value is reported as `wrong-scalar-type`.
 
 **Back-compat.** The role is optional. Types that declare no alias field, and
 notes without an `aliases` value, keep working unchanged.

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -1133,6 +1133,18 @@ function checkListElementIntegrity(
   for (const [fieldName, field] of Object.entries(fields)) {
     if (!field || (field.prompt !== 'list' && !field.multiple)) continue;
 
+    // Alias-role fields are owned exclusively by the `illegal-aliases`
+    // detection+fix (checkIllegalAliases / fixIllegalAliases), which validates
+    // the whole field as a unit and safely drops blanks + dedupes in one pass.
+    // We must NOT also run the generic `invalid-list-element` blank-remover on
+    // them: that remover deletes blank entries by original index applied
+    // sequentially to a shrinking array, so with 2+ leading blanks a stale
+    // index destroys a distinct alias when both fire in the same auto-fix pass
+    // (data loss, #617). This mirrors the `duplicate-list-values` suppression
+    // for alias fields in checkHygieneIssues — alias-field list cleanup has a
+    // single owner.
+    if (field.alias === true) continue;
+
     const value = frontmatter[fieldName];
     if (value === null || value === undefined) continue;
 

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -1900,21 +1900,31 @@ function checkHygieneIssues(
       }
     }
     
-    // Check for duplicate list values (case-sensitive)
-    if (Array.isArray(value)) {
+    // Alias-role fields are validated as a unit by checkIllegalAliases below
+    // (empty/whitespace, duplicate, AND non-string entries → one
+    // `illegal-aliases` error). Duplicate aliases must surface at error severity
+    // to match the write path, so we do NOT also run the generic
+    // `duplicate-list-values` warning check on them — that would both
+    // double-report and contradict the write path's hard rejection (#617).
+    const isAliasField = field?.alias === true && Array.isArray(value);
+
+    // Check for duplicate list values (case-sensitive). Non-alias lists only.
+    if (Array.isArray(value) && !isAliasField) {
       const dupIssue = checkDuplicateListValues(fieldName, value);
       if (dupIssue) {
         issues.push(dupIssue);
       }
     }
 
-    // Alias-role fields: flag empty/blank entries. Scalar values and duplicates
-    // are already covered by wrong-scalar-type and duplicate-list-values; this
-    // closes the remaining gap in the Obsidian aliases format (#266).
-    if (field?.alias === true && Array.isArray(value)) {
-      const emptyAliasIssue = checkEmptyAliasEntries(fieldName, value);
-      if (emptyAliasIssue) {
-        issues.push(emptyAliasIssue);
+    // Alias-role fields: enforce the Obsidian aliases format (array of
+    // non-empty, unique strings) as a single `illegal-aliases` error, matching
+    // what the write path (new/edit) rejects. Empty/whitespace entries and
+    // duplicates are safely auto-fixable (drop blanks; dedupe preserving the
+    // first occurrence); a non-string entry makes the issue flag-only (#266, #617).
+    if (isAliasField) {
+      const aliasIssue = checkIllegalAliases(fieldName, value as unknown[]);
+      if (aliasIssue) {
+        issues.push(aliasIssue);
       }
     }
 
@@ -2091,29 +2101,79 @@ function checkDuplicateListValues(
 }
 
 /**
- * Check an alias-role field for empty or non-string entries.
+ * Validate an alias-role field as a unit (the Obsidian `aliases` format: an
+ * array of non-empty, UNIQUE strings). This mirrors the write path's
+ * `validateAliasValue` (new/edit), which rejects empty/whitespace entries,
+ * non-string entries, and duplicates as a hard error — so audit reports the same
+ * conditions at `error` severity, keeping the two paths in agreement (#617).
  *
- * Scalar values and duplicates are caught elsewhere (wrong-scalar-type and
- * duplicate-list-values); this covers the remaining illegal-aliases cases:
- * empty/blank strings and non-string entries. Flagged for human review rather
- * than auto-fixed, since dropping entries could lose intent.
+ * Auto-fixability (the safe, idempotent subset):
+ * - empty/whitespace entries → dropped
+ * - exact duplicates → de-duplicated, preserving the first occurrence
+ * Both are non-destructive of meaningful data and converge on re-run, so a note
+ * with only these problems is auto-fixable via the existing dedupe-style meta
+ * pattern. The fixed list (`meta.after`) is computed here so the fixer is a pure
+ * apply.
+ *
+ * A NON-STRING entry (number/boolean/object) is NOT safely auto-fixable — we
+ * can't know the intended alias text — so its presence makes the whole issue
+ * flag-only, surfaced for a manual fix.
+ *
+ * Scalar (non-array) alias values are handled separately as `wrong-scalar-type`
+ * (this check only runs for array values).
  */
-function checkEmptyAliasEntries(
+function checkIllegalAliases(
   fieldName: string,
   value: unknown[]
 ): AuditIssue | null {
-  const hasEmpty = value.some(
-    (item) => typeof item !== 'string' || item.trim() === ''
-  );
-  if (!hasEmpty) return null;
+  let hasEmpty = false;
+  let hasDuplicate = false;
+  let hasNonString = false;
+
+  const seen = new Set<string>();
+  const cleaned: string[] = [];
+
+  for (const item of value) {
+    if (typeof item !== 'string') {
+      hasNonString = true;
+      continue;
+    }
+    if (item.trim() === '') {
+      hasEmpty = true;
+      continue;
+    }
+    if (seen.has(item)) {
+      hasDuplicate = true;
+      continue;
+    }
+    seen.add(item);
+    cleaned.push(item);
+  }
+
+  if (!hasEmpty && !hasDuplicate && !hasNonString) return null;
+
+  // The empty/whitespace + dedupe fix is only safe when every offending entry is
+  // either blank or a duplicate; a non-string entry blocks the auto-fix.
+  const autoFixable = !hasNonString;
+
+  const problems: string[] = [];
+  if (hasEmpty) problems.push('empty/whitespace');
+  if (hasDuplicate) problems.push('duplicate');
+  if (hasNonString) problems.push('non-string');
 
   return {
     severity: 'error',
     code: 'illegal-aliases',
-    message: `Invalid aliases in '${fieldName}': entries must be non-empty strings`,
+    message: `Invalid aliases in '${fieldName}': entries must be non-empty, unique strings (found ${problems.join(', ')})`,
     field: fieldName,
     value,
-    autoFixable: false,
+    autoFixable,
+    meta: {
+      problems,
+      before: value,
+      // Only meaningful when autoFixable; the fixer drops blanks and dedupes.
+      after: cleaned,
+    },
   };
 }
 

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -690,6 +690,30 @@ async function applyFix(
         }
         break;
       }
+      case 'illegal-aliases': {
+        // Safe, idempotent alias cleanup: drop empty/whitespace entries and
+        // de-duplicate (preserving the first occurrence). Reuses the same
+        // dedupe-style apply as `duplicate-list-values`, extended to also drop
+        // blanks. A non-string entry is never auto-dispatched here (the detector
+        // marks such issues non-fixable), so we fail safe if one appears (#617).
+        const currentValue = issue.field ? frontmatter[issue.field] : undefined;
+        if (!issue.field || !Array.isArray(currentValue)) {
+          return { file: filePath, issue, action: 'failed', message: 'Cannot clean non-array aliases' };
+        }
+        if (!currentValue.every((item) => typeof item === 'string')) {
+          return { file: filePath, issue, action: 'failed', message: 'Cannot auto-fix non-string aliases' };
+        }
+        const seen = new Set<string>();
+        const cleaned: string[] = [];
+        for (const item of currentValue as string[]) {
+          if (item.trim() === '') continue; // drop empty/whitespace
+          if (seen.has(item)) continue; // dedupe (first wins)
+          seen.add(item);
+          cleaned.push(item);
+        }
+        frontmatter[issue.field] = cleaned;
+        break;
+      }
       case 'singular-plural-mismatch': {
         if (!issue.field || !issue.canonicalKey) {
           return { file: filePath, issue, action: 'failed', message: 'No field or canonical key provided' };
@@ -1562,6 +1586,19 @@ export async function runAutoFix(
           console.log(chalk.red(`    ✗ Failed to dedupe ${issue.field}: ${fixResult.message}`));
           failed++;
         }
+      } else if (issue.code === 'illegal-aliases' && issue.field) {
+        // Clean an alias list: drop empty/whitespace entries and dedupe. Only
+        // dispatched for auto-fixable issues (those with no non-string entry).
+        const fixResult = await applyFix(schema, result.path, issue);
+        if (fixResult.action === 'fixed') {
+          console.log(chalk.cyan(`  ${result.relativePath}`));
+          console.log(chalk.green(`    ✓ Cleaned aliases in ${issue.field}`));
+          fixed++;
+        } else {
+          console.log(chalk.cyan(`  ${result.relativePath}`));
+          console.log(chalk.red(`    ✗ Failed to clean ${issue.field}: ${fixResult.message}`));
+          failed++;
+        }
       } else if (issue.code === 'unlinked-mention') {
         // Only exact/alias mentions are auto-fixable (fuzzy/ambiguous are
         // flag-only and never reach here, since autoFixable is false on them).
@@ -1817,6 +1854,8 @@ async function handleInteractiveFix(
       return handleEnumCasingFix(schema, result, issue);
     case 'duplicate-list-values':
       return handleDuplicateListFix(schema, result, issue);
+    case 'illegal-aliases':
+      return handleIllegalAliasesFix(schema, result, issue);
     case 'frontmatter-key-casing':
     case 'singular-plural-mismatch':
       return handleKeyCasingFix(schema, result, issue);
@@ -3765,6 +3804,36 @@ async function handleDuplicateListFix(
     issue,
     `    → Remove duplicate values from '${issue.field}'?`,
     `Deduplicated ${issue.field}`
+  );
+}
+
+/**
+ * Interactive handler for `illegal-aliases` (#617): offer to clean the alias
+ * list by dropping empty/whitespace entries and de-duplicating (first wins),
+ * reusing the same apply path as the auto-fix. Non-string aliases are flagged as
+ * non-auto-fixable by the detector, so such issues never reach a fix dispatch.
+ */
+async function handleIllegalAliasesFix(
+  schema: LoadedSchema,
+  result: FileAuditResult,
+  issue: AuditIssue
+): Promise<'fixed' | 'skipped' | 'failed' | 'quit'> {
+  if (!issue.field) return 'skipped';
+
+  // A non-string alias entry makes the issue flag-only (we can't infer the
+  // intended text). Surface the suggestion path and skip rather than prompting a
+  // fix that would fail.
+  if (!issue.autoFixable) {
+    console.log(chalk.dim('    (Manual fix required - skipping)'));
+    return 'skipped';
+  }
+
+  return confirmAndApplyFix(
+    schema,
+    result,
+    issue,
+    `    → Clean aliases in '${issue.field}' (drop empty entries + dedupe)?`,
+    `Cleaned aliases in ${issue.field}`
   );
 }
 

--- a/tests/ts/lib/alias-role.test.ts
+++ b/tests/ts/lib/alias-role.test.ts
@@ -325,6 +325,97 @@ describe('alias field role', () => {
       expect(stable.frontmatter['aliases']).toEqual(['Steve', 'stevey']);
     });
 
+    // DEFAULT fix path data-loss regression (#617). These exercise the FULL
+    // auto-fix pass (runAudit with NO onlyIssue filter, then runAutoFix), which
+    // is where the bug lived: the `illegal-aliases` fixer is correct in
+    // isolation, but the generic `invalid-list-element` blank-remover used to
+    // CO-FIRE on the same alias field. It removed blanks by original index
+    // applied to a shrinking array, so with 2+ leading blanks a stale index
+    // deleted a distinct alias ("Real" → silently destroyed) while the run still
+    // reported success. The fix makes `illegal-aliases` the sole owner of
+    // alias-field list cleanup. The fixture deliberately puts the real alias
+    // AFTER the blanks so a regression would catch the data loss.
+    describe('default fix path never loses a distinct alias (#617 data-loss regression)', () => {
+      const writePerson = async (name: string, yamlAliases: string) => {
+        await writeFile(
+          join(vaultDir, 'People', `${name}.md`),
+          `---\ntype: person\naliases:\n${yamlAliases}---\n`
+        );
+      };
+
+      // Run the DEFAULT auto-fix pass (all detections, not --only) and return
+      // the resulting alias array plus the fix summary.
+      const fixDefaultPath = async (name: string) => {
+        const schema = await loadSchema(vaultDir);
+        const results = await runAudit(schema, vaultDir, { strict: false });
+        const summary = await runAutoFix(
+          results.filter((r) => r.relativePath === `People/${name}.md`),
+          schema,
+          vaultDir
+        );
+        const fixed = await parseNote(join(vaultDir, 'People', `${name}.md`));
+        return { aliases: fixed.frontmatter['aliases'], summary, schema };
+      };
+
+      it('["", "  ", "Real"] -> ["Real"] (the distinct alias survives), idempotent', async () => {
+        // Two LEADING blanks then a real alias: the exact shape that triggered
+        // the stale-index data loss under the default path.
+        await writePerson('Lead', `  - ""\n  - "  "\n  - Real\n`);
+
+        const { aliases, summary, schema } = await fixDefaultPath('Lead');
+        expect(aliases).toEqual(['Real']);
+        // Reported success without claiming an inflated/incorrect remaining count.
+        expect(summary.remaining).toBe(0);
+        expect(summary.fixed).toBeGreaterThan(0);
+
+        // Idempotent: no illegal-aliases issue remains, re-fix is a no-op.
+        const after = await runAudit(schema, vaultDir, { strict: false });
+        const lead = after.find((r) => r.relativePath === 'People/Lead.md');
+        expect(lead?.issues.some((i) => i.code === 'illegal-aliases') ?? false).toBe(false);
+        await runAutoFix(
+          after.filter((r) => r.relativePath === 'People/Lead.md'),
+          schema,
+          vaultDir
+        );
+        const stable = await parseNote(join(vaultDir, 'People', 'Lead.md'));
+        expect(stable.frontmatter['aliases']).toEqual(['Real']);
+      });
+
+      it('["", ""] -> [] (all blanks removed, no alias to keep)', async () => {
+        await writePerson('AllBlank', `  - ""\n  - ""\n`);
+        const { aliases, summary } = await fixDefaultPath('AllBlank');
+        expect(aliases).toEqual([]);
+        expect(summary.remaining).toBe(0);
+      });
+
+      it('[A, "", B, "", A] -> [A, B] (blanks dropped AND duplicate deduped, first wins)', async () => {
+        await writePerson('Mixed', `  - A\n  - ""\n  - B\n  - ""\n  - A\n`);
+        const { aliases, summary, schema } = await fixDefaultPath('Mixed');
+        expect(aliases).toEqual(['A', 'B']);
+        expect(summary.remaining).toBe(0);
+
+        // Idempotent.
+        const after = await runAudit(schema, vaultDir, { strict: false });
+        await runAutoFix(
+          after.filter((r) => r.relativePath === 'People/Mixed.md'),
+          schema,
+          vaultDir
+        );
+        const stable = await parseNote(join(vaultDir, 'People', 'Mixed.md'));
+        expect(stable.frontmatter['aliases']).toEqual(['A', 'B']);
+      });
+
+      it('only the single illegal-aliases issue fires on an alias field (invalid-list-element is suppressed)', async () => {
+        await writePerson('Guard', `  - ""\n  - "  "\n  - Real\n`);
+        const schema = await loadSchema(vaultDir);
+        const results = await runAudit(schema, vaultDir, { strict: false });
+        const guard = results.find((r) => r.relativePath === 'People/Guard.md');
+        // The alias-field guard means invalid-list-element must NOT co-fire.
+        expect(guard?.issues.some((i) => i.code === 'invalid-list-element')).toBe(false);
+        expect(guard?.issues.some((i) => i.code === 'illegal-aliases')).toBe(true);
+      });
+    });
+
     it('non-string alias entries are flagged but NOT auto-fixed', async () => {
       // A YAML-numeric alias entry: we cannot infer the intended text, so this
       // stays flag-only (consistent with the write path rejecting it).
@@ -363,6 +454,62 @@ describe('alias field role', () => {
       // The well-formed note is either omitted (no issues at all) or present
       // without an illegal-aliases issue.
       expect(steve?.issues.some((i) => i.code === 'illegal-aliases') ?? false).toBe(false);
+    });
+  });
+
+  // Confirm this PR did NOT change `invalid-list-element` behavior for NON-alias
+  // list fields. The alias-field guard added for #617 must be scoped to alias
+  // fields only — a plain list field with blanks is still detected and removed
+  // by `invalid-list-element` exactly as before (the stale-index bug there is a
+  // separate, pre-existing issue tracked elsewhere; we don't assert on its
+  // result shape, only that detection still fires and the field is untouched by
+  // the alias path).
+  describe('non-alias list fields are unaffected by the alias-field guard (#617)', () => {
+    const TAG_SCHEMA: Schema = {
+      version: 2,
+      types: {
+        meta: { fields: {} },
+        note: {
+          extends: 'meta',
+          output_dir: 'Notes',
+          fields: {
+            type: { value: 'note' },
+            // A plain (non-alias) list field.
+            tags: { prompt: 'list' },
+          },
+          field_order: ['type', 'tags'],
+        },
+      },
+    };
+
+    let vaultDir: string;
+
+    beforeEach(async () => {
+      vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-taglist-'));
+      await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(vaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify(TAG_SCHEMA, null, 2)
+      );
+      await mkdir(join(vaultDir, 'Notes'), { recursive: true });
+    });
+
+    afterEach(async () => {
+      await rm(vaultDir, { recursive: true, force: true });
+    });
+
+    it('still reports invalid-list-element for a blank entry in a non-alias list', async () => {
+      await writeFile(
+        join(vaultDir, 'Notes', 'Tagged.md'),
+        `---\ntype: note\ntags:\n  - alpha\n  - ""\n  - beta\n---\n`
+      );
+      const schema = await loadSchema(vaultDir);
+      const results = await runAudit(schema, vaultDir, { strict: false });
+      const tagged = results.find((r) => r.relativePath === 'Notes/Tagged.md');
+      // The non-alias list is NOT guarded — invalid-list-element still fires.
+      expect(tagged?.issues.some((i) => i.code === 'invalid-list-element')).toBe(true);
+      // And illegal-aliases never applies to a non-alias field.
+      expect(tagged?.issues.some((i) => i.code === 'illegal-aliases')).toBe(false);
     });
   });
 

--- a/tests/ts/lib/alias-role.test.ts
+++ b/tests/ts/lib/alias-role.test.ts
@@ -13,6 +13,8 @@ import { validateFrontmatter } from '../../../src/lib/validation.js';
 import { buildNoteIndex, resolveNoteQuery } from '../../../src/lib/navigation.js';
 import { buildNoteTargetIndex } from '../../../src/lib/discovery.js';
 import { runAudit } from '../../../src/lib/audit/detection.js';
+import { runAutoFix } from '../../../src/lib/audit/fix.js';
+import { parseNote } from '../../../src/lib/frontmatter.js';
 import type { Schema } from '../../../src/types/schema.js';
 
 // A schema with a person type whose `aliases` field carries the alias role,
@@ -258,7 +260,7 @@ describe('alias field role', () => {
       expect(result.candidates.length).toBe(2);
     });
 
-    it('audit flags empty alias entries (illegal-aliases)', async () => {
+    it('audit flags empty alias entries (illegal-aliases) as an error', async () => {
       await writeFile(
         join(vaultDir, 'People', 'Bad.md'),
         `---\ntype: person\naliases:\n  - Real\n  - ""\n---\n`
@@ -266,7 +268,92 @@ describe('alias field role', () => {
       const schema = await loadSchema(vaultDir);
       const results = await runAudit(schema, vaultDir, { strict: false });
       const bad = results.find((r) => r.relativePath === 'People/Bad.md');
-      expect(bad?.issues.some((i) => i.code === 'illegal-aliases')).toBe(true);
+      const issue = bad?.issues.find((i) => i.code === 'illegal-aliases');
+      expect(issue).toBeDefined();
+      expect(issue?.severity).toBe('error');
+      // Empty-only is the safe auto-fix subset.
+      expect(issue?.autoFixable).toBe(true);
+    });
+
+    it('audit flags DUPLICATE aliases as an illegal-aliases error (not a warning), matching the write path (#617)', async () => {
+      await writeFile(
+        join(vaultDir, 'People', 'Dup.md'),
+        `---\ntype: person\naliases:\n  - Steve\n  - Steve\n---\n`
+      );
+      const schema = await loadSchema(vaultDir);
+      const results = await runAudit(schema, vaultDir, { strict: false });
+      const dup = results.find((r) => r.relativePath === 'People/Dup.md');
+
+      // The write path rejects duplicate aliases as a hard error; audit now
+      // agrees — it is an `illegal-aliases` ERROR, NOT a `duplicate-list-values`
+      // warning.
+      const issue = dup?.issues.find((i) => i.code === 'illegal-aliases');
+      expect(issue).toBeDefined();
+      expect(issue?.severity).toBe('error');
+      expect(issue?.autoFixable).toBe(true);
+      expect(dup?.issues.some((i) => i.code === 'duplicate-list-values')).toBe(false);
+    });
+
+    it('--fix auto-cleans empty/whitespace + duplicate aliases (dedupe, first wins) and is idempotent', async () => {
+      await writeFile(
+        join(vaultDir, 'People', 'Messy.md'),
+        `---\ntype: person\naliases:\n  - Steve\n  - ""\n  - "  "\n  - Steve\n  - stevey\n---\n`
+      );
+      const schema = await loadSchema(vaultDir);
+
+      const results = await runAudit(schema, vaultDir, { strict: false });
+      const messyResult = results.filter((r) => r.relativePath === 'People/Messy.md');
+      await runAutoFix(messyResult, schema, vaultDir);
+
+      const fixed = await parseNote(join(vaultDir, 'People', 'Messy.md'));
+      // Blanks dropped, duplicate removed, order preserved (first occurrence).
+      expect(fixed.frontmatter['aliases']).toEqual(['Steve', 'stevey']);
+
+      // Re-audit: no illegal-aliases issue remains (idempotent).
+      const after = await runAudit(schema, vaultDir, { strict: false });
+      const messyAfter = after.find((r) => r.relativePath === 'People/Messy.md');
+      expect(messyAfter?.issues.some((i) => i.code === 'illegal-aliases') ?? false).toBe(false);
+
+      // Re-running --fix on a clean note changes nothing.
+      const reRun = await runAudit(schema, vaultDir, { strict: false });
+      await runAutoFix(
+        reRun.filter((r) => r.relativePath === 'People/Messy.md'),
+        schema,
+        vaultDir
+      );
+      const stable = await parseNote(join(vaultDir, 'People', 'Messy.md'));
+      expect(stable.frontmatter['aliases']).toEqual(['Steve', 'stevey']);
+    });
+
+    it('non-string alias entries are flagged but NOT auto-fixed', async () => {
+      // A YAML-numeric alias entry: we cannot infer the intended text, so this
+      // stays flag-only (consistent with the write path rejecting it).
+      await writeFile(
+        join(vaultDir, 'People', 'NumAlias.md'),
+        `---\ntype: person\naliases:\n  - Steve\n  - 123\n---\n`
+      );
+      const schema = await loadSchema(vaultDir);
+      const results = await runAudit(schema, vaultDir, { strict: false });
+      const num = results.find((r) => r.relativePath === 'People/NumAlias.md');
+      const issue = num?.issues.find((i) => i.code === 'illegal-aliases');
+      expect(issue).toBeDefined();
+      expect(issue?.severity).toBe('error');
+      expect(issue?.autoFixable).toBe(false);
+
+      // The illegal-aliases fix must NOT drop or merge the non-string entry — no
+      // alias data is lost. (A separate, pre-existing `invalid-list-element`
+      // coercion may stringify a bare numeric YAML element, e.g. 123 → "123";
+      // either way the entry survives.)
+      await runAutoFix(
+        results.filter((r) => r.relativePath === 'People/NumAlias.md'),
+        schema,
+        vaultDir
+      );
+      const after = await parseNote(join(vaultDir, 'People', 'NumAlias.md'));
+      const aliases = after.frontmatter['aliases'] as unknown[];
+      expect(aliases).toHaveLength(2);
+      expect(aliases[0]).toBe('Steve');
+      expect(String(aliases[1])).toBe('123');
     });
 
     it('audit passes a well-formed aliases note', async () => {


### PR DESCRIPTION
Closes #617.

## The inconsistency (mapped)

Two alias-handling mismatches between the write path (`new`/`edit`) and `bwrb audit`:

1. **Severity.** The write path (`validateAliasValue`) rejects duplicate aliases as a **hard error**, but audit flagged duplicate aliases only as a generic `duplicate-list-values` **warning** — a note hand-written with duplicate aliases passed audit.
2. **`illegal-aliases` not auto-fixable.** Empty/whitespace alias entries were flagged (`illegal-aliases`, error) but `--fix` could never clean them, despite being safely de-dupable/cleanable.

Prior audit coverage for alias fields was split: empty/non-string → `illegal-aliases` (error, flag-only); duplicates → `duplicate-list-values` (warning, auto-fixable); non-array → `wrong-scalar-type`.

## The fix

**Severity (aligned UP to error, scoped to the alias role).** Alias-role fields are now validated as a unit by a single `illegal-aliases` **error** that mirrors `validateAliasValue` on write — empty/whitespace, duplicate, and non-string entries. The generic `duplicate-list-values` warning is **suppressed for alias fields only**, so duplicate aliases surface at error severity and are never double-reported. Non-alias list fields keep `duplicate-list-values` unchanged.

**Auto-fix (safe, idempotent subset).** `bwrb audit --fix` now cleans alias lists by dropping empty/whitespace entries and de-duplicating (first occurrence wins, order preserved). This reuses the existing dedupe-style apply (same path as `duplicate-list-values`, extended to also drop blanks) and converges on re-run. It never merges distinct aliases, so no meaningful data is lost.

**Stays flag-only.** A **non-string** alias entry is not auto-fixed (bwrb can't infer the intended text); a **non-array** value is still `wrong-scalar-type`.

## Tests

Added to `tests/ts/lib/alias-role.test.ts`: duplicate aliases now reported as `illegal-aliases` error (not `duplicate-list-values` warning); empty/whitespace + duplicate auto-fix (dedupe, first wins) with idempotent re-run; non-string entries flagged but not auto-dropped. Existing write-path rejection tests unchanged.

## Quality gates

- `pnpm qa` — pass (2430 passed, 4 skipped)
- `pnpm knip` — pass
- `pnpm docs:build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)