### PR TITLE
fix(open): support positional app mode so `open <name> print` works (#662)

### DIFF
--- a/docs-site/src/content/docs/reference/commands/open.md
+++ b/docs-site/src/content/docs/reference/commands/open.md
@@ -8,8 +8,11 @@ Open a note by query in your preferred application. This is an alias for `search
 ## Synopsis
 
 ```bash
-bwrb open [options] [query]
+bwrb open [options] [query] [mode]
 ```
+
+`[mode]` is an optional positional app mode (e.g. `bwrb open "My Note" print`),
+equivalent to passing `--app <mode>`. An explicit `--app` flag always wins.
 
 ## Options
 
@@ -50,6 +53,9 @@ bwrb open "My Note" --app obsidian
 
 # Open in $EDITOR
 bwrb open "My Note" --app editor
+
+# Print the resolved path to stdout (positional mode, handy for scripting)
+bwrb open "My Note" print
 ```
 
 ### With Targeting
@@ -73,9 +79,10 @@ bwrb open --body "TODO"
 The default app is determined by:
 
 1. `--app` flag (explicit)
-2. `BWRB_DEFAULT_APP` environment variable
-3. `config.open_with` in `.bwrb/schema.json`
-4. Fallback: `system`
+2. `[mode]` positional argument (e.g. `bwrb open "My Note" print`)
+3. `BWRB_DEFAULT_APP` environment variable
+4. `config.open_with` in `.bwrb/schema.json`
+5. Fallback: `system`
 
 ```bash
 # Set default via environment

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -278,9 +278,10 @@ Picker Modes:
 
 Precedence (for default app):
   1. --app flag (explicit)
-  2. BWRB_DEFAULT_APP environment variable
-  3. config.open_with in .bwrb/schema.json
-  4. Fallback: system
+  2. [mode] positional argument (e.g. bwrb open "My Note" print)
+  3. BWRB_DEFAULT_APP environment variable
+  4. config.open_with in .bwrb/schema.json
+  5. Fallback: system
 
 Examples:
   bwrb open "My Note"                   Open note (uses config default)
@@ -293,6 +294,11 @@ Examples:
   bwrb open --body "TODO"               Find and open note containing TODO
 `
   )
