### PR TITLE
feat(audit): tunable unlinked-mention fuzzy threshold + interactive ambiguous resolution

### DIFF
--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -33,6 +33,8 @@ The target argument is auto-detected as type, path (contains `/`), or where expr
 | `--ignore <issue-type>` | Ignore specific issue type |
 | `--strict` | Treat unknown fields as errors instead of warnings |
 | `--allow-field <fields>` | Allow additional fields beyond schema (repeatable) |
+| `--mention-fuzzy-threshold <n>` | Max edit distance (0–5) for the `unlinked-mention` fuzzy "did you mean?" tier (default: `config.mention_fuzzy_threshold` or `2`) |
+| `--no-mention-fuzzy` | Disable the `unlinked-mention` fuzzy "did you mean?" tier entirely |
 | `--check-schema-docs` | Also report schema types/fields that have no `description` |
 
 ### Repair
@@ -221,8 +223,8 @@ It enforces a strict **trust line** — only matches bwrb can be certain about a
 | Tier | What it matches | Behavior |
 |------|-----------------|----------|
 | **Exact / alias** | The literal note name, or a registered alias, present as unlinked plain text and resolving to exactly **one** entity | **Trusted → auto-fixable.** `--fix --auto --execute` converts it to a wikilink (`--fix --auto` alone previews). |
