### PR TITLE
feat(schema): show inherited/trait provenance in flat fields view

### DIFF
--- a/docs-site/src/content/docs/reference/commands/schema.md
+++ b/docs-site/src/content/docs/reference/commands/schema.md
@@ -95,6 +95,24 @@ bwrb schema list type [options] <name>
 - Use shorthand (`<typePath>` or `--type`) for all other type paths
 - If mixed forms are provided (for example positional + `--type`), the command errors with guidance
 
+### Field provenance
+
+`schema list fields` lists the **resolved** fields for every type, so each type
+shows its own fields plus the fields it inherits from a parent and the fields it
+composes from traits — matching what `schema list type <name>` reports. Every
+field row carries an `origin` so you can tell where it came from:
+
+| `origin` | Meaning |
+|----------|---------|
+| `own` | Declared directly on the type |
+| `trait:<name>` | Composed from the named trait |
+| `inherited:<name>` | Inherited from the named ancestor type |
+
+In text output the origin is the leading token in the `DETAILS` column. In JSON
+output (`--output json`) each entry in `data.fields` gains an `origin` string
+alongside the existing `type`, `field`, and `definition`. A schema with no
+inheritance or traits lists the same fields as before, each with `origin: "own"`.
+
 ### Examples
 
 ```bash

--- a/src/commands/schema/list.ts
+++ b/src/commands/schema/list.ts
@@ -5,7 +5,7 @@
 
 import { Command, Option } from 'commander';
 import chalk from 'chalk';
-import { loadCurrentSchema, getTypeNames } from '../../lib/schema.js';
+import { loadCurrentSchema, getTypeNames, getFieldsByOrigin } from '../../lib/schema.js';
 import { resolveVaultDirWithSelection } from '../../lib/vaultSelection.js';
 import { printJson, jsonSuccess, jsonError, ExitCodes } from '../../lib/output.js';
 import { getGlobalOpts } from '../../lib/command.js';
@@ -237,14 +237,34 @@ listCommand
       const schema = await loadCurrentSchema(vaultDir);
       await warnIfPendingMigration(vaultDir, schema, jsonMode);
 
-      const allFields: Array<{ type: string; field: string; definition: Field }> = [];
-      
+      // Enumerate the RESOLVED fields per type (own + trait-composed +
+      // inherited) using the same origin attribution as `schema list type`.
+      // `origin` is one of: 'own', `trait:<name>`, `inherited:<name>`.
+      const allFields: Array<{
+        type: string;
+        field: string;
+        origin: string;
+        definition: Field;
+      }> = [];
+
       for (const typeName of getTypeNames(schema)) {
         if (typeName === 'meta') continue;
-        const typeEntry = schema.raw.types[typeName];
-        if (typeEntry?.fields) {
-          for (const [fieldName, fieldDef] of Object.entries(typeEntry.fields)) {
-            allFields.push({ type: typeName, field: fieldName, definition: fieldDef });
+        const { ownFields, inheritedFields, traitFields } = getFieldsByOrigin(
+          schema,
+          typeName
+        );
+
+        for (const [fieldName, fieldDef] of Object.entries(ownFields)) {
+          allFields.push({ type: typeName, field: fieldName, origin: 'own', definition: fieldDef });
+        }
+        for (const [traitName, fields] of traitFields) {
+          for (const [fieldName, fieldDef] of Object.entries(fields)) {
+            allFields.push({ type: typeName, field: fieldName, origin: `trait:${traitName}`, definition: fieldDef });
+          }
+        }
+        for (const [ancestorName, fields] of inheritedFields) {
+          for (const [fieldName, fieldDef] of Object.entries(fields)) {
+            allFields.push({ type: typeName, field: fieldName, origin: `inherited:${ancestorName}`, definition: fieldDef });
           }
         }
       }
@@ -258,8 +278,11 @@ listCommand
         console.log(chalk.bold('\nFields:\n'));
         const context = getTtyContext();
         const lines = renderSchemaFieldsTable(
-          allFields.map(({ type, field, definition }) => {
+          allFields.map(({ type, field, origin, definition }) => {
             const details: string[] = [];
+            // Provenance first so it reads as a leading marker:
+            // own / trait:<name> / inherited:<name>.
+            details.push(origin);
             if (definition.options?.length) {
               const optionValues = getOptionValues(definition.options);
               if (context.isTTY) {

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -1127,6 +1127,138 @@ milestone: "[[Active Milestone]]"
     });
   });
 
+  describe('schema list fields provenance', () => {
+    async function withProvenanceVault(
+      fn: (dir: string) => Promise<void>
+    ): Promise<void> {
+      const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-fields-prov-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          traits: {
+            timestamped: {
+              fields: {
+                created: { prompt: 'date' },
+                updated: { prompt: 'date' },
+              },
+            },
+          },
+          types: {
+            meta: {},
+            objective: {
+              extends: 'meta',
+              output_dir: 'Objectives',
+              fields: { title: { prompt: 'text', required: true } },
+            },
+            task: {
+              extends: 'objective',
+              traits: ['timestamped'],
+              output_dir: 'Objectives/Tasks',
+              fields: { status: { prompt: 'select', options: ['todo', 'done'] } },
+            },
+          },
+        })
+      );
+      try {
+        await fn(tempVaultDir);
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    }
+
+    it('JSON shows inherited fields with provenance on the child type', async () => {
+      await withProvenanceVault(async (dir) => {
+        const result = await runCLI(['schema', 'list', 'fields', '--output', 'json'], dir);
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+
+        const inheritedTitle = json.data.fields.find(
+          (f: { type: string; field: string }) => f.type === 'task' && f.field === 'title'
+        );
+        expect(inheritedTitle).toBeDefined();
+        expect(inheritedTitle.origin).toBe('inherited:objective');
+      });
+    });
+
+    it('JSON shows trait-composed fields with provenance', async () => {
+      await withProvenanceVault(async (dir) => {
+        const result = await runCLI(['schema', 'list', 'fields', '--output', 'json'], dir);
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+
+        const created = json.data.fields.find(
+          (f: { type: string; field: string }) => f.type === 'task' && f.field === 'created'
+        );
+        expect(created).toBeDefined();
+        expect(created.origin).toBe('trait:timestamped');
+      });
+    });
+
+    it('JSON shows own fields as own', async () => {
+      await withProvenanceVault(async (dir) => {
+        const result = await runCLI(['schema', 'list', 'fields', '--output', 'json'], dir);
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+
+        const status = json.data.fields.find(
+          (f: { type: string; field: string }) => f.type === 'task' && f.field === 'status'
+        );
+        expect(status).toBeDefined();
+        expect(status.origin).toBe('own');
+      });
+    });
+
+    it('text output surfaces inherited and trait provenance markers', async () => {
+      await withProvenanceVault(async (dir) => {
+        const result = await runCLI(['schema', 'list', 'fields'], dir);
+        expect(result.exitCode).toBe(0);
+        // Inherited title field from objective shows on task.
+        expect(result.stdout).toMatch(/task\s+title.*inherited:objective/);
+        // Trait fields show with their trait provenance.
+        expect(result.stdout).toMatch(/task\s+created.*trait:timestamped/);
+        // Own fields are marked own.
+        expect(result.stdout).toMatch(/task\s+status.*own/);
+      });
+    });
+
+    it('schema with no inheritance/traits keeps the existing shape', async () => {
+      const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-fields-flat-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          types: {
+            meta: {},
+            note: {
+              extends: 'meta',
+              output_dir: 'Notes',
+              fields: { body: { prompt: 'text' } },
+            },
+          },
+        })
+      );
+      try {
+        const result = await runCLI(['schema', 'list', 'fields', '--output', 'json'], tempVaultDir);
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+
+        // Only the single own field, attributed as own. Every field carries the
+        // new origin key but the field set is unchanged.
+        expect(json.data.fields).toHaveLength(1);
+        const body = json.data.fields[0];
+        expect(body.type).toBe('note');
+        expect(body.field).toBe('body');
+        expect(body.origin).toBe('own');
+        expect(body.definition).toEqual({ prompt: 'text' });
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('schema list --verbose', () => {
     it('should show all types with their fields inline', async () => {
       const result = await runCLI(['schema', 'list', '--verbose'], vaultDir);


### PR DESCRIPTION
## Summary

`bwrb schema list fields` (the flat, all-fields listing) previously read each type's **raw per-type `fields` only**, so it never surfaced inherited fields and never showed trait-composed fields — inconsistent with `schema list type <name>`, which shows Own / Trait / Inherited provenance (from #442).

This makes the flat view enumerate the **resolved** fields per type and surface provenance, reusing the existing resolution helper rather than re-deriving anything.

## What changed

- `src/commands/schema/list.ts` — the `fields` subcommand now iterates each type via `getFieldsByOrigin(schema, typeName)` (own + trait-composed + inherited), instead of reading `schema.raw.types[name].fields`.
- Each field row gains an `origin`: `own`, `trait:<name>`, or `inherited:<name>` — matching how `schema list type` labels fields.
- **Text output**: origin is the leading token in the `DETAILS` column.
- **JSON output** (`--output json`): each entry in `data.fields` gains an `origin` string alongside the existing `type`, `field`, `definition` (additive shape change).
- Schemas with no inheritance/traits list the same field set as before, each attributed `own`.

### Example (inheritance + trait)

```
TYPE       FIELD    KIND    DETAILS
objective  title    text    own required
task       status   select  own options=[todo, done]
task       created  date    trait:timestamped
task       updated  date    trait:timestamped
task       title    text    inherited:objective required
```

## Tests

Added a `schema list fields provenance` block: inherited fields shown on the child with `inherited:<parent>`, trait fields with `trait:<name>`, own fields as `own` (text + JSON), and a no-inheritance/no-traits schema verified to keep its shape (single `own` field, unchanged `definition`).

## Docs

Updated `docs-site/.../reference/commands/schema.md` with a "Field provenance" section and origin table. `pnpm docs:build` passes.

## Quality gates

- `pnpm qa` — pass (106 files, 2460 tests)
- `pnpm knip` — pass
- `pnpm docs:build` — pass

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)