### PR TITLE
feat(list,recent): add file.* sort keys and recent --open/--save-as flags

### DIFF
--- a/docs-site/src/content/docs/reference/commands/list.md
+++ b/docs-site/src/content/docs/reference/commands/list.md
@@ -30,7 +30,7 @@ The positional argument is auto-detected as type, path (contains `/`), or where 
 |--------|-------------|
 | `--output <format>` | Output format: `text`, `paths`, `tree`, `link`, `json` |
 | `--fields <fields>` | Show frontmatter fields in a table (comma-separated) |
-| `--sort <field>` | Sort by a frontmatter field, `name`, `_name`, or `_path` |
+| `--sort <field>` | Sort by a frontmatter field, `name`, `_name`, `_path`, or a file stat (`file.mtime`, `file.ctime`, `file.size`) |
 | `--desc` | Sort descending (requires `--sort`) |
 | `--limit <n>` | Show only the first `n` matching notes |
 | `--count` | Print only the number of matching notes |
@@ -152,6 +152,11 @@ bwrb list --type task --sort deadline
 bwrb list --type task --sort priority --desc
 bwrb list --sort name
 
+# Sort by file stats (filesystem metadata, no frontmatter needed)
+bwrb list --sort file.mtime --desc              # Most recently modified first
+bwrb list --type task --sort file.ctime         # Oldest-created first
+bwrb list --sort file.size --desc               # Largest notes first
+
 # Show the first five matches after filtering
 bwrb list --type task --where "status == 'in-progress'" --limit 5
 
@@ -159,6 +164,12 @@ bwrb list --type task --where "status == 'in-progress'" --limit 5
 bwrb list --type task --count
 bwrb list --type task --count --output json  # {"count": 12}
 ```
+
+The `file.*` sort keys read filesystem metadata and mirror the `file.*`
+accessors available in `--where`: `file.mtime` (modification time),
+`file.ctime` (creation time), and `file.size` (bytes). They compare
+numerically. `bwrb recent` is `bwrb list --sort file.mtime --desc` with a
+default limit of 20.
 
 Missing sort values are always placed at the end, including with `--desc`.
 `--count` reports the total number of matching notes before any `--limit` is applied.

--- a/docs-site/src/content/docs/reference/commands/recent.md
+++ b/docs-site/src/content/docs/reference/commands/recent.md
@@ -44,6 +44,22 @@ is always available.
 | `--limit <n>` | Show only the first `n` notes (default `20`) |
 | `--output <format>` | Output format: `text`, `paths`, `link`, `json` |
 
+### Actions
+
+| Option | Description |
+|--------|-------------|
+| `-o, --open` | Open the most recent note (picker if several, in a TTY) |
+| `--app <mode>` | How to open: `system`, `editor`, `visual`, `obsidian`, `print` |
+| `--save-as <name>` | Save this recency query as a dashboard |
+| `--force` | Overwrite an existing dashboard when using `--save-as` |
+
+These mirror the equivalent [`bwrb list`](/reference/commands/list/) flags. With
+`--open`, a single result opens directly; in a TTY with several results you get
+an interactive picker; non-interactively the most recent note (the top result)
+is opened. `--save-as` persists the query as a dashboard stored in the canonical
+`list --sort file.mtime --desc` form (with the effective `--limit`), so running
+the saved dashboard reproduces the recency view.
+
 ## Output Formats
 
 | Format | Description |
@@ -71,6 +87,14 @@ bwrb recent --path "Projects/**"
 # Machine-readable output
 bwrb recent --output paths
 bwrb recent --output json
+
+# Open the most recent note (or the most recent task, in your editor)
+bwrb recent --open
+bwrb recent --type task --open --app editor
+
+# Save a recency view as a reusable dashboard
+bwrb recent --type task --save-as "recent-tasks"
+bwrb dashboard recent-tasks
 ```
 
 ## JSON output
@@ -109,6 +133,12 @@ output is deterministic.
 
 ## Equivalent `list` query
 
