### PR TITLE
fix(list): render file.* stats as --fields columns

### DIFF
--- a/docs-site/src/content/docs/reference/commands/list.md
+++ b/docs-site/src/content/docs/reference/commands/list.md
@@ -29,7 +29,7 @@ The positional argument is auto-detected as type, path (contains `/`), or where 
 | Option | Description |
 |--------|-------------|
 | `--output <format>` | Output format: `text`, `paths`, `tree`, `link`, `json` |
-| `--fields <fields>` | Show frontmatter fields in a table (comma-separated) |
+| `--fields <fields>` | Show fields in a table (comma-separated). Accepts frontmatter fields plus the file stats `file.mtime`, `file.ctime`, `file.size` |
 | `--sort <field>` | Sort by a frontmatter field, `name`, `_name`, `_path`, or a file stat (`file.mtime`, `file.ctime`, `file.size`) |
 | `--desc` | Sort descending (requires `--sort`) |
 | `--limit <n>` | Show only the first `n` matching notes |
@@ -66,6 +66,9 @@ bwrb list objective/milestone
 
 # With field columns
 bwrb list task --fields=status,priority
+
+# File stats can also be shown as columns (not just sorted on)
+bwrb list task --fields=status,file.mtime,file.size
 ```
 
 ### Filtering
@@ -165,11 +168,23 @@ bwrb list --type task --count
 bwrb list --type task --count --output json  # {"count": 12}
 ```
 
-The `file.*` sort keys read filesystem metadata and mirror the `file.*`
+The `file.*` keys read filesystem metadata and mirror the `file.*`
 accessors available in `--where`: `file.mtime` (modification time),
