### PR TITLE
fix(template): multi-select fields get multi-value defaults (#668)

### DIFF
--- a/docs-site/src/content/docs/templates/creating-templates.md
+++ b/docs-site/src/content/docs/templates/creating-templates.md
@@ -68,9 +68,12 @@ defaults:
 ```
 
 When you build or edit a template interactively (`bwrb template new` /
-`bwrb template edit`), these fields use a checkbox-style multi-select prompt so
-you can choose several values at once. In `template edit`, a multi-select
-default offers `(keep)`, `(clear)`, `(set empty [])`, and `(select values)`.
+`bwrb template edit`), multi-select fields use a checkbox-style multi-select
+prompt in both modes, so you can choose several values at once. Multi-relation
+fields offer the same checkbox multi-select in `bwrb template edit`, but in
+`bwrb template new` they currently set a single relation default. In `template
+edit`, a multi-select default offers `(keep)`, `(clear)`, `(set empty [])`, and
+`(select values)`.
 
 ### Dynamic Defaults (Date Expressions)
 

--- a/docs-site/src/content/docs/templates/creating-templates.md
+++ b/docs-site/src/content/docs/templates/creating-templates.md
@@ -56,6 +56,22 @@ defaults:
   tags: []
 ```
 
+Fields declared with `multiple: true` (multi-select and multi-relation fields)
+store their defaults as an **array**, so a template can pre-fill more than one
+value:
+
+```yaml
+defaults:
+  labels:
+    - urgent
+    - review
+```
+
+When you build or edit a template interactively (`bwrb template new` /
+`bwrb template edit`), these fields use a checkbox-style multi-select prompt so
+you can choose several values at once. In `template edit`, a multi-select
+default offers `(keep)`, `(clear)`, `(set empty [])`, and `(select values)`.
+
 ### Dynamic Defaults (Date Expressions)
 
 Use date expressions for dynamic values that evaluate at note creation time. A

--- a/src/lib/field-prompt.ts
+++ b/src/lib/field-prompt.ts
@@ -185,11 +185,11 @@ async function promptSelectField(
 
   const selectOptions = getOptionValues(field.options);
 
-  // create mode supports multi-select.
-  if (opts.mode === 'create' && field.multiple) {
-    const selected = await promptMultiSelect(`Select ${fieldName}:`, selectOptions);
-    if (selected === null) throw new UserCancelledError();
-    return selected.length > 0 ? selected : (field.default ?? []);
+  // Multi-select fields use a checkbox-style multiselect across every mode so a
+  // template default can store more than one value (mirrors the
+  // multiple-relation template-edit flow).
+  if (field.multiple) {
+    return promptMultiSelectField(label, fieldName, selectOptions, field, opts);
   }
 
   const { options, hints, skipLabel } = buildSelectOptions(field, selectOptions, opts);
@@ -207,6 +207,52 @@ async function promptSelectField(
   // template-edit
   if (selected === '(keep)') return opts.currentValue;
   if (selected === '(clear)') return CLEAR;
+  return selected;
+}
+
+/**
+ * Prompt for a `multiple: true` select field, storing the chosen values as an
+ * array. Shared across all modes (mirrors the multiple-relation flow):
+ *
+ * - `create`: a checkbox multiselect; falls back to `field.default` (or `[]`)
+ *   when nothing is picked.
+ * - `template-default`: a checkbox multiselect; an empty selection skips
+ *   (returns `undefined`, so no default is stored).
+ * - `template-edit`: a `(keep)` / `(clear)` / `(set empty [])` / `(select
+ *   values)` action menu, where `(select values)` opens the checkbox multiselect.
+ */
+async function promptMultiSelectField(
+  label: string,
+  fieldName: string,
+  selectOptions: string[],
+  field: Field,
+  opts: FieldPromptOptions
+): Promise<unknown> {
+  if (opts.mode === 'create') {
+    const selected = await promptMultiSelect(`Select ${fieldName}:`, selectOptions);
+    if (selected === null) throw new UserCancelledError();
+    return selected.length > 0 ? selected : (field.default ?? []);
+  }
+
+  if (opts.mode === 'template-default') {
+    const selected = await promptMultiSelect(`Default ${label}:`, selectOptions);
+    if (selected === null) throw new UserCancelledError();
+    return selected.length > 0 ? selected : undefined;
+  }
+
+  // template-edit
+  const actionOptions = ['(keep)', '(clear)', '(set empty [])'];
+  if (selectOptions.length > 0) {
+    actionOptions.push('(select values)');
+  }
+  const action = await promptSelection(`How to update ${label}:`, actionOptions);
+  if (action === null) throw new UserCancelledError();
+  if (action === '(keep)') return opts.currentValue;
+  if (action === '(clear)') return CLEAR;
+  if (action === '(set empty [])') return [];
+
+  const selected = await promptMultiSelect(`Select ${label}:`, selectOptions);
+  if (selected === null) throw new UserCancelledError();
   return selected;
 }
 

--- a/tests/ts/commands/new.test.ts
+++ b/tests/ts/commands/new.test.ts
@@ -151,6 +151,40 @@ describe('new command', () => {
       expect(registryIds.has(id)).toBe(true);
     });
 
+    it('should apply a multi-value select default (array) from a template', async () => {
+      // idea.labels is a multiple: true select field.
+      await writeFile(
+        join(vaultDir, '.bwrb', 'templates', 'idea', 'multi-labels.md'),
+        `---
+type: template
+template-for: idea
+description: Multi-value labels default
+defaults:
+  labels:
+    - urgent
+    - review
+---
+
+# {title}
+`
+      );
+
+      const result = await runCLI(
+        ['new', 'idea', '--json', '{"name": "Multi label note"}', '--template', 'multi-labels'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(ExitCodes.SUCCESS);
+      const output = JSON.parse(result.stdout);
+      expect(output.success).toBe(true);
+
+      const content = await readFile(join(vaultDir, output.path), 'utf-8');
+      const fm = content.split('---')[1] ?? '';
+      expect(fm).toContain('labels:');
+      expect(fm).toContain('- urgent');
+      expect(fm).toContain('- review');
+    });
+
     it('should reject unknown JSON frontmatter fields', async () => {
       const result = await runCLI(
         ['new', 'task', '--json', '{"name":"Extra Field","status":"backlog","totally-extra":"yep"}'],

--- a/tests/ts/commands/template.pty.test.ts
+++ b/tests/ts/commands/template.pty.test.ts
@@ -48,6 +48,22 @@ defaults:
 `,
 };
 
+const MULTI_LABELS_IDEA_TEMPLATE: TempVaultFile = {
+  path: '.bwrb/templates/idea/multi-labels.md',
+  content: `---
+type: template
+template-for: idea
+description: Idea template with multi-select labels default
+defaults:
+  labels:
+    - urgent
+    - review
+---
+
+# {title}
+`,
+};
+
 const RELATION_MULTIPLE_SCHEMA = {
   version: 2,
   config: {
@@ -221,6 +237,102 @@ describePty('template command PTY tests', () => {
           const content = await readFile(templatePath, 'utf-8');
           expect(content).toContain('defaults:');
           expect(content).toContain('status:');
+        },
+        { schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should store multiple values for a multi-select default (issue #668)', async () => {
+      await withTempVault(
+        ['template', 'new', 'idea'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Template name', 10000);
+          await proc.typeAndEnter('multi-labels');
+
+          await proc.waitFor('Description', 5000);
+          await proc.typeAndEnter('Multi-select labels default');
+
+          await proc.waitFor('Set default values', 5000);
+          proc.write('y');
+
+          // status (select) - skip
+          await proc.waitFor('status', 5000);
+          proc.write('1');
+          // priority (select) - skip
+          await proc.waitFor('priority', 5000);
+          proc.write('1');
+
+          // labels (multi-select) - pick the first two options
+          await proc.waitFor('Default labels', 5000);
+          await proc.waitForStable(150, 2000);
+          proc.write(' ');      // select urgent
+          proc.write('\x1b[B'); // down to blocked
+          proc.write(' ');      // select blocked
+          proc.write('\r');     // submit
+
+          // effort (number) - skip
+          await proc.waitFor('Default effort', 5000);
+          proc.write('\r');
+          // archived (boolean) - skip
+          await proc.waitFor('Default archived', 5000);
+          await proc.waitForStable(150, 2000);
+          proc.write('1');
+
+          await proc.waitFor('Force prompting', 5000);
+          proc.write('n');
+          await proc.waitFor('Custom filename', 5000);
+          proc.write('n');
+          await proc.waitFor('Created:', 10000);
+
+          const templatePath = join(vaultPath, '.bwrb/templates/idea', 'multi-labels.md');
+          const content = await readFile(templatePath, 'utf-8');
+          const frontmatter = parseFrontmatter(content);
+          const defaults = frontmatter.defaults as Record<string, unknown>;
+          // Stored as an array with both chosen values, not a single string.
+          expect(defaults.labels).toEqual(['urgent', 'blocked']);
+        },
+        { schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should omit a multi-select default when nothing is picked (issue #668)', async () => {
+      await withTempVault(
+        ['template', 'new', 'idea'],
+        async (proc, vaultPath) => {
+          await proc.waitFor('Template name', 10000);
+          await proc.typeAndEnter('no-labels');
+
+          await proc.waitFor('Description', 5000);
+          await proc.typeAndEnter('No labels default');
+
+          await proc.waitFor('Set default values', 5000);
+          proc.write('y');
+
+          await proc.waitFor('status', 5000);
+          proc.write('1');
+          await proc.waitFor('priority', 5000);
+          proc.write('1');
+
+          // labels (multi-select) - submit with no selection -> skipped
+          await proc.waitFor('Default labels', 5000);
+          await proc.waitForStable(150, 2000);
+          proc.write('\r');
+
+          await proc.waitFor('Default effort', 5000);
+          proc.write('\r');
+          await proc.waitFor('Default archived', 5000);
+          await proc.waitForStable(150, 2000);
+          proc.write('1');
+
+          await proc.waitFor('Custom filename', 5000);
+          proc.write('n');
+          await proc.waitFor('Created:', 10000);
+
+          const templatePath = join(vaultPath, '.bwrb/templates/idea', 'no-labels.md');
+          const content = await readFile(templatePath, 'utf-8');
+          const frontmatter = parseFrontmatter(content);
+          const defaults = (frontmatter.defaults as Record<string, unknown>) ?? {};
+          expect(defaults.labels).toBeUndefined();
         },
         { schema: TEST_SCHEMA }
       );
@@ -508,8 +620,8 @@ describePty('template command PTY tests', () => {
           // priority (select) - keep
           await proc.waitFor('New priority', 5000);
           proc.write('1'); // (keep)
-          // labels (multi relation? select multiple) - keep
-          await proc.waitFor('New labels', 5000);
+          // labels (multi-select) - keep
+          await proc.waitFor('How to update labels', 5000);
           proc.write('1'); // (keep)
 
           // effort (number) - Enter keeps current
@@ -555,7 +667,7 @@ describePty('template command PTY tests', () => {
           proc.write('1'); // keep
           await proc.waitFor('New priority', 5000);
           proc.write('1'); // keep
-          await proc.waitFor('New labels', 5000);
+          await proc.waitFor('How to update labels', 5000);
           proc.write('1'); // keep
 
           // effort (number) - change to a real number (invalid first, then valid)
@@ -603,7 +715,7 @@ describePty('template command PTY tests', () => {
           proc.write('1');
           await proc.waitFor('New priority', 5000);
           proc.write('1');
-          await proc.waitFor('New labels', 5000);
+          await proc.waitFor('How to update labels', 5000);
           proc.write('1');
 
           await proc.waitFor('New effort', 5000);
@@ -629,6 +741,147 @@ describePty('template command PTY tests', () => {
           expect(defaults.effort).toBe(3);
         },
         { files: [TYPED_DEFAULTS_IDEA_TEMPLATE], schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should keep an existing multi-select default via (keep) (issue #668)', async () => {
+      await withTempVault(
+        ['template', 'edit', 'idea', 'multi-labels'],
+        async (proc, vaultPath) => {
+          const templatePath = join(vaultPath, '.bwrb/templates/idea/multi-labels.md');
+
+          await proc.waitFor('Current description:', 10000);
+          proc.write('\r');
+
+          await proc.waitFor('Edit default values', 5000);
+          proc.write('y');
+
+          await proc.waitFor('New status', 5000);
+          proc.write('1'); // keep
+          await proc.waitFor('New priority', 5000);
+          proc.write('1'); // keep
+
+          // labels (multi-select) - keep the current array
+          await proc.waitFor('How to update labels', 5000);
+          proc.write('1'); // (keep)
+
+          await proc.waitFor('New effort', 5000);
+          proc.write('\r');
+          await proc.waitFor('New archived', 5000);
+          await proc.waitForStable(150, 2000);
+          proc.write('1');
+
+          await proc.waitFor('Edit prompt-fields', 5000);
+          proc.write('n');
+          await proc.waitFor('Edit filename pattern', 5000);
+          proc.write('n');
+          await proc.waitFor('Edit body', 5000);
+          proc.write('n');
+          await proc.waitFor('Updated:', 5000);
+
+          const content = await readFile(templatePath, 'utf-8');
+          const frontmatter = parseFrontmatter(content);
+          const defaults = frontmatter.defaults as Record<string, unknown>;
+          expect(defaults.labels).toEqual(['urgent', 'review']);
+        },
+        { files: [MULTI_LABELS_IDEA_TEMPLATE], schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should clear a multi-select default via (clear) (issue #668)', async () => {
+      await withTempVault(
+        ['template', 'edit', 'idea', 'multi-labels'],
+        async (proc, vaultPath) => {
+          const templatePath = join(vaultPath, '.bwrb/templates/idea/multi-labels.md');
+
+          await proc.waitFor('Current description:', 10000);
+          proc.write('\r');
+
+          await proc.waitFor('Edit default values', 5000);
+          proc.write('y');
+
+          await proc.waitFor('New status', 5000);
+          proc.write('1');
+          await proc.waitFor('New priority', 5000);
+          proc.write('1');
+
+          // labels - clear removes the default entirely
+          await proc.waitFor('How to update labels', 5000);
+          proc.write('2'); // (clear)
+
+          await proc.waitFor('New effort', 5000);
+          proc.write('\r');
+          await proc.waitFor('New archived', 5000);
+          await proc.waitForStable(150, 2000);
+          proc.write('1');
+
+          await proc.waitFor('Edit prompt-fields', 5000);
+          proc.write('n');
+          await proc.waitFor('Edit filename pattern', 5000);
+          proc.write('n');
+          await proc.waitFor('Edit body', 5000);
+          proc.write('n');
+          await proc.waitFor('Updated:', 5000);
+
+          const content = await readFile(templatePath, 'utf-8');
+          const frontmatter = parseFrontmatter(content);
+          const defaults = (frontmatter.defaults as Record<string, unknown>) ?? {};
+          expect(defaults.labels).toBeUndefined();
+        },
+        { files: [MULTI_LABELS_IDEA_TEMPLATE], schema: TEST_SCHEMA }
+      );
+    }, 30000);
+
+    it('should change a multi-select default via (select values) (issue #668)', async () => {
+      await withTempVault(
+        ['template', 'edit', 'idea', 'multi-labels'],
+        async (proc, vaultPath) => {
+          const templatePath = join(vaultPath, '.bwrb/templates/idea/multi-labels.md');
+
+          await proc.waitFor('Current description:', 10000);
+          proc.write('\r');
+
+          await proc.waitFor('Edit default values', 5000);
+          proc.write('y');
+
+          await proc.waitFor('New status', 5000);
+          proc.write('1');
+          await proc.waitFor('New priority', 5000);
+          proc.write('1');
+
+          // labels - pick a fresh multi-value selection
+          await proc.waitFor('How to update labels', 5000);
+          proc.write('4'); // (select values)
+
+          await proc.waitFor('Select labels', 5000);
+          await proc.waitForStable(150, 2000);
+          proc.write('\x1b[B'); // down to blocked (options: urgent, blocked, review, wip)
+          proc.write(' ');      // select blocked
+          proc.write('\x1b[B'); // down to review
+          proc.write('\x1b[B'); // down to wip
+          proc.write(' ');      // select wip
+          proc.write('\r');     // submit
+
+          await proc.waitFor('New effort', 5000);
+          proc.write('\r');
+          await proc.waitFor('New archived', 5000);
+          await proc.waitForStable(150, 2000);
+          proc.write('1');
+
+          await proc.waitFor('Edit prompt-fields', 5000);
+          proc.write('n');
+          await proc.waitFor('Edit filename pattern', 5000);
+          proc.write('n');
+          await proc.waitFor('Edit body', 5000);
+          proc.write('n');
+          await proc.waitFor('Updated:', 5000);
+
+          const content = await readFile(templatePath, 'utf-8');
+          const frontmatter = parseFrontmatter(content);
+          const defaults = frontmatter.defaults as Record<string, unknown>;
+          expect(defaults.labels).toEqual(['blocked', 'wip']);
+        },
+        { files: [MULTI_LABELS_IDEA_TEMPLATE], schema: TEST_SCHEMA }
       );
     }, 30000);
 


### PR DESCRIPTION
## Summary

A `multiple: true` SELECT field (e.g. `labels`) was prompted as a **single-select** (`(skip)` + values) in the `template new` (template-default) and `template edit` flows, so a template could only store **one** value as the default for a multi-select field. The `field.multiple` multiselect branch only fired in CREATE mode.

This wires multi-select SELECT fields through a checkbox-style multiselect in **every** mode, mirroring the multiple-RELATION template-edit flow from #596.

## Behavior

- **template-default** (`template new`): checkbox multiselect (`Default <label>:`). Pick several values; an empty selection **skips** (returns `undefined`, no default stored).
- **template-edit** (`template edit`): a `How to update <label>:` action menu with `(keep)` / `(clear)` / `(set empty [])` / `(select values)`. `(select values)` opens the checkbox multiselect. Values are stored as an **array**.
- A note created from such a template (e.g. via `--template`) picks up the multi-value array default.

Unchanged: single-select fields, create mode, and boolean/number (#648) template defaults.

## Tests

- Unit: existing `buildSelectOptions` coverage intact.
- New `new.test.ts` (JSON mode): a multi-value `labels` array default applies to a created note.
- New `template.pty.test.ts`: `template new` picks multiple labels (array stored) and omits when none picked; `template edit` keep / clear / `(select values)` for a multi-select default.
- Updated existing template-edit PTY tests that previously expected `New labels` (single-select) to expect `How to update labels`.

## Gate

`pnpm qa` and `pnpm knip` green; `pnpm docs:build` clean.

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)