### PR TITLE
fix(audit): make frequent-unlinked-term Unicode-aware

### DIFF
--- a/src/lib/audit/frequent-unlinked-term.ts
+++ b/src/lib/audit/frequent-unlinked-term.ts
@@ -142,9 +142,12 @@ export function extractCandidates(
   maxPhraseWords: number
 ): CandidateHit[] {
   const hits: CandidateHit[] = [];
-  // A Capitalized word: leading uppercase letter, then letters/marks. We keep
-  // internal apostrophes/hyphens (O'Brien, Jean-Luc) but trim trailing ones.
-  const wordRe = /[A-Z][A-Za-z'À-ɏ-]*/g;
+  // A Capitalized word: a leading uppercase/titlecase letter (Unicode-aware, so
+  // `Émile`, `Über`, `Öland`, `Ægir` all qualify, not just ASCII A–Z), then any
+  // run of Unicode letters / combining marks. We keep internal
+  // apostrophes/hyphens (O'Brien, Jean-Luc) but trim trailing ones, and accented
+  // continuations (café, naïve, Müller) are no longer truncated.
+  const wordRe = /[\p{Lu}\p{Lt}][\p{L}\p{M}'-]*/gu;
 
   // Walk word-by-word, grouping consecutive Capitalized words that are
   // separated only by a single space into a phrase.

--- a/tests/ts/lib/audit-frequent-unlinked-term.test.ts
+++ b/tests/ts/lib/audit-frequent-unlinked-term.test.ts
@@ -75,6 +75,38 @@ describe('frequent-unlinked-term: extractCandidates', () => {
     expect(today?.atSentenceStart).toBe(true);
     expect(rust?.atSentenceStart).toBe(true);
   });
+
+  it('keeps an accented LEADING word in a multi-word phrase (#624)', () => {
+    // Previously the ASCII-only word-start dropped "Émile", surfacing only
+    // "Durkheim". The full phrase must now survive.
+    const hits = extractCandidates('I read Émile Durkheim again today.', 3);
+    const texts = hits.map((h) => h.text);
+    expect(texts).toContain('Émile Durkheim');
+    expect(texts).not.toContain('Durkheim');
+  });
+
+  it('captures a single non-ASCII-uppercase term (#624)', () => {
+    const hits = extractCandidates('We visited Öland and saw Über things.', 3);
+    const texts = hits.map((h) => h.text);
+    expect(texts).toContain('Öland');
+    expect(texts).toContain('Über');
+  });
+
+  it('does not truncate accented continuations (#624)', () => {
+    // "José", "Müller", "naïve" must be captured whole, not cut at the accent.
+    const jose = extractCandidates('met José there.', 3).map((h) => h.text);
+    expect(jose).toContain('José');
+    const muller = extractCandidates('asked Müller about it.', 3).map((h) => h.text);
+    expect(muller).toContain('Müller');
+  });
+
+  it('preserves ASCII extraction behavior unchanged (#624)', () => {
+    const hits = extractCandidates("O'Brien met Jean-Luc in New York Times.", 3);
+    const texts = hits.map((h) => h.text);
+    expect(texts).toContain("O'Brien");
+    expect(texts).toContain('Jean-Luc');
+    expect(texts).toContain('New York Times');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -172,6 +204,31 @@ describe('frequent-unlinked-term: FrequentTermAccumulator', () => {
     for (const issue of acc.finish()) {
       expect(issue.autoFixable).toBe(false);
     }
+  });
+
+  it('surfaces an accented multi-word phrase as the FULL phrase (#624)', () => {
+    const acc = new FrequentTermAccumulator(emptyIndex, { minMentions: 4, minNotes: 2 });
+    acc.addBody('we cite Émile Durkheim here. Émile Durkheim is key.', 'a.md');
+    acc.addBody('we read Émile Durkheim. Émile Durkheim again.', 'b.md');
+    const issues = acc.finish();
+    expect(issues.find((i) => i.value === 'Émile Durkheim')).toBeDefined();
+    // Must NOT have collapsed to just the ASCII tail.
+    expect(issues.find((i) => i.value === 'Durkheim')).toBeUndefined();
+  });
+
+  it('surfaces a single non-ASCII-uppercase term when it meets thresholds (#624)', () => {
+    const acc = new FrequentTermAccumulator(emptyIndex, { minMentions: 2, minNotes: 2 });
+    acc.addBody('we love Öland a lot, and also Öland nearby.', 'a.md');
+    acc.addBody('we visit Öland yearly, plus Öland again.', 'b.md');
+    expect(acc.finish().find((i) => i.value === 'Öland')).toBeDefined();
+  });
+
+  it('applies thresholds to unicode tokens the same as ASCII (#624)', () => {
+    const acc = new FrequentTermAccumulator(emptyIndex, { minMentions: 4, minNotes: 2 });
+    // Only 3 mid-sentence mentions across 2 notes → below threshold.
+    acc.addBody('about Müller here, and Müller too.', 'a.md');
+    acc.addBody('about Müller again.', 'b.md');
+    expect(acc.finish().find((i) => i.value === 'Müller')).toBeUndefined();
   });
 
   it('exposes sensible documented defaults', () => {


### PR DESCRIPTION
## What & why

`frequent-unlinked-term` (the advisory open-world audit detection from #601) extracted candidate proper-noun phrases with a regex whose word-START class was ASCII `A-Z` only. As a result:

- A phrase with an accented leading word lost it — `Émile Durkheim` surfaced as just `Durkheim`.
- A term whose first letter is non-ASCII uppercase (`Über`, `Öland`, `Ægir`, lone `Émile`) was entirely invisible.

These are advisory-only **false negatives** (the detection never acts or mutates), so this is a coverage gap, not a safety issue.

## The change

In `src/lib/audit/frequent-unlinked-term.ts`, the candidate word regex:

```diff
- const wordRe = /[A-Z][A-Za-z'À-ɏ-]*/g;
+ const wordRe = /[\p{Lu}\p{Lt}][\p{L}\p{M}'-]*/gu;
```

- **word-START** broadened from ASCII `[A-Z]` to Unicode uppercase + titlecase `[\p{Lu}\p{Lt}]`, so `Émile`, `Über`, `Öland`, `Ægir` all qualify as phrase starters.
- **word-CONTINUATION** broadened from `[A-Za-z'À-ɏ-]` to Unicode letters + combining marks plus apostrophe/hyphen `[\p{L}\p{M}'-]`, so accented continuations (`café`, `naïve`, `Müller`) are no longer truncated.
- Added the `u` flag (required for `\p{...}`). `stripTrailingPunct` already used `u`, so behavior stays consistent.

All existing heuristics (stopword filtering, length thresholds, mid-sentence requirement for single words, leading-stopword stripping) and exclusions (non-prose masking, entity/alias closed-world handoff) operate on the extracted tokens and apply **unchanged** to Unicode-aware tokens. No thresholds changed.

## Tests

Added to `tests/ts/lib/audit-frequent-unlinked-term.test.ts`:

- `Émile Durkheim` surfaces as the FULL phrase (not just `Durkheim`).
- Single non-ASCII-uppercase term (`Öland`, `Über`) captured / surfaced when it meets thresholds.
- Accented continuations (`José`, `Müller`) not truncated.
- Thresholds still gate Unicode tokens (`Müller` below threshold → not surfaced).
- ASCII behavior unchanged (`O'Brien`, `Jean-Luc`, `New York Times`); all existing #601 tests pass.

## Quality gates

- `pnpm qa` (typecheck + lint + docs:lint + docs:doctor + build + test): **pass** — 2455 tests passed, 4 skipped.
- `pnpm knip`: **pass** (clean).

Docs: the audit reference's "honest limits" note never mentioned the ASCII-only limitation, so no docs change was needed.

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)