### PR TITLE
refactor: rename buildParentMap to distinct, contract-specific names

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -9,7 +9,7 @@ import {
   formatUnknownTypeError,
 } from '../lib/schema.js';
 import {
-  buildParentMap,
+  buildParentMapFromFiles,
   buildChildrenMap,
   collectDescendants,
   createFileComparator,
@@ -508,7 +508,7 @@ export async function listObjects(
   // Apply hierarchy filters for recursive types
   if (isRecursive) {
     // Build parent map for hierarchy queries
-    const parentMap = buildParentMap(filteredFiles);
+    const parentMap = buildParentMapFromFiles(filteredFiles);
     const childrenMap = buildChildrenMap(parentMap);
 
     if (options.roots) {
@@ -660,7 +660,7 @@ export async function listObjects(
       // This lets any entity type with a parent hierarchy (e.g. a context /
       // domain type per #554) render its nesting via `--output tree` (#637).
       // The directory tree remains the fallback when there are no parent links.
-      const parentMap = buildParentMap(filteredFiles);
+      const parentMap = buildParentMapFromFiles(filteredFiles);
       const tree = buildTree(filteredFiles, parentMap, options.depth, fileComparator);
       if (treeHasNestedNotes(tree)) {
         printTree(tree, vaultDir, showPaths);

--- a/src/lib/hierarchy.ts
+++ b/src/lib/hierarchy.ts
@@ -32,9 +32,10 @@ export interface ParentMapOptions {
 
 /**
  * Build a map from note names to their parent note names for recursive types.
+ * Schema-driven: discovers and parses managed files from the vault.
  * Used to detect cycles in parent references (e.g., A -> B -> A).
  */
-export async function buildParentMap(
+export async function buildParentMapFromSchema(
   schema: LoadedSchema,
   vaultDir: string,
   options: ParentMapOptions = {}
@@ -233,7 +234,7 @@ export async function validateParentNoCycle(
   }
   
   // Build the parent map for cycle detection
-  const parentMap = await buildParentMap(schema, vaultDir);
+  const parentMap = await buildParentMapFromSchema(schema, vaultDir);
   
   // Check for cycle
   const result = detectCycle(noteName, parentTarget, parentMap);

--- a/src/lib/list-helpers.ts
+++ b/src/lib/list-helpers.ts
@@ -220,8 +220,9 @@ export function extractNoteName(value: string): string | null {
 
 /**
  * Build a map from note name -> parent note name from frontmatter.
+ * Operates on an already-loaded array of files (sync).
  */
-export function buildParentMap(files: FileWithFrontmatter[]): Map<string, string> {
+export function buildParentMapFromFiles(files: FileWithFrontmatter[]): Map<string, string> {
   const parentMap = new Map<string, string>();
 
   for (const file of files) {

--- a/tests/ts/lib/hierarchy.test.ts
+++ b/tests/ts/lib/hierarchy.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, writeFile, mkdir, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
-  buildParentMap,
+  buildParentMapFromSchema,
   buildNotePathMap,
   detectCycle,
   checkExistingCycle,
@@ -106,7 +106,7 @@ describe('hierarchy', () => {
     });
   });
 
-  describe('buildParentMap', () => {
+  describe('buildParentMapFromSchema', () => {
     let tempDir: string;
 
     beforeAll(async () => {
@@ -171,7 +171,7 @@ parent: "[[Child Task]]"
 
     it('should build parent map from files', async () => {
       const schema = await loadSchema(tempDir);
-      const parentMap = await buildParentMap(schema, tempDir);
+      const parentMap = await buildParentMapFromSchema(schema, tempDir);
 
       expect(parentMap.get('Child Task')).toBe('Parent Task');
       expect(parentMap.get('Grandchild Task')).toBe('Child Task');

--- a/tests/ts/lib/list-helpers.test.ts
+++ b/tests/ts/lib/list-helpers.test.ts
@@ -9,7 +9,7 @@ import {
   isFileSortKey,
   type FileStatMap,
   extractNoteName,
-  buildParentMap,
+  buildParentMapFromFiles,
   buildChildrenMap,
   collectDescendants,
   buildTree,
@@ -278,21 +278,21 @@ describe('list-helpers: hierarchy/tree', () => {
     });
   });
 
-  describe('buildParentMap', () => {
+  describe('buildParentMapFromFiles', () => {
     it('maps note name to parent name from frontmatter (wikilink and plain)', () => {
       const files = [
         file('Child A.md', { parent: '[[Root]]' }),
         file('Child B.md', { parent: 'Root' }),
         file('Root.md', {}),
       ];
-      const map = buildParentMap(files);
+      const map = buildParentMapFromFiles(files);
       expect(map.get('Child A')).toBe('Root');
       expect(map.get('Child B')).toBe('Root');
       expect(map.has('Root')).toBe(false);
     });
 
     it('ignores notes without a parent value', () => {
-      const map = buildParentMap([file('Solo.md', {})]);
+      const map = buildParentMapFromFiles([file('Solo.md', {})]);
       expect(map.size).toBe(0);
     });
   });
@@ -339,7 +339,7 @@ describe('list-helpers: hierarchy/tree', () => {
         file('Child.md', { parent: '[[Root]]' }),
         file('Grandchild.md', { parent: '[[Child]]' }),
       ];
-      const tree = buildTree(files, buildParentMap(files));
+      const tree = buildTree(files, buildParentMapFromFiles(files));
       expect(tree).toHaveLength(1);
       expect(tree[0]!.name).toBe('Root');
       expect(tree[0]!.depth).toBe(0);
@@ -351,7 +351,7 @@ describe('list-helpers: hierarchy/tree', () => {
 
     it('treats notes whose parent is absent from the set as roots (orphans)', () => {
       const files = [file('Orphan.md', { parent: '[[Missing]]' })];
-      const tree = buildTree(files, buildParentMap(files));
+      const tree = buildTree(files, buildParentMapFromFiles(files));
       expect(tree.map(n => n.name)).toEqual(['Orphan']);
     });
 
@@ -361,13 +361,13 @@ describe('list-helpers: hierarchy/tree', () => {
         file('Zeta.md', { parent: '[[Root]]' }),
         file('Alpha.md', { parent: '[[Root]]' }),
       ];
-      const tree = buildTree(files, buildParentMap(files));
+      const tree = buildTree(files, buildParentMapFromFiles(files));
       expect(tree[0]!.children.map(c => c.name)).toEqual(['Alpha', 'Zeta']);
     });
 
     it('sorts multiple roots by comparator', () => {
       const files = [file('Zed.md', {}), file('Ann.md', {})];
-      const tree = buildTree(files, buildParentMap(files));
+      const tree = buildTree(files, buildParentMapFromFiles(files));
       expect(tree.map(n => n.name)).toEqual(['Ann', 'Zed']);
     });
 
@@ -377,7 +377,7 @@ describe('list-helpers: hierarchy/tree', () => {
         file('Child.md', { parent: '[[Root]]' }),
         file('Grandchild.md', { parent: '[[Child]]' }),
       ];
-      const tree = buildTree(files, buildParentMap(files), 2);
+      const tree = buildTree(files, buildParentMapFromFiles(files), 2);
       expect(tree[0]!.children[0]!.name).toBe('Child');
       // Depth limit of 2 means grandchildren are pruned
       expect(tree[0]!.children[0]!.children).toEqual([]);
@@ -387,12 +387,12 @@ describe('list-helpers: hierarchy/tree', () => {
   describe('treeHasNestedNotes', () => {
     it('returns false for a flat list of roots', () => {
       const files = [file('A.md', {}), file('B.md', {})];
-      expect(treeHasNestedNotes(buildTree(files, buildParentMap(files)))).toBe(false);
+      expect(treeHasNestedNotes(buildTree(files, buildParentMapFromFiles(files)))).toBe(false);
     });
 
     it('returns true when any node has children', () => {
       const files = [file('Root.md', {}), file('Child.md', { parent: '[[Root]]' })];
-      expect(treeHasNestedNotes(buildTree(files, buildParentMap(files)))).toBe(true);
+      expect(treeHasNestedNotes(buildTree(files, buildParentMapFromFiles(files)))).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Two exported functions shared the name `buildParentMap` but had different, non-interchangeable contracts (noticed in #597 / PR #645):

- `src/lib/list-helpers.ts` — **sync**, takes an already-loaded file array
- `src/lib/hierarchy.ts` — **async**, schema-driven (discovers and parses vault files)

This renames them for clarity:

| Old | New | Contract |
| --- | --- | --- |
| `buildParentMap` (list-helpers) | `buildParentMapFromFiles` | sync, file-array input |
| `buildParentMap` (hierarchy) | `buildParentMapFromSchema` | async, schema-driven vault scan |

## Changes

Pure rename — no logic change:
- Function definitions + doc comments in both modules
- Internal caller in `hierarchy.ts` (`validateParentNoCycle`)
- Importer/call sites in `src/commands/list.ts` (both `list` tree paths)
- Test imports, `describe` labels, and call sites in `hierarchy.test.ts` and `list-helpers.test.ts`

## Out of scope

A third, **module-private** `buildParentMap` exists in `src/lib/audit/detection.ts` (async, takes a `noteIndex`). It is not exported, so it causes no import-name collision and is outside the issue's scope; left untouched.

## Verification

- `pnpm qa` green (typecheck, lint, docs:lint, docs:doctor, build, 2508 tests pass / 4 skipped)
- `pnpm knip` clean

Existing tests are the behavior guarantee: this is a symbol rename only, so the unchanged test suite passing confirms identical behavior.

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)