### PR TITLE
feat(schema): wire per-note before→after preview into schema migrate

### DIFF
--- a/docs-site/src/content/docs/concepts/migrations.md
+++ b/docs-site/src/content/docs/concepts/migrations.md
@@ -85,6 +85,29 @@ Files affected: 0
 Run `bwrb schema migrate --execute` to apply these changes.
 ```
 
+By default the preview shows schema-level operations plus a scanned/affected
+file count. To also see the concrete per-note before→after edits, add
+`--show-changes`:
+
+```bash
+bwrb schema migrate --show-changes
+```
+
+```
+Per-note changes:
+  Ideas/Idea A.md:
+    importance: (empty) → medium
+    priority → rank: 3
+```
+
+Missing or null values render as `(empty)`. On large vaults the per-note list
+is capped (200 lines) with a `... and N more changes` footer; the schema-level
+summary is never truncated. The flag also works with `--execute` to echo what
+was applied.
+
+In `--output json` mode, the per-note changes are always included under
+`data.fileChanges` (uncapped), so automation never needs the flag.
+
 ### 4. Apply the Migration
 
 When ready, execute the migration:

--- a/docs/product/migrations.md
+++ b/docs/product/migrations.md
@@ -47,12 +47,36 @@ Applies schema changes to existing notes.
 # Dry-run (default) - shows what would change
 bwrb schema migrate
 
+# Dry-run + per-note before→after changes
+bwrb schema migrate --show-changes
+
 # Execute migration - prompts for new version, creates backup, applies changes
 bwrb schema migrate --execute
 
 # Skip backup (power users)
 bwrb schema migrate --execute --no-backup
 ```
+
+By default the dry-run preview shows schema-level operations plus a
+files-scanned / files-affected summary. Add `--show-changes` to also print the
+concrete per-note before→after edits, e.g.:
+
+```text
+Per-note changes:
+  Objectives/Tasks/Task A.md:
+    priority: (empty) → medium
+    owner → assignee: alice
+```
+
+Null/missing values render as `(empty)` (consistent with the bulk change
+preview). To keep output manageable on large vaults, the per-note list is
+capped (currently 200 lines) with a trailing `... and N more changes` summary;
+the schema-level summary always prints in full. The flag also applies to
+`--execute` to echo what was applied.
+
+In `--output json` mode the per-note changes are **always** included under
+`data.fileChanges` (an array of `{ relativePath, changes[] }`), uncapped, for
+both dry-run and execute — no flag required.
 
 When executing:
 1. Shows pending changes

--- a/src/commands/schema/migrate.ts
+++ b/src/commands/schema/migrate.ts
@@ -25,8 +25,12 @@ import { loadRawSchemaJson, writeSchema } from '../../lib/schema-writer.js';
 import { diffSchemas, formatDiffForDisplay, formatDiffForJson } from '../../lib/migration/diff.js';
 import { loadSchemaSnapshot, saveSchemaSnapshot, hasSchemaSnapshot } from '../../lib/migration/snapshot.js';
 import { loadMigrationHistory, recordMigration } from '../../lib/migration/history.js';