+  // Reject excess positional args (e.g. `open "Note" print bogus`). Only
+  // [query] and [mode] are accepted; a third+ token is almost certainly a
+  // mistake and silently swallowing it (commander's default) hides the typo
+  // — which is precisely the failure mode #662 set out to fix.
+  .allowExcessArguments(false)
   .action(async (query: string | undefined, mode: string | undefined, options: OpenOptions, cmd) => {
     const jsonMode = options.output === "json";
 

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -250,6 +250,7 @@ interface OpenOptions {
 export const openCommand = new Command("open")
   .description("Open a note (alias for search --open)")
   .argument("[query]", "Note name or path to open")
+  .argument("[mode]", "App mode to open with: system, editor, visual, obsidian, print")
   .option("-a, --app <mode>", "Application to open with: system, editor, visual, obsidian, print")
   .option("--picker <mode>", "Picker mode: fzf, numbered, none", "fzf")
   .option("--output <format>", "Output format: text, json", "text")
@@ -283,6 +284,7 @@ Precedence (for default app):
 
 Examples:
   bwrb open "My Note"                   Open note (uses config default)
+  bwrb open "My Note" print             Print path to stdout (positional mode)
   bwrb open "My Note" --app obsidian    Open in Obsidian
   bwrb open "My Note" --app editor      Open in $EDITOR
   bwrb open --type task                 Pick from all tasks
@@ -291,7 +293,7 @@ Examples:
   bwrb open --body "TODO"               Find and open note containing TODO
 `
   )
-  .action(async (query: string | undefined, options: OpenOptions, cmd) => {
+  .action(async (query: string | undefined, mode: string | undefined, options: OpenOptions, cmd) => {
     const jsonMode = options.output === "json";
 
     try {
@@ -306,8 +308,13 @@ Examples:
       // Parse picker mode
       const pickerMode = parsePickerMode(resolveGlobalPickerMode(options.picker, globalOpts, "fzf"));
 
-      // Resolve app mode using precedence: CLI > env > config > default
-      const appMode = resolveAppMode(options.app, schema.config);
+      // Resolve app mode using precedence:
+      //   --app flag > positional [mode] > BWRB_DEFAULT_APP > config > default
+      // The positional mode (e.g. `bwrb open "X" print`) is a convenience form;
+      // an explicit --app flag always wins. A positional that is not a valid app
+      // mode throws via parseAppMode, surfacing the typo instead of silently
+      // running the default app and producing no output.
+      const appMode = resolveAppMode(options.app ?? mode, schema.config);
 
       // Check if we have any targeting options
       const hasTargeting = options.type || options.path || options.where?.length || options.id || options.body;

--- a/tests/ts/commands/open.test.ts
+++ b/tests/ts/commands/open.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
 import { createTestVault, cleanupTestVault, runCLI } from '../fixtures/setup.js';
 import { parseAppMode, resolveAppMode } from '../../../src/commands/open.js';
 import type { ResolvedConfig } from '../../../src/types/schema.js';
@@ -312,5 +314,128 @@ describe('open command', () => {
       expect(result.stdout).toContain('--preview');
       expect(result.stdout).toContain('fzf');
     });
+  });
+
+  describe('positional app mode', () => {
+    it('should accept app mode as a positional argument (open <name> print)', async () => {
+      const result = await runCLI(['open', 'Sample Idea', 'print'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Ideas/Sample Idea.md');
+    });
+
+    it('should let --app flag take precedence over positional mode', async () => {
+      // Positional says system, flag says print -> print wins (prints path).
+      const result = await runCLI(
+        ['open', 'Sample Idea', 'system', '--app', 'print'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Ideas/Sample Idea.md');
+    });
+
+    it('should error on an invalid positional mode instead of silently doing nothing', async () => {
+      const result = await runCLI(['open', 'Sample Idea', 'bogus-mode'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Invalid app mode');
+    });
+
+    it('should treat a single positional as the query, not the mode', async () => {
+      // `open print` searches for a note literally named "print" (none here).
+      const result = await runCLI(['open', 'print', '--picker', 'none'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('No matching notes found');
+    });
+  });
+});
+
+// Regression coverage for #662: `open <name> print` (positional, non-interactive)
+// must resolve and print notes filed in nested subdirs under a type's output_dir,
+// consistently with `search`/`list` (#619). Before the fix the trailing `print`
+// token was silently swallowed, the command fell back to the default app mode,
+// and nothing was printed (exit 0) for nested notes.
+describe('open nested-subdir notes via positional print (#662)', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  it('prints a nested note path with positional print mode', async () => {
+    await mkdir(join(vaultDir, 'Ideas', 'Sub'), { recursive: true });
+    await writeFile(
+      join(vaultDir, 'Ideas', 'Sub', 'Nested Idea.md'),
+      '---\ntype: idea\nstatus: raw\n---\n'
+    );
+
+    const result = await runCLI(['open', 'Nested Idea', 'print'], vaultDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Ideas/Sub/Nested Idea.md');
+  });
+
+  it('prints a nested note path with --app print as well', async () => {
+    await mkdir(join(vaultDir, 'Ideas', 'Sub'), { recursive: true });
+    await writeFile(
+      join(vaultDir, 'Ideas', 'Sub', 'Nested Idea.md'),
+      '---\ntype: idea\nstatus: raw\n---\n'
+    );
+
+    const result = await runCLI(
+      ['open', 'Nested Idea', '--app', 'print'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Ideas/Sub/Nested Idea.md');
+  });
+
+  it('prints a deeply nested note path with positional print mode', async () => {
+    await mkdir(join(vaultDir, 'Ideas', 'A', 'B', 'C'), { recursive: true });
+    await writeFile(
+      join(vaultDir, 'Ideas', 'A', 'B', 'C', 'Deeply Nested Idea.md'),
+      '---\ntype: idea\nstatus: raw\n---\n'
+    );
+
+    const result = await runCLI(['open', 'Deeply Nested Idea', 'print'], vaultDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Ideas/A/B/C/Deeply Nested Idea.md');
+  });
+
+  it('still surfaces ambiguity for nested duplicate basenames in non-interactive mode', async () => {
+    await mkdir(join(vaultDir, 'Ideas', 'One'), { recursive: true });
+    await mkdir(join(vaultDir, 'Ideas', 'Two'), { recursive: true });
+    await writeFile(
+      join(vaultDir, 'Ideas', 'One', 'Dup Idea.md'),
+      '---\ntype: idea\nstatus: raw\n---\n'
+    );
+    await writeFile(
+      join(vaultDir, 'Ideas', 'Two', 'Dup Idea.md'),
+      '---\ntype: idea\nstatus: raw\n---\n'
+    );
+
+    const result = await runCLI(
+      ['open', 'Dup Idea', 'print', '--picker', 'none'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toContain('Ideas/One/Dup Idea.md');
+    expect(result.stdout + result.stderr).toContain('Ideas/Two/Dup Idea.md');
+  });
+
+  it('keeps top-level note resolution working with positional print mode', async () => {
+    const result = await runCLI(['open', 'Sample Idea', 'print'], vaultDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Ideas/Sample Idea.md');
   });
 });

--- a/tests/ts/commands/open.test.ts
+++ b/tests/ts/commands/open.test.ts
@@ -349,6 +349,35 @@ describe('open command', () => {
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('No matching notes found');
     });
+
+    it('should reject excess positional args (open <query> <mode> <extra>)', async () => {
+      // A third positional is almost certainly a mistake. Rather than silently
+      // swallowing `bogus` and exiting 0, the command must error loudly.
+      const result = await runCLI(
+        ['open', 'Sample Idea', 'print', 'bogus'],
+        vaultDir
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('too many arguments');
+    });
+
+    it('should still accept exactly two positionals (open <query> <mode>)', async () => {
+      const result = await runCLI(['open', 'Sample Idea', 'print'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Ideas/Sample Idea.md');
+    });
+
+    it('should still accept a single positional (open <query>)', async () => {
+      const result = await runCLI(
+        ['open', 'Sample Idea', '--app', 'print'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Ideas/Sample Idea.md');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

`bwrb open <name> print` — the natural non-interactive print form — silently output nothing and exited 0. `open` only accepted `[query]` as a positional argument, so the trailing `print` token was swallowed by commander, the app mode fell back to the default (`system`), and nothing was printed. This was most visible on nested-subdir notes: `bwrb search <name> --output paths` resolved and printed them (post #619), but `bwrb open <name> print` produced no output, which read as an `open`/print plumbing gap specific to nested notes.

## Root cause

Resolution was never the problem. `open` already builds its note index via `buildNoteIndex` → `discoverFilesForNavigation` — the same #619-updated discovery that `search`/`list` use, which recurses into subdirs under a type's `output_dir`. With `--app print`, nested notes already resolved and printed correctly. The gap was purely app-mode plumbing: the documented form `open <name> print` (positional) was never wired up, so `print` was dropped and the default app ran with no stdout.

## Fix

Add an optional `[mode]` positional to `open`, parsed as an app mode (`system`/`editor`/`visual`/`obsidian`/`print`). Precedence:

1. `--app` flag (explicit)
2. `[mode]` positional argument
3. `BWRB_DEFAULT_APP`
4. `config.open_with`
5. `system`

An invalid positional mode now errors via `parseAppMode` instead of silently running the default app. A single positional remains the query (a note literally named `print` is unaffected). Exact/alias/ambiguous resolution (#266/#616), the interactive picker, and all other app modes are unchanged.

## Tests

- Regression test for #662 (`open <nested> print` prints the nested path) — fails on `main`, passes here.
- Positional mode form, `--app` precedence over positional, invalid-mode error, single-positional-is-query.
- Nested + deeply nested print resolution; ambiguity still surfaced in non-interactive mode; top-level notes unchanged.
- `pnpm qa` green (108 files, 2566 tests), `pnpm knip` green, docs build green.

## Docs

Documented the positional `[mode]` form in the `open` command reference (synopsis, example, precedence).

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)