### PR TITLE
fix(edit): recurse nested body sections so add-sections agrees with audit

### DIFF
--- a/src/lib/audit/body-sections.ts
+++ b/src/lib/audit/body-sections.ts
@@ -91,20 +91,33 @@ function findHeadingLine(maskedBody: string, title: string): number | undefined 
   return undefined;
 }
 
+/** One declared heading, flattened out of the `body_sections` tree. */
+export interface FlatBodySection {
+  /** The declared section (carries `content_type` for the scaffold). */
+  section: BodySection;
+  title: string;
+  level: number;
+}
+
 /**
- * Recursively collect every declared section as a flat list of (section, level)
- * entries. A child's level defaults to one deeper than its declared value via
- * the schema's own `level` field (children carry their own `level`), so we read
- * each section's `level` directly (default 2) rather than inferring depth.
+ * Recursively collect every declared section (top-level AND nested children) as
+ * a flat, tree-order list of {@link FlatBodySection} entries. A child's level
+ * defaults to one deeper than its declared value via the schema's own `level`
+ * field (children carry their own `level`), so we read each section's `level`
+ * directly (default 2) rather than inferring depth.
+ *
+ * Shared tree-walk: the audit `missing-body-section` detector AND `bwrb edit`'s
+ * add-missing-sections flow both iterate this so they can't drift in which
+ * declared headings they consider (#697).
  */
