### PR TITLE
docs(migrations): clarify diff does not auto-detect field renames

### DIFF
--- a/docs-site/src/content/docs/concepts/migrations.md
+++ b/docs-site/src/content/docs/concepts/migrations.md
@@ -9,7 +9,6 @@ Schemas evolve. Bowerbird provides tools to migrate your notes when your schema 
 
 When you modify your schema, existing notes may become inconsistent:
 
-- **Rename a field** — Old notes still use the old name
 - **Remove a select option** — Notes may reference invalid values
 - **Rename a type** — Notes live in the wrong directory
 - **Remove a field** — Old notes have orphaned data
@@ -144,10 +143,30 @@ These require confirmation because they affect existing data:
 | Change | What Happens |
 |--------|--------------|
 | Remove field | Field is removed from affected notes |
-| Rename field | Field name is updated in affected notes |
 | Remove select option | Affected notes flagged for review |
 | Rename type | Notes are moved to the new directory |
 | Remove type | Existing notes become orphaned (warning) |
+
+:::caution[Field renames are not auto-detected]
+The schema diff engine compares two schema snapshots and has no way to tell an
+intentional rename apart from an unrelated drop-and-add. Renaming a field in
+`.bwrb/schema.json` always surfaces as a separate **add field** + **remove
+field** pair — and removing a field **deletes the old field's data** from
+affected notes.
+
+The `old → new: value` per-note rename preview only appears for an explicit
+`rename-field` operation, which the diff-driven `bwrb schema migrate` workflow
+never produces.
+
+To rename a field while preserving its values, use the bulk command, which
+moves the data in one step:
+
+```bash
+bwrb bulk --all --rename old=new --execute
+```
+
+See [Bulk Operations](/reference/commands/bulk/) for details.
+:::
 
 ## Version Suggestion
 

--- a/docs/product/migrations.md
+++ b/docs/product/migrations.md
@@ -86,7 +86,9 @@ the schema-level summary always prints in full. The flag also applies to
 > bwrb bulk --all --rename owner=assignee --execute
 > ```
 >
-> See [issue #694](https://github.com/3mdistal/bwrb/issues/694) for background.
+> Canonical user-facing behavior lives in the docs-site
+> [Migrations](../../docs-site/src/content/docs/concepts/migrations.md) page; see
+> [issue #694](https://github.com/3mdistal/bwrb/issues/694) for background.
 
 In `--output json` mode the per-note changes are **always** included under
 `data.fileChanges` (an array of `{ relativePath, changes[] }`), uncapped, for

--- a/docs/product/migrations.md
+++ b/docs/product/migrations.md
@@ -65,7 +65,7 @@ concrete per-note before→after edits, e.g.:
 Per-note changes:
   Objectives/Tasks/Task A.md:
     priority: (empty) → medium
-    owner → assignee: alice
+    owner: (deleted)
 ```
 
 Null/missing values render as `(empty)` (consistent with the bulk change
@@ -73,6 +73,20 @@ preview). To keep output manageable on large vaults, the per-note list is
 capped (currently 200 lines) with a trailing `... and N more changes` summary;
 the schema-level summary always prints in full. The flag also applies to
 `--execute` to echo what was applied.
+
+> **Field renames are not auto-detected.** The schema diff engine compares two
+> schema snapshots and has no way to tell an intentional rename apart from an
+> unrelated drop-and-add: renaming a field in `schema.json` always surfaces as a
+> separate **add field** + **remove field** pair (which deletes the old field's
+> data). The `old → new: value` rename preview only appears for an explicit
+> `rename-field` operation. To rename a field while preserving its values, use
+> the bulk command, which moves the data in one step:
+>
+> ```bash
+> bwrb bulk --all --rename owner=assignee --execute
+> ```
+>
+> See [issue #694](https://github.com/3mdistal/bwrb/issues/694) for background.
 
 In `--output json` mode the per-note changes are **always** included under
 `data.fileChanges` (an array of `{ relativePath, changes[] }`), uncapped, for
@@ -103,7 +117,7 @@ bwrb schema history --json
 |--------|---------------|------------------|
 | Add field | Deterministic | No action needed (field absent in old notes is valid) |
 | Remove field | Non-deterministic | Removes field from affected notes |
-| Rename field | Non-deterministic | Renames field in affected notes |
+| Rename field | Not detected by diff | A schema rename is seen as add + remove. Use `bwrb bulk --rename old=new` to rename while preserving values |
 | Add select option | Deterministic | No action needed |
 | Remove select option | Non-deterministic | Prompts for value mapping |
 | Rename select option | Non-deterministic | Updates references in notes |

--- a/tests/ts/lib/migration/diff.test.ts
+++ b/tests/ts/lib/migration/diff.test.ts
@@ -85,6 +85,47 @@ describe("diffSchemas", () => {
       );
       expect(removeOps.length).toBeGreaterThanOrEqual(1);
     });
