### PR TITLE
fix(search): wire --open/--edit into --fuzzy mode

### DIFF
--- a/docs-site/src/content/docs/reference/commands/search.md
+++ b/docs-site/src/content/docs/reference/commands/search.md
@@ -123,12 +123,28 @@ bwrb search "Steve" --fuzzy --output json
 
 # Print the full contents of ranked matches, best-first
 bwrb search "Steve" --fuzzy --output content
+
+# Open the best fuzzy match (picker on ambiguity in a terminal)
+bwrb search "Stephen Yeg" --fuzzy --open
+
+# Open the best match in $EDITOR
+bwrb search "Stephen Yeg" --fuzzy --open --app editor
+
+# Edit the best match's frontmatter
+bwrb search "Stephen Yeg" --fuzzy --edit --json '{"status":"settled"}'
 ```
 
 All output formats work uniformly across search modes. With `--fuzzy`,
 `--output content` prints the full file contents (frontmatter + body) of the
 ranked matches — identical in shape to plain `search --output content` — emitted
 best-first by score.
+
+`--open` and `--edit` work with `--fuzzy` too, reusing the same open/edit and
+app-mode handling as the other search modes. In an interactive terminal with
+multiple matches, you get the picker (ordered best-first by score); otherwise
+(non-interactive, `--picker none`, JSON mode, or a single match) the **best**
+match is acted on. A query with no matches is a hard error rather than a silent
+no-op.
 
 #### What participates in matching
 

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -668,6 +668,17 @@ async function handleFuzzySearch(
   const index = await buildNoteIndex(schema, vaultDir);
   const matches = await fuzzySearch(index, query, schema, vaultDir, { threshold, limit });
 
+  // --open / --edit: act on the matched note(s), reusing the exact open/edit +
+  // app-mode + picker logic that plain and content search use. Without this,
+  // fuzzy silently ignored these flags (#676). Mutual exclusivity of
+  // --open/--edit, "--json requires --edit", and the non-interactive
+  // "--edit requires --json" rule are all enforced up front in the action
+  // handler before dispatch, so we only have to wire the behavior here.
+  if (options.open || options.edit) {
+    await handleFuzzyOpenOrEdit(query, options, vaultDir, schema, jsonMode, matches);
+    return;
+  }
+
   if (jsonMode) {
     printJson(jsonSuccess({
       data: matches.map(m => ({
@@ -691,6 +702,86 @@ async function handleFuzzySearch(
 
   for (const match of matches) {
     await outputFuzzyResult(index, match, outputFormat);
+  }
+}
+
+/**
+ * Apply --open / --edit to fuzzy results.
+ *
+ * Behavior mirrors content search (which, like fuzzy, returns a ranked list of
+ * candidates):
+ * - Interactive (TTY, picker != none, not JSON, >1 match): present the picker
+ *   over the ranked candidates (best first) and act on the selection.
+ * - Non-interactive (no TTY, --picker none, or JSON) or a single match: act on
+ *   the best (top) match — never a silent no-op.
+ *
+ * No matches is an error (not a silent no-op), consistent with failing to find
+ * a note to open/edit. This is the key difference from the read-only fuzzy
+ * paths, which stay silent on no-match like grep.
+ */
+async function handleFuzzyOpenOrEdit(
+  query: string,
+  options: SearchOptions,
+  vaultDir: string,
+  schema: import('../types/schema.js').LoadedSchema,
+  jsonMode: boolean,
+  matches: FuzzyMatch[]
+): Promise<void> {
+  if (matches.length === 0) {
+    const error = `No matching notes found for: ${query}`;
+    if (jsonMode) {
+      printJson(jsonError(error));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    printError(error);
+    process.exit(1);
+  }
+
+  const pickerMode = parsePickerMode(options.picker);
+  const shouldPick =
+    !jsonMode &&
+    pickerMode !== 'none' &&
+    matches.length > 1 &&
+    Boolean(process.stdin.isTTY && process.stdout.isTTY);
+
+  let target: ManagedFile;
+  if (shouldPick) {
+    // Interactive: pick among ranked candidates (already best-first).
+    const pickerResult = await pickFile(matches.map(m => m.file), {
+      mode: pickerMode,
+      prompt: options.open ? 'Select note to open' : 'Select note to edit',
+      preview: options.preview ?? false,
+      vaultDir,
+    });
+
+    if (pickerResult.cancelled || !pickerResult.selected) {
+      process.exit(0);
+    }
+    target = pickerResult.selected;
+  } else {
+    // Non-interactive (or single match): act on the best match.
+    target = matches[0]!.file;
+  }
+
+  if (options.open) {
+    const appMode = resolveAppMode(options.app, schema.config);
+    await openNote(vaultDir, target.path, appMode, schema.config, jsonMode);
+    return;
+  }
+
+  // --edit
+  if (options.json) {
+    const result = await editNoteFromJson(schema, vaultDir, target.path, options.json, { jsonMode });
+    if (jsonMode) {
+      printJson(jsonSuccess({
+        path: target.relativePath,
+        updated: result.updatedFields,
+      }));
+    } else {
+      printSuccess(`Updated: ${target.relativePath}`);
+    }
+  } else {
+    await editNoteInteractive(schema, vaultDir, target.path);
   }
 }
 

--- a/tests/ts/commands/search-fuzzy.test.ts
+++ b/tests/ts/commands/search-fuzzy.test.ts
@@ -16,8 +16,10 @@ const FUZZY_SCHEMA = {
       fields: {
         type: { value: 'person' },
         aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
+        // A plain editable field so `--edit --json` has a target field (#676).
+        status: { prompt: 'text' },
       },
-      field_order: ['type', 'aliases'],
+      field_order: ['type', 'aliases', 'status'],
     },
     idea: {
       output_dir: 'Ideas',
@@ -379,5 +381,122 @@ describe('search --fuzzy', () => {
     expect(result.exitCode).not.toBe(0);
     const json = JSON.parse(result.stdout);
     expect(json.success).toBe(false);
+  });
+
+  // --open / --edit wiring (#676). Previously fuzzy silently ignored these
+  // flags (no error, no action). They now act on the resolved/best match,
+  // reusing plain/content search's open/edit + app-mode logic. Tests use
+  // `--app print` so nothing is actually launched.
+  describe('--open / --edit (#676)', () => {
+    it('--open no longer silently ignores: it opens the resolved match', async () => {
+      // Regression guard: a single exact match opens directly. With --app print
+      // the resolved path is emitted, proving the flag took effect (not a no-op).
+      const result = await runCLI(
+        ['search', 'Steve Yegge', '--fuzzy', '--open', '--app', 'print'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('People/Steve Yegge.md');
+      // Must NOT fall through to the default scored text output.
+      expect(result.stdout).not.toMatch(/^\d\.\d{2}\s+Steve Yegge/m);
+    });
+
+    it('--open opens the best (top-ranked) match non-interactively on multi-match', async () => {
+      // "Steve" fuzzily matches several notes; best match is Steve Yegge.
+      const result = await runCLI(
+        ['search', 'Steve', '--fuzzy', '--open', '--app', 'print'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('People/Steve Yegge.md');
+    });
+
+    it('--open resolves the best match via an alias', async () => {
+      const result = await runCLI(
+        ['search', 'Stevey', '--fuzzy', '--open', '--app', 'print'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('People/Steve Yegge.md');
+    });
+
+    it('--open with --output json emits the resolved path as JSON', async () => {
+      const result = await runCLI(
+        ['search', 'Steve Yegge', '--fuzzy', '--open', '--app', 'print', '--output', 'json'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.data.relativePath).toBe('People/Steve Yegge.md');
+    });
+
+    it('--open errors (not silent no-op) when nothing matches', async () => {
+      const result = await runCLI(
+        ['search', 'zzzzzzzzzzxxxxxxx', '--fuzzy', '--open', '--app', 'print'],
+        vaultDir
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr + result.stdout).toMatch(/No matching notes/i);
+    });
+
+    it('--edit --json updates the best match (non-interactive)', async () => {
+      const result = await runCLI(
+        [
+          'search',
+          'Margret Hamiltn',
+          '--fuzzy',
+          '--edit',
+          '--json',
+          '{"status":"reviewed"}',
+          '--output',
+          'json',
+        ],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      // Same JSON shape as plain `search --edit --json`: top-level path +
+      // updated field names.
+      expect(json.path).toBe('People/Margaret Hamilton.md');
+      expect(json.updated).toContain('status');
+    });
+
+    it('--edit errors (not silent no-op) when nothing matches', async () => {
+      const result = await runCLI(
+        [
+          'search',
+          'zzzzzzzzzzxxxxxxx',
+          '--fuzzy',
+          '--edit',
+          '--json',
+          '{"status":"reviewed"}',
+          '--output',
+          'json',
+        ],
+        vaultDir
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+    });
+
+    it('still rejects --open together with --edit', async () => {
+      const result = await runCLI(
+        ['search', 'Steve', '--fuzzy', '--open', '--edit'],
+        vaultDir
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr + result.stdout).toMatch(/--open and --edit/);
+    });
   });
 });


### PR DESCRIPTION
## What

`bwrb search --fuzzy` silently ignored `--open`/`--edit` (no error, no action) — the same "silent ignore" class that #620 fixed for `--output content`. This wires both flags into the fuzzy path.

## How

`handleFuzzySearch` now branches into a new `handleFuzzyOpenOrEdit` when `--open`/`--edit` is present, reusing the **same** `openNote` / `resolveAppMode` / `editNoteFromJson` / `editNoteInteractive` / `pickFile` logic that plain and content search use.

**Multi-match / non-interactive behavior** mirrors content search (which, like fuzzy, returns a ranked candidate list):
- Interactive terminal + multiple matches → picker, ordered best-first by score.
- Non-interactive (no TTY, `--picker none`, JSON mode) or a single match → act on the **best** (top-ranked) match.
- No matches → hard error, never a silent no-op.

The mutual-exclusivity (`--open` + `--edit`), `--json requires --edit`, and non-interactive `--edit requires --json` rules are unchanged — they're enforced up front in the action handler before dispatch.

Existing fuzzy output modes (`json`/`paths`/`link`/`content`/`default`) are untouched when `--open`/`--edit` are absent.

## Tests

Added a `--open / --edit (#676)` block in `search-fuzzy.test.ts`: single-match open, best-match open on multi-match, alias-resolved open, `--open --output json` shape, no-match error (proving no silent no-op), `--edit --json` updates the best match, edit no-match error, and `--open`+`--edit` still rejected. Uses `--app print` so nothing is launched.

## Docs

Documented `--open`/`--edit` with `--fuzzy` in the search reference, including the best-match / picker / no-match-error semantics. `pnpm docs:build` green.

## Gate

`pnpm qa` (2577 passed, 4 skipped) and `pnpm knip` both green.

Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)