-| **Fuzzy** | A capitalized phrase that is a near (small Levenshtein distance) match to a known name, e.g. `Steve Yeg` ≈ `Steve Yegge` | **Review item ("did you mean?") — never auto-linked.** |
-| **Ambiguous** | A surface that matches **multiple** distinct entities/aliases, e.g. `Mercury` | **Never auto-resolved.** Listed as a review item with all candidates. |
+| **Fuzzy** | A capitalized phrase that is a near (small Levenshtein distance) match to a known name, e.g. `Steve Yeg` ≈ `Steve Yegge` | **Review item ("did you mean?") — never auto-linked.** Distance threshold is [configurable](#tuning-the-fuzzy-tier-622). |
+| **Ambiguous** | A surface that matches **multiple** distinct entities/aliases, e.g. `Mercury` | **Never auto-resolved by `--auto`.** Listed as a review item with all candidates; interactive `--fix` offers a [pick-a-candidate prompt](#resolving-ambiguous-mentions-interactively-622). |
 
 Auto-fix output format:
 
@@ -255,7 +257,49 @@ bwrb audit --only unlinked-mention
 bwrb audit --path "Notes/**" --fix --auto --execute
 ```
 
-Fuzzy and ambiguous mentions are reported with a suggestion but are **never** modified by `--fix --auto`; resolve them with interactive `--fix` (which will skip them with the suggestion) or by editing manually.
+Fuzzy and ambiguous mentions are **never** modified by `--fix --auto`. Fuzzy matches are always flag-only (resolve them with interactive `--fix`, which skips them with the suggestion, or by editing manually). Ambiguous matches can be resolved in an interactive `--fix` session — see below.
+
+#### Tuning the fuzzy tier (#622)
+
+The fuzzy "did you mean?" tier is deliberately conservative (max Levenshtein distance **2** by default), so only genuine near-misses surface. You can tune how aggressive it is:
+
+- **Per run (flag):** `--mention-fuzzy-threshold <n>` sets the max edit distance, where `n` is an integer in `0`–`5`. Raising it surfaces looser matches (more "did you mean?" suggestions); lowering it surfaces fewer. `0` (or `--no-mention-fuzzy`) disables the fuzzy tier entirely. Out-of-range or non-integer values produce a clear validation error.
+- **Persistent (config):** set `mention_fuzzy_threshold` in your vault `config` (integer `0`–`5`). The flag, when present, overrides the config value for that run.
+
+```bash
+# Loosen the fuzzy tier for one run (more "did you mean?" suggestions)
+bwrb audit --only unlinked-mention --mention-fuzzy-threshold 3
+
+# Turn off fuzzy suggestions entirely
+bwrb audit --only unlinked-mention --no-mention-fuzzy
+```
+
+```json
+// .bwrb/schema.json — persist a looser threshold for every run
+{
+  "config": { "mention_fuzzy_threshold": 3 }
+}
+```
+
+The threshold affects **only** the fuzzy tier. Exact/alias auto-fix and ambiguous flagging are unchanged.
+
+#### Resolving ambiguous mentions interactively (#622)
+
+When a surface matches more than one entity (for example `Mercury` resolving to both a `[[Mercury]]` note and a person aliased `Mercury`), bwrb never guesses. In an interactive `--fix` session (a real TTY), an ambiguous mention now prompts you to **pick a candidate** (or skip / quit):
+
+```text
+Notes/Daily.md
+  ⚠ Ambiguous unlinked mention on line 1: 'Mercury' could link to 2 entities
+    Resolve ambiguous mention 'Mercury' to:
+      1. Freddie
+      2. Mercury
+      3. [skip]
+      4. [quit]
+```
+
+Choosing a candidate rewrites the plain-text mention to a wikilink using the **same** rewrite as exact/alias auto-fix: `[[Chosen]]`, or `[[Chosen|surface]]` when the surface text differs from the chosen note name (so picking `Freddie` for the surface `Mercury` yields `[[Freddie|Mercury]]`). The same masking and word-boundary guarantees apply, so it never relinks inside code or existing links, and it is idempotent.
+
+This is **interactive-only**. In `--auto` / `--fix --auto` and any non-TTY (headless) run, ambiguous mentions remain flag-only and are never auto-resolved.
 
 ### Frequent-unlinked-term semantics (open-world nudge)
 

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -55,6 +55,7 @@ import {
   findUndocumentedSchemaEntries,
   type UndocumentedSchemaEntries,
 } from '../lib/audit/schema-docs.js';
+import { parseFuzzyThreshold } from '../lib/audit/unlinked-mention.js';
 import chalk from 'chalk';
 
 const FIX_TARGETING_ERROR_SUMMARY =
@@ -165,6 +166,8 @@ Examples:
   bwrb audit --ignore unknown-field
   bwrb audit --output json        # JSON output for CI
   bwrb audit --allow-field custom # Allow specific extra field
+  bwrb audit --only unlinked-mention --mention-fuzzy-threshold 3 # Looser fuzzy "did you mean?"
+  bwrb audit --only unlinked-mention --no-mention-fuzzy          # Disable fuzzy tier
   bwrb audit --all --fix                  # Interactive guided fixes across vault (writes)
   bwrb audit --fix --path "Ideas/**"      # Interactive guided fixes (writes)
   bwrb audit --fix --dry-run --path "Ideas/**"    # Preview guided fixes (no writes)
@@ -187,6 +190,11 @@ Examples:
   .option('--dry-run', 'With --fix: preview fixes without writing')
   .option('--execute', 'With --fix --auto: apply fixes (omit to preview)')
   .option('--allow-field <fields...>', 'Allow additional fields beyond schema (repeatable)')
+  .option(
+    '--mention-fuzzy-threshold <n>',
+    'unlinked-mention fuzzy "did you mean?" max edit distance (0-5; default from config or 2)'
+  )
+  .option('--no-mention-fuzzy', 'Disable the unlinked-mention fuzzy "did you mean?" tier')
   .option('--check-schema-docs', 'Also report schema types/fields that have no description')
   .action(async (target: string | undefined, options: AuditOptions & {
     type?: string;
@@ -255,6 +263,20 @@ Examples:
       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
       const schema = await loadSchema(vaultDir);
+
+      // Resolve the unlinked-mention fuzzy tuning (#622). Precedence: CLI flag
+      // > schema config > built-in default. `--no-mention-fuzzy` disables the
+      // tier outright. The CLI threshold is validated to a sensible range.
+      const mentionFuzzyEnabled = options.mentionFuzzy !== false;
+      let mentionFuzzyThreshold = schema.config.mentionFuzzyThreshold;
+      if (options.mentionFuzzyThreshold !== undefined) {
+        const parsed = parseFuzzyThreshold(options.mentionFuzzyThreshold);
+        if (!parsed.ok) {
+          exitWithValidationError(parsed.error);
+        } else {
+          mentionFuzzyThreshold = parsed.value;
+        }
+      }
 
       if (globalOpts.nonInteractive && fixMode && !autoMode) {
         exitWithValidationError('bwrb audit --fix requires --auto when --non-interactive is set.');
@@ -347,6 +369,8 @@ Examples:
         allowedFields,
         vaultDir,
         schema,
+        mentionFuzzyThreshold,
+        mentionFuzzyEnabled,
       });
 
       // Handle fix mode

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -777,7 +777,14 @@ export async function auditFile(
 
       if (wantsUnlinkedMention && hasBody && entityMentionIndex) {
         issues.push(
-          ...detectUnlinkedMentions(body, file.relativePath, entityMentionIndex)
+          ...detectUnlinkedMentions(body, file.relativePath, entityMentionIndex, {
+            ...(options.mentionFuzzyThreshold !== undefined
+              ? { fuzzyThreshold: options.mentionFuzzyThreshold }
+              : {}),
+            ...(options.mentionFuzzyEnabled !== undefined
+              ? { fuzzyEnabled: options.mentionFuzzyEnabled }
+              : {}),
+          })
         );
       }
 

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -3501,8 +3501,14 @@ async function handleTrailingWhitespaceFix(
  * Handle an unlinked-mention fix interactively.
  *
  * Exact/alias mentions (autoFixable) offer to convert the plain-text mention to
- * a wikilink. Fuzzy/ambiguous mentions are flag-only: we surface the suggestion
- * and skip, honoring the trust line (never auto-resolve fuzziness/ambiguity).
+ * a wikilink. Ambiguous mentions (multiple candidate entities) prompt the human
+ * to pick one candidate (or skip), then rewrite using the SAME mention-rewrite
+ * as the exact/alias auto-fix (#622). Fuzzy mentions remain flag-only: we
+ * surface the suggestion and skip (never auto-resolve fuzziness).
+ *
+ * This handler runs ONLY in interactive `--fix` (a TTY). `--auto` and non-TTY
+ * paths never reach here for non-autoFixable issues, so ambiguous mentions are
+ * never auto-resolved.
  */
 async function handleUnlinkedMentionFix(
   schema: LoadedSchema,
@@ -3510,7 +3516,15 @@ async function handleUnlinkedMentionFix(
   issue: AuditIssue
 ): Promise<'fixed' | 'skipped' | 'failed' | 'quit'> {
   if (!issue.autoFixable) {
-    // Fuzzy / ambiguous — review only.
+    // Ambiguous mentions: interactive pick-a-candidate (#622).
+    if (
+      issue.meta?.['tier'] === 'ambiguous' &&
+      issue.candidates &&
+      issue.candidates.length > 0
+    ) {
+      return handleAmbiguousMentionFix(schema, result, issue);
+    }
+    // Fuzzy — review only.
     if (issue.suggestion) {
       console.log(chalk.dim(`    ${issue.suggestion}`));
     }
@@ -3531,6 +3545,74 @@ async function handleUnlinkedMentionFix(
   const fixResult = await applyFix(schema, result.path, issue);
   if (fixResult.action === 'fixed') {
     console.log(chalk.green(`    ✓ Linked '${String(issue.value)}' → ${replacement}`));
+    return 'fixed';
+  } else if (fixResult.action === 'skipped') {
+    console.log(chalk.dim(`    → Skipped: ${fixResult.message}`));
+    return 'skipped';
+  } else {
+    console.log(chalk.red(`    ✗ Failed: ${fixResult.message}`));
+    return 'failed';
+  }
+}
+
+/**
+ * Interactive resolution of an *ambiguous* unlinked mention (#622): the surface
+ * matches multiple distinct entities, so it is never auto-resolved. In a TTY,
+ * offer the candidate entities (plus skip/quit) and, on selection, rewrite the
+ * plain-text mention to `[[Chosen]]` (or `[[Chosen|surface]]` when the surface
+ * differs from the chosen note name).
+ *
+ * The rewrite REUSES the exact/alias auto-fix path: it synthesizes a
+ * `replacement` + `surface` on the issue meta and dispatches to
+ * {@link applyUnlinkedMentionFix} via {@link applyFix}, so the masking and
+ * word-boundary guarantees are identical and idempotent. Never invoked outside
+ * interactive `--fix` (so `--auto`/non-TTY never auto-resolve ambiguity).
+ */
+async function handleAmbiguousMentionFix(
+  schema: LoadedSchema,
+  result: FileAuditResult,
+  issue: AuditIssue
+): Promise<'fixed' | 'skipped' | 'failed' | 'quit'> {
+  const candidates = issue.candidates ?? [];
+  const surface =
+    (issue.meta?.['surface'] as string | undefined) ??
+    (typeof issue.value === 'string' ? issue.value : undefined);
+  if (candidates.length === 0 || !surface) {
+    console.log(chalk.dim('    (Cannot resolve — no candidates)'));
+    return 'skipped';
+  }
+
+  const options = [...candidates, '[skip]', '[quit]'];
+  const selected = await promptSelection(
+    `    Resolve ambiguous mention '${surface}' to:`,
+    options
+  );
+
+  if (selected === null || selected === '[quit]') {
+    return 'quit';
+  }
+  if (selected === '[skip]') {
+    console.log(chalk.dim('    → Skipped'));
+    return 'skipped';
+  }
+
+  const canonical = selected;
+  // Mirror the exact-tier replacement logic: keep the author's surface via the
+  // display form when it differs from the chosen canonical note name.
+  const replacement =
+    surface !== canonical ? `[[${canonical}|${surface}]]` : `[[${canonical}]]`;
+
+  // Synthesize an auto-fixable issue that the shared mention-rewrite understands.
+  const fixIssue: AuditIssue = {
+    ...issue,
+    autoFixable: true,
+    targetName: canonical,
+    meta: { ...(issue.meta ?? {}), surface, replacement },
+  };
+
+  const fixResult = await applyFix(schema, result.path, fixIssue);
+  if (fixResult.action === 'fixed') {
+    console.log(chalk.green(`    ✓ Linked '${surface}' → ${replacement}`));
     return 'fixed';
   } else if (fixResult.action === 'skipped') {
     console.log(chalk.dim(`    → Skipped: ${fixResult.message}`));

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -220,6 +220,16 @@ export interface AuditOptions {
   execute?: boolean;
   all?: boolean;
   allowField?: string[];
+  /**
+   * Max Levenshtein distance for the unlinked-mention fuzzy tier (#622). Raw
+   * string as parsed by commander from `--mention-fuzzy-threshold <n>`.
+   */
+  mentionFuzzyThreshold?: string;
+  /**
+   * False when `--no-mention-fuzzy` is passed, disabling the fuzzy "did you
+   * mean?" tier. Commander stores the negatable boolean here.
+   */
+  mentionFuzzy?: boolean;
 }
 
 /**
@@ -240,6 +250,16 @@ export interface AuditRunOptions {
   vaultDir?: string | undefined;
   /** Schema for looking up field formats */
   schema?: LoadedSchema | undefined;
+  /**
+   * Resolved max Levenshtein distance for the unlinked-mention fuzzy tier
+   * (#622). Undefined means use the built-in default. Already validated.
+   */
+  mentionFuzzyThreshold?: number | undefined;
+  /**
+   * When false, the unlinked-mention fuzzy "did you mean?" tier is disabled
+   * (#622). Undefined means enabled (default).
+   */
+  mentionFuzzyEnabled?: boolean | undefined;
 }
 
 /**

--- a/src/lib/audit/unlinked-mention.ts
+++ b/src/lib/audit/unlinked-mention.ts
@@ -46,11 +46,23 @@ import type { AuditIssue } from './types.js';
 const MIN_SURFACE_LENGTH = 3;
 
 /**
- * Fuzzy tier: maximum Levenshtein distance (case-insensitive) between an
+ * Fuzzy tier: default maximum Levenshtein distance (case-insensitive) between an
  * unmatched candidate phrase and a known entity surface for it to be offered as
  * a "did you mean?" review item. Kept small so only genuine near-misses surface.
+ *
+ * This is the *default*; it is configurable per run via
+ * {@link UnlinkedMentionOptions.fuzzyThreshold} (CLI `--mention-fuzzy-threshold`
+ * or schema `config.mention_fuzzy_threshold`). See #622.
  */
-const FUZZY_MAX_DISTANCE = 2;
+const DEFAULT_FUZZY_MAX_DISTANCE = 2;
+
+/**
+ * Inclusive bounds for a user-supplied fuzzy threshold. 0 disables the fuzzy
+ * tier (no near-miss is ever within distance 0 of a non-exact surface); the
+ * upper bound keeps the tier from degenerating into noise.
+ */
+const MIN_FUZZY_THRESHOLD = 0;
+const MAX_FUZZY_THRESHOLD = 5;
 
 /**
  * Fuzzy tier: a candidate must be at least this long to be eligible, so short
@@ -64,6 +76,54 @@ const FUZZY_MAX_SUGGESTIONS = 3;
 // ============================================================================
 // Types
 // ============================================================================
+
+/**
+ * Per-run tunables for the `unlinked-mention` fuzzy ("did you mean?") tier (#622).
+ *
+ * Both fields are optional and default to the conservative built-in behavior:
+ * fuzzy enabled at distance {@link DEFAULT_FUZZY_MAX_DISTANCE}. The exact/alias
+ * and ambiguous tiers are NOT affected by these options.
+ */
+export interface UnlinkedMentionOptions {
+  /**
+   * Maximum Levenshtein distance for a fuzzy near-match. Defaults to
+   * {@link DEFAULT_FUZZY_MAX_DISTANCE}. A value of 0 effectively disables the
+   * fuzzy tier (only an exact match has distance 0, and exact matches are
+   * handled by the exact tier). Must be within
+   * [{@link MIN_FUZZY_THRESHOLD}, {@link MAX_FUZZY_THRESHOLD}].
+   */
+  fuzzyThreshold?: number;
+  /**
+   * When false, the fuzzy ("did you mean?") tier is skipped entirely (the
+   * capitalized-phrase heuristic never runs). Exact/alias auto-fix and ambiguous
+   * flagging are unchanged. Defaults to true.
+   */
+  fuzzyEnabled?: boolean;
+}
+
+/**
+ * Validate a user-supplied fuzzy threshold, returning the parsed integer or a
+ * descriptive error. Accepts string (CLI) or number (config) input. Rejects
+ * non-integers and out-of-range values with a clear message (#622).
+ */
+export function parseFuzzyThreshold(
+  raw: string | number
+): { ok: true; value: number } | { ok: false; error: string } {
+  const n = typeof raw === 'number' ? raw : Number(raw.trim());
+  if (!Number.isFinite(n) || !Number.isInteger(n)) {
+    return {
+      ok: false,
+      error: `Invalid fuzzy threshold '${raw}': must be an integer between ${MIN_FUZZY_THRESHOLD} and ${MAX_FUZZY_THRESHOLD}.`,
+    };
+  }
+  if (n < MIN_FUZZY_THRESHOLD || n > MAX_FUZZY_THRESHOLD) {
+    return {
+      ok: false,
+      error: `Invalid fuzzy threshold '${raw}': must be between ${MIN_FUZZY_THRESHOLD} and ${MAX_FUZZY_THRESHOLD}.`,
+    };
+  }
+  return { ok: true, value: n };
+}
 
 /** How a known surface relates to its entity. */
 export type SurfaceKind = 'name' | 'alias';
@@ -298,10 +358,14 @@ function lineNumberAt(text: string, offset: number): number {
 export function detectUnlinkedMentions(
   body: string,
   selfPath: string,
-  index: EntityMentionIndex
+  index: EntityMentionIndex,
+  options?: UnlinkedMentionOptions
 ): AuditIssue[] {
   const issues: AuditIssue[] = [];
   if (!index.surfacePattern) return issues;
+
+  const fuzzyEnabled = options?.fuzzyEnabled ?? true;
+  const fuzzyThreshold = options?.fuzzyThreshold ?? DEFAULT_FUZZY_MAX_DISTANCE;
 
   const masked = maskNonProse(body);
 
@@ -385,8 +449,18 @@ export function detectUnlinkedMentions(
   // --- Fuzzy tier ("did you mean?") -------------------------------------
   // Only run on prose not already consumed by an exact match. Tokenize
   // capitalized words/phrases and offer near-miss entity names. Flag-only.
-  for (const fuzzy of detectFuzzyCandidates(masked, body, selfPath, index, consumed)) {
-    issues.push(fuzzy);
+  // Skipped entirely when disabled or when the threshold is 0 (#622).
+  if (fuzzyEnabled && fuzzyThreshold > 0) {
+    for (const fuzzy of detectFuzzyCandidates(
+      masked,
+      body,
+      selfPath,
+      index,
+      consumed,
+      fuzzyThreshold
+    )) {
+      issues.push(fuzzy);
+    }
   }
 
   return issues;
@@ -401,7 +475,8 @@ function detectFuzzyCandidates(
   body: string,
   selfPath: string,
   index: EntityMentionIndex,
-  consumed: Array<[number, number]>
+  consumed: Array<[number, number]>,
+  fuzzyMaxDistance: number
 ): AuditIssue[] {
   const issues: AuditIssue[] = [];
 
@@ -460,7 +535,7 @@ function detectFuzzyCandidates(
         if (name.length < FUZZY_MIN_CANDIDATE_LENGTH) continue;
         const dist = levenshteinDistance(lower, name.toLowerCase());
         if (dist === 0) continue;
-        if (dist <= FUZZY_MAX_DISTANCE) {
+        if (dist <= fuzzyMaxDistance) {
           suggestions.push({ name, distance: dist });
         }
       }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -526,6 +526,9 @@ function resolveConfig(config: Schema['config']): ResolvedConfig {
     defaultDashboard: config?.default_dashboard,
     dateFormat: config?.date_format ?? 'YYYY-MM-DD',
     dateGranularity: config?.date_granularity ?? 'day',
+    // Default mirrors DEFAULT_FUZZY_MAX_DISTANCE in audit/unlinked-mention.ts.
+    // Inlined to avoid importing the audit module into the schema loader (#622).
+    mentionFuzzyThreshold: config?.mention_fuzzy_threshold ?? 2,
   };
 }
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -241,6 +241,10 @@ export const ConfigSchema = z.object({
   // - year: YYYY or finer
   // Per-field `granularity` overrides this default.
   date_granularity: z.enum(['day', 'month', 'year']).optional(),
+  // Max Levenshtein distance for the `unlinked-mention` audit fuzzy ("did you
+  // mean?") tier (#622). Integer 0-5; default 2. 0 disables the fuzzy tier.
+  // Overridden per run by `--mention-fuzzy-threshold` / `--no-mention-fuzzy`.
+  mention_fuzzy_threshold: z.number().int().min(0).max(5).optional(),
 });
 
 // ============================================================================
@@ -386,6 +390,11 @@ export interface ResolvedConfig {
   dateFormat: string;
   /** Default coarsest date precision allowed for date fields (defaults to 'day') */
   dateGranularity: 'day' | 'month' | 'year';
+  /**
+   * Max Levenshtein distance for the `unlinked-mention` audit fuzzy tier (#622).
+   * Defaults to 2. A CLI flag (`--mention-fuzzy-threshold`) overrides this.
+   */
+  mentionFuzzyThreshold: number;
 }
 
 /**

--- a/tests/ts/lib/audit-unlinked-mention-interactive.test.ts
+++ b/tests/ts/lib/audit-unlinked-mention-interactive.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdir, writeFile, rm, readFile, mkdtemp } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Mock the prompt module so we can drive the interactive candidate picker
+// without a real TTY. `promptSelection` is the only prompt the ambiguous
+// mention handler uses; we queue its responses per test.
+const promptSelectionMock = vi.fn<(message: string, options: string[]) => Promise<string | null>>();
+vi.mock('../../../src/lib/prompt.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/lib/prompt.js')>();
+  return {
+    ...actual,
+    promptSelection: (message: string, options: string[]) =>
+      promptSelectionMock(message, options),
+  };
+});
+
+import { loadSchema } from '../../../src/lib/schema.js';
+import { runAudit } from '../../../src/lib/audit/detection.js';
+import { runInteractiveFix, runAutoFix } from '../../../src/lib/audit/fix.js';
+import type { Schema } from '../../../src/types/schema.js';
+
+const SCHEMA: Schema = {
+  version: 2,
+  types: {
+    meta: { fields: {} },
+    person: {
+      extends: 'meta',
+      output_dir: 'People',
+      fields: {
+        type: { value: 'person' },
+        aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
+      },
+      field_order: ['type', 'aliases'],
+    },
+    note: {
+      extends: 'meta',
+      output_dir: 'Notes',
+      fields: { type: { value: 'note' } },
+      field_order: ['type'],
+    },
+  },
+};
+
+describe('unlinked-mention: interactive ambiguous resolution (#622)', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    promptSelectionMock.mockReset();
+    vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-unlinked-int-'));
+    await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+    await writeFile(join(vaultDir, '.bwrb', 'schema.json'), JSON.stringify(SCHEMA, null, 2));
+    await mkdir(join(vaultDir, 'People'), { recursive: true });
+    await mkdir(join(vaultDir, 'Notes'), { recursive: true });
+
+    // Two distinct entities both expose the surface "Mercury":
+    //   - the planet note "Mercury"
+    //   - the person "Freddie" via alias "Mercury"
+    await writeFile(join(vaultDir, 'Notes', 'Mercury.md'), `---\ntype: note\n---\n`);
+    await writeFile(
+      join(vaultDir, 'People', 'Freddie.md'),
+      `---\ntype: person\naliases:\n  - Mercury\n---\n`
+    );
+  });
+
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  async function writeDaily(body: string): Promise<void> {
+    await writeFile(join(vaultDir, 'Notes', 'Daily.md'), `---\ntype: note\n---\n${body}\n`);
+  }
+
+  it('rewrites the mention to [[Chosen]] when a candidate is picked', async () => {
+    await writeDaily('Talking about Mercury.');
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false });
+
+    // Pick the planet "Mercury" (the surface equals the canonical name).
+    promptSelectionMock.mockResolvedValueOnce('Mercury');
+
+    await runInteractiveFix(results, schema, vaultDir, { dryRun: false });
+
+    expect(promptSelectionMock).toHaveBeenCalledTimes(1);
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(after).toContain('[[Mercury]]');
+    // No leftover plain-text mention.
+    expect(after).not.toMatch(/(?<!\[\[)Mercury(?!\]\])/);
+  });
+
+  it('uses the display form [[Chosen|surface]] when surface differs from the note', async () => {
+    await writeDaily('Talking about Mercury.');
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false });
+
+    // Pick "Freddie" — the surface "Mercury" differs from the note name.
+    promptSelectionMock.mockResolvedValueOnce('Freddie');
+
+    await runInteractiveFix(results, schema, vaultDir, { dryRun: false });
+
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(after).toContain('[[Freddie|Mercury]]');
+  });
+
+  it('leaves the mention untouched when the user skips', async () => {
+    await writeDaily('Talking about Mercury.');
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false });
+
+    promptSelectionMock.mockResolvedValueOnce('[skip]');
+
+    await runInteractiveFix(results, schema, vaultDir, { dryRun: false });
+
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(after).toContain('Talking about Mercury.');
+    expect(after).not.toContain('[[');
+  });
+
+  it('--auto (runAutoFix) never resolves an ambiguous mention', async () => {
+    await writeDaily('Talking about Mercury.');
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false });
+
+    await runAutoFix(results, schema, vaultDir, { dryRun: false });
+
+    // No prompt is shown and nothing is rewritten.
+    expect(promptSelectionMock).not.toHaveBeenCalled();
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(after).toContain('Talking about Mercury.');
+    expect(after).not.toContain('[[');
+  });
+
+  it('offers the candidate entities (plus skip/quit) in the prompt', async () => {
+    await writeDaily('Talking about Mercury.');
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false });
+
+    promptSelectionMock.mockResolvedValueOnce('[skip]');
+    await runInteractiveFix(results, schema, vaultDir, { dryRun: false });
+
+    const [, options] = promptSelectionMock.mock.calls[0]!;
+    expect(options).toContain('Freddie');
+    expect(options).toContain('Mercury');
+    expect(options).toContain('[skip]');
+    expect(options).toContain('[quit]');
+  });
+});

--- a/tests/ts/lib/audit-unlinked-mention.test.ts
+++ b/tests/ts/lib/audit-unlinked-mention.test.ts
@@ -10,6 +10,7 @@ import {
   buildEntityMentionIndex,
   detectUnlinkedMentions,
   maskNonProse,
+  parseFuzzyThreshold,
 } from '../../../src/lib/audit/unlinked-mention.js';
 import { buildVaultNoteSnapshot } from '../../../src/lib/discovery.js';
 import type { Schema } from '../../../src/types/schema.js';
@@ -174,6 +175,117 @@ describe('unlinked-mention: detectUnlinkedMentions', () => {
     ]);
     const issues = detectUnlinkedMentions('Hi there.', 'Notes/Daily.md', index);
     expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Configurable fuzzy threshold (#622)
+// ---------------------------------------------------------------------------
+
+describe('unlinked-mention: configurable fuzzy threshold', () => {
+  const schema = resolveSchema(SCHEMA);
+
+  function indexFor(
+    notes: Array<{ relativePath: string; frontmatter?: Record<string, unknown>; resolvedType?: string }>
+  ) {
+    return buildEntityMentionIndex(
+      {
+        notes: notes.map((n) => ({
+          path: n.relativePath,
+          relativePath: n.relativePath,
+          ...(n.frontmatter ? { frontmatter: n.frontmatter } : {}),
+          ...(n.resolvedType ? { resolvedType: n.resolvedType } : {}),
+        })),
+      },
+      schema
+    );
+  }
+
+  // "Canadians" is Levenshtein distance 3 from "Canada" — just outside the
+  // conservative default of 2.
+  const notes = [
+    { relativePath: 'People/Canada.md', resolvedType: 'note', frontmatter: { type: 'note' } },
+  ];
+
+  it('does NOT fuzzy-flag a near-match just outside the default threshold', () => {
+    const index = indexFor(notes);
+    // "Canadians" → "Canada": distance 3 — outside default 2.
+    const issues = detectUnlinkedMentions('Visiting Canadians today.', 'Notes/Daily.md', index);
+    const fuzzy = issues.filter((i) => i.meta?.['tier'] === 'fuzzy');
+    expect(fuzzy).toHaveLength(0);
+  });
+
+  it('flags the same near-match when the threshold is raised', () => {
+    const index = indexFor(notes);
+    const issues = detectUnlinkedMentions(
+      'Visiting Canadians today.',
+      'Notes/Daily.md',
+      index,
+      { fuzzyThreshold: 3 }
+    );
+    const fuzzy = issues.find((i) => i.meta?.['tier'] === 'fuzzy');
+    expect(fuzzy).toBeDefined();
+    expect(fuzzy!.similarFiles).toContain('Canada');
+  });
+
+  it('lowering the threshold reduces fuzzy flags (distance-2 match suppressed at threshold 1)', () => {
+    const index = indexFor([
+      { relativePath: 'People/Steve Yegge.md', resolvedType: 'person', frontmatter: { type: 'person' } },
+    ]);
+    // "Steve Yeg" → "Steve Yegge": distance 2.
+    const atDefault = detectUnlinkedMentions('Reading Steve Yeg.', 'Notes/Daily.md', index);
+    expect(atDefault.some((i) => i.meta?.['tier'] === 'fuzzy')).toBe(true);
+
+    const lowered = detectUnlinkedMentions('Reading Steve Yeg.', 'Notes/Daily.md', index, {
+      fuzzyThreshold: 1,
+    });
+    expect(lowered.some((i) => i.meta?.['tier'] === 'fuzzy')).toBe(false);
+  });
+
+  it('a threshold of 0 disables the fuzzy tier entirely', () => {
+    const index = indexFor([
+      { relativePath: 'People/Steve Yegge.md', resolvedType: 'person', frontmatter: { type: 'person' } },
+    ]);
+    const issues = detectUnlinkedMentions('Reading Steve Yeg.', 'Notes/Daily.md', index, {
+      fuzzyThreshold: 0,
+    });
+    expect(issues.some((i) => i.meta?.['tier'] === 'fuzzy')).toBe(false);
+  });
+
+  it('fuzzyEnabled:false disables the fuzzy tier but keeps exact/ambiguous', () => {
+    const index = indexFor([
+      { relativePath: 'People/Steve Yegge.md', resolvedType: 'person', frontmatter: { type: 'person', aliases: ['Stevey'] } },
+    ]);
+    const body = 'Reading Steve Yeg, said Stevey.';
+    const issues = detectUnlinkedMentions(body, 'Notes/Daily.md', index, { fuzzyEnabled: false });
+    expect(issues.some((i) => i.meta?.['tier'] === 'fuzzy')).toBe(false);
+    // The exact alias mention ("Stevey") is still flagged + auto-fixable.
+    expect(issues.some((i) => i.meta?.['tier'] === 'exact' && i.autoFixable)).toBe(true);
+  });
+});
+
+describe('unlinked-mention: parseFuzzyThreshold validation', () => {
+  it('accepts valid integers in range (string and number)', () => {
+    expect(parseFuzzyThreshold('2')).toEqual({ ok: true, value: 2 });
+    expect(parseFuzzyThreshold(0)).toEqual({ ok: true, value: 0 });
+    expect(parseFuzzyThreshold('5')).toEqual({ ok: true, value: 5 });
+  });
+
+  it('rejects out-of-range values', () => {
+    const tooHigh = parseFuzzyThreshold('6');
+    expect(tooHigh.ok).toBe(false);
+    const negative = parseFuzzyThreshold('-1');
+    expect(negative.ok).toBe(false);
+  });
+
+  it('rejects non-integers and garbage with a clear message', () => {
+    const frac = parseFuzzyThreshold('2.5');
+    expect(frac.ok).toBe(false);
+    const garbage = parseFuzzyThreshold('abc');
+    expect(garbage.ok).toBe(false);
+    if (!garbage.ok) {
+      expect(garbage.error).toMatch(/integer between 0 and 5/);
+    }
   });
 });
 


### PR DESCRIPTION
Implements #622 — two enhancements to the `unlinked-mention` audit detection (#600).

## 1. Configurable fuzzy threshold
The fuzzy "did you mean?" tier's max Levenshtein distance is now tunable, defaulting to the previous conservative behavior (distance **2**).

- **Flag (per run):** `--mention-fuzzy-threshold <n>` — integer `0`–`5`, validated with a clear error for out-of-range / non-integer input.
- **Config (persistent):** `config.mention_fuzzy_threshold` (integer `0`–`5`). The flag overrides config.
- `0` (or `--no-mention-fuzzy`) disables the fuzzy tier entirely.
- Only the fuzzy tier is affected — exact/alias auto-fix and ambiguous flagging are unchanged.

## 2. Interactive ambiguous resolution
In an interactive `--fix` (TTY) session, an ambiguous unlinked mention (a surface matching multiple entities) now prompts to **pick a candidate** (or skip/quit). Choosing one rewrites the plain-text mention to a wikilink, **reusing the same mention-rewrite** as exact/alias auto-fix: `[[Chosen]]`, or `[[Chosen|surface]]` when the surface differs. Same masking / word-boundary / idempotency guarantees.

`--auto`, `--fix --auto`, and non-TTY runs are **unchanged**: ambiguous mentions stay flag-only and are never auto-resolved.

## Tests
- Threshold: near-match just outside default is not flagged; raising flags it; lowering / `0` / `fuzzyEnabled:false` reduces flags; exact/alias still flagged. Validator: range + non-integer errors.
- Interactive ambiguous: pick rewrites to `[[Chosen]]` and `[[Chosen|surface]]`; skip leaves text; `--auto` never prompts or rewrites; prompt offers candidates + skip + quit.

## Docs
- Updated `reference/commands/audit.md` (options table + "Tuning the fuzzy tier" and "Resolving ambiguous mentions interactively" subsections). `pnpm docs:build` passes.

## Quality gates
- `pnpm qa` ✅ (2448 passed, 4 skipped)
- `pnpm knip` ✅
- `pnpm docs:build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)