-import { executeMigration } from '../../lib/migration/execute.js';
-import type { MigrationPlan } from '../../types/migration.js';
+import {
+  executeMigration,
+  formatPerNoteChanges,
+  DEFAULT_CHANGE_PREVIEW_CAP,
+} from '../../lib/migration/execute.js';
+import type { MigrationPlan, FileMigrationResult } from '../../types/migration.js';
 
 interface DiffOptions {
   output?: string;
@@ -36,6 +40,20 @@ interface MigrateOptions {
   output?: string;
   execute?: boolean;
   backup?: boolean;
+  showChanges?: boolean;
+}
+
+/**
+ * Build the JSON-friendly per-note change payload from file results.
+ * Only includes notes that actually have changes.
+ */
+function toFileChangesJson(fileResults: FileMigrationResult[]): Array<{
+  relativePath: string;
+  changes: FileMigrationResult['changes'];
+}> {
+  return fileResults
+    .filter(f => f.changes.length > 0)
+    .map(f => ({ relativePath: f.relativePath, changes: f.changes }));
 }
 
 interface HistoryOptions {
@@ -177,15 +195,18 @@ Examples:
     .option('-x, --execute', 'Actually apply the migration (default is dry-run)')
     // NOTE: Commander maps --no-backup to options.backup === false.
     .option('--no-backup', 'Skip backup creation (not recommended)')
+    .option('--show-changes', 'Show per-note before→after changes in the dry-run preview')
     .addHelpText('after', `
 Examples:
-  bwrb schema migrate              # Preview migration (dry-run)
-  bwrb schema migrate --execute    # Apply migration with backup
+  bwrb schema migrate                  # Preview migration (dry-run)
+  bwrb schema migrate --show-changes   # Preview + per-note before→after changes
+  bwrb schema migrate --execute        # Apply migration with backup
   bwrb schema migrate --execute --no-backup  # Apply without backup`)
     .action(async (options: MigrateOptions, cmd: Command) => {
       const jsonMode = options.output === 'json';
       const execute = options.execute ?? false;
       const backup = options.backup !== false;
+      const showChanges = options.showChanges ?? false;
 
       try {
         const globalOpts = getGlobalOpts(cmd);
@@ -265,6 +286,8 @@ Examples:
             });
             
             if (jsonMode) {
+              // Per-note before→after changes are always included in JSON so
+              // automation gets the full picture without a flag.
               printJson(jsonSuccess({
                 message: 'Migration preview (dry-run)',
                 data: {
@@ -274,6 +297,7 @@ Examples:
                   totalFiles: result.totalFiles,
                   affectedFiles: result.affectedFiles,
                   changes: diff,
+                  fileChanges: toFileChangesJson(result.fileResults),
                 },
               }));
             } else {
@@ -281,6 +305,21 @@ Examples:
               console.log(formatDiffForDisplay(diff));
               console.log(chalk.cyan(`Files scanned: ${result.totalFiles}`));
               console.log(chalk.cyan(`Files affected: ${result.affectedFiles}`));
+
+              // Per-note before→after changes are gated behind --show-changes
+              // since a large vault could produce a great many lines.
+              if (showChanges) {
+                const changeBlock = formatPerNoteChanges(result.fileResults, {
+                  cap: DEFAULT_CHANGE_PREVIEW_CAP,
+                });
+                if (changeBlock) {
+                  console.log(chalk.bold('\nPer-note changes:'));
+                  console.log(changeBlock);
+                }
+              } else if (result.affectedFiles > 0) {
+                console.log(chalk.gray('\nRun with --show-changes to see per-note before→after changes.'));
+              }
+
               console.log('');
               console.log('Run `bwrb schema migrate --execute` to apply these changes.');
             }
@@ -379,6 +418,7 @@ Examples:
               totalFiles: result.totalFiles,
               affectedFiles: result.affectedFiles,
               backupPath: result.backupPath,
+              fileChanges: toFileChangesJson(result.fileResults),
               errors: result.errors,
             },
           }));
