### PR TITLE
fix(audit): make invalid-list-element blank removal index-safe (#683)

### DIFF
--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -105,6 +105,18 @@ function isDryRunEnabled(): boolean {
   return dryRunStorage.getStore() ?? false;
 }
 
+/**
+ * A list entry that the `invalid-list-element` remover is allowed to drop:
+ * `null`/`undefined` or a whitespace-only string. Mirrors the blank/empty
+ * detection in checkInvalidListElements (detection.ts) so the fixer only ever
+ * removes the entries that detection flagged for removal — never distinct
+ * content (#683).
+ */
+function isBlankListEntry(entry: unknown): boolean {
+  if (entry === null || entry === undefined) return true;
+  return typeof entry === 'string' && entry.trim().length === 0;
+}
+
 function registerManualReview(
   list: { file: string; issue: AuditIssue }[],
   file: string,
@@ -1419,13 +1431,30 @@ export async function runAutoFix(
         const fixResult = await updateFrontmatterValue(schema, result, (frontmatter) => {
           const current = frontmatter[issue.field!];
           if (!Array.isArray(current)) return false;
-          if (listIndex < 0 || listIndex >= current.length) return false;
 
           if (action === 'remove') {
-            current.splice(listIndex, 1);
+            // Index-safe blank removal (#683). Detection reports each blank/null
+            // entry with its ORIGINAL index, but every issue is applied as its
+            // own read-modify-write to a SHRINKING array. Splicing blindly by the
+            // original index uses a stale offset once an earlier blank has been
+            // removed and can delete a distinct, non-blank element (data loss).
+            //
+            // Only ever remove a blank/null entry: prefer the reported index when
+            // it still points at a blank, otherwise drop the first remaining
+            // blank. This preserves every distinct value regardless of how many
+            // blanks there are or where they sit, and is idempotent — once no
+            // blanks remain the predicate returns false and the file is untouched.
+            const removeAt =
+              listIndex >= 0 && listIndex < current.length && isBlankListEntry(current[listIndex])
+                ? listIndex
+                : current.findIndex((entry) => isBlankListEntry(entry));
+            if (removeAt < 0) return false;
+            current.splice(removeAt, 1);
             frontmatter[issue.field!] = current;
             return true;
           }
+
+          if (listIndex < 0 || listIndex >= current.length) return false;
 
           if (action === 'coerce') {
             current[listIndex] = String(current[listIndex]);

--- a/tests/ts/lib/alias-role.test.ts
+++ b/tests/ts/lib/alias-role.test.ts
@@ -511,6 +511,92 @@ describe('alias field role', () => {
       // And illegal-aliases never applies to a non-alias field.
       expect(tagged?.issues.some((i) => i.code === 'illegal-aliases')).toBe(false);
     });
+
+    // #683 regression: the `invalid-list-element` blank-remover used to splice by
+    // ORIGINAL index against a SHRINKING array. With 2+ blanks a later removal
+    // used a stale offset and deleted a distinct, non-blank element (data loss).
+    // #617 only sidestepped this for ALIAS fields; non-alias lists were still
+    // exposed. These tests run the real default auto-fix pass on a non-alias list
+    // and assert ONLY blanks are dropped, every distinct value survives in order,
+    // and the fix is idempotent — regardless of where the blanks sit.
+    describe('blank removal is index-safe on non-alias lists (#683 data loss)', () => {
+      const writeNoteFile = async (name: string, yamlTags: string) => {
+        await writeFile(
+          join(vaultDir, 'Notes', `${name}.md`),
+          `---\ntype: note\ntags:\n${yamlTags}---\n`
+        );
+      };
+
+      // Default auto-fix pass (all detections, not --only); returns the resulting
+      // tags array, the fix summary, and the schema for a follow-up re-run.
+      const fixDefaultPath = async (name: string) => {
+        const schema = await loadSchema(vaultDir);
+        const results = await runAudit(schema, vaultDir, { strict: false });
+        const summary = await runAutoFix(
+          results.filter((r) => r.relativePath === `Notes/${name}.md`),
+          schema,
+          vaultDir
+        );
+        const fixed = await parseNote(join(vaultDir, 'Notes', `${name}.md`));
+        return { tags: fixed.frontmatter['tags'], summary, schema };
+      };
+
+      // Re-run the default fix once more and return the resulting tags — used to
+      // assert idempotency.
+      const refix = async (name: string, schema: Awaited<ReturnType<typeof loadSchema>>) => {
+        const after = await runAudit(schema, vaultDir, { strict: false });
+        expect(
+          after
+            .find((r) => r.relativePath === `Notes/${name}.md`)
+            ?.issues.some((i) => i.code === 'invalid-list-element') ?? false
+        ).toBe(false);
+        await runAutoFix(
+          after.filter((r) => r.relativePath === `Notes/${name}.md`),
+          schema,
+          vaultDir
+        );
+        const stable = await parseNote(join(vaultDir, 'Notes', `${name}.md`));
+        return stable.frontmatter['tags'];
+      };
+
+      it('["", "  ", "Real"] -> ["Real"] (the exact regression: distinct value survives)', async () => {
+        // Two LEADING blanks then a real value — the shape that triggered the
+        // stale-index data loss. The naive splice-by-original-index would delete
+        // "Real" here.
+        await writeNoteFile('Lead', `  - ""\n  - "  "\n  - Real\n`);
+        const { tags, schema } = await fixDefaultPath('Lead');
+        expect(tags).toEqual(['Real']);
+        expect(await refix('Lead', schema)).toEqual(['Real']);
+      });
+
+      it('["", ""] -> [] (all blanks removed)', async () => {
+        await writeNoteFile('AllBlank', `  - ""\n  - ""\n`);
+        const { tags, schema } = await fixDefaultPath('AllBlank');
+        expect(tags).toEqual([]);
+        expect(await refix('AllBlank', schema)).toEqual([]);
+      });
+
+      it('[A, "", B, "", C] -> [A, B, C] (interleaved blanks, all distinct values kept)', async () => {
+        await writeNoteFile('Inter', `  - A\n  - ""\n  - B\n  - ""\n  - C\n`);
+        const { tags, schema } = await fixDefaultPath('Inter');
+        expect(tags).toEqual(['A', 'B', 'C']);
+        expect(await refix('Inter', schema)).toEqual(['A', 'B', 'C']);
+      });
+
+      it('[Real, "", ""] -> [Real] (trailing blanks)', async () => {
+        await writeNoteFile('Trail', `  - Real\n  - ""\n  - ""\n`);
+        const { tags, schema } = await fixDefaultPath('Trail');
+        expect(tags).toEqual(['Real']);
+        expect(await refix('Trail', schema)).toEqual(['Real']);
+      });
+
+      it('["", Real, ""] -> [Real] (surrounding blanks)', async () => {
+        await writeNoteFile('Around', `  - ""\n  - Real\n  - ""\n`);
+        const { tags, schema } = await fixDefaultPath('Around');
+        expect(tags).toEqual(['Real']);
+        expect(await refix('Around', schema)).toEqual(['Real']);
+      });
+    });
   });
 
   // End-to-end relation resolution: a relation field reference must resolve


### PR DESCRIPTION
## Summary

The `invalid-list-element` auto-fix removed blank/empty list entries by their **original** index, applied as a separate read-modify-write per issue against a **shrinking** array. With 2+ blank entries, a later removal used a stale offset and spliced the **wrong** element, silently destroying a distinct, non-blank value (e.g. `["", "  ", "Real"]` could lose `Real`). This is data loss on non-alias list fields.

#617 (PR #682) only sidestepped this for **alias** fields by suppressing `invalid-list-element` there (illegal-aliases owns alias cleanup). The underlying stale-index bug still affected non-alias list fields — this PR root-causes and fixes it.

## Fix

In `src/lib/audit/fix.ts`, the `remove` action now removes **only** a blank/null entry: it prefers the reported index when that index still points at a blank, otherwise it drops the first remaining blank (`isBlankListEntry` predicate, mirroring detection). Every distinct value is preserved regardless of how many blanks there are or where they sit, and the fix is idempotent (no blanks left → no-op). Alias-field behavior (#617 suppression) and non-blank handling (coerce/flatten/dedupe) are untouched.

## Tests

New non-alias regression tests in `tests/ts/lib/alias-role.test.ts` run the real default auto-fix pass and assert only blanks are dropped:
- `["", "  ", "Real"]` → `["Real"]` (the exact failing regression)
- `["", ""]` → `[]`
- `[A, "", B, "", C]` → `[A, B, C]` (interleaved)
- `[Real, "", ""]` → `[Real]` (trailing)
- `["", Real, ""]` → `[Real]` (surrounding)

All assert idempotency. Verified these 5 fail on the pre-fix code (data loss reproduced) and pass with the fix.

## Gate
- `pnpm qa` — green (2524 passed, 4 skipped)
- `pnpm knip` — green
- Real CLI smoke test (`audit --all --fix --auto --execute`) confirms no data loss on leading and surrounding blank cases.

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)