### PR TITLE
refactor(lib): dedupe fuzzy close-match helpers into shared util

### DIFF
--- a/src/lib/audit/body-links.ts
+++ b/src/lib/audit/body-links.ts
@@ -43,7 +43,7 @@
 import { existsSync } from 'fs';
 import { basename, isAbsolute, resolve } from 'path';
 import type { NoteTargetIndex } from '../discovery.js';
-import { levenshteinDistance } from '../levenshtein.js';
+import { closeMatches } from '../close-match.js';
 import type { AuditIssue } from './types.js';
 import { maskCodeSpans } from './unlinked-mention.js';
 
@@ -99,21 +99,23 @@ function noteDir(selfRelativePath: string): string {
 function fuzzyNoteSuggestions(target: string, index: NoteTargetIndex): string[] {
   if (target.length < FUZZY_MIN_LENGTH) return [];
   const lower = target.toLowerCase();
-  const scored: Array<{ name: string; distance: number }> = [];
-  for (const [key, paths] of index.targetToPaths) {
-    if (key.length < FUZZY_MIN_LENGTH) continue;
-    const dist = levenshteinDistance(lower, key);
-    if (dist === 0) continue;
-    if (dist <= FUZZY_MAX_DISTANCE) {
-      // `targetToPaths` keys are lowercased; surface the canonical-case basename
-      // (reconstructed from the resolved note path) so the "did you mean?" hint
-      // shows `RealNote` rather than the index key `realnote`. Fall back to the
-      // key if no path is recorded (shouldn't happen for real notes).
-      const firstPath = paths[0];
-      const name = firstPath ? basename(firstPath, '.md') : key;
-      scored.push({ name, distance: dist });
-    }
-  }
+  // `targetToPaths` keys are already lowercased; only keys of a substantial
+  // length are eligible. Match against those keys, excluding exact (distance 0).
+  const eligibleKeys = [...index.targetToPaths.keys()].filter(
+    (key) => key.length >= FUZZY_MIN_LENGTH
+  );
+  const scored = closeMatches(lower, eligibleKeys, {
+    maxDistance: FUZZY_MAX_DISTANCE,
+    caseInsensitive: false,
+    excludeExact: true,
+  }).map((m) => {
+    // Surface the canonical-case basename (reconstructed from the resolved note
+    // path) so the "did you mean?" hint shows `RealNote` rather than the index
+    // key `realnote`. Fall back to the key if no path is recorded.
+    const firstPath = index.targetToPaths.get(m.value)?.[0];
+    const name = firstPath ? basename(firstPath, '.md') : m.value;
+    return { name, distance: m.distance };
+  });
   scored.sort((a, b) => a.distance - b.distance || a.name.localeCompare(b.name, 'en'));
   return scored.slice(0, FUZZY_MAX_SUGGESTIONS).map((s) => s.name);
 }

--- a/src/lib/close-match.ts
+++ b/src/lib/close-match.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared "close match" (typo-suggestion) utility.
+ *
+ * Many call sites want the same primitive: take a (possibly misspelled) query,
+ * compare it against a list of candidate strings via {@link levenshteinDistance},
+ * keep the ones within an edit-distance threshold, and return them best-first.
+ * Before this util that loop was copy-pasted in `schema.ts`
+ * (`findCloseMatches`), `template.ts` (`findClosestMatch`), and the audit
+ * detections, each with subtly different thresholds and return shapes.
+ *
+ * The legitimate per-caller differences are parameterized via {@link CloseMatchOptions}
+ * (case handling, threshold, whether exact matches count, result cap) so each
+ * caller keeps its EXACT prior behavior. This util deliberately does NOT cover
+ * the richer scoring helpers that are a different contract:
+ *  - `validation.ts` `suggestOptionValue`/`suggestFieldName` (tiered
+ *    exact/prefix/contains-then-distance),
+ *  - `audit/unknown-field.ts` `getSimilarFieldCandidates` (token normalization +
+ *    singular/plural + type-mismatch priority),
+ *  - `discovery.ts` `findSimilarFiles` (weighted multi-signal score),
+ *  - `fuzzy-search.ts` `similarityScore` (0..1 score with a substring floor).
+ */
+
+import { levenshteinDistance } from './levenshtein.js';
+
+/** A single close-match result: the original candidate and its edit distance. */
+export interface CloseMatch {
+  /** The candidate string, in its original casing. */
+  value: string;
+  /** Levenshtein distance from the query (after optional lowercasing). */
+  distance: number;
+}
+
+export interface CloseMatchOptions {
+  /**
+   * Maximum (inclusive) Levenshtein distance for a candidate to be kept.
+   * Required — thresholds differ per caller and there is no sensible default.
+   */
+  maxDistance: number;
+  /**
+   * Lowercase both the query and each candidate before comparing.
+   * Defaults to `true` (the common typo-suggestion behavior).
+   */
+  caseInsensitive?: boolean;
+  /**
+   * Drop candidates whose distance is 0 (i.e. an exact, case-folded match).
+   * Some callers only ever pass already-unknown queries and want to keep a
+   * distance-0 row out of the results; others rely on exact matches never
+   * occurring. Defaults to `false`.
+   */
+  excludeExact?: boolean;
+  /** Cap the number of returned matches. Defaults to unlimited. */
+  limit?: number;
+}
+
+/**
+ * Return candidates within `maxDistance` of `query`, sorted closest-first.
+ *
+ * Ordering is by ascending distance; ties preserve the input order of
+ * `candidates` (the sort is stable), matching the behavior of the hand-written
+ * loops this replaces. Callers that need alphabetical tie-breaking should sort
+ * the returned list themselves (or sort their candidate list beforehand).
+ */
+export function closeMatches(
+  query: string,
+  candidates: Iterable<string>,
+  options: CloseMatchOptions
+): CloseMatch[] {
+  const { maxDistance, caseInsensitive = true, excludeExact = false, limit } = options;
+
+  const normalizedQuery = caseInsensitive ? query.toLowerCase() : query;
+  const matches: CloseMatch[] = [];
+
+  for (const candidate of candidates) {
+    const normalizedCandidate = caseInsensitive ? candidate.toLowerCase() : candidate;
+    const distance = levenshteinDistance(normalizedQuery, normalizedCandidate);
+    if (distance > maxDistance) continue;
+    if (excludeExact && distance === 0) continue;
+    matches.push({ value: candidate, distance });
+  }
+
+  // Stable sort by distance keeps input order on ties.
+  matches.sort((a, b) => a.distance - b.distance);
+
+  return typeof limit === 'number' ? matches.slice(0, limit) : matches;
+}
+
+/**
+ * Return only the candidate values within `maxDistance`, sorted closest-first.
+ * Thin wrapper over {@link closeMatches} for callers that just want names.
+ */
+export function closeMatchValues(
+  query: string,
+  candidates: Iterable<string>,
+  options: CloseMatchOptions
+): string[] {
+  return closeMatches(query, candidates, options).map((m) => m.value);
+}
+
+/**
+ * Return the single closest candidate within `maxDistance`, or `undefined`.
+ * On a distance tie the first-encountered candidate wins (stable order).
+ */
+export function closestMatch(
+  query: string,
+  candidates: Iterable<string>,
+  options: CloseMatchOptions
+): string | undefined {
+  return closeMatches(query, candidates, { ...options, limit: 1 })[0]?.value;
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import { existsSync } from 'fs';
 import { basename } from 'path';
 import { SCHEMA_RELATIVE_PATH } from './bwrb-paths.js';
-import { levenshteinDistance } from './levenshtein.js';
+import { closeMatchValues } from './close-match.js';
 import type { DatePrecision } from './local-date.js';
 import {
   BwrbSchema,
@@ -989,26 +989,6 @@ export function getEntityAliases(
 // ============================================================================
 
 /**
- * Find close matches for a string within a list of candidates.
- * Returns candidates within the specified maximum distance, sorted by distance.
- */
-function findCloseMatches(target: string, candidates: string[], maxDistance: number): string[] {
-  const matches: Array<{ candidate: string; distance: number }> = [];
-
-  for (const candidate of candidates) {
-    const distance = levenshteinDistance(target.toLowerCase(), candidate.toLowerCase());
-    if (distance <= maxDistance && distance > 0) {
-      matches.push({ candidate, distance });
-    }
-  }
-
-  // Sort by distance (closest first)
-  matches.sort((a, b) => a.distance - b.distance);
-
-  return matches.map(m => m.candidate);
-}
-
-/**
  * Suggest the closest concrete type name for a (likely-misspelled) type name.
  *
  * Used to surface a "Did you mean 'X'?" hint when a user supplies an unknown
@@ -1033,7 +1013,10 @@ export function suggestTypeName(
   // Threshold: at most 3 edits, but never more than 60% of the input length so
   // very short inputs don't match unrelated types and long gibberish is rejected.
   const maxDistance = Math.min(3, Math.ceil(typeName.length * 0.6));
-  const matches = findCloseMatches(typeName, availableTypes, maxDistance);
+  const matches = closeMatchValues(typeName, availableTypes, {
+    maxDistance,
+    excludeExact: true,
+  });
   return matches[0];
 }
 

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -2,7 +2,7 @@ import { readdir, mkdir } from 'fs/promises';
 import { join, basename, relative } from 'path';
 import { existsSync } from 'fs';
 import { parseNote, writeNote, generateBodySections } from './frontmatter.js';
-import { levenshteinDistance } from './levenshtein.js';
+import { closestMatch } from './close-match.js';
 import { TemplateFrontmatterSchema, type Template, type LoadedSchema, type Field, type Constraint, type InstanceScaffold, type ResolvedType } from '../types/schema.js';
 import { getType, getFieldsForType, getFieldOptions, getOutputDir } from './schema.js';
 import { isBwrbBuiltinFrontmatterField } from './frontmatter/systemFields.js';
@@ -891,18 +891,8 @@ export interface TemplateValidationResult {
  * Returns undefined if no close match found (distance > 3).
  */
 function findClosestMatch(target: string, options: string[]): string | undefined {
-  let closest: string | undefined;
-  let minDistance = 4; // Max distance for suggestions
-  
-  for (const option of options) {
-    const distance = levenshteinDistance(target.toLowerCase(), option.toLowerCase());
-    if (distance < minDistance) {
-      minDistance = distance;
-      closest = option;
-    }
-  }
-  
-  return closest;
+  // Case-insensitive, max edit distance 3; first option wins on a distance tie.
+  return closestMatch(target, options, { maxDistance: 3 });
 }
 
 function buildUnknownFieldSuggestion(

--- a/tests/ts/lib/close-match.test.ts
+++ b/tests/ts/lib/close-match.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+  closeMatches,
+  closeMatchValues,
+  closestMatch,
+} from '../../../src/lib/close-match.js';
+
+describe('closeMatches', () => {
+  it('returns candidates within maxDistance sorted closest-first', () => {
+    // 'taks' -> 'tasks' is one insertion (1); -> 'task' is a transposition (2).
+    const result = closeMatches('taks', ['task', 'tasks', 'idea'], {
+      maxDistance: 2,
+    });
+    expect(result).toEqual([
+      { value: 'tasks', distance: 1 },
+      { value: 'task', distance: 2 },
+    ]);
+  });
+
+  it('excludes candidates beyond maxDistance', () => {
+    expect(closeMatches('idea', ['objective'], { maxDistance: 3 })).toEqual([]);
+  });
+
+  it('is case-insensitive by default', () => {
+    const result = closeMatches('TASK', ['Task'], { maxDistance: 2 });
+    expect(result).toEqual([{ value: 'Task', distance: 0 }]);
+  });
+
+  it('honors caseInsensitive: false', () => {
+    // 'Task' vs 'task' differs by one char when case-sensitive.
+    const result = closeMatches('Task', ['task'], {
+      maxDistance: 2,
+      caseInsensitive: false,
+    });
+    expect(result).toEqual([{ value: 'task', distance: 1 }]);
+  });
+
+  it('excludes exact matches when excludeExact is set', () => {
+    const result = closeMatches('task', ['task', 'tasks'], {
+      maxDistance: 2,
+      excludeExact: true,
+    });
+    expect(result).toEqual([{ value: 'tasks', distance: 1 }]);
+  });
+
+  it('keeps exact matches by default', () => {
+    const result = closeMatches('task', ['task'], { maxDistance: 2 });
+    expect(result).toEqual([{ value: 'task', distance: 0 }]);
+  });
+
+  it('preserves input order on distance ties (stable)', () => {
+    // Both 'bbbb' and 'cccc' are distance 4 from 'aaaa'; first-encountered wins.
+    const result = closeMatches('aaaa', ['bbbb', 'cccc'], { maxDistance: 4 });
+    expect(result.map((m) => m.value)).toEqual(['bbbb', 'cccc']);
+  });
+
+  it('applies the limit after sorting', () => {
+    // 'tasks' (dist 1) outranks 'task'/'taskz' (transpositions, dist 2).
+    const result = closeMatches('taks', ['task', 'tasks', 'taskz'], {
+      maxDistance: 2,
+      limit: 1,
+    });
+    expect(result).toEqual([{ value: 'tasks', distance: 1 }]);
+  });
+
+  it('returns empty for an empty candidate list', () => {
+    expect(closeMatches('task', [], { maxDistance: 3 })).toEqual([]);
+  });
+
+  it('accepts any iterable of candidates', () => {
+    const candidates = new Set(['task', 'idea']);
+    expect(closeMatchValues('taks', candidates, { maxDistance: 2 })).toEqual([
+      'task',
+    ]);
+  });
+});
+
+describe('closeMatchValues', () => {
+  it('returns only the candidate values', () => {
+    expect(
+      closeMatchValues('taks', ['task', 'tasks', 'idea'], { maxDistance: 2 })
+    ).toEqual(['tasks', 'task']);
+  });
+});
+
+describe('closestMatch', () => {
+  it('returns the single closest candidate', () => {
+    expect(
+      closestMatch('taks', ['task', 'tasks', 'idea'], { maxDistance: 2 })
+    ).toBe('tasks');
+  });
+
+  it('returns undefined when nothing is within range', () => {
+    expect(
+      closestMatch('zzzzzz', ['task', 'idea'], { maxDistance: 2 })
+    ).toBeUndefined();
+  });
+
+  it('returns the first candidate on a distance tie', () => {
+    expect(closestMatch('aaaa', ['bbbb', 'cccc'], { maxDistance: 4 })).toBe(
+      'bbbb'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Internal refactor — **behavior is identical**. Closes #608.

After `levenshteinDistance` was centralized in `src/lib/levenshtein.ts` (#604), the higher-level "close match" helpers were still scattered. This consolidates the genuine "lowercase + levenshtein + threshold + pick best/sorted" loops behind one parameterized util.

## New util: `src/lib/close-match.ts`

- `closeMatches(query, candidates, { maxDistance, caseInsensitive?, excludeExact?, limit? })` → `{ value, distance }[]`, sorted closest-first (stable on ties).
- `closeMatchValues(...)` → just the candidate strings.
- `closestMatch(...)` → single best (first-wins on a distance tie).

All built on the shared `levenshteinDistance`.

## Migrated call sites (each keeps EXACT prior behavior via options)

| Site | Before | After |
| --- | --- | --- |
| `schema.ts` `findCloseMatches` (feeds `suggestTypeName` / unknown-type hints, #609) | lowercase, `0 < dist <= maxDistance`, sort by distance | `closeMatchValues` with `excludeExact: true` |
| `template.ts` `findClosestMatch` (instance-type / field / option suggestions) | lowercase, `dist <= 3`, first-wins on ties | `closestMatch` `{ maxDistance: 3 }` |
| `audit/body-links.ts` `fuzzyNoteSuggestions` (broken-wikilink "did you mean?") | lowercase, `0 < dist <= 2`, length-gated keys | `closeMatches` over eligible (length-filtered) lowercased index keys, `caseInsensitive: false, excludeExact: true`; canonical-case name reconstruction + final `distance‖name` sort preserved |

## Deliberately NOT merged (different contracts)

- `validation.ts` `suggestOptionValue` / `suggestFieldName` — **tiered** exact → prefix → contains → distance, with their own per-tier thresholds. Consumed by audit `detection.ts` and `expression-validation.ts`.
- `audit/unknown-field.ts` `getSimilarFieldCandidates` — token-normalized keys, singular/plural detection, type-mismatch priority ordering.
- `discovery.ts` `findSimilarFiles` — weighted multi-signal score (prefix/contains/word-overlap/distance).
- `fuzzy-search.ts` `similarityScore` — 0..1 score with a substring-containment floor (the `search --fuzzy` contract). Left untouched to avoid regressing #93.
- `audit/unlinked-mention.ts` fuzzy tier — interleaved with phrase expansion and consumed-offset selection, not a standalone "pick best" loop.

## Tests

- New `tests/ts/lib/close-match.test.ts` (thresholds, case, exact-exclusion, ties, limit, empty, iterable input).
- All existing typo-suggestion tests (schema / template / validation / audit-body-links / unknown-field / fuzzy-search / levenshtein) pass **unchanged** — the behavior-preservation guarantee.

## Quality gates

- `pnpm qa` ✅ (typecheck, lint, docs:lint, docs:doctor, build, test — 2499 passed / 4 skipped)
- `pnpm knip` ✅ clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)