@@ -390,6 +430,16 @@ Examples:
           console.log(chalk.cyan(`  Files modified: ${result.affectedFiles}`));
           if (result.backupPath) {
             console.log(chalk.cyan(`  Backup: ${result.backupPath}`));
+          }
+          if (showChanges) {
+            const changeBlock = formatPerNoteChanges(result.fileResults, {
+              cap: DEFAULT_CHANGE_PREVIEW_CAP,
+            });
+            if (changeBlock) {
+              console.log('');
+              console.log(chalk.bold('  Per-note changes:'));
+              console.log(changeBlock);
+            }
           }
           if (result.errors.length > 0) {
             console.log('');

--- a/src/lib/migration/execute.ts
+++ b/src/lib/migration/execute.ts
@@ -385,19 +385,10 @@ export function formatMigrationResult(result: MigrationResult): string {
     lines.push(`Backup created: ${result.backupPath}`);
   }
 
-  if (result.fileResults.length > 0) {
+  const changeBlock = formatPerNoteChanges(result.fileResults, { cap: Infinity });
+  if (changeBlock) {
     lines.push('\nChanges:');
-    for (const file of result.fileResults) {
-      if (file.changes.length === 0) continue;
-
-      lines.push(`  ${file.relativePath}:`);
-      for (const change of file.changes) {
-        lines.push(`    ${formatAppliedChange(change)}`);
-      }
-      if (file.error) {
-        lines.push(`    ERROR: ${file.error}`);
-      }
-    }
+    lines.push(changeBlock);
   }
 
   if (result.errors.length > 0) {
@@ -405,6 +396,76 @@ export function formatMigrationResult(result: MigrationResult): string {
     for (const error of result.errors) {
       lines.push(`  ${error}`);
     }
+  }
+
+  return lines.join('\n');
+}
+
+/** Default maximum number of per-note change lines to render in a preview. */
+export const DEFAULT_CHANGE_PREVIEW_CAP = 200;
+
+export interface FormatPerNoteChangesOptions {
+  /**
+   * Maximum number of individual change lines to render. When the total exceeds
+   * this, output is truncated and a "+N more" line is appended. Use
+   * `Infinity` to render everything. Defaults to {@link DEFAULT_CHANGE_PREVIEW_CAP}.
+   */
+  cap?: number;
+}
+
+/**
+ * Format the per-note before→after changes from a set of file results.
+ *
+ * Renders one block per affected note with a change line per field, e.g.:
+ *
+ *   Work/Task.md:
+ *     deadline: (empty) → 2026-01-07
+ *     owner → assignee: alice
+ *
+ * Output is capped (see {@link FormatPerNoteChangesOptions.cap}) so a large
+ * vault doesn't produce thousands of lines; the remainder is summarized as
+ * "... and N more changes". Returns an empty string when there are no changes.
+ */
+export function formatPerNoteChanges(
+  fileResults: FileMigrationResult[],
+  options: FormatPerNoteChangesOptions = {}
+): string {
+  const cap = options.cap ?? DEFAULT_CHANGE_PREVIEW_CAP;
+  const lines: string[] = [];
+
+  let rendered = 0;
+  let total = 0;
+  let truncated = false;
+
+  for (const file of fileResults) {
+    if (file.changes.length === 0) continue;
+    total += file.changes.length;
+
+    if (truncated) continue;
+
+    const fileLines: string[] = [];
+    for (const change of file.changes) {
+      if (rendered >= cap) {
+        truncated = true;
+        break;
+      }
+      fileLines.push(`    ${formatAppliedChange(change)}`);
+      rendered += 1;
+    }
+
+    if (fileLines.length > 0) {
+      lines.push(`  ${file.relativePath}:`);
+      lines.push(...fileLines);
+      if (file.error) {
+        lines.push(`    ERROR: ${file.error}`);
+      }
+    }
+  }
+
+  if (lines.length === 0) return '';
+
+  if (truncated) {
+    lines.push(`  ... and ${total - rendered} more change${total - rendered === 1 ? '' : 's'}`);
   }
 
   return lines.join('\n');

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -536,6 +536,149 @@ milestone: "[[Active Milestone]]"
         await cleanupTestVault(tempVaultDir);
       }
     });