-function flattenSections(
+export function flattenBodySections(
   sections: BodySection[],
-  out: Array<{ title: string; level: number }> = []
-): Array<{ title: string; level: number }> {
+  out: FlatBodySection[] = []
+): FlatBodySection[] {
   for (const section of sections) {
-    out.push({ title: section.title, level: section.level ?? 2 });
+    out.push({ section, title: section.title, level: section.level ?? 2 });
     if (section.children && section.children.length > 0) {
-      flattenSections(section.children, out);
+      flattenBodySections(section.children, out);
     }
   }
   return out;
@@ -133,7 +146,7 @@ export function detectMissingBodySections(
   // line number at masked content).
   const masked = maskNonProse(body);
 
-  for (const { title, level } of flattenSections(bodySections)) {
+  for (const { title, level } of flattenBodySections(bodySections)) {
     if (headingPresentInMasked(masked, level, title)) continue;
 
     const wrongLevelLine = findHeadingLine(masked, title);

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -13,7 +13,11 @@ import {
   getFrontmatterOrder,
 } from './schema.js';
 import { parseNote, writeNote, generateBodySections } from './frontmatter.js';
-import { isBodySectionPresent } from './audit/body-sections.js';
+import {
+  isBodySectionPresent,
+  flattenBodySections,
+  type FlatBodySection,
+} from './audit/body-sections.js';
 import { queryByType, formatValue } from './vault.js';
 import {
   promptSelection,
@@ -528,8 +532,49 @@ function formatCurrentValue(value: unknown): string {
 }
 
 /**
+ * Collect the declared body-section headings missing from `body`, in tree order.
+ *
+ * Recurses the FULL `body_sections` tree (top-level AND nested children) via the
+ * shared {@link flattenBodySections} tree-walk that the audit
+ * `missing-body-section` detector uses, so `edit`'s candidate set agrees with
+ * audit's missing-section set (#697). A declared child heading whose parent is
+ * already present is still reported (at its own declared level) — previously
+ * such a child was skipped because `edit` only iterated top-level sections and
+ * emitted children solely via the parent's scaffold. Presence is checked with
+ * the shared {@link isBodySectionPresent} helper (#653), so present headings
+ * (incl. trailing-ws / ATX-closing-`##` / code-fenced-not-counted) are not
+ * reported.
+ */
+export function collectMissingBodySections(
+  body: string,
+  sections: BodySection[]
+): FlatBodySection[] {
+  return flattenBodySections(sections).filter(
+    ({ title, level }) => !isBodySectionPresent(body, level, title)
+  );
+}
+
+/**
+ * Append a single declared heading's scaffold to `body`, WITHOUT its children
+ * (children are appended on their own turn in the tree-walk). Mirrors the audit
+ * auto-fix (`applyBodySectionFix`) spacing/placement so `edit` and `audit`
+ * produce consistent output, and so re-running adds nothing (idempotent — the
+ * caller re-checks presence against the growing body before each append).
+ */
+export function appendBodySection(body: string, section: BodySection): string {
+  const sectionScaffold = generateBodySections([{ ...section, children: undefined }]);
+  const existing = body.replace(/\s*$/, '');
+  return existing.length > 0 ? `${existing}\n\n${sectionScaffold}` : sectionScaffold;
+}
+
+/**
  * Check for missing sections and offer to add them.
  * Throws UserCancelledError if user cancels any prompt.
+ *
+ * Iterates the shared tree-walk so it agrees with audit (#697); for each missing
+ * heading it prompts, then appends just that heading. The presence re-check runs
+ * against the growing `updatedBody`, so a heading is never duplicated within a
+ * single run.
  */
 async function addMissingSections(
   body: string,
@@ -537,19 +582,16 @@ async function addMissingSections(
 ): Promise<string> {
   let updatedBody = body;
 
-  for (const section of sections) {
-    const level = section.level ?? 2;
+  for (const { section, title, level } of flattenBodySections(sections)) {
+    if (isBodySectionPresent(updatedBody, level, title)) continue;
 
-    if (!isBodySectionPresent(body, level, section.title)) {
-      printWarning(`Missing section: ${section.title}`);
-      const addIt = await promptConfirm('Add it?');
-      if (addIt === null) {
-        throw new UserCancelledError();
-      }
-      if (addIt) {
-        const newSection = generateBodySections([section]);
-        updatedBody += '\n' + newSection;
-      }
+    printWarning(`Missing section: ${title}`);
+    const addIt = await promptConfirm('Add it?');
+    if (addIt === null) {
+      throw new UserCancelledError();
+    }
+    if (addIt) {
+      updatedBody = appendBodySection(updatedBody, section);
     }
   }
 

--- a/tests/ts/lib/edit-add-sections.test.ts
+++ b/tests/ts/lib/edit-add-sections.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for `bwrb edit`'s add-missing-sections tree-walk (#697).
+ *
+ * `edit`'s add-sections flow must recurse the full `body_sections` tree (like
+ * the audit `missing-body-section` detector) so a declared nested CHILD heading
+ * is added even when its PARENT heading already exists. These tests pin the pure
+ * helpers (`collectMissingBodySections` / `appendBodySection`) that the
+ * interactive flow is built on, plus the edit<->audit agreement guarantee.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  collectMissingBodySections,
+  appendBodySection,
+} from '../../../src/lib/edit.js';
+import { detectMissingBodySections } from '../../../src/lib/audit/body-sections.js';
+import type { BodySection } from '../../../src/types/schema.js';
+
+const NESTED: BodySection[] = [
+  {
+    title: 'Plan',
+    level: 2,
+    content_type: 'paragraphs',
+    children: [
+      { title: 'Risks', level: 3, content_type: 'bullets' },
+      { title: 'Mitigations', level: 3, content_type: 'bullets' },
+    ],
+  },
+  { title: 'Notes', level: 2, content_type: 'paragraphs' },
+];
+
+/** Apply every still-missing section to the body, mirroring the interactive
+ * loop's "yes to all" path (re-checking against the growing body). */
+function addAll(body: string, sections: BodySection[]): string {
+  let out = body;
+  for (const { section } of collectMissingBodySections(out, sections)) {
+    out = appendBodySection(out, section);
+  }
+  return out;
+}
+
+describe('edit add-sections: collectMissingBodySections', () => {
+  it('adds a missing nested CHILD when its parent is already present (#697)', () => {
+    // Parent "## Plan" is present; declared children are missing.
+    const body = '## Plan\n\nThe plan.\n\n## Notes\n\nstuff\n';
+    const missing = collectMissingBodySections(body, NESTED);
+    expect(missing.map((m) => m.title)).toEqual(['Risks', 'Mitigations']);
+    expect(missing.map((m) => m.level)).toEqual([3, 3]);
+  });
+
+  it('adds nothing for a fully-present note (idempotent candidate set)', () => {
+    const body =
+      '## Plan\n\nThe plan.\n\n### Risks\n\n- \n\n### Mitigations\n\n- \n\n## Notes\n\nstuff\n';
+    expect(collectMissingBodySections(body, NESTED)).toHaveLength(0);
+  });
+
+  it('still reports missing TOP-LEVEL sections (behavior unchanged)', () => {
+    const body = '## Plan\n\nThe plan.\n\n### Risks\n\n- \n\n### Mitigations\n\n- \n';
+    expect(collectMissingBodySections(body, NESTED).map((m) => m.title)).toEqual(['Notes']);
+  });
+
+  it('does not re-report present headings with trailing ws / closing hashes', () => {
+    const body =
+      '## Plan  \n\n### Risks ##\n\n### Mitigations ###  \n\n## Notes\t\n';
+    expect(collectMissingBodySections(body, NESTED)).toHaveLength(0);
+  });
+
+  it('treats a code-fenced heading as missing', () => {
+    const body = '## Plan\n\n```\n### Risks\n```\n\n### Mitigations\n\n- \n\n## Notes\n\nx\n';
+    expect(collectMissingBodySections(body, NESTED).map((m) => m.title)).toEqual(['Risks']);
+  });
+});
+
+describe('edit add-sections: appendBodySection', () => {
+  it('appends a child heading at its declared level without children', () => {
+    const body = '## Plan\n\nThe plan.\n';
+    const child = NESTED[0]!.children![0]!; // Risks, level 3
+    const out = appendBodySection(body, child);
+    expect(out).toContain('### Risks');
+    expect(out).not.toContain('### Mitigations'); // siblings not pulled in
+    // Existing content preserved.
+    expect(out).toContain('## Plan');
+    expect(out).toContain('The plan.');
+  });
+
+  it('is idempotent end-to-end: re-running adds nothing and never duplicates', () => {
+    const start = '## Plan\n\nThe plan.\n\n## Notes\n\nstuff\n';
+    const once = addAll(start, NESTED);
+    expect(once).toContain('### Risks');
+    expect(once).toContain('### Mitigations');
+    const twice = addAll(once, NESTED);
+    expect(twice).toBe(once);
+    expect(twice.match(/### Risks/g)).toHaveLength(1);
+    expect(twice.match(/### Mitigations/g)).toHaveLength(1);
+  });
+});
+
+describe('edit add-sections <-> audit agreement (#697)', () => {
+  const cases: Array<{ name: string; body: string; sections: BodySection[] }> = [
+    { name: 'present parent, missing children', body: '## Plan\n\nx\n\n## Notes\n\ny\n', sections: NESTED },
+    { name: 'empty body', body: '', sections: NESTED },
+    { name: 'fully present', body: '## Plan\n\n### Risks\n\n### Mitigations\n\n## Notes\n', sections: NESTED },
+    { name: 'code-fenced heading', body: '## Plan\n\n```\n### Risks\n```\n\n## Notes\n', sections: NESTED },
+  ];
+
+  for (const { name, body, sections } of cases) {
+    it(`edit's missing set == audit's missing set: ${name}`, () => {
+      const editTitles = collectMissingBodySections(body, sections).map((m) => m.title).sort();
+      const auditTitles = detectMissingBodySections(body, sections)
+        .map((i) => i.meta?.['title'] as string)
+        .sort();
+      expect(editTitles).toEqual(auditTitles);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

`bwrb edit`'s add-missing-sections only iterated TOP-LEVEL `body_sections` and emitted children via `generateBodySections` solely when their parent was being added. So a declared nested CHILD heading whose parent already existed was never added — while `bwrb audit`'s `missing-body-section` detector (which flattens/recurses sections, #510) flagged it. The two disagreed.

This makes `edit` recurse the full `body_sections` tree like audit, so their missing/added sets match.

## What changed

- Extracted the audit detector's recursion as a shared, exported `flattenBodySections` tree-walk in `src/lib/audit/body-sections.ts`. Both the audit `missing-body-section` detector and `edit`'s add-sections now iterate it, so they can't drift in which declared headings they consider.
- `edit` now appends each missing heading individually (without children — children get their own turn in the walk) using the canonical `generateBodySections` scaffold and the same `\n\n` spacing/placement as the audit auto-fix (`applyBodySectionFix`).
- Presence is re-checked via the shared `isBodySectionPresent` helper (#653) against the *growing* body, so present headings (trailing-ws / `## x ##` / code-fenced-not-counted) are never duplicated and re-running adds nothing (idempotent).
- A missing child under a PRESENT parent is now added at its own declared level; top-level-missing behavior is unchanged.

For the same note + schema, `edit`'s added-section set now equals audit's `missing-body-section` set.

## Tests

New `tests/ts/lib/edit-add-sections.test.ts` pins:
- present parent + missing nested child → child added at correct level (#697);
- fully-present note → nothing added (idempotent, including end-to-end re-run no-duplicate);
- top-level missing still added;
- present-with-trailing-ws / closing-hashes not re-reported;
- code-fenced heading treated as missing;
- `edit` ↔ audit agreement across several note shapes (same note → same missing set).

Existing edit + audit body-section tests pass.

## Gate

- `pnpm qa` ✅ (typecheck, lint, docs:lint, docs:doctor, build, 2607 tests pass / 4 skipped)
- `pnpm knip` ✅

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)