### PR TITLE
fix(schema): extend unknown-type 'did you mean?' to template commands + case-only mismatches

### DIFF
--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -6,6 +6,7 @@ import {
   loadSchema,
   getTypeDefByPath,
   getFieldsForType,
+  formatUnknownTypeError,
 } from '../lib/schema.js';
 import {
   findAllTemplates,
@@ -212,7 +213,7 @@ templateCommand
       if (typePath) {
         const typeDef = getTypeDefByPath(schema, typePath);
         if (!typeDef) {
-          const error = `Unknown type: ${typePath}`;
+          const error = formatUnknownTypeError(schema, typePath);
           if (jsonMode) {
             printJson(jsonError(error));
             process.exit(ExitCodes.VALIDATION_ERROR);
@@ -583,7 +584,7 @@ templateCommand
       if (typePath) {
         const typeDef = getTypeDefByPath(schema, typePath);
         if (!typeDef) {
-          const error = `Unknown type: ${typePath}`;
+          const error = formatUnknownTypeError(schema, typePath);
           if (jsonMode) {
             printJson(jsonError(error));
             process.exit(ExitCodes.VALIDATION_ERROR);
@@ -713,7 +714,7 @@ templateCommand
       // Validate type path
       const typeDef = getTypeDefByPath(schema, resolvedTypePath);
       if (!typeDef) {
-        const error = `Unknown type: ${resolvedTypePath}`;
+        const error = formatUnknownTypeError(schema, resolvedTypePath);
         if (jsonMode) {
           printJson(jsonError(error));
           process.exit(ExitCodes.VALIDATION_ERROR);
@@ -1090,7 +1091,7 @@ templateCommand
         // Validate type path
         const typeDef = getTypeDefByPath(schema, typePath);
         if (!typeDef) {
-          const error = `Unknown type: ${typePath}`;
+          const error = formatUnknownTypeError(schema, typePath);
           if (jsonMode) {
             printJson(jsonError(error));
             process.exit(ExitCodes.VALIDATION_ERROR);
@@ -1480,7 +1481,7 @@ templateCommand
         // Validate type path
         const typeDef = getTypeDefByPath(schema, typePath);
         if (!typeDef) {
-          const error = `Unknown type: ${typePath}`;
+          const error = formatUnknownTypeError(schema, typePath);
           if (jsonMode) {
             printJson(jsonError(error));
             process.exit(ExitCodes.VALIDATION_ERROR);

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1010,6 +1010,17 @@ export function suggestTypeName(
   if (schema.types.has(typeName)) return undefined;
 
   const availableTypes = getConcreteTypeNames(schema);
+
+  // Case-only mismatch: if the input matches a real type name except for
+  // casing (e.g. `TASK` → `task`), the canonical-case name is the single most
+  // useful "did you mean" — surface it directly. The distance-based path below
+  // can't, because it case-folds both sides and then drops the resulting
+  // distance-0 row via `excludeExact`. Valid correct-case types already
+  // returned above, so this never fires for a genuinely valid type.
+  const lowered = typeName.toLowerCase();
+  const caseMatch = availableTypes.find((t) => t.toLowerCase() === lowered);
+  if (caseMatch) return caseMatch;
+
   // Threshold: at most 3 edits, but never more than 60% of the input length so
   // very short inputs don't match unrelated types and long gibberish is rejected.
   const maxDistance = Math.min(3, Math.ceil(typeName.length * 0.6));
@@ -1026,7 +1037,7 @@ export function suggestTypeName(
  *
  * This is the single shared formatter used by every command that accepts a
  * type name (`list`/`recent`/`search`/`audit`/`bulk`/`dashboard`/`new`/
- * `schema list`/`edit`). Keeping the `Unknown type: <name>` prefix preserves
+ * `schema list`/`edit`/`template *`). Keeping the `Unknown type: <name>` prefix preserves
  * the existing message shape (and JSON error payload), only adding the
  * suggestion — so valid types are unaffected and JSON consumers get the hint
  * inline in the error string.

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -4,7 +4,7 @@ import { existsSync } from 'fs';
 import { parseNote, writeNote, generateBodySections } from './frontmatter.js';
 import { closestMatch } from './close-match.js';
 import { TemplateFrontmatterSchema, type Template, type LoadedSchema, type Field, type Constraint, type InstanceScaffold, type ResolvedType } from '../types/schema.js';
-import { getType, getFieldsForType, getFieldOptions, getOutputDir } from './schema.js';
+import { getType, getFieldsForType, getFieldOptions, getOutputDir, formatUnknownTypeError } from './schema.js';
 import { isBwrbBuiltinFrontmatterField } from './frontmatter/systemFields.js';
 import { matchesExpression, parseExpression, type EvalContext } from './expression.js';
 import { applyDefaults } from './validation.js';
@@ -1467,7 +1467,7 @@ export async function createScaffoldedInstances(
         errors.push({
           subtype: instance.type,
           filename: instance.filename,
-          message: `Unknown type: ${instance.type}`,
+          message: formatUnknownTypeError(schema, instance.type),
         });
         continue;
       }

--- a/tests/ts/commands/list.test.ts
+++ b/tests/ts/commands/list.test.ts
@@ -844,6 +844,14 @@ describe('list command', () => {
       expect(result.stderr).toContain('Unknown type');
     });
 
+    it('suggests the canonical-case type for a case-only mismatch (#670)', async () => {
+      const result = await runCLI(['list', '--type', 'TASK'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown type: TASK');
+      expect(result.stderr).toContain("Did you mean 'task'?");
+    });
+
     it('should show ambiguous error for positional that could be type or path', async () => {
       const result = await runCLI(['list', 'nonexistent'], vaultDir);
 

--- a/tests/ts/commands/template.test.ts
+++ b/tests/ts/commands/template.test.ts
@@ -614,4 +614,55 @@ Body
       expect(existsSync(templatePath)).toBe(false);
     });
   });
+
+  describe('unknown-type "did you mean" suggestions (#670)', () => {
+    it('suggests a close type for a typo on template list (text)', async () => {
+      const result = await runCLI(['template', 'list', 'taks'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown type: taks');
+      expect(result.stderr).toContain("Did you mean 'task'?");
+    });
+
+    it('suggests a close type for a typo on template new (json)', async () => {
+      const result = await runCLI([
+        'template', 'new', 'taks',
+        '--name', 'test',
+        '--json', '{}',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('Unknown type: taks');
+      expect(json.error).toContain("Did you mean 'task'?");
+    });
+
+    it('suggests a close type for a typo on template delete (json)', async () => {
+      const result = await runCLI([
+        'template', 'delete', 'taks', 'default', '--force', '--output', 'json',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain("Did you mean 'task'?");
+    });
+
+    it('suggests the canonical-case type for a case-only mismatch', async () => {
+      const result = await runCLI(['template', 'list', 'TASK'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown type: TASK');
+      expect(result.stderr).toContain("Did you mean 'task'?");
+    });
+
+    it('omits the hint for a far-unknown type', async () => {
+      const result = await runCLI(['template', 'list', 'completely-unknown-type'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown type: completely-unknown-type');
+      expect(result.stderr).not.toContain('Did you mean');
+    });
+  });
 });

--- a/tests/ts/lib/schema.test.ts
+++ b/tests/ts/lib/schema.test.ts
@@ -595,12 +595,24 @@ describe('schema', () => {
       // 'low' is not a type name and not within threshold of any type
       expect(suggestTypeName(schema, 'low')).toBeUndefined();
     });
+
+    it('suggests the canonical-case type for a case-only mismatch', () => {
+      // Right name, wrong case → the canonical-case name is the best hint.
+      expect(suggestTypeName(schema, 'TASK')).toBe('task');
+      expect(suggestTypeName(schema, 'Idea')).toBe('idea');
+    });
   });
 
   describe('formatUnknownTypeError', () => {
     it('includes a "Did you mean" hint when there is a close match', () => {
       const msg = formatUnknownTypeError(schema, 'taks');
       expect(msg).toContain('Unknown type: taks');
+      expect(msg).toContain("Did you mean 'task'?");
+    });
+
+    it('suggests the canonical-case type for a case-only mismatch', () => {
+      const msg = formatUnknownTypeError(schema, 'TASK');
+      expect(msg).toContain('Unknown type: TASK');
       expect(msg).toContain("Did you mean 'task'?");
     });
 


### PR DESCRIPTION
Closes #670

## Summary
Closes the two completeness gaps left after #609 (PR #669) wired `formatUnknownTypeError` into `list`/`recent`/`search`/`audit`/`bulk`/`dashboard`/`new`/`schema`/`edit`.

### 1. Template commands now suggest
`src/commands/template.ts` (5 sites: `template list`, `template list [type] [name]`, `template new`, `template edit`, `template delete`) and the `scaffoldInstances` site in `src/lib/template.ts` emitted a bare `Unknown type: X`. They now route through `formatUnknownTypeError(schema, type)`, so they get `Did you mean 'Y'?` consistently in both text and `--output json` (the hint rides inline in the JSON `error` string, matching the other commands).

The `validateTemplate` instances site in `lib/template.ts` already had a richer, context-aware child-type suggestion and is left untouched.

### 2. Case-only mismatches now suggest the canonical-case name
`suggestTypeName` (`src/lib/schema.ts`) case-folds both sides and then drops the resulting distance-0 row via `excludeExact`, so `--type TASK` (right name, wrong case) produced no hint. It now checks for a case-insensitive-but-not-exact match against the concrete type names first and suggests the canonical-case name (`TASK` → `task`). Because the fix lives in `suggestTypeName`, it applies everywhere that helper is used — every #609 command benefits, not just template.

Guarantees preserved:
- A genuinely valid (correct-case) type returns early and never errors.
- Real typos still get the existing distance-based suggestion.
- Far/gibberish input still gets no suggestion.

## Tests
- `tests/ts/lib/schema.test.ts`: case-only unit tests for `suggestTypeName` and `formatUnknownTypeError`.
- `tests/ts/commands/template.test.ts`: new `unknown-type "did you mean" suggestions (#670)` block — template typo (text + json across list/new/delete), case-only, and far-unknown (no hint).
- `tests/ts/commands/list.test.ts`: a case-only test on an existing #609 command for cross-command consistency.

## Verification
`pnpm qa` (typecheck + lint + docs:lint + docs:doctor + build + test, 2616 passed) and `pnpm knip` both green. Manually exercised via the built CLI against a real vault:
- `template list TASK` → `Unknown type: TASK. Did you mean 'task'?`
- `template list taks` / `template new taks --json` → suggests `task` (text + json)
- `template list zzzzzzzz` → no hint
- `template list task` → no error
- `list --type TASK` → case-only suggestion (proves #609 commands now consistent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)