+
+    /**
+     * Set up a vault where the current schema adds a `priority` field (with a
+     * default) to the `task` type relative to the applied snapshot, so an
+     * existing task note will get a per-note `priority: (empty) → medium`
+     * change in the migration preview.
+     */
+    async function setupAddFieldVault(): Promise<string> {
+      const tempVaultDir = await createTestVault();
+
+      await writeFile(
+        join(tempVaultDir, 'Objectives', 'Tasks', 'Preview Task.md'),
+        `---
+type: task
+status: in-flight
+---
+`
+      );
+
+      const schemaPath = join(tempVaultDir, '.bwrb', 'schema.json');
+      const currentSchema = JSON.parse(await readFile(schemaPath, 'utf8'));
+      const snapshotSchema = JSON.parse(JSON.stringify(currentSchema));
+
+      // Add a new field with a default to the current schema only.
+      currentSchema.types.task.fields = {
+        ...(currentSchema.types.task.fields ?? {}),
+        priority: { prompt: 'text', default: 'medium' },
+      };
+
+      await writeFile(schemaPath, JSON.stringify(currentSchema, null, 2));
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.applied.json'),
+        JSON.stringify(
+          {
+            schemaVersion: '1.0.0',
+            snapshotAt: new Date().toISOString(),
+            schema: snapshotSchema,
+          },
+          null,
+          2
+        )
+      );
+
+      return tempVaultDir;
+    }
+
+    it('dry-run does NOT show per-note changes by default', async () => {
+      const tempVaultDir = await setupAddFieldVault();
+      try {
+        const result = await runCLI(['schema', 'migrate'], tempVaultDir);
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Migration Preview (Dry-Run)');
+        expect(result.stdout).toContain('Files affected:');
+        expect(result.stdout).not.toContain('Per-note changes:');
+        // Hint to opt in is shown when there are affected files.
+        expect(result.stdout).toContain('--show-changes');
+      } finally {
+        await cleanupTestVault(tempVaultDir);
+      }
+    });
+
+    it('dry-run --show-changes prints per-note before→after lines incl. (empty)', async () => {
+      const tempVaultDir = await setupAddFieldVault();
+      try {
+        const result = await runCLI(
+          ['schema', 'migrate', '--show-changes'],
+          tempVaultDir
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Per-note changes:');
+        expect(result.stdout).toContain('Preview Task.md:');
+        // add-field with a default surfaces the unified #595 (empty) placeholder.
+        expect(result.stdout).toContain('priority: (empty) → medium');
+      } finally {
+        await cleanupTestVault(tempVaultDir);
+      }
+    });
+
+    it('dry-run --output json always includes fileChanges', async () => {
+      const tempVaultDir = await setupAddFieldVault();
+      try {
+        const result = await runCLI(
+          ['schema', 'migrate', '--output', 'json'],
+          tempVaultDir
+        );
+
+        expect(result.exitCode).toBe(0);
+        const response = JSON.parse(result.stdout);
+        expect(response.success).toBe(true);
+        expect(Array.isArray(response.data.fileChanges)).toBe(true);
+        expect(response.data.fileChanges.length).toBeGreaterThan(0);
+
+        const taskEntry = response.data.fileChanges.find(
+          (f: { relativePath: string }) =>
+            f.relativePath.endsWith('Preview Task.md')
+        );
+        expect(taskEntry).toBeDefined();
+        const priorityChange = taskEntry.changes.find(
+          (c: { field: string }) => c.field === 'priority'
+        );
+        expect(priorityChange).toMatchObject({
+          kind: 'set',
+          field: 'priority',
+          newValue: 'medium',
+        });
+      } finally {
+        await cleanupTestVault(tempVaultDir);
+      }
+    });
+
+    it('execute --output json includes fileChanges and applies the change', async () => {
+      const tempVaultDir = await setupAddFieldVault();
+      try {
+        const result = await runCLI(
+          [
+            'schema',
+            'migrate',
+            '--output',
+            'json',
+            '--execute',
+            '--no-backup',
+          ],
+          tempVaultDir
+        );
+
+        expect(result.exitCode).toBe(0);
+        const response = JSON.parse(result.stdout);
+        expect(response.success).toBe(true);
+        expect(response.data.affectedFiles).toBeGreaterThan(0);
+        expect(Array.isArray(response.data.fileChanges)).toBe(true);
+
+        // The field was actually written to the note.
+        const noteContent = await readFile(
+          join(tempVaultDir, 'Objectives', 'Tasks', 'Preview Task.md'),
+          'utf8'
+        );
+        expect(noteContent).toContain('priority: medium');
+      } finally {
+        await cleanupTestVault(tempVaultDir);
+      }
+    });
   });
 
   describe('schema list type <name> --output json', () => {

--- a/tests/ts/lib/migration/format.test.ts
+++ b/tests/ts/lib/migration/format.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { formatMigrationResult } from "../../../../src/lib/migration/execute.js";
+import {
+  formatMigrationResult,
+  formatPerNoteChanges,
+} from "../../../../src/lib/migration/execute.js";
 import type {
   AppliedChange,
+  FileMigrationResult,
   MigrationResult,
 } from "../../../../src/types/migration.js";
 
@@ -178,5 +182,82 @@ describe("formatMigrationResult - null/empty rendering", () => {
         })
       ).toBe("tags: [a, b] → []");
     });