-`file.ctime` (creation time), and `file.size` (bytes). They compare
-numerically. `bwrb recent` is `bwrb list --sort file.mtime --desc` with a
-default limit of 20.
+`file.ctime` (creation time), and `file.size` (bytes). When used with
+`--sort` they compare numerically. `bwrb recent` is
+`bwrb list --sort file.mtime --desc` with a default limit of 20.
+
+The same `file.*` keys can also be passed to `--fields` to render them as
+table columns (and as keys in `--output json`):
+
+```bash
+bwrb list --type task --fields file.mtime,file.size,status
+```
+
+In the text table, `file.mtime`/`file.ctime` render as a local
+`YYYY-MM-DD HH:MM` timestamp (matching `bwrb recent`'s MODIFIED column) and
+`file.size` renders as a byte count. In `--output json`, `file.mtime`/
+`file.ctime` are ISO-8601 strings and `file.size` is a number.
 
 Missing sort values are always placed at the end, including with `--desc`.
 `--count` reports the total number of matching notes before any `--limit` is applied.

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -18,6 +18,9 @@ import {
   buildDirectoryTree,
   extractNoteName,
   isFileSortKey,
+  isFileStatField,
+  formatFileStatDisplay,
+  fileStatJsonValue,
   type TreeNode,
   type DirectoryTreeNode,
   type FileStatMap,
@@ -544,12 +547,17 @@ export async function listObjects(
     }
   }
 
-  // When sorting by a filesystem-stat `file.*` key, stat the files first and
-  // thread the results into the comparator (which stays pure/synchronous).
-  const fileStats =
-    options.sortField && isFileSortKey(options.sortField)
-      ? await collectFileStats(filteredFiles.map(f => f.path))
-      : undefined;
+  // Stat the files first when a `file.*` stat key is needed — either for
+  // SORTING (`--sort file.mtime`) or for DISPLAY (`--fields file.size`). The
+  // same {@link FileStatMap} is threaded into the comparator (which stays
+  // pure/synchronous) and into the table/JSON renderers so `file.*` columns
+  // render real values instead of an empty column (#689).
+  const needsFileStats =
+    (options.sortField !== undefined && isFileSortKey(options.sortField)) ||
+    (options.fields?.some(isFileStatField) ?? false);
+  const fileStats = needsFileStats
+    ? await collectFileStats(filteredFiles.map(f => f.path))
+    : undefined;
 
   const fileComparator = createFileComparator(
     vaultDir,
@@ -643,6 +651,14 @@ export async function listObjects(
             selected[field] = noteName;
             continue;
           }
+          if (isFileStatField(field)) {
+            // `file.*` stat fields render from the stat map collected above
+            // (times as ISO-8601, size as a number). Mirrors the text table so
+            // JSON consumers see the same data the table shows (#689).
+            const value = fileStatJsonValue(field, fileStats?.get(path));
+            if (value !== undefined) selected[field] = value;
+            continue;
+          }
           if (Object.prototype.hasOwnProperty.call(frontmatter, field)) {
             selected[field] = frontmatter[field];
           }
@@ -690,7 +706,7 @@ export async function listObjects(
 
   // Default output (table with fields or simple names)
   if (options.fields && options.fields.length > 0) {
-    printTable(filteredFiles, vaultDir, showPaths, options.fields);
+    printTable(filteredFiles, vaultDir, showPaths, options.fields, fileStats);
   } else {
     for (const { path } of filteredFiles) {
       console.log(basename(path, '.md'));
@@ -705,7 +721,8 @@ function printTable(
   files: { path: string; frontmatter: Record<string, unknown> }[],
   vaultDir: string,
   showPaths: boolean,
-  fields: string[]
+  fields: string[],
+  fileStats?: FileStatMap
 ): void {
   const context = getTtyContext();
   const headerStyle = context.colorEnabled ? (text: string) => chalk.gray(text) : null;
@@ -740,6 +757,12 @@ function printTable(
     };
 
     for (const field of fields) {
+      if (isFileStatField(field)) {
+        // `file.*` stat columns render from the stat map collected for sorting
+        // and/or fields (times as YYYY-MM-DD HH:MM, size as bytes) (#689).
+        row[field] = formatFileStatDisplay(field, fileStats?.get(path)) ?? '—';
+        continue;
+      }
       const value = field === 'name' || field === '_name'
         ? basename(path, '.md')
         : field === '_path'

--- a/src/commands/recent.ts
+++ b/src/commands/recent.ts
@@ -23,6 +23,7 @@ import {
 } from '../lib/targeting.js';
 import { getTtyContext } from '../lib/tty/context.js';
 import { renderTable } from '../lib/tty/table.js';
+import { formatFileTimestamp } from '../lib/list-helpers.js';
 import { openNote, resolveAppMode } from './open.js';
 import { pickFile, parsePickerMode } from '../lib/picker.js';
 import { createDashboard, updateDashboard, getDashboard } from '../lib/dashboard.js';
@@ -386,18 +387,6 @@ Examples:
   });
 
 /**
- * Format a timestamp for the default (human) table output.
- * Uses the local-timezone date and time, second precision dropped.
- */
-function formatModified(mtimeMs: number): string {
-  const d = new Date(mtimeMs);
-  const pad = (n: number): string => String(n).padStart(2, '0');
-  const date = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
-  const time = `${pad(d.getHours())}:${pad(d.getMinutes())}`;
-  return `${date} ${time}`;
-}
-
-/**
  * Render the default table: NAME + MODIFIED columns.
  */
 function printRecentTable(files: RecentFile[]): void {
@@ -427,7 +416,7 @@ function printRecentTable(files: RecentFile[]): void {
 
   const rows = files.map(({ path, mtimeMs }) => ({
     primary: basename(path, '.md'),
-    modified: formatModified(mtimeMs),
+    modified: formatFileTimestamp(mtimeMs),
   }));
 
   const lines = renderTable({ columns, rows, context });

--- a/src/lib/list-helpers.ts
+++ b/src/lib/list-helpers.ts
@@ -59,6 +59,63 @@ export function isFileSortKey(field: string): boolean {
   return FILE_SORT_KEYS.has(field);
 }
 
+/**
+ * Whether the given `--fields` key is a filesystem-stat `file.*` key. These can
+ * be requested as display columns (text table) and JSON fields in addition to
+ * being used as `--sort` keys. Currently identical to {@link isFileSortKey}
+ * (same key set), but named separately so the two intents read clearly at call
+ * sites and can diverge later if needed.
+ */
+export function isFileStatField(field: string): boolean {
+  return FILE_SORT_KEYS.has(field);
+}
+
+/**
+ * Format a filesystem timestamp (epoch millis) for human (text-table) output as
+ * `YYYY-MM-DD HH:MM` in local time. Shared with `recent`'s MODIFIED column so
+ * the two commands render `file.mtime` identically.
+ */
+export function formatFileTimestamp(timeMs: number): string {
+  const d = new Date(timeMs);
+  const pad = (n: number): string => String(n).padStart(2, '0');
+  const date = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  const time = `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  return `${date} ${time}`;
+}
+
+/**
+ * Render a `file.*` stat value for the human (text-table) display. Times are
+ * formatted via {@link formatFileTimestamp}; `file.size` is the raw byte count.
+ * Returns `undefined` when no stat was collected for the file (e.g. unreadable),
+ * letting the caller fall back to its empty placeholder.
+ */
+export function formatFileStatDisplay(
+  field: string,
+  stat: FileStat | undefined
+): string | undefined {
+  if (!stat) return undefined;
+  if (field === 'file.mtime') return formatFileTimestamp(stat.mtimeMs);
+  if (field === 'file.ctime') return formatFileTimestamp(stat.ctimeMs);
+  if (field === 'file.size') return String(stat.size);
+  return undefined;
+}
+
+/**
+ * Resolve a `file.*` stat value for JSON output. Times are ISO-8601 strings
+ * (matching `recent`'s `_modified` convention); `file.size` is a number.
+ * Returns `undefined` when no stat was collected (the key is then omitted).
+ */
+export function fileStatJsonValue(
+  field: string,
+  stat: FileStat | undefined
+): string | number | undefined {
+  if (!stat) return undefined;
+  if (field === 'file.mtime') return new Date(stat.mtimeMs).toISOString();
+  if (field === 'file.ctime') return new Date(stat.ctimeMs).toISOString();
+  if (field === 'file.size') return stat.size;
+  return undefined;
+}
+
 export interface TreeNode {
   name: string;
   path: string;

--- a/tests/ts/commands/list.test.ts
+++ b/tests/ts/commands/list.test.ts
@@ -700,6 +700,142 @@ describe('list command', () => {
     });
   });
 
+  describe('--fields file.* stat columns (#689)', () => {
+    let statVault: string;
+
+    beforeEach(async () => {
+      statVault = await createTestVault();
+    });
+
+    afterEach(async () => {
+      await cleanupTestVault(statVault);
+    });
+
+    /** Set a file's mtime to a fixed epoch-seconds value. */
+    async function setMtime(rel: string, seconds: number): Promise<void> {
+      const { utimes } = await import('fs/promises');
+      const when = new Date(seconds * 1000);
+      await utimes(join(statVault, rel), when, when);
+    }
+
+    /** Local-time YYYY-MM-DD HH:MM rendering, matching formatFileTimestamp. */
+    function expectedStamp(seconds: number): string {
+      const d = new Date(seconds * 1000);
+      const pad = (n: number): string => String(n).padStart(2, '0');
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    }
+
+    it('renders file.mtime as a populated date column (regression: was empty)', async () => {
+      const seconds = 1_700_000_000;
+      await setMtime('Ideas/Sample Idea.md', seconds);
+
+      const result = await runCLI(['list', 'idea', '--fields', 'file.mtime'], statVault);
+
+      expect(result.exitCode).toBe(0);
+      // Header present and column populated (not the empty-cell placeholder).
+      expect(result.stdout).toContain('FILE.MTIME');
+      const stamp = expectedStamp(seconds);
+      expect(result.stdout).toContain(stamp);
+      // The Sample Idea row must carry the stamp, not the em-dash placeholder.
+      const sampleRow = result.stdout
+        .split('\n')
+        .find(line => line.includes('Sample Idea'));
+      expect(sampleRow).toBeDefined();
+      expect(sampleRow).toContain(stamp);
+    });
+
+    it('renders file.size as a numeric byte column', async () => {
+      const { stat } = await import('fs/promises');
+      const size = (await stat(join(statVault, 'Ideas/Sample Idea.md'))).size;
+
+      const result = await runCLI(['list', 'idea', '--fields', 'file.size'], statVault);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('FILE.SIZE');
+      const sampleRow = result.stdout
+        .split('\n')
+        .find(line => line.includes('Sample Idea'));
+      expect(sampleRow).toBeDefined();
+      expect(sampleRow).toContain(String(size));
+    });
+
+    it('mixes file.* columns with a frontmatter field', async () => {
+      const seconds = 1_700_000_000;
+      await setMtime('Ideas/Sample Idea.md', seconds);
+
+      const result = await runCLI(
+        ['list', 'idea', '--fields', 'file.mtime,file.size,status'],
+        statVault
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('FILE.MTIME');
+      expect(result.stdout).toContain('FILE.SIZE');
+      expect(result.stdout).toContain('STATUS');
+      // Frontmatter column still works alongside file.* columns.
+      expect(result.stdout).toContain('raw');
+      expect(result.stdout).toContain(expectedStamp(seconds));
+    });
+
+    it('includes file.* values in --output json (mtime ISO, size number)', async () => {
+      const seconds = 1_700_000_000;
+      await setMtime('Ideas/Sample Idea.md', seconds);
+      const { stat } = await import('fs/promises');
+      const size = (await stat(join(statVault, 'Ideas/Sample Idea.md'))).size;
+
+      const result = await runCLI(
+        ['list', 'idea', '--fields', 'file.mtime,file.size,status', '--output', 'json'],
+        statVault
+      );
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as Array<Record<string, unknown>>;
+      const sample = parsed.find(row => row['_name'] === 'Sample Idea');
+      expect(sample).toBeDefined();
+      expect(sample!['file.mtime']).toBe(new Date(seconds * 1000).toISOString());
+      expect(sample!['file.size']).toBe(size);
+      expect(typeof sample!['file.size']).toBe('number');
+      // Frontmatter field still present in JSON.
+      expect(sample!['status']).toBe('raw');
+    });
+
+    it('renders file.* columns even without --sort (stat map collected for fields)', async () => {
+      const seconds = 1_700_000_000;
+      await setMtime('Ideas/Sample Idea.md', seconds);
+
+      // No --sort here: previously the stat map was only collected when sorting,
+      // so this column was empty. It must now be populated.
+      const result = await runCLI(['list', 'idea', '--fields', 'file.mtime'], statVault);
+
+      expect(result.exitCode).toBe(0);
+      const sampleRow = result.stdout
+        .split('\n')
+        .find(line => line.includes('Sample Idea'));
+      expect(sampleRow).toContain(expectedStamp(seconds));
+      // The placeholder em-dash must NOT be the value for this column's cell.
+      expect(sampleRow).not.toMatch(/Sample Idea\s+—\s*$/);
+    });
+
+    it('still sorts by file.mtime while rendering it as a field', async () => {
+      const base = 1_700_000_000;
+      await setMtime('Ideas/Sample Idea.md', base + 100);
+      await setMtime('Ideas/Another Idea.md', base + 300);
+
+      const result = await runCLI(
+        ['list', 'idea', '--fields', 'file.mtime', '--sort', 'file.mtime', '--desc'],
+        statVault
+      );
+
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout.split('\n');
+      const anotherIdx = lines.findIndex(l => l.includes('Another Idea'));
+      const sampleIdx = lines.findIndex(l => l.includes('Sample Idea'));
+      expect(anotherIdx).toBeGreaterThanOrEqual(0);
+      expect(anotherIdx).toBeLessThan(sampleIdx);
+      expect(result.stdout).toContain(expectedStamp(base + 300));
+    });
+  });
+
   describe('error handling', () => {
     it('should error on unknown type', async () => {
       const result = await runCLI(['list', '--type', 'nonexistent'], vaultDir);

--- a/tests/ts/lib/list-helpers.test.ts
+++ b/tests/ts/lib/list-helpers.test.ts
@@ -7,6 +7,10 @@ import {
   compareSortValues,
   createFileComparator,
   isFileSortKey,
+  isFileStatField,
+  formatFileTimestamp,
+  formatFileStatDisplay,
+  fileStatJsonValue,
   type FileStatMap,
   extractNoteName,
   buildParentMapFromFiles,
@@ -78,6 +82,55 @@ describe('list-helpers: sort/comparison', () => {
       expect(isFileSortKey('file.name')).toBe(false);
       expect(isFileSortKey('name')).toBe(false);
       expect(isFileSortKey('priority')).toBe(false);
+    });
+  });
+
+  describe('isFileStatField', () => {
+    it('recognizes the same stat-backed file.* keys as --fields columns', () => {
+      expect(isFileStatField('file.mtime')).toBe(true);
+      expect(isFileStatField('file.ctime')).toBe(true);
+      expect(isFileStatField('file.size')).toBe(true);
+    });
+
+    it('rejects frontmatter and reserved keys', () => {
+      expect(isFileStatField('file.name')).toBe(false);
+      expect(isFileStatField('status')).toBe(false);
+      expect(isFileStatField('_path')).toBe(false);
+    });
+  });
+
+  describe('file.* display + json formatting (#689)', () => {
+    const stat = { mtimeMs: 1_700_000_000_000, ctimeMs: 1_690_000_000_000, size: 4096 };
+
+    function localStamp(ms: number): string {
+      const d = new Date(ms);
+      const pad = (n: number): string => String(n).padStart(2, '0');
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    }
+
+    it('formatFileTimestamp renders local YYYY-MM-DD HH:MM', () => {
+      expect(formatFileTimestamp(stat.mtimeMs)).toBe(localStamp(stat.mtimeMs));
+    });
+
+    it('formatFileStatDisplay renders times as stamps and size as bytes', () => {
+      expect(formatFileStatDisplay('file.mtime', stat)).toBe(localStamp(stat.mtimeMs));
+      expect(formatFileStatDisplay('file.ctime', stat)).toBe(localStamp(stat.ctimeMs));
+      expect(formatFileStatDisplay('file.size', stat)).toBe('4096');
+    });
+
+    it('formatFileStatDisplay returns undefined for a missing stat', () => {
+      expect(formatFileStatDisplay('file.mtime', undefined)).toBeUndefined();
+    });
+
+    it('fileStatJsonValue renders times as ISO strings and size as a number', () => {
+      expect(fileStatJsonValue('file.mtime', stat)).toBe(new Date(stat.mtimeMs).toISOString());
+      expect(fileStatJsonValue('file.ctime', stat)).toBe(new Date(stat.ctimeMs).toISOString());
+      expect(fileStatJsonValue('file.size', stat)).toBe(4096);
+      expect(typeof fileStatJsonValue('file.size', stat)).toBe('number');
+    });
+
+    it('fileStatJsonValue returns undefined for a missing stat', () => {
+      expect(fileStatJsonValue('file.size', undefined)).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

`bwrb list --fields file.mtime` rendered an EMPTY column. From #655, `file.mtime`/`file.ctime`/`file.size` became valid `--sort` keys, and `--fields` validation already `continue`d past them (accepting them) — but `printTable` only read frontmatter, so those columns came out blank.

This wires `--fields file.*` to **render** the stat value (preferring rendering over rejecting, since the data is available and useful).

## What changed

- **Stat-map collection**: the `FileStatMap` is now collected whenever a `file.*` key is requested for **sorting OR display** (previously only when sorting), and threaded into both the text table and JSON renderers.
- **Text table**: `file.mtime`/`file.ctime` render as local `YYYY-MM-DD HH:MM` (shared with `recent`'s MODIFIED column via a new `formatFileTimestamp` helper); `file.size` renders as a byte count.
- **`--output json`**: `file.mtime`/`file.ctime` render as ISO-8601 strings (matching `recent`'s `_modified` convention); `file.size` as a number.
- **Reuse, no fork**: `recent` now imports `formatFileTimestamp` instead of carrying its own copy.

Ordinary frontmatter `--fields`, `--sort`, and non-file columns are unaffected.

## Tests

- New regression test that **fails on `main`** (column rendered `—`) and passes here.
- CLI coverage: `--fields file.mtime,file.size,<frontmatter>` populated in text + JSON; mixing with frontmatter fields; rendering without `--sort`; `--sort file.*` still works alongside the field.
- Unit coverage for `isFileStatField`, `formatFileTimestamp`, `formatFileStatDisplay`, `fileStatJsonValue`.

## Gate

- `pnpm qa` green (2590 passed, 4 skipped).
- `pnpm knip` green.
- `pnpm docs:build` green; `list` reference updated to document `file.*` in `--fields` + display format.

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)