-`recent` is a convenience wrapper. The closest hand-written equivalent is a
-listing sorted by mtime, descending, with a limit — `recent` adds the `_modified`
-field and a sensible default limit on top.
+`recent` is a convenience wrapper. The hand-written equivalent is:
+
+```bash
+bwrb list --sort file.mtime --desc --limit 20
+```
+
+`recent` adds the `_modified` field to JSON output, a `NAME` / `MODIFIED` default
+table, and a sensible default limit on top. The `file.mtime` / `file.ctime` /
+`file.size` sort keys it relies on are also available directly on `list`.

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -17,9 +17,12 @@ import {
   treeHasNestedNotes,
   buildDirectoryTree,
   extractNoteName,
+  isFileSortKey,
   type TreeNode,
   type DirectoryTreeNode,
+  type FileStatMap,
 } from '../lib/list-helpers.js';
+import { stat } from 'fs/promises';
 
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts, resolveGlobalPickerMode } from '../lib/command.js';
@@ -132,6 +135,31 @@ interface ListCommandOptions {
 
 const RESERVED_DISPLAY_FIELDS = new Set(['name', '_name', '_path']);
 
+/**
+ * Stat the given file paths and build a {@link FileStatMap} for the `file.*`
+ * sort keys. Files that can't be stat'd are simply omitted (the comparator
+ * treats a missing stat as a missing sort value, sorting them last) rather than
+ * failing the whole command.
+ */
+async function collectFileStats(paths: string[]): Promise<FileStatMap> {
+  const map: FileStatMap = new Map();
+  await Promise.all(
+    paths.map(async path => {
+      try {
+        const stats = await stat(path);
+        map.set(path, {
+          mtimeMs: stats.mtimeMs,
+          ctimeMs: stats.birthtimeMs,
+          size: stats.size,
+        });
+      } catch {
+        // Skip unreadable files
+      }
+    })
+  );
+  return map;
+}
+
 export const listCommand = new Command('list')
   .description('List notes with optional filtering')
   .addHelpText('after', `
@@ -141,7 +169,8 @@ Targeting Selectors (compose via AND):
   --where <expr>       Filter by frontmatter expression (can repeat)
   --id <uuid>          Filter by stable note id
   --body <query>       Filter by body content (uses ripgrep)
-  --sort <field>       Sort by frontmatter field, name, _name, or _path
+  --sort <field>       Sort by frontmatter field, name, _name, _path,
+                       or a file stat: file.mtime, file.ctime, file.size
   --desc               Sort descending (requires --sort)
   --limit <n>          Show only the first n matching notes
   --count              Print only the number of matching notes
@@ -162,6 +191,7 @@ Examples:
   bwrb list --path "Projects/**" --body "TODO"
   bwrb list --type task --sort deadline
   bwrb list --type task --sort priority --desc
+  bwrb list --sort file.mtime --desc              # Most recently modified first
   bwrb list --type task --limit 5
   bwrb list --type task --count
   bwrb list --type task --output json
@@ -201,7 +231,7 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
   .option('--fields <fields>', 'Show frontmatter fields in a table (comma-separated)')
   .option('-w, --where <expression...>', 'Filter with expression (multiple are ANDed)')
   .option('--id <uuid>', 'Filter by stable note id')
-  .option('--sort <field>', 'Sort by frontmatter field, name, _name, or _path')
+  .option('--sort <field>', 'Sort by frontmatter field, name, _name, _path, or file stat (file.mtime, file.ctime, file.size)')
   .option('--desc', 'Sort descending (requires --sort)')
   .option('--limit <n>', 'Limit output to the first n matching notes')
   .option('--count', 'Print only the number of matching notes')
@@ -324,6 +354,9 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
         ];
 
         for (const field of fieldNamesToValidate) {
+          // `file.*` stat keys are valid sort keys but not frontmatter/display
+          // fields, so they bypass the per-type field validation.
+          if (isFileSortKey(field)) continue;
           if (!allFieldNames.has(field) && !RESERVED_DISPLAY_FIELDS.has(field)) {
             const fieldList = Array.from(allFieldNames);
             const suggestion = suggestFieldName(field, fieldList);
@@ -511,7 +544,19 @@ export async function listObjects(
     }
   }
 
-  const fileComparator = createFileComparator(vaultDir, options.sortField, options.sortDesc);
+  // When sorting by a filesystem-stat `file.*` key, stat the files first and
+  // thread the results into the comparator (which stays pure/synchronous).
+  const fileStats =
+    options.sortField && isFileSortKey(options.sortField)
+      ? await collectFileStats(filteredFiles.map(f => f.path))
+      : undefined;
+
+  const fileComparator = createFileComparator(
+    vaultDir,
+    options.sortField,
+    options.sortDesc,
+    fileStats
+  );
   filteredFiles.sort(fileComparator);
 
   const matchCount = filteredFiles.length;

--- a/src/commands/recent.ts
+++ b/src/commands/recent.ts
@@ -4,7 +4,7 @@ import { stat } from 'fs/promises';
 import chalk from 'chalk';
 import { loadSchema, getTypeDefByPath, formatUnknownTypeError } from '../lib/schema.js';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
-import { getGlobalOpts } from '../lib/command.js';
+import { getGlobalOpts, resolveGlobalPickerMode } from '../lib/command.js';
 import { printError } from '../lib/prompt.js';
 import {
   printJson,
@@ -23,6 +23,10 @@ import {
 } from '../lib/targeting.js';
 import { getTtyContext } from '../lib/tty/context.js';
 import { renderTable } from '../lib/tty/table.js';
+import { openNote, resolveAppMode } from './open.js';
+import { pickFile, parsePickerMode } from '../lib/picker.js';
+import { createDashboard, updateDashboard, getDashboard } from '../lib/dashboard.js';
+import type { DashboardDefinition } from '../types/schema.js';
 
 /**
  * Default number of recently-modified notes to show when --limit is omitted.
@@ -36,6 +40,12 @@ interface RecentCommandOptions {
   where?: string[];
   limit?: string;
   output?: string;
+  // Open options (parity with `list`)
+  open?: boolean;
+  app?: string;
+  // Dashboard save options (parity with `list`)
+  saveAs?: string;
+  force?: boolean;
 }
 
 /**
@@ -95,6 +105,22 @@ Targeting Selectors (compose via AND):
   --body <query>       Filter by body content (uses ripgrep)
   --limit <n>          Show only the first n notes (default ${DEFAULT_RECENT_LIMIT})
 
+Open Options:
+  --open               Open the most recent note (picker if multiple)
+  --app <mode>         How to open: system (default), editor, visual, obsidian, print
+
+App Modes:
+  system      Open with OS default handler (default)
+  editor      Open in terminal editor ($EDITOR or config.editor)
+  visual      Open in GUI editor ($VISUAL or config.visual)
+  obsidian    Open in Obsidian via URI scheme
+  print       Print the resolved path (for scripting)
+
+Dashboard Save:
+  --save-as <name>   Save this recency query as a reusable dashboard
+                     (stored as 'list --sort file.mtime --desc')
+  --force            Overwrite if the dashboard already exists
+
 Examples:
   bwrb recent
   bwrb recent --limit 5
@@ -102,7 +128,10 @@ Examples:
   bwrb recent --type task --limit 10
   bwrb recent --output json
   bwrb recent --output paths
-  bwrb recent --path "Projects/**"`)
+  bwrb recent --path "Projects/**"
+  bwrb recent --open                              # Open the most recent note
+  bwrb recent --type task --open --app editor
+  bwrb recent --type task --save-as "recent-tasks"`)
   .argument('[positional]', 'Smart positional: type, path (contains /), or where expression (contains =<>~)')
   .option('-t, --type <type>', 'Filter by type path (e.g., idea, objective/task)')
   .option('-p, --path <glob>', 'Filter by file path glob (e.g., Projects/**, Ideas/)')
@@ -110,6 +139,12 @@ Examples:
   .option('-w, --where <expression...>', 'Filter with expression (multiple are ANDed)')
   .option('--limit <n>', `Limit output to the first n notes (default ${DEFAULT_RECENT_LIMIT})`)
   .option('--output <format>', 'Output format: text (default), paths, link, json')
+  // Open options (parity with `list`)
+  .option('-o, --open', 'Open the most recent note (picker if multiple)')
+  .option('--app <mode>', 'How to open: system (default), editor, visual, obsidian, print')
+  // Dashboard save options (parity with `list`)
+  .option('--save-as <name>', 'Save this recency query as a dashboard')
+  .option('--force', 'Overwrite existing dashboard when using --save-as')
   .action(async (positional: string | undefined, options: RecentCommandOptions, cmd: Command) => {
     const outputFormat = resolveRecentOutputFormat(options.output);
     const jsonMode = outputFormat === 'json';
@@ -120,6 +155,21 @@ Examples:
       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
       const schema = await loadSchema(vaultDir);
+
+      // Pre-flight check: if --save-as is provided without --force, error early
+      // if the dashboard already exists (mirrors `list`).
+      if (options.saveAs && !options.force) {
+        const existing = await getDashboard(vaultDir, options.saveAs);
+        if (existing) {
+          const error = `Dashboard "${options.saveAs}" already exists. Use --force to overwrite.`;
+          if (jsonMode) {
+            printJson(jsonError(error));
+            process.exit(ExitCodes.VALIDATION_ERROR);
+          }
+          printError(error);
+          process.exit(1);
+        }
+      }
 
       // Build targeting options from flags
       const targeting: TargetingOptions = {};
@@ -191,6 +241,48 @@ Examples:
 
       const limited = withMtime.slice(0, limit);
 
+      // Save as dashboard if --save-as was provided. A `recent` query is just
+      // `list --sort file.mtime --desc`, so persist it in that canonical form
+      // (the dashboard command runs it through `listObjects`). Saving runs even
+      // for an empty result set, mirroring `list`.
+      if (options.saveAs) {
+        const definition: DashboardDefinition = {
+          sort: 'file.mtime',
+          desc: true,
+        };
+        if (targeting.type) definition.type = targeting.type;
+        if (targeting.path) definition.path = targeting.path;
+        if (targeting.where?.length) definition.where = targeting.where;
+        if (targeting.body) definition.body = targeting.body;
+        if (outputFormat !== 'default') definition.output = outputFormat;
+        // `recent` always limits (default 20), so persist the effective limit.
+        definition.limit = limit;
+
+        try {
+          if (options.force) {
+            const existing = await getDashboard(vaultDir, options.saveAs);
+            if (existing) {
+              await updateDashboard(vaultDir, options.saveAs, definition);
+              console.error(`Dashboard "${options.saveAs}" updated.`);
+            } else {
+              await createDashboard(vaultDir, options.saveAs, definition);
+              console.error(`Dashboard "${options.saveAs}" saved.`);
+            }
+          } else {
+            await createDashboard(vaultDir, options.saveAs, definition);
+            console.error(`Dashboard "${options.saveAs}" saved.`);
+          }
+        } catch (saveErr) {
+          const saveMessage = saveErr instanceof Error ? saveErr.message : String(saveErr);
+          if (jsonMode) {
+            printJson(jsonError(`Failed to save dashboard: ${saveMessage}`));
+            process.exit(ExitCodes.VALIDATION_ERROR);
+          }
+          printError(`Failed to save dashboard: ${saveMessage}`);
+          process.exit(1);
+        }
+      }
+
       // No results
       if (limited.length === 0) {
         if (jsonMode) {
@@ -204,6 +296,42 @@ Examples:
             console.log('No notes found.');
           }
         }
+        return;
+      }
+
+      // Handle --open: open the most recent note, or pick from the limited set
+      // when there are several and we're attached to a TTY (mirrors `list`).
+      if (options.open) {
+        let targetPath: string;
+
+        if (limited.length === 1) {
+          targetPath = limited[0]!.path;
+        } else if (process.stdin.isTTY && process.stdout.isTTY) {
+          const pickerFiles = limited.map(f => ({
+            path: f.path,
+            relativePath: relative(vaultDir, f.path),
+          }));
+          const pickerResult = await pickFile(pickerFiles, {
+            mode: parsePickerMode(resolveGlobalPickerMode(undefined, globalOpts, 'auto')),
+            prompt: `${limited.length} notes - select to open`,
+          });
+
+          if (pickerResult.cancelled || !pickerResult.selected) {
+            process.exit(0);
+          }
+          targetPath = pickerResult.selected.path;
+        } else {
+          // Non-interactive with multiple matches: open the most recent (top).
+          targetPath = limited[0]!.path;
+        }
+
+        await openNote(
+          vaultDir,
+          targetPath,
+          resolveAppMode(options.app, schema.config),
+          schema.config,
+          jsonMode
+        );
         return;
       }
 

--- a/src/lib/list-helpers.ts
+++ b/src/lib/list-helpers.ts
@@ -25,6 +25,40 @@ export type FileWithFrontmatter = {
 
 export type FileComparator = (a: FileWithFrontmatter, b: FileWithFrontmatter) => number;
 
+/**
+ * Filesystem stat values used by the `file.*` sort keys. Mirrors the subset of
+ * `file.*` accessors that `--where` exposes (see `buildEvalContext` in
+ * `expression.ts`): modification time, creation time, and size. Times are kept
+ * as epoch-millisecond numbers so they compare numerically.
+ */
+export interface FileStat {
+  mtimeMs: number;
+  ctimeMs: number;
+  size: number;
+}
+
+/**
+ * Map from a file's absolute path to its {@link FileStat}. Built by the caller
+ * (which can do async I/O) and threaded into the comparator so the sort itself
+ * stays pure and synchronous.
+ */
+export type FileStatMap = Map<string, FileStat>;
+
+/**
+ * Sort keys backed by filesystem stats rather than frontmatter. These mirror
+ * the stat-derived `file.*` accessors available in `--where`. `file.name`,
+ * `file.path`, etc. are intentionally omitted because `name`/`_name`/`_path`
+ * already cover them.
+ */
+const FILE_SORT_KEYS = new Set(['file.mtime', 'file.ctime', 'file.size']);
+
+/**
+ * Whether the given sort field is one of the filesystem-stat `file.*` keys.
+ */
+export function isFileSortKey(field: string): boolean {
+  return FILE_SORT_KEYS.has(field);
+}
+
 export interface TreeNode {
   name: string;
   path: string;
@@ -58,12 +92,24 @@ export function compareByName(a: FileWithFrontmatter, b: FileWithFrontmatter): n
  * Handles the reserved fields `name`/`_name` (note basename) and `_path`
  * (vault-relative path); everything else is read from frontmatter.
  */
-export function getSortValue(file: FileWithFrontmatter, vaultDir: string, field: string): unknown {
+export function getSortValue(
+  file: FileWithFrontmatter,
+  vaultDir: string,
+  field: string,
+  fileStats?: FileStatMap
+): unknown {
   if (field === 'name' || field === '_name') {
     return basename(file.path, '.md');
   }
   if (field === '_path') {
     return relative(vaultDir, file.path);
+  }
+  if (isFileSortKey(field)) {
+    const stat = fileStats?.get(file.path);
+    if (!stat) return undefined;
+    if (field === 'file.mtime') return stat.mtimeMs;
+    if (field === 'file.ctime') return stat.ctimeMs;
+    return stat.size; // file.size
   }
   return file.frontmatter[field];
 }
@@ -124,15 +170,16 @@ export function compareSortValues(a: unknown, b: unknown): number {
 export function createFileComparator(
   vaultDir: string,
   sortField: string | undefined,
-  descending: boolean | undefined
+  descending: boolean | undefined,
+  fileStats?: FileStatMap
 ): FileComparator {
   if (!sortField) {
     return compareByName;
   }
 
   return (a, b) => {
-    const valueA = getSortValue(a, vaultDir, sortField);
-    const valueB = getSortValue(b, vaultDir, sortField);
+    const valueA = getSortValue(a, vaultDir, sortField, fileStats);
+    const valueB = getSortValue(b, vaultDir, sortField, fileStats);
     const missingA = isMissingSortValue(valueA);
     const missingB = isMissingSortValue(valueB);
 

--- a/tests/ts/commands/list.test.ts
+++ b/tests/ts/commands/list.test.ts
@@ -589,6 +589,117 @@ describe('list command', () => {
     });
   });
 
+  describe('--sort file.* stat keys', () => {
+    let statVault: string;
+
+    beforeEach(async () => {
+      statVault = await createTestVault();
+    });
+
+    afterEach(async () => {
+      await cleanupTestVault(statVault);
+    });
+
+    /** Set a file's mtime/atime to a fixed epoch-seconds value. */
+    async function setMtime(rel: string, seconds: number): Promise<void> {
+      const { utimes } = await import('fs/promises');
+      const when = new Date(seconds * 1000);
+      await utimes(join(statVault, rel), when, when);
+    }
+
+    it('sorts by file.mtime ascending (oldest first)', async () => {
+      const base = 1_700_000_000;
+      await setMtime('Ideas/Sample Idea.md', base + 300);
+      await setMtime('Ideas/Another Idea.md', base + 100);
+
+      const result = await runCLI(
+        ['list', 'idea', '--sort', 'file.mtime', '--output', 'paths'],
+        statVault
+      );
+
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout.trim().split('\n');
+      expect(lines.indexOf('Ideas/Another Idea.md')).toBeLessThan(
+        lines.indexOf('Ideas/Sample Idea.md')
+      );
+    });
+
+    it('sorts by file.mtime descending (most-recent first)', async () => {
+      const base = 1_700_000_000;
+      await setMtime('Ideas/Sample Idea.md', base + 100);
+      await setMtime('Ideas/Another Idea.md', base + 300);
+
+      const result = await runCLI(
+        ['list', 'idea', '--sort', 'file.mtime', '--desc', '--output', 'paths'],
+        statVault
+      );
+
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout.trim().split('\n');
+      expect(lines.indexOf('Ideas/Another Idea.md')).toBeLessThan(
+        lines.indexOf('Ideas/Sample Idea.md')
+      );
+    });
+
+    it('accepts file.ctime as a sort key', async () => {
+      const result = await runCLI(
+        ['list', 'idea', '--sort', 'file.ctime', '--desc', '--output', 'paths'],
+        statVault
+      );
+      expect(result.exitCode).toBe(0);
+      // All ideas present (ordering by ctime is platform-dependent for fixtures)
+      expect(result.stdout).toContain('Ideas/Sample Idea.md');
+      expect(result.stdout).toContain('Ideas/Another Idea.md');
+    });
+
+    it('accepts file.size as a sort key', async () => {
+      const result = await runCLI(
+        ['list', 'idea', '--sort', 'file.size', '--output', 'paths'],
+        statVault
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Ideas/Sample Idea.md');
+    });
+
+    it('combines file.mtime sort with --limit', async () => {
+      const base = 1_700_000_000;
+      await setMtime('Ideas/Sample Idea.md', base + 100);
+      await setMtime('Ideas/Another Idea.md', base + 300);
+
+      const result = await runCLI(
+        ['list', 'idea', '--sort', 'file.mtime', '--desc', '--limit', '1'],
+        statVault
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('Another Idea');
+    });
+
+    it('combines file.mtime sort with --where', async () => {
+      const base = 1_700_000_000;
+      await setMtime('Ideas/Sample Idea.md', base + 100);
+      await setMtime('Ideas/Another Idea.md', base + 300);
+
+      const result = await runCLI(
+        ['list', 'idea', '--where', '!isEmpty(status)', '--sort', 'file.mtime', '--desc', '--output', 'paths'],
+        statVault
+      );
+
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout.trim().split('\n').filter(Boolean);
+      // Both ideas pass the filter; most-recent (Another Idea) first.
+      expect(lines.indexOf('Ideas/Another Idea.md')).toBeLessThan(
+        lines.indexOf('Ideas/Sample Idea.md')
+      );
+    });
+
+    it('still rejects an unknown sort key', async () => {
+      const result = await runCLI(['list', 'idea', '--sort', 'file.bogus'], statVault);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Unknown field 'file.bogus'");
+    });
+  });
+
   describe('error handling', () => {
     it('should error on unknown type', async () => {
       const result = await runCLI(['list', '--type', 'nonexistent'], vaultDir);

--- a/tests/ts/commands/recent.test.ts
+++ b/tests/ts/commands/recent.test.ts
@@ -161,6 +161,87 @@ describe('recent command', () => {
     });
   });
 
+  describe('--open / --app', () => {
+    it('opens the most recent note (top result) in non-interactive mode', async () => {
+      const base = 1_700_000_000;
+      await setMtime(join(vaultDir, 'Ideas', 'Sample Idea.md'), base + 100);
+      await setMtime(join(vaultDir, 'Ideas', 'Another Idea.md'), base + 999);
+
+      // --app print resolves to printing the path of the opened note.
+      const result = await runCLI(
+        ['recent', '--type', 'idea', '--open', '--app', 'print'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toContain('Ideas/Another Idea.md');
+      // Only the single most-recent note is opened.
+      expect(result.stdout.trim()).not.toContain('Sample Idea');
+    });
+
+    it('opens the selected note resolved from --type filtering', async () => {
+      const result = await runCLI(
+        ['recent', '--type', 'task', '--limit', '1', '--open', '--app', 'print'],
+        vaultDir
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Task');
+    });
+
+    it('prints nothing and exits 0 when --open finds no notes', async () => {
+      const result = await runCLI(
+        ['recent', '--path', 'NoSuchDir/**', '--open', '--app', 'print'],
+        vaultDir
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('No notes found');
+    });
+  });
+
+  describe('--save-as', () => {
+    it('saves a recency query as a dashboard (sort file.mtime --desc)', async () => {
+      const result = await runCLI(
+        ['recent', '--type', 'task', '--save-as', 'recent-tasks'],
+        vaultDir
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain('Dashboard "recent-tasks" saved.');
+
+      const { readFile } = await import('fs/promises');
+      const raw = await readFile(join(vaultDir, '.bwrb', 'dashboards.json'), 'utf8');
+      const data = JSON.parse(raw);
+      const def = data.dashboards['recent-tasks'];
+      expect(def).toBeDefined();
+      expect(def.sort).toBe('file.mtime');
+      expect(def.desc).toBe(true);
+      expect(def.type).toBe('task');
+      // recent always limits; the default limit is persisted.
+      expect(def.limit).toBe(20);
+    });
+
+    it('errors if the dashboard exists without --force', async () => {
+      await runCLI(['recent', '--save-as', 'dup'], vaultDir);
+      const result = await runCLI(['recent', '--save-as', 'dup'], vaultDir);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('already exists');
+    });
+
+    it('overwrites an existing dashboard with --force', async () => {
+      await runCLI(['recent', '--save-as', 'forced'], vaultDir);
+      const result = await runCLI(
+        ['recent', '--type', 'idea', '--save-as', 'forced', '--force'],
+        vaultDir
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain('Dashboard "forced" updated.');
+
+      const { readFile } = await import('fs/promises');
+      const raw = await readFile(join(vaultDir, '.bwrb', 'dashboards.json'), 'utf8');
+      const def = JSON.parse(raw).dashboards['forced'];
+      expect(def.type).toBe('idea');
+    });
+  });
+
   describe('empty vault', () => {
     it('reports no notes found', async () => {
       const emptyVault = await createTestVault();

--- a/tests/ts/lib/list-helpers.test.ts
+++ b/tests/ts/lib/list-helpers.test.ts
@@ -6,6 +6,8 @@ import {
   normalizeSortValue,
   compareSortValues,
   createFileComparator,
+  isFileSortKey,
+  type FileStatMap,
   extractNoteName,
   buildParentMap,
   buildChildrenMap,
@@ -46,6 +48,65 @@ describe('list-helpers: sort/comparison', () => {
       const f = file('A.md', { priority: 3 });
       expect(getSortValue(f, VAULT, 'priority')).toBe(3);
       expect(getSortValue(f, VAULT, 'missing')).toBeUndefined();
+    });
+
+    it('reads file.* stat keys from the provided stat map', () => {
+      const f = file('A.md');
+      const stats: FileStatMap = new Map([
+        [f.path, { mtimeMs: 200, ctimeMs: 100, size: 42 }],
+      ]);
+      expect(getSortValue(f, VAULT, 'file.mtime', stats)).toBe(200);
+      expect(getSortValue(f, VAULT, 'file.ctime', stats)).toBe(100);
+      expect(getSortValue(f, VAULT, 'file.size', stats)).toBe(42);
+    });
+
+    it('returns undefined for file.* keys when the stat is missing', () => {
+      const f = file('A.md');
+      expect(getSortValue(f, VAULT, 'file.mtime')).toBeUndefined();
+      expect(getSortValue(f, VAULT, 'file.mtime', new Map())).toBeUndefined();
+    });
+  });
+
+  describe('isFileSortKey', () => {
+    it('recognizes the stat-backed file.* keys', () => {
+      expect(isFileSortKey('file.mtime')).toBe(true);
+      expect(isFileSortKey('file.ctime')).toBe(true);
+      expect(isFileSortKey('file.size')).toBe(true);
+    });
+
+    it('rejects non-stat keys', () => {
+      expect(isFileSortKey('file.name')).toBe(false);
+      expect(isFileSortKey('name')).toBe(false);
+      expect(isFileSortKey('priority')).toBe(false);
+    });
+  });
+
+  describe('createFileComparator with file.* stats', () => {
+    it('sorts by file.mtime ascending and descending', () => {
+      const files = [file('A.md'), file('B.md'), file('C.md')];
+      const stats: FileStatMap = new Map([
+        [files[0]!.path, { mtimeMs: 300, ctimeMs: 0, size: 0 }],
+        [files[1]!.path, { mtimeMs: 100, ctimeMs: 0, size: 0 }],
+        [files[2]!.path, { mtimeMs: 200, ctimeMs: 0, size: 0 }],
+      ]);
+
+      expect(sortedNames(files, createFileComparator(VAULT, 'file.mtime', false, stats)))
+        .toEqual(['B', 'C', 'A']);
+      expect(sortedNames(files, createFileComparator(VAULT, 'file.mtime', true, stats)))
+        .toEqual(['A', 'C', 'B']);
+    });
+
+    it('sorts files with a missing stat to the end', () => {
+      const files = [file('A.md'), file('B.md')];
+      const stats: FileStatMap = new Map([
+        [files[0]!.path, { mtimeMs: 100, ctimeMs: 0, size: 0 }],
+        // B.md has no stat entry -> treated as missing -> sorts last
+      ]);
+      expect(sortedNames(files, createFileComparator(VAULT, 'file.mtime', false, stats)))
+        .toEqual(['A', 'B']);
+      // Even descending, missing stays last.
+      expect(sortedNames(files, createFileComparator(VAULT, 'file.mtime', true, stats)))
+        .toEqual(['A', 'B']);
     });
   });
 


### PR DESCRIPTION
Closes #655.

## What

Two related enhancements noticed while implementing #68.

### 1. `file.*` sort keys for `list`

`bwrb list --sort` now accepts filesystem-stat keys in addition to frontmatter fields and `name`/`_name`/`_path`:

- `file.mtime` — modification time
- `file.ctime` — creation time (`birthtime`)
- `file.size` — size in bytes

These mirror the stat-derived `file.*` accessors already exposed in `--where` (see `buildEvalContext` in `expression.ts`). `file.name`/`file.path`/etc. are intentionally omitted because `name`/`_name`/`_path` already cover them.

Implementation: `getSortValue`/`createFileComparator` stay pure and synchronous, gaining an optional `path -> {mtimeMs, ctimeMs, size}` stat map. `listObjects` stats the result set up front (in parallel) only when sorting by a `file.*` key, then threads the map into the comparator. Timestamps/size compare numerically; files that can't be stat'd are treated as missing (sorted last, including with `--desc`), consistent with other sort keys. Unknown keys like `file.bogus` still error.

```bash
bwrb list --sort file.mtime --desc      # most recently modified first
```

### 2. `recent` parity flags

`bwrb recent` now supports `--open`/`--app` and `--save-as`/`--force`, reusing list's `openNote`/`resolveAppMode` and dashboard helpers.

`recent` keeps its own output contract (NAME/MODIFIED table, `_modified` in JSON, default limit 20) rather than becoming a thin alias, so #68's behavior/tests are preserved. `--save-as` persists the query in the canonical `list --sort file.mtime --desc` form (with the effective limit) so the saved dashboard reproduces the recency view. With `--open`: single result opens directly; a TTY with several shows a picker; non-interactively the most-recent (top) note is opened.

```bash
bwrb recent --open
bwrb recent --type task --save-as "recent-tasks"
```

## Tests

- `list`: `file.mtime` asc/desc ordering with distinct mtimes; `file.ctime`/`file.size` accepted; combines with `--limit`/`--where`; unknown `file.*` key still errors.
- `list-helpers` units: `getSortValue`/`isFileSortKey`/comparator with a stat map, including missing-stat-sorts-last.
- `recent`: `--open --app print` opens the top/selected note; no-match `--open` exits 0; `--save-as` writes a `file.mtime`/`desc` dashboard; `--force` overwrite + duplicate error. #68's existing tests still pass.

## Quality gates

- `pnpm qa` — pass (typecheck, lint, docs:lint, docs:doctor, build, 2485 tests)
- `pnpm knip` — pass
- `pnpm docs:build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)