### PR TITLE
feat(list): render any parent hierarchy as a tree via --output tree (#637)

### DIFF
--- a/docs-site/src/content/docs/concepts/hierarchical-scope.md
+++ b/docs-site/src/content/docs/concepts/hierarchical-scope.md
@@ -100,6 +100,40 @@ bwrb list --type task --where "under(context, '[[career]]')"
 `isDescendantOf('[[X]]')` walks the **current note's own** `parent` chain. `under(field, '[[X]]')` first **dereferences a relation field**, then walks **that target's** chain. The context lives in a *field*, not the note's structural parent, so `under` is the operator you want here. See [Targeting Model](/reference/targeting/#underfield-node-vs-isdescendantofnode).
 :::
 
+## See the hierarchy as a tree
+
+Querying tells you *which* notes are in a domain; rendering the tree tells you *how the domain is shaped*. Because contexts are real notes in a `parent` hierarchy, `bwrb list --output tree` draws that hierarchy directly:
+
+```bash
+bwrb list --type context --output tree
+```
+
+```text
+└── career
+    └── Builder
+        └── Vercel
+```
+
+This is the fastest way to see — or onboard someone else to — the shape of your context tree. `--output tree` builds the parent hierarchy whenever the matched notes carry `parent` links, so it works for **any** entity type modelling a hierarchy this way, not only types marked `recursive`. (When the result set has no `parent` links, `--output tree` falls back to grouping notes by directory.)
+
+Limit the depth with `-L`/`--depth`, and order siblings with `--sort`/`--desc`:
+
+```bash
+# Just the top two levels (domains and their immediate projects)
+bwrb list --type context --output tree -L 2
+
+# Order siblings by name, descending
+bwrb list --type context --output tree --sort name --desc
+```
+
+You can also narrow the tree to a single subtree first, then render it:
+
+```bash
+bwrb list --type context --where "isDescendantOf('[[career]]')" --output tree
+```
+
+See [bwrb list](/reference/commands/list/) for the full `--output tree` reference.
+
 ## Why one field beats two
 
 Collapsing `scope` + `context` into a single context tree removes the redundancy and unlocks transitive queries:

--- a/docs-site/src/content/docs/reference/commands/list.md
+++ b/docs-site/src/content/docs/reference/commands/list.md
@@ -117,6 +117,33 @@ bwrb list --type task --output link      # [[Task 1]], [[Task 2]], ...
 bwrb list --type task --output tree      # Hierarchical display
 ```
 
+#### `--output tree`
+
+`--output tree` renders a **parent hierarchy** whenever the matched notes carry
+`parent` links — drawing the nesting directly from each note's `parent` relation.
+This works for any entity type that models a hierarchy this way (for example a
+`context`/`domain` type, see [Hierarchical Scope (Contexts as Notes)](/concepts/hierarchical-scope/)),
+not only types marked `recursive`:
+
+```bash
+bwrb list --type context --output tree
+```
+
+```text
+└── career
+    └── Builder
+        └── Vercel
+```
+
+When the matched notes have **no** `parent` links, `--output tree` instead groups
+them by their vault directory. Use `-L`/`--depth` to limit how deep the tree
+renders, and `--sort`/`--desc` to order siblings:
+
+```bash
+bwrb list --type context --output tree -L 2          # top two levels only
+bwrb list --type context --output tree --sort name --desc
+```
+
 ### Limiting and Counting
 
 ```bash

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -610,13 +610,16 @@ export async function listObjects(
     }
 
     case 'tree': {
-      if (isRecursive) {
-        const parentMap = buildParentMap(filteredFiles);
-        const tree = buildTree(filteredFiles, parentMap, options.depth, fileComparator);
-        if (treeHasNestedNotes(tree)) {
-          printTree(tree, vaultDir, showPaths);
-          return;
-        }
+      // Render a parent-based hierarchy tree whenever the result set actually
+      // has `parent` links — regardless of whether the type is `recursive`.
+      // This lets any entity type with a parent hierarchy (e.g. a context /
+      // domain type per #554) render its nesting via `--output tree` (#637).
+      // The directory tree remains the fallback when there are no parent links.
+      const parentMap = buildParentMap(filteredFiles);
+      const tree = buildTree(filteredFiles, parentMap, options.depth, fileComparator);
+      if (treeHasNestedNotes(tree)) {
+        printTree(tree, vaultDir, showPaths);
+        return;
       }
 
       const directoryTree = buildDirectoryTree(filteredFiles, vaultDir, options.depth, fileComparator);

--- a/tests/ts/commands/list-tree-hierarchy.test.ts
+++ b/tests/ts/commands/list-tree-hierarchy.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runCLI } from '../fixtures/setup.js';
+
+/**
+ * Guard test for #637 — "render a context/parent hierarchy as a tree".
+ *
+ * `list --output tree` builds a parent-based hierarchy tree whenever the result
+ * set actually carries `parent` links — regardless of whether the type is
+ * `recursive`. This makes any entity type modelling a context/domain hierarchy
+ * via `parent` (the #554 pattern) renderable with `--output tree`, while keeping
+ * the directory tree as the fallback when there are no parent links.
+ *
+ * The vault defines two structurally-identical hierarchies:
+ *   - `context`  — recursive: true   (already trees pre-#637)
+ *   - `domain`   — recursive: false  (the #637 gap: previously fell to dir tree)
+ * plus a `note` type with NO parent field (directory-tree fallback).
+ */
+describe('#637 list --output tree renders parent hierarchy', () => {
+  let vaultDir: string;
+
+  const SCHEMA = {
+    version: 2,
+    types: {
+      entity: {
+        output_dir: 'Entities',
+        fields: { type: { value: 'entity' } },
+        field_order: ['type'],
+      },
+      context: {
+        extends: 'entity',
+        output_dir: 'Contexts',
+        recursive: true,
+        fields: {
+          type: { value: 'context' },
+          parent: { prompt: 'relation', source: 'context', format: 'quoted-wikilink' },
+        },
+        field_order: ['type', 'parent'],
+      },
+      // Same parent hierarchy, but NOT marked recursive. This is the #637 case.
+      domain: {
+        extends: 'entity',
+        output_dir: 'Domains',
+        fields: {
+          type: { value: 'domain' },
+          parent: { prompt: 'relation', source: 'domain', format: 'quoted-wikilink' },
+        },
+        field_order: ['type', 'parent'],
+      },
+      // No parent field at all — must keep using the directory tree.
+      note: {
+        output_dir: 'Notes',
+        fields: { type: { value: 'note' } },
+        field_order: ['type'],
+      },
+    },
+    audit: { ignored_directories: [] },
+  };
+
+  const writeNote = async (rel: string, frontmatter: string[]) => {
+    const path = join(vaultDir, rel);
+    await mkdir(join(path, '..'), { recursive: true });
+    await writeFile(path, ['---', ...frontmatter, '---', ''].join('\n'));
+  };
+
+  // The index of `line` within `lines`, or -1.
+  const lineIndex = (lines: string[], substr: string): number =>
+    lines.findIndex(l => l.includes(substr));
+
+  beforeAll(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-637-'));
+    await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+    await writeFile(join(vaultDir, '.bwrb', 'schema.json'), JSON.stringify(SCHEMA, null, 2));
+
+    // career -> Builder -> Vercel (3 levels), plus a second root.
+    for (const type of ['context', 'domain'] as const) {
+      const dir = type === 'context' ? 'Contexts' : 'Domains';
+      await writeNote(`${dir}/career.md`, [`type: ${type}`]);
+      await writeNote(`${dir}/Builder.md`, [`type: ${type}`, 'parent: "[[career]]"']);
+      await writeNote(`${dir}/Vercel.md`, [`type: ${type}`, 'parent: "[[Builder]]"']);
+      await writeNote(`${dir}/personal.md`, [`type: ${type}`]);
+    }
+
+    // note type — no parent anywhere; lives in nested directories.
+    await writeNote('Notes/a.md', ['type: note']);
+    await writeNote('Notes/Sub/b.md', ['type: note']);
+  });
+
+  afterAll(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('renders a NON-recursive type with parent links as a parent tree (the #637 gap)', async () => {
+    const result = await runCLI(['list', '--type', 'domain', '--output', 'tree'], vaultDir);
+
+    expect(result.exitCode).toBe(0);
+    const lines = result.stdout.split('\n');
+
+    // Parent tree, not a directory tree: no "Domains/" directory node.
+    expect(result.stdout).not.toContain('Domains/');
+
+    // career and Builder and Vercel all present, nested in order.
+    const career = lineIndex(lines, 'career');
+    const builder = lineIndex(lines, 'Builder');
+    const vercel = lineIndex(lines, 'Vercel');
+    expect(career).toBeGreaterThanOrEqual(0);
+    expect(builder).toBeGreaterThan(career);
+    expect(vercel).toBeGreaterThan(builder);
+
+    // Builder is indented under career; Vercel deeper than Builder.
+    const indent = (i: number) => lines[i]!.search(/[^\s│├└─]/);
+    expect(indent(builder)).toBeGreaterThan(indent(career));
+    expect(indent(vercel)).toBeGreaterThan(indent(builder));
+  });
+
+  it('still renders a recursive type with parent links as a parent tree (no regression)', async () => {
+    const result = await runCLI(['list', '--type', 'context', '--output', 'tree'], vaultDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('Contexts/');
+    const lines = result.stdout.split('\n');
+    const career = lineIndex(lines, 'career');
+    const builder = lineIndex(lines, 'Builder');
+    const vercel = lineIndex(lines, 'Vercel');
+    expect(builder).toBeGreaterThan(career);
+    expect(vercel).toBeGreaterThan(builder);
+  });
+
+  it('shows multiple roots, each with their own subtree', async () => {
+    const result = await runCLI(['list', '--type', 'domain', '--output', 'tree'], vaultDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('career');
+    expect(result.stdout).toContain('personal');
+  });
+
+  it('-L/--depth truncates the parent tree', async () => {
+    const result = await runCLI(
+      ['list', '--type', 'domain', '--output', 'tree', '-L', '2'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    // Depth 2: career (1) + Builder (2) visible, Vercel (3) truncated.
+    expect(result.stdout).toContain('career');
+    expect(result.stdout).toContain('Builder');
+    expect(result.stdout).not.toContain('Vercel');
+  });
+
+  it('respects --sort / --desc ordering of roots and children', async () => {
+    const asc = await runCLI(
+      ['list', '--type', 'domain', '--output', 'tree', '--sort', 'name'],
+      vaultDir
+    );
+    const desc = await runCLI(
+      ['list', '--type', 'domain', '--output', 'tree', '--sort', 'name', '--desc'],
+      vaultDir
+    );
+
+    expect(asc.exitCode).toBe(0);
+    expect(desc.exitCode).toBe(0);
+
+    // Roots are career and personal. Ascending: career before personal.
+    const ascLines = asc.stdout.split('\n');
+    const descLines = desc.stdout.split('\n');
+    expect(lineIndex(ascLines, 'career')).toBeLessThan(lineIndex(ascLines, 'personal'));
+    // Descending flips root order.
+    expect(lineIndex(descLines, 'personal')).toBeLessThan(lineIndex(descLines, 'career'));
+  });
+
+  it('falls back to a directory tree when the result set has NO parent links', async () => {
+    const result = await runCLI(['list', '--type', 'note', '--output', 'tree'], vaultDir);
+
+    expect(result.exitCode).toBe(0);
+    // Directory tree: directory nodes with trailing slash are present.
+    expect(result.stdout).toContain('Notes/');
+    expect(result.stdout).toContain('Sub/');
+    expect(result.stdout).toContain('a');
+    expect(result.stdout).toContain('b');
+  });
+});


### PR DESCRIPTION
## Summary

`bwrb list --output tree` now renders a **parent hierarchy** whenever the matched notes carry `parent` links — regardless of whether the type is marked `recursive`. This makes a context/domain hierarchy (the #554 pattern) renderable as a visual tree, which aids onboarding to the hierarchical-scope pattern.

```text
$ bwrb list --type context --output tree
└── career
    └── Builder
        └── Vercel
```

## What already worked vs. the gap

`--output tree` (from #597) already built the parent tree for **recursive** types and a directory tree for everything else. Testing against a real vault confirmed the exact gap #637 anticipated: a type with a `parent` hierarchy that is **not** marked `recursive` (e.g. a `domain` type) fell through to a flat directory tree, losing the hierarchy.

## The fix

Drop the `isRecursive` gate around the parent-tree build in the `tree` case of `listObjects`. The existing `treeHasNestedNotes()` guard already ensures the parent tree is only used when the matched notes actually have `parent` links, and otherwise falls through to the directory tree. So:

- Recursive types with parent links → still a parent tree (no change).
- Non-recursive types with parent links → now a parent tree (**fixed**).
- Any type with no parent links in the result set → directory tree (unchanged).

`buildParentMap` reads the `parent` frontmatter field uniformly, so this is type-agnostic. `-L/--depth`, `--sort/--desc`, and root ordering all go through the same `buildTree`/`fileComparator` path and are unchanged.

## Tests

New guard test `tests/ts/commands/list-tree-hierarchy.test.ts`: non-recursive parent tree (the gap), recursive parent tree (no regression), multiple roots, `-L/--depth` truncation, `--sort`/`--desc` ordering, and the directory-tree fallback when there are no parent links. Existing `list.test.ts` directory-tree cases for `objective` (non-recursive) and `idea` (recursive, no parent links) still pass.

## Docs

- `concepts/hierarchical-scope.md`: a new "See the hierarchy as a tree" section.
- `reference/commands/list.md`: an `--output tree` subsection covering the parent-tree-vs-directory-tree behavior, `-L`, and `--sort`.

## Quality gates

- `pnpm qa` ✅ (2466 passed, 4 skipped)
- `pnpm knip` ✅
- `pnpm docs:build` ✅

Closes #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)