+  });
+});
+
+describe("formatPerNoteChanges", () => {
+  function fileResult(
+    relativePath: string,
+    changes: AppliedChange[]
+  ): FileMigrationResult {
+    return {
+      filePath: `/vault/${relativePath}`,
+      relativePath,
+      changes,
+      applied: false,
+    };
+  }
+
+  const setChange = (field: string, n: number): AppliedChange => ({
+    kind: "set",
+    field,
+    oldValue: undefined,
+    newValue: String(n),
+  });
+
+  it("returns an empty string when there are no changes", () => {
+    expect(formatPerNoteChanges([])).toBe("");
+    expect(formatPerNoteChanges([fileResult("Empty.md", [])])).toBe("");
+  });
+
+  it("renders a block per affected note with indented change lines", () => {
+    const out = formatPerNoteChanges([
+      fileResult("Work/Task.md", [
+        { kind: "set", field: "deadline", oldValue: null, newValue: "2026-01-07" },
+        {
+          kind: "rename",
+          field: "owner",
+          newField: "assignee",
+          oldValue: "alice",
+          newValue: "alice",
+        },
+      ]),
+    ]);
+    expect(out).toBe(
+      [
+        "  Work/Task.md:",
+        "    deadline: (empty) → 2026-01-07",
+        "    owner → assignee: alice",
+      ].join("\n")
+    );
+  });
+
+  it("caps output and appends a '+N more' summary", () => {
+    const changes = Array.from({ length: 5 }, (_, i) => setChange(`f${i}`, i));
+    const out = formatPerNoteChanges([fileResult("Big.md", changes)], {
+      cap: 3,
+    });
+    const lines = out.split("\n");
+    // 1 header + 3 change lines + 1 summary line
+    expect(lines).toHaveLength(5);
+    expect(lines[lines.length - 1]).toBe("  ... and 2 more changes");
+  });
+
+  it("uses singular 'change' when exactly one is truncated", () => {
+    const changes = Array.from({ length: 3 }, (_, i) => setChange(`f${i}`, i));
+    const out = formatPerNoteChanges([fileResult("Big.md", changes)], {
+      cap: 2,
+    });
+    expect(out.split("\n").pop()).toBe("  ... and 1 more change");
+  });
+
+  it("does not truncate when cap is Infinity", () => {
+    const changes = Array.from({ length: 50 }, (_, i) => setChange(`f${i}`, i));
+    const out = formatPerNoteChanges([fileResult("Big.md", changes)], {
+      cap: Infinity,
+    });
+    expect(out).not.toContain("more change");
+    // 1 header + 50 change lines
+    expect(out.split("\n")).toHaveLength(51);
   });
 });


### PR DESCRIPTION
## Summary

`formatMigrationResult` / `formatAppliedChange` in `src/lib/migration/execute.ts` formatted per-note before→after change lines but had **no production callers** — `bwrb schema migrate` only rendered schema-level ops via `formatDiffForDisplay` plus file counts. The unified `(empty)` null rendering from #595 was therefore never surfaced to users.

**Decision: WIRE IT IN.** Per-note before→after is genuinely useful for a migration dry-run, so rather than delete the code we surfaced it.

## What changed

- Extracted a focused, capped `formatPerNoteChanges(fileResults, { cap })` helper in `execute.ts` (reused by `formatMigrationResult` for consistency).
- `bwrb schema migrate --show-changes` now prints per-note before→after lines in the dry-run preview, and echoes applied changes with `--execute`.
- **Gating/cap:** per-note output is opt-in via `--show-changes` in text mode (a large vault could produce many lines). When shown, it's capped at 200 change lines with a `... and N more changes` footer. The schema-level summary + file counts always print in full. When changes exist but the flag is off, a hint to use `--show-changes` is shown.
- **JSON:** `--output json` **always** includes per-note changes under `data.fileChanges` (array of `{ relativePath, changes[] }`, uncapped) for both dry-run and execute — no flag required, consistent with the JSON-as-API contract.

### Example output (text, `--show-changes`)

```
Migration Preview (Dry-Run)

Deterministic changes (will be auto-applied):
  + Add field "priority" to type "task" (default: "medium")
Files scanned: 1
Files affected: 1

Per-note changes:
  Tasks/Task A.md:
    priority: (empty) → medium

Run `bwrb schema migrate --execute` to apply these changes.
```

The `(empty)` placeholder (from #595) is now user-visible.

## Tests
- Unit tests for `formatPerNoteChanges`: block rendering, cap + `+N more` (plural/singular), `Infinity` (no truncation), empty input.
- CLI tests: dry-run hides per-note by default; `--show-changes` shows them incl. an `(empty)` add-field case; `--output json` always includes `fileChanges`; `--execute --output json` includes `fileChanges` and actually writes the field.

## Quality gates
- `pnpm qa` (typecheck, lint, docs:lint, docs:doctor, build, 2508 tests) — pass
- `pnpm knip` — pass
- `pnpm docs:build` — pass

## Docs
- `docs/product/migrations.md` and the docs-site migrations concept page document `--show-changes`, the cap, and `data.fileChanges`.

## Note on knip
knip did not flag the dead function because `src/lib/migration/*.ts` is in knip's `ignore` list — so it was never detecting test-only usage; the whole module is exempt.

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)