+
+    // The diff engine does not auto-detect field renames. A schema-only rename
+    // (drop one field, add another) is inherently ambiguous — it is
+    // indistinguishable from two unrelated changes — so it surfaces as an
+    // add-field + remove-field pair, never as a `rename-field` op. Intentional
+    // renames are performed explicitly via `bwrb bulk --rename old=new`.
+    // See issue #694 and docs/product/migrations.md.
+    it("should surface a schema-only field rename as add+remove, never rename-field", () => {
+      const newSchema: BwrbSchemaType = {
+        ...baseSchema,
+        schemaVersion: "2.0.0",
+        types: {
+          ...baseSchema.types,
+          task: {
+            ...baseSchema.types.task,
+            fields: {
+              status: baseSchema.types.task.fields!.status,
+              priority: baseSchema.types.task.fields!.priority,
+              // `assignee` replaces a removed `due` field; from the schema
+              // diff's perspective this is just an add + a remove.
+              assignee: { prompt: "text" },
+            },
+          },
+        },
+      };
+
+      const plan = diffSchemas(baseSchema, newSchema, "1.0.0", "2.0.0");
+
+      const allOps = [...plan.deterministic, ...plan.nonDeterministic];
+      expect(allOps.some((op) => op.op === "rename-field")).toBe(false);
+      expect(
+        plan.deterministic.some(
+          (op) => op.op === "add-field" && op.field === "assignee"
+        )
+      ).toBe(true);
+      expect(
+        plan.nonDeterministic.some(
+          (op) => op.op === "remove-field" && op.field === "due"
+        )
+      ).toBe(true);
+    });
   });
 
   describe("type changes", () => {


### PR DESCRIPTION
## Summary

Issue #694: the migration DIFF engine (`src/lib/migration/diff.ts`) does not auto-detect a field rename — renaming a field in the schema surfaces as **add-field + remove-field**, so the `rename-field` formatting path (`old → new: value`) only ever fires from synthetic test plans, never from real diff-driven CLI usage. The #650 docs example `owner → assignee: alice` therefore can never appear from the CLI.

## Decision: correct the docs (option b), not implement detection

Investigation findings:

- **No schema-level rename intent exists.** `diffSchemas` only compares two schema *snapshots*. The schema format has no alias / `from→to` marker, so a rename is structurally identical to "drop field X, add field Y". The `rename-field` op (`src/types/migration.ts`) and its `execute.ts` handler are real and correct, but the diff engine has no signal to emit it.
- **Renames already have an explicit, unambiguous mechanism**: `bwrb bulk --rename old=new` (`src/commands/bulk.ts`), which moves the data in one step and preserves values. The migration flow is for schema-version evolution, not field renames.
- **Heuristic detection has real false-positive risk.** A "1 removed + 1 added of same type → rename" heuristic would mis-merge two genuinely-unrelated changes. Even gated behind an interactive confirm it can't run in non-interactive `--execute --output json` (the migrate command skips all prompts in `jsonMode`), and it bolts a confirmation subsystem onto a flow that has none today — disproportionate given the explicit `bulk --rename` alternative already exists. The issue itself marks this low priority.

So the proportionate, lower-risk fix is to make the docs accurately describe reality.

## Changes

`docs/product/migrations.md`:
- Replaced the unreachable `owner → assignee: alice` per-note preview example with a realistic delete example.
- Added a callout: field renames are **not** auto-detected; a schema rename surfaces as add + remove (deleting the old field's data); the `old → new` preview only appears for an explicit `rename-field` op; use `bwrb bulk --all --rename owner=assignee --execute` to rename while preserving values.
- Fixed the misleading "Rename field" row in the Migration Types table (was "Non-deterministic / Renames field in affected notes" → now "Not detected by diff" with a pointer to `bulk --rename`).

`tests/ts/lib/migration/diff.test.ts`:
- Added a test locking the behavior: a schema-only field rename emits `add-field` + `remove-field` and **never** a `rename-field` op.

## Gates
- `pnpm qa` green (typecheck, lint, docs:lint, docs:doctor, build, 2608 tests pass).
- `pnpm knip` green.
- `pnpm docs:build` green.

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)