### PR TITLE
refactor(body-sections): share declared-heading presence check (#653)

### DIFF
--- a/src/lib/audit/body-sections.ts
+++ b/src/lib/audit/body-sections.ts
@@ -36,19 +36,45 @@ function escapeRegExp(value: string): string {
 
 /**
  * Whether a heading with the given level and title is present in the (already
- * non-prose-masked) body. Matches an ATX heading line: the exact number of `#`
- * for the declared level, a single space, then the exact title (trailing
- * whitespace and trailing `#` closing sequence tolerated). Matching is
- * case-sensitive on the title to mirror how the scaffold writes it.
+ * non-prose-masked) body. Matches an ATX heading line: optional leading
+ * indentation, the exact number of `#` for the declared level, a single space,
+ * then the exact title (trailing whitespace and trailing `#` closing sequence
+ * tolerated). Matching is case-sensitive on the title to mirror how the scaffold
+ * writes it.
+ *
+ * Shared low-level matcher. Callers that already hold a `maskNonProse`-masked
+ * body use this directly (to avoid re-masking); callers with a raw body should
+ * use the exported {@link isBodySectionPresent} which masks first.
  */
-function headingPresent(maskedBody: string, level: number, title: string): boolean {
+function headingPresentInMasked(maskedBody: string, level: number, title: string): boolean {
   const prefix = '#'.repeat(level);
-  // ^## Title  with optional trailing spaces and optional closing ### run.
+  // ^## Title  with optional leading indent, trailing spaces, optional closing
+  // ### run.
   const pattern = new RegExp(
     `^[ \\t]*${prefix} ${escapeRegExp(title)}[ \\t]*#*[ \\t]*$`,
     'm'
   );
   return pattern.test(maskedBody);
+}
+
+/**
+ * Whether a declared body-section heading is present in a note body.
+ *
+ * The single source of truth for the "is this declared heading present?" check
+ * shared by `bwrb edit`'s add-missing-sections flow, the audit
+ * `missing-body-section` detector, and that audit's auto-fix idempotency guard
+ * (#653). It masks code fences / links / wikilinks via {@link maskNonProse} so a
+ * `## Heading` written inside a fenced code block never counts as satisfying the
+ * requirement, then matches the heading line exactly at the declared level
+ * (leading indent, trailing whitespace, and ATX closing `##` run tolerated;
+ * title matched case-sensitively and regex-escaped).
+ *
+ * @param body  The raw markdown body (frontmatter already stripped). NOT masked.
+ * @param level The declared heading level (number of `#`).
+ * @param title The declared heading title.
+ */
+export function isBodySectionPresent(body: string, level: number, title: string): boolean {
+  return headingPresentInMasked(maskNonProse(body), level, title);
 }
 
 /**
@@ -108,7 +134,7 @@ export function detectMissingBodySections(
   const masked = maskNonProse(body);
 
   for (const { title, level } of flattenSections(bodySections)) {
-    if (headingPresent(masked, level, title)) continue;
+    if (headingPresentInMasked(masked, level, title)) continue;
 
     const wrongLevelLine = findHeadingLine(masked, title);
     const meta: Record<string, unknown> = { title, level };

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -59,6 +59,7 @@ import {
 import { toMarkdownLink, toWikilink } from '../links.js';
 import { spawnSuccessor, needsSuccessor, CHAIN_NEXT_FIELD } from '../recurrence.js';
 import { maskNonProse } from './unlinked-mention.js';
+import { isBodySectionPresent } from './body-sections.js';
 import {
   readStructuralFrontmatterFromRaw,
   movePrimaryBlockToTop,
@@ -201,21 +202,6 @@ function findBodySectionByTitle(
 }
 
 /**
- * Whether a heading at the given level/title already exists in the body. Mirrors
- * the detector's matcher so the fix is idempotent: if a prior fix (or the user)
- * already added the heading, we skip rather than appending a duplicate.
- */
-function bodyHasSectionHeading(body: string, level: number, title: string): boolean {
-  const masked = maskNonProse(body);
-  const prefix = '#'.repeat(level);
-  const pattern = new RegExp(
-    `^[ \\t]*${prefix} ${escapeRegExp(title)}[ \\t]*#*[ \\t]*$`,
-    'm'
-  );
-  return pattern.test(masked);
-}
-
-/**
  * Apply a `missing-body-section` auto-fix (#510): append the declared heading
  * section (with its canonical content-type placeholder) to the end of the body.
  *
@@ -253,7 +239,7 @@ async function applyBodySectionFix(
   }
 
   // Idempotency: skip if the heading is already present at its declared level.
-  if (bodyHasSectionHeading(parsed.body, section.level ?? level, title)) {
+  if (isBodySectionPresent(parsed.body, section.level ?? level, title)) {
     return {
       file: filePath,
       issue,

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -13,6 +13,7 @@ import {
   getFrontmatterOrder,
 } from './schema.js';
 import { parseNote, writeNote, generateBodySections } from './frontmatter.js';
+import { isBodySectionPresent } from './audit/body-sections.js';
 import { queryByType, formatValue } from './vault.js';
 import {
   promptSelection,
@@ -538,10 +539,8 @@ async function addMissingSections(
 
   for (const section of sections) {
     const level = section.level ?? 2;
-    const prefix = '#'.repeat(level);
-    const pattern = new RegExp(`^${prefix} ${section.title}`, 'm');
 
-    if (!pattern.test(body)) {
+    if (!isBodySectionPresent(body, level, section.title)) {
       printWarning(`Missing section: ${section.title}`);
       const addIt = await promptConfirm('Add it?');
       if (addIt === null) {

--- a/tests/ts/lib/audit-body-sections.test.ts
+++ b/tests/ts/lib/audit-body-sections.test.ts
@@ -5,7 +5,10 @@ import { tmpdir } from 'os';
 import { loadSchema } from '../../../src/lib/schema.js';
 import { runAudit } from '../../../src/lib/audit/detection.js';
 import { runAutoFix } from '../../../src/lib/audit/fix.js';
-import { detectMissingBodySections } from '../../../src/lib/audit/body-sections.js';
+import {
+  detectMissingBodySections,
+  isBodySectionPresent,
+} from '../../../src/lib/audit/body-sections.js';
 import type { BodySection, Schema } from '../../../src/types/schema.js';
 
 // ---------------------------------------------------------------------------
@@ -81,6 +84,67 @@ describe('body-sections: detectMissingBodySections', () => {
 
   it('returns nothing when the type declares no body sections', () => {
     expect(detectMissingBodySections('anything', [])).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shared presence helper (#653): single source of truth used by both
+// `bwrb edit`'s add-missing-sections flow and the audit
+// `missing-body-section` detector + fix.
+// ---------------------------------------------------------------------------
+
+describe('body-sections: isBodySectionPresent', () => {
+  it('returns true for an exact heading match', () => {
+    expect(isBodySectionPresent('## Notes\n\nstuff\n', 2, 'Notes')).toBe(true);
+  });
+
+  it('returns false when the heading is absent', () => {
+    expect(isBodySectionPresent('# Title\n\nbody\n', 2, 'Notes')).toBe(false);
+  });
+
+  it('returns false when the heading exists only at the wrong level', () => {
+    expect(isBodySectionPresent('### Notes\n', 2, 'Notes')).toBe(false);
+    expect(isBodySectionPresent('# Notes\n', 2, 'Notes')).toBe(false);
+  });
+
+  it('tolerates trailing whitespace', () => {
+    expect(isBodySectionPresent('## Notes   \n', 2, 'Notes')).toBe(true);
+  });
+
+  it('tolerates an ATX closing-hash sequence', () => {
+    expect(isBodySectionPresent('## Notes ##\n', 2, 'Notes')).toBe(true);
+    expect(isBodySectionPresent('## Notes ###  \n', 2, 'Notes')).toBe(true);
+  });
+
+  it('tolerates leading indentation', () => {
+    expect(isBodySectionPresent('   ## Notes\n', 2, 'Notes')).toBe(true);
+  });
+
+  it('does not count a heading inside a fenced code block as present', () => {
+    expect(isBodySectionPresent('```\n## Notes\n```\n', 2, 'Notes')).toBe(false);
+  });
+
+  it('is case-sensitive on the title', () => {
+    expect(isBodySectionPresent('## notes\n', 2, 'Notes')).toBe(false);
+  });
+
+  it('does not match a heading with extra trailing text (anchored end)', () => {
+    // Pins the unified behavior (#653): `bwrb edit` previously used an
+    // unanchored prefix matcher that would have treated this as present;
+    // the shared helper anchors the line end, matching the audit matcher.
+    expect(isBodySectionPresent('## Notes and more\n', 2, 'Notes')).toBe(false);
+  });
+
+  it('regex-escapes special characters in the title', () => {
+    // Pins the unified behavior (#653): `bwrb edit` previously fed the raw
+    // title into a RegExp, so `.` matched any char. The shared helper escapes.
+    expect(isBodySectionPresent('## A.B\n', 2, 'A.B')).toBe(true);
+    expect(isBodySectionPresent('## AxB\n', 2, 'A.B')).toBe(false);
+  });
+
+  it('supports level 1 and deeper levels', () => {
+    expect(isBodySectionPresent('# Top\n', 1, 'Top')).toBe(true);
+    expect(isBodySectionPresent('#### Deep\n', 4, 'Deep')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What

Consolidates the duplicated "is this declared body-section heading present in the note body?" logic that lived in three places:

- `bwrb edit`'s `addMissingSections` (`src/lib/edit.ts`)
- the audit `missing-body-section` detector (`src/lib/audit/body-sections.ts`)
- the audit `missing-body-section` fix's idempotency guard (`src/lib/audit/fix.ts`)

All three now route through a single exported helper `isBodySectionPresent(body, level, title)` in `src/lib/audit/body-sections.ts`.

## The two matchers

- **Audit detector + fix** were byte-identical: `maskNonProse` the body, then match `^[ \t]*#{level} <escaped title>[ \t]*#*[ \t]*$` (`m` flag) — anchored, code-fence-masked, regex-escaped, leading-indent + trailing-whitespace + ATX closing-hash tolerant.
- **`edit`** used a looser matcher: `^#{level} <raw title>` (`m` flag) — no masking, no regex-escape, no end-anchor, no indent/closing-hash tolerance.

## Unify vs parameterize

**Unified** onto the audit (more-correct) matcher. The two are observably identical for the normal scaffold-written headings both paths actually produce (`generateBodySections`). They only diverged on edge cases — headings inside fenced code blocks, ATX closing-hash runs (`## Notes ##`), leading indentation, regex-special titles (`A.B`), and headings with trailing text (`## Notes and more`) — and in every one of those the audit matcher is the correct one. No existing test pinned `edit`'s old loose behavior (its only add-sections test is `it.skip`-ped). Added unit tests pinning the now-unified anchored + regex-escaped behavior.

## Tests

- Existing `audit-body-sections` (14) and `edit` (52) tests pass unchanged.
- Added 11 unit tests for `isBodySectionPresent` (present / absent / wrong-level / trailing-whitespace / closing-hashes / leading-indent / code-fenced / case-sensitivity / anchored-end / regex-escape / level 1 + deep).

## Gates

- `pnpm qa` ✅ (108 files, 2519 passed, 4 skipped)
- `pnpm knip` ✅

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)