### PR TITLE
fix(audit): exempt correctly-placed owned notes from wrong-directory

### DIFF
--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -72,7 +72,7 @@ Delete semantics in repair mode:
 | `empty-string-required` | Required field is empty/whitespace/empty list |
 | `invalid-option` | Field value not in allowed option values |
 | `unknown-field` | Field not defined in schema (warning by default) |
-| `wrong-directory` | File location doesn't match its type's output_dir |
+| `wrong-directory` | File location doesn't match its type's output_dir (a subdirectory of `output_dir` counts as correct). An [**owned** note](/reference/schema/) is exempt: it correctly lives under its owner at `<owner-dir>/<field>/`, so it is checked against that location, not the owned type's own `output_dir` |
 | `format-violation` | Field value doesn't match expected format (wikilink, etc.) |
 | `stale-reference` | Wikilink points to non-existent file |
 | `trailing-whitespace` | Trailing spaces/tabs on raw frontmatter `key: value` lines (warning; auto-fixable) |

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -384,6 +384,16 @@ export async function auditFile(
   // the owner-subtree exemption when the note's resolved type matches the owned
   // field's child type (or is a descendant of it). Otherwise we fall through to
   // the type's own `output_dir` so the mismatched-type note IS flagged.
+  //
+  // Discovery also attaches ownership purely because `<owner-dir>/<owner>.md`
+  // EXISTS — it never checks that the owner note's own `type` actually resolves
+  // to the expected owner type. A "fake owner" (e.g. `Albums/Fake/Fake.md` with
+  // `type: note`, not `album`) therefore still makes its `songs/` children look
+  // owned, exempting them from this check even though there is no real album to
+  // own them. Validate the owner note's ACTUAL resolved type against the
+  // expected `ownerType` (cheaply, via the audit run's existing note-type index)
+  // so a child under a fake/wrong-type owner falls through to its real type's
+  // `output_dir` and IS flagged.
   const ownedChildType = file.ownership
     ? getOwnedFields(schema, file.ownership.ownerType).find(
         f => f.fieldName === file.ownership!.fieldName
@@ -393,8 +403,21 @@ export async function auditFile(
     ownedChildType !== undefined &&
     (resolvedTypePath === ownedChildType ||
       getDescendants(schema, ownedChildType).includes(resolvedTypePath));
+  // Owner note's actual type, resolved from the shared note-type index (keyed by
+  // the owner note's path without the `.md` extension). Only treat the owner as
+  // valid when its resolved type equals the expected `ownerType` (or is a
+  // descendant of it). When no index is available we cannot validate the owner,
+  // so we conservatively skip the exemption rather than risk a false negative.
+  const ownerNoteType = file.ownership
+    ? noteIndex?.noteTypeMap.get(file.ownership.ownerPath.replace(/\.md$/, ''))
+    : undefined;
+  const ownerNoteIsValid =
+    file.ownership !== undefined &&
+    ownerNoteType !== undefined &&
+    (ownerNoteType === file.ownership.ownerType ||
+      getDescendants(schema, file.ownership.ownerType).includes(ownerNoteType));
   const expectedOutputDir =
-    file.ownership && resolvedTypeMatchesOwnedChild
+    file.ownership && resolvedTypeMatchesOwnedChild && ownerNoteIsValid
       ? getOwnedChildFolder(file.ownership.ownerPath, file.ownership.fieldName)
       : getOutputDir(schema, resolvedTypePath);
   if (expectedOutputDir) {

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -14,6 +14,7 @@ import {
   getOutputDir,
   getTypeFamilies,
   getDescendants,
+  getOwnedFields,
   resolveDateGranularity,
   getRecurrenceForType,
 } from '../schema.js';
@@ -374,9 +375,28 @@ export async function auditFile(
   // is NOT in its valid owner-subtree location is still reported here (and a
   // genuinely misplaced owned note is additionally caught by the dedicated
   // `owned-wrong-location` check in checkOwnershipViolations).
-  const expectedOutputDir = file.ownership
-    ? getOwnedChildFolder(file.ownership.ownerPath, file.ownership.fieldName)
-    : getOutputDir(schema, resolvedTypePath);
+  //
+  // Discovery attaches `file.ownership` based on FOLDER LOCATION alone, so a
+  // note whose actual `type` does NOT match the owned field's expected child
+  // type can still land here with ownership attached (e.g. a `type: album` note
+  // dropped into `Albums/Best Album/songs/`). Such a note is not a legitimate
+  // owned note — its real type determines where it belongs — so we only honor
+  // the owner-subtree exemption when the note's resolved type matches the owned
+  // field's child type (or is a descendant of it). Otherwise we fall through to
+  // the type's own `output_dir` so the mismatched-type note IS flagged.
+  const ownedChildType = file.ownership
+    ? getOwnedFields(schema, file.ownership.ownerType).find(
+        f => f.fieldName === file.ownership!.fieldName
+      )?.childType
+    : undefined;
+  const resolvedTypeMatchesOwnedChild =
+    ownedChildType !== undefined &&
+    (resolvedTypePath === ownedChildType ||
+      getDescendants(schema, ownedChildType).includes(resolvedTypePath));
+  const expectedOutputDir =
+    file.ownership && resolvedTypeMatchesOwnedChild
+      ? getOwnedChildFolder(file.ownership.ownerPath, file.ownership.fieldName)
+      : getOutputDir(schema, resolvedTypePath);
   if (expectedOutputDir) {
     const expectedPath = expectedOutputDir;
     const actualDir = dirname(file.relativePath);

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -18,6 +18,7 @@ import {
   getRecurrenceForType,
 } from '../schema.js';
 import { readStructuralFrontmatter } from './structural.js';
+import { getOwnedChildFolder } from '../ownership-paths.js';
 import {
   splitLinesPreserveEol,
   parseSimpleYamlKeyValueLine,
@@ -363,14 +364,26 @@ export async function auditFile(
   }
 
   // Check wrong directory
-  const expectedOutputDir = getOutputDir(schema, resolvedTypePath);
+  //
+  // An OWNED note (e.g. a `track` owned by an `album` via an `owned` field) does
+  // NOT live in its type's own `output_dir`. It legitimately lives under its
+  // owner at `<owner-dir>/<field>/` — the same place `bwrb new --owner` and
+  // ownership-aware discovery (#619/#660) place and accept it. Discovery already
+  // attached the owner info to `file.ownership`, so reuse it (and the shared
+  // path rule) instead of the type's top-level `output_dir`. An owned note that
+  // is NOT in its valid owner-subtree location is still reported here (and a
+  // genuinely misplaced owned note is additionally caught by the dedicated
+  // `owned-wrong-location` check in checkOwnershipViolations).
+  const expectedOutputDir = file.ownership
+    ? getOwnedChildFolder(file.ownership.ownerPath, file.ownership.fieldName)
+    : getOutputDir(schema, resolvedTypePath);
   if (expectedOutputDir) {
     const expectedPath = expectedOutputDir;
     const actualDir = dirname(file.relativePath);
     // Normalize for comparison
     const normalizedExpected = expectedPath.replace(/\/$/, '');
     const normalizedActual = actualDir.replace(/\/$/, '');
-    
+
     // Segment-aware check: actualDir must be exactly expectedDir or a subdirectory
     const isCorrectLocation =
       normalizedActual === normalizedExpected ||

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -2618,6 +2618,11 @@ status: raw
           fields: { type: { value: 'track' } },
           field_order: ['type'],
         },
+        note: {
+          output_dir: 'Notes',
+          fields: { type: { value: 'note' } },
+          field_order: ['type'],
+        },
       },
     };
 
@@ -2699,6 +2704,33 @@ status: raw
         f.path.includes('Nested Track.md')
       );
       expect(nestedFile).toBeUndefined();
+    });
+
+    it('flags a note whose type differs from the owned field child type placed in an owned-field folder', async () => {
+      // A `type: note` note dropped into the `songs/` owned-field folder gets
+      // `file.ownership` attached by discovery (folder-location only), but it is
+      // NOT a legitimate owned note: the owned field's child type is `track`, not
+      // `note`. Its real type (`note`) determines where it belongs, so it must be
+      // flagged against note's own output_dir (Notes), not exempted by the
+      // owner-subtree rule. (Regression for the Codex P2 false-negative on #701.)
+      await writeFile(
+        join(tempVaultDir, 'Albums/Best Album/songs', 'Misfiled Note.md'),
+        `---\ntype: note\n---\n`
+      );
+
+      const result = await runCLI(['audit', '--output', 'json'], tempVaultDir);
+
+      expect(result.exitCode).toBe(1);
+      const output = JSON.parse(result.stdout);
+      const misfiled = output.files.find((f: { path: string }) =>
+        f.path.includes('Misfiled Note.md')
+      );
+      expect(misfiled).toBeDefined();
+      const wrongDirIssue = misfiled.issues.find(
+        (i: { code: string }) => i.code === 'wrong-directory'
+      );
+      expect(wrongDirIssue).toBeDefined();
+      expect(wrongDirIssue.expected).toBe('Notes');
     });
   });
 

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -2580,10 +2580,125 @@ status: raw
       expect(wrongDirIssue.expected).toBe('notes');
       
       // The correctly placed note should have no issues
-      const correctFile = output.files.find((f: { path: string }) => 
+      const correctFile = output.files.find((f: { path: string }) =>
         f.path.includes('Correct Note.md')
       );
       expect(correctFile).toBeUndefined();
+    });
+  });
+
+  // Owned notes (e.g. a `track` owned by an `album` via an `owned` field) live
+  // under their owner at `<owner-dir>/<field>/`, NOT in the owned type's own
+  // `output_dir`. Regression coverage for #661: audit must not flag a
+  // correctly-placed owned note as wrong-directory, while a genuinely-misplaced
+  // owned note (outside any valid owner subtree) is still flagged.
+  describe('wrong-directory detection for owned notes (#661)', () => {
+    let tempVaultDir: string;
+
+    // album (output_dir: Albums) owns `track` (output_dir: Tracks) via `songs`.
+    const OWNERSHIP_SCHEMA = {
+      version: 2,
+      types: {
+        album: {
+          output_dir: 'Albums',
+          fields: {
+            type: { value: 'album' },
+            status: {
+              prompt: 'select',
+              options: ['raw', 'in-flight', 'settled'],
+              default: 'raw',
+              required: true,
+            },
+            songs: { prompt: 'relation', source: 'track', owned: true },
+          },
+          field_order: ['type', 'status', 'songs'],
+        },
+        track: {
+          output_dir: 'Tracks',
+          fields: { type: { value: 'track' } },
+          field_order: ['type'],
+        },
+      },
+    };
+
+    beforeEach(async () => {
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-audit-owned-wrongdir-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify(OWNERSHIP_SCHEMA, null, 2)
+      );
+      // Owner note + its owned-field subfolder.
+      await mkdir(join(tempVaultDir, 'Albums/Best Album/songs'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, 'Albums/Best Album', 'Best Album.md'),
+        `---\ntype: album\nstatus: in-flight\n---\n`
+      );
+      await mkdir(join(tempVaultDir, 'Tracks'), { recursive: true });
+      await mkdir(join(tempVaultDir, 'Random'), { recursive: true });
+    });
+
+    afterEach(async () => {
+      await rm(tempVaultDir, { recursive: true, force: true });
+    });
+
+    it('does not flag a correctly-placed owned note as wrong-directory', async () => {
+      // Owned `track` living under its owner at Albums/Best Album/songs/.
+      await writeFile(
+        join(tempVaultDir, 'Albums/Best Album/songs', 'Opening Track.md'),
+        `---\ntype: track\n---\n`
+      );
+
+      const result = await runCLI(['audit', '--output', 'json'], tempVaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const output = JSON.parse(result.stdout);
+      const ownedFile = output.files.find((f: { path: string }) =>
+        f.path.includes('Opening Track.md')
+      );
+      expect(ownedFile).toBeUndefined();
+    });
+
+    it('still flags a genuinely-misplaced owned-type note', async () => {
+      // A `track` placed in Random/ is NOT under any valid owner subtree, so it
+      // is discovered as a plain pooled note and must be flagged against Tracks.
+      await writeFile(
+        join(tempVaultDir, 'Random', 'Stray Track.md'),
+        `---\ntype: track\n---\n`
+      );
+
+      const result = await runCLI(['audit', '--output', 'json'], tempVaultDir);
+
+      expect(result.exitCode).toBe(1);
+      const output = JSON.parse(result.stdout);
+      const strayFile = output.files.find((f: { path: string }) =>
+        f.path.includes('Stray Track.md')
+      );
+      expect(strayFile).toBeDefined();
+      const wrongDirIssue = strayFile.issues.find(
+        (i: { code: string }) => i.code === 'wrong-directory'
+      );
+      expect(wrongDirIssue).toBeDefined();
+      expect(wrongDirIssue.expected).toBe('Tracks');
+    });
+
+    it('does not flag a non-owned note nested under its output_dir (#660 unchanged)', async () => {
+      // A non-owned `track` filed in a nested subdir of its own output_dir is a
+      // correct location and must remain clean.
+      await mkdir(join(tempVaultDir, 'Tracks/Sub'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, 'Tracks/Sub', 'Nested Track.md'),
+        `---\ntype: track\n---\n`
+      );
+
+      const result = await runCLI(['audit', '--output', 'json'], tempVaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const output = JSON.parse(result.stdout);
+      const nestedFile = output.files.find((f: { path: string }) =>
+        f.path.includes('Nested Track.md')
+      );
+      expect(nestedFile).toBeUndefined();
     });
   });
 

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -2732,6 +2732,41 @@ status: raw
       expect(wrongDirIssue).toBeDefined();
       expect(wrongDirIssue.expected).toBe('Notes');
     });
+
+    it('flags an owned-type child under a fake (wrong-type) owner note', async () => {
+      // `Albums/Fake/Fake.md` is a fake owner: it exists where an owner note
+      // would live, but its `type` is `note`, not `album`. Discovery attaches
+      // ownership to children purely from folder structure (the owner note's
+      // existence), so a `type: track` child under `Albums/Fake/songs/` arrives
+      // with `file.ownership` even though there is no real album owning it.
+      // Because the owner note does not actually resolve to the expected owner
+      // type, the owner-subtree exemption must NOT apply: the child is flagged
+      // against `track`'s own output_dir (Tracks). (Regression for the Codex P2
+      // owner-side false-negative on #701.)
+      await mkdir(join(tempVaultDir, 'Albums/Fake/songs'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, 'Albums/Fake', 'Fake.md'),
+        `---\ntype: note\n---\n`
+      );
+      await writeFile(
+        join(tempVaultDir, 'Albums/Fake/songs', 'Stranded Track.md'),
+        `---\ntype: track\n---\n`
+      );
+
+      const result = await runCLI(['audit', '--output', 'json'], tempVaultDir);
+
+      expect(result.exitCode).toBe(1);
+      const output = JSON.parse(result.stdout);
+      const stranded = output.files.find((f: { path: string }) =>
+        f.path.includes('Stranded Track.md')
+      );
+      expect(stranded).toBeDefined();
+      const wrongDirIssue = stranded.issues.find(
+        (i: { code: string }) => i.code === 'wrong-directory'
+      );
+      expect(wrongDirIssue).toBeDefined();
+      expect(wrongDirIssue.expected).toBe('Tracks');
+    });
   });
 
   describe('--execute flag validation', () => {


### PR DESCRIPTION
## Summary

`bwrb audit` flagged a legitimately-**owned** note as `wrong-directory`. An owned note (e.g. a `research` note owned by a `project` via an `owned` field) correctly lives under its owner at `<owner-dir>/<field>/` (e.g. `Projects/My Project/research/R1.md`) — the same place `bwrb new --owner` and ownership-aware discovery (#619/#660) put and accept it. But the wrong-directory check computed the expected location only from the type's own `output_dir`, producing a false positive:

> Wrong directory: type is 'research', expected in Research

## Fix

`src/lib/audit/detection.ts` — the wrong-directory check now reuses the ownership info discovery already attaches to a discovered file (`file.ownership`). When set, the expected directory is computed via the shared `getOwnedChildFolder(ownerPath, field)` rule (identical to discovery / `bwrb new`) instead of the type's `output_dir`.

Because ownership-aware discovery only attaches `file.ownership` when the note is physically under a valid owner subtree, the exemption is precise:

- **Correctly-placed owned note** → checked against `<owner-dir>/<field>/` → clean.
- **Genuinely-misplaced owned-type note** (outside any valid owner subtree) → discovered as a plain pooled note with no `file.ownership` → falls through to the normal `output_dir` check → still flagged.
- **Non-owned notes** → unchanged, including #660's nested-subdir-under-`output_dir` = correct.

## Tests

New describe block in `tests/ts/commands/audit.test.ts` (#661): correctly-placed owned → clean; misplaced owned-type → still flagged (`expected: Tracks`); non-owned nested-under-`output_dir` → clean. Verified the suite fails by exactly one test without the source fix and passes with it.

Manually verified via the CLI on a `project` owns `research` vault: correctly-placed owned note audits clean; moving it to `Random/` reports `wrong-directory ... expected in Research`.

## Gates

- `pnpm qa` ✅ (2527 passed, 4 skipped)
- `pnpm knip` ✅
- `pnpm docs:build` ✅

Closes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)