### PR TITLE
feat(recurrence): optional name_template for successor naming (#679)

### DIFF
--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -81,6 +81,10 @@
           "type": "string",
           "description": "Template to spawn the successor from. Defaults to the completed note's type default template (a task begets a task). A named template can spawn a different type (finish \"draft\" -> spawn \"review\")."
         },
+        "name_template": {
+          "type": "string",
+          "description": "Optional name template for the successor (#679). Interpolated with the same tokens as filename patterns -- {name} (the predecessor's name), {date} / {date:FORMAT} (today), and any predecessor field {field} -- then sanitized for a filename (e.g. \"Review: {name}\" -> \"Review Chapter One\"). Gives a cross-type successor a meaningful, distinct name instead of a numeric suffix. When omitted, the predecessor's name is carried forward. Vault-global basename uniqueness is still enforced on the result -- if the interpolated name also collides, a numeric suffix is appended on top."
+        },
         "set": {
           "type": "object",
           "description": "Field-offset assignments for the successor. Each value is a field-offset expression `<dateField> <+|-> <duration>` (e.g. \"deadline + 7d\"). The base must be a date field on the predecessor. Transition-time offsets and calendar-anchored bases are not supported.",

--- a/docs-site/src/content/docs/automation/task-system.md
+++ b/docs-site/src/content/docs/automation/task-system.md
@@ -83,15 +83,40 @@ spawn a `review`:
 The audit validates that the referenced template exists (a rule pointing at a deleted
 template is a deterministic error — see below).
 
-**Successor naming.** The successor carries the predecessor's name so the chain reads
-naturally, but bwrb wikilinks are **name-based** (`[[Chapter One]]` resolves by basename
-across every directory). So the spawned successor's basename is guaranteed **unique across
-the whole vault**: if the carried name is already taken anywhere, bwrb appends ` 2`, ` 3`,
-… A same-type successor in a busy directory and a **cross-type** successor (finish a
-`draft` → spawn a `review`) are handled the same way — finishing `drafts/Chapter One.md`
-spawns `reviews/Chapter One 2.md`, not `reviews/Chapter One.md`, so the predecessor's
-`next` and the successor's `prev` resolve unambiguously to the right notes (a type whose
-template defines a filename pattern disambiguates via that pattern instead).
+**Successor naming.** By default the successor carries the predecessor's name so the chain
+reads naturally, but bwrb wikilinks are **name-based** (`[[Chapter One]]` resolves by
+basename across every directory). So the spawned successor's basename is guaranteed
+**unique across the whole vault**: if the carried name is already taken anywhere, bwrb
+appends ` 2`, ` 3`, … A same-type successor in a busy directory and a **cross-type**
+successor (finish a `draft` → spawn a `review`) are handled the same way — finishing
+`drafts/Chapter One.md` spawns `reviews/Chapter One 2.md`, not `reviews/Chapter One.md`, so
+the predecessor's `next` and the successor's `prev` resolve unambiguously to the right notes
+(a type whose template defines a filename pattern disambiguates via that pattern instead).
+
+**Naming a cross-type successor (`name_template`).** A numeric suffix keeps links
+unambiguous but is cosmetically ugly and decouples the name from a meaningful title. Set
+`name_template` on the recurrence rule to give the successor a **meaningful, distinct name**
+instead:
+
+```yaml
+    recurrence:
+      on: "status = done"
+      template: review-checklist     # spawns a `review`
+      name_template: "Review: {name}"  # → "Review Chapter One"
+```
+
+The template is interpolated with the **same tokens** used for filename patterns —
+`{name}` (the predecessor's name), `{date}` / `{date:FORMAT}` (today), and any predecessor
+field `{field}` — then sanitized for a filename (the `:` is filesystem-illegal, so
+`Review: Chapter One` is filed as `Review Chapter One`). Finishing `drafts/Chapter One.md`
+now spawns `reviews/Review Chapter One.md`.
+
+Vault-global uniqueness still applies **on top of** the result: if the interpolated name
+also collides (e.g. another `Review Chapter One` already exists), bwrb appends the same
+` 2`, ` 3`, … suffix, so `next`/`prev` always resolve to the right notes. If the template
+references a token the predecessor doesn't have, bwrb falls back to the carried name rather
+than failing the spawn. Omit `name_template` to keep the carried-name + numeric-suffix
+behavior described above.
 
 ### The `next` field does three jobs
 

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -231,6 +231,7 @@ A trait may carry a `recurrence` block. Any type that composes the trait then sp
 |----------|------|----------|-------------|
 | `on` | string | Yes | Trigger transition, `<field> = <value>` (e.g. `"status = done"`). The successor is spawned when the field transitions **into** this value |
 | `template` | string | No | Template to spawn from. Defaults to the type's own default template (a task begets a task); a named template can spawn a different type |
+| `name_template` | string | No | Name pattern for the successor (e.g. `"Review: {name}"`). Interpolated with the same tokens as filename patterns — `{name}` (predecessor's name), `{date}` / `{date:FORMAT}`, and any predecessor field `{field}` — then sanitized for a filename. Gives a cross-type successor a meaningful name instead of a numeric suffix; vault-global basename uniqueness is still enforced on the result. Defaults to carrying the predecessor's name forward |
 | `set` | object | No | Field-offset assignments. Each value is `<dateField> + <duration>` (e.g. `"deadline + 7d"`); the base **must** be a date field |
 
 The `next` relation field does triple duty: it is the **chain link** (history), the **idempotency guard** (a successor is spawned only when `next` is empty), and the basis for the audit **backstop** (`missing-successor`). See the [task system guide](/automation/task-system/) for the full two-path execution model and validation rules.

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -77,6 +77,10 @@
           "type": "string",
           "description": "Template to spawn the successor from. Defaults to the completed note's type default template (a task begets a task). A named template can spawn a different type (finish \"draft\" -> spawn \"review\")."
         },
+        "name_template": {
+          "type": "string",
+          "description": "Optional name template for the successor (#679). Interpolated with the same tokens as filename patterns -- {name} (the predecessor's name), {date} / {date:FORMAT} (today), and any predecessor field {field} -- then sanitized for a filename (e.g. \"Review: {name}\" -> \"Review Chapter One\"). Gives a cross-type successor a meaningful, distinct name instead of a numeric suffix. When omitted, the predecessor's name is carried forward. Vault-global basename uniqueness is still enforced on the result -- if the interpolated name also collides, a numeric suffix is appended on top."
+        },
         "set": {
           "type": "object",
           "description": "Field-offset assignments for the successor. Each value is a field-offset expression `<dateField> <+|-> <duration>` (e.g. \"deadline + 7d\"). The base must be a date field on the predecessor. Transition-time offsets and calendar-anchored bases are not supported.",

--- a/src/lib/recurrence.ts
+++ b/src/lib/recurrence.ts
@@ -30,7 +30,7 @@ import { getRecurrenceForType, getFieldsForType, getType, getOutputDir } from '.
 import { parseDate, parsePartialIsoDate } from './local-date.js';
 import { formatDateWithPattern } from './local-date.js';
 import { formatValue } from './vault.js';
-import { getFilenamePattern } from './template.js';
+import { getFilenamePattern, resolveFilenamePattern } from './template.js';
 import { createNoteFromJson } from '../commands/new/json-mode.js';
 import { findDefaultTemplateWithInheritance } from './template.js';
 import { buildNoteIndex } from './navigation.js';
@@ -182,6 +182,17 @@ export function validateRecurrenceRule(
     });
   }
 
+  // The optional successor name template (#679) must be a non-empty string when
+  // present. Its interpolation tokens (`{name}`, `{date}`, `{field}`) are
+  // resolved at spawn time against the predecessor — an unresolvable token there
+  // falls back to the carried name rather than failing — so there is nothing
+  // further to validate statically here.
+  if (recurrence.name_template !== undefined && recurrence.name_template.trim() === '') {
+    issues.push({
+      message: `Recurrence trait '${trait}' on type '${typeName}' has an empty 'name_template'. Provide a name pattern (e.g. "Review: {name}") or omit it.`,
+    });
+  }
+
   // The successor's type is the spawned type. Without a named template we spawn
   // the same type (a task begets a task), so validate offsets against this type.
   const targetFields = getFieldsForType(schema, typeName);
@@ -307,6 +318,58 @@ export function computeOffsetFields(
  */
 function basenameNoExt(filePath: string): string {
   return basename(filePath, '.md');
+}
+
+/**
+ * Resolve the successor's BASE name (before uniqueness disambiguation).
+ *
+ * Without `recurrence.name_template` (#679): carry the predecessor's `name`
+ * forward verbatim (falling back to its filename), exactly as before.
+ *
+ * With `name_template`: interpolate the template against the predecessor's
+ * frontmatter using the SAME token engine the rest of bwrb uses for filename
+ * patterns (`resolveFilenamePattern`) — `{name}` (the predecessor's name),
+ * `{date}` / `{date:FORMAT}` (today), and any predecessor field `{field}`. The
+ * result is sanitized for a filename (so `Review: {name}` → `Review Chapter
+ * One`, the colon being filesystem-illegal). Uniqueness (#632) is enforced
+ * separately, on top of this result, by `resolveSuccessorName`.
+ *
+ * Falls back to the carried name when the template references an unresolvable
+ * token or sanitizes to empty — we never want a recurrence rule to be unable to
+ * name its successor.
+ */
+function resolveSuccessorBaseName(
+  schema: LoadedSchema,
+  recurringTypeName: string,
+  predecessor: Record<string, unknown>,
+  predecessorName: string
+): string {
+  const carriedName =
+    typeof predecessor['name'] === 'string' && predecessor['name'].trim() !== ''
+      ? (predecessor['name'] as string)
+      : predecessorName;
+
+  const resolved = getRecurrenceForType(schema, recurringTypeName);
+  const nameTemplate = resolved?.recurrence.name_template;
+  if (!nameTemplate || nameTemplate.trim() === '') {
+    return carriedName;
+  }
+
+  // Interpolate `{name}`/`{date}`/`{field}` against the predecessor frontmatter,
+  // ensuring `{name}` resolves to the carried name even when the predecessor's
+  // own `name` field is blank.
+  const interpolationContext: Record<string, unknown> = { ...predecessor, name: carriedName };
+  const result = resolveFilenamePattern(
+    nameTemplate,
+    interpolationContext,
+    schema.config.dateFormat
+  );
+  if (result.resolved && result.filename) {
+    return result.filename;
+  }
+  // Unresolvable template (missing token / empty after sanitization): fall back
+  // to the carried name so the spawn still succeeds.
+  return carriedName;
 }
 
 /**
@@ -493,22 +556,22 @@ export async function prepareSuccessor(
   const offsetFields = computeOffsetFields(schema, typeName, predecessor);
 
   // Resolve a successor name whose basename is UNIQUE across the whole vault.
-  // When the spawn type uses a filename pattern, the pattern disambiguates (so we
-  // keep the carried-forward name); otherwise we suffix a counter until no
-  // existing note shares the basename. Vault-global (not per-output-dir) so a
-  // cross-type successor doesn't reuse the predecessor's basename and break
-  // name-based `next`/`prev` resolution (#632).
-  const carriedName =
-    typeof predecessor['name'] === 'string' && predecessor['name'].trim() !== ''
-      ? (predecessor['name'] as string)
-      : predecessorName;
+  // The BASE name is the predecessor's carried name, OR — when the rule defines a
+  // `name_template` (#679) — that template interpolated (e.g. "Review: {name}").
+  // On TOP of the base, resolveSuccessorName enforces uniqueness: when the spawn
+  // type uses a filename pattern, the pattern disambiguates (so the base is kept
+  // as-is); otherwise it suffixes a counter until no existing note shares the
+  // basename. Vault-global (not per-output-dir) so a cross-type successor doesn't
+  // reuse the predecessor's basename and break name-based `next`/`prev`
+  // resolution (#632).
+  const baseName = resolveSuccessorBaseName(schema, typeName, predecessor, predecessorName);
   const noteIndex = await buildNoteIndex(schema, vaultDir);
   const successorName = resolveSuccessorName(
     schema,
     vaultDir,
     spawnType,
     template,
-    carriedName,
+    baseName,
     noteIndex
   );
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -116,6 +116,16 @@ export const RecurrenceSchema = z.object({
   // type default template (a task begets a task). Naming a template can spawn a
   // different type (finish "draft" → spawn "review").
   template: z.string().optional(),
+  // Optional name template for the successor. When set, the successor's name is
+  // this string interpolated with the SAME tokens used elsewhere — `{name}` (the
+  // predecessor's name), `{date}` / `{date:FORMAT}` (today), and any predecessor
+  // field `{field}` — then sanitized for a filename (e.g. "Review: {name}" →
+  // "Review Chapter One"). This gives a cross-type successor a meaningful,
+  // distinct name instead of a numeric suffix (#679). When unset, the
+  // predecessor's name is carried forward as before. Vault-global basename
+  // uniqueness (#632) is still enforced on the RESULT — if the interpolated name
+  // also collides, a numeric suffix is appended on top.
+  name_template: z.string().optional(),
   // Field-offset assignments for the successor. Each value is a field-offset
   // expression `<dateField> <+|-> <duration>` (e.g. "deadline + 7d"). The base
   // must be a date field on the predecessor.

--- a/tests/ts/lib/recurrence.test.ts
+++ b/tests/ts/lib/recurrence.test.ts
@@ -965,6 +965,286 @@ due: 2026-04-01
   });
 });
 
+describe('recurrence: successor name template (#679)', () => {
+  // A `draft` whose completion spawns a `review` via a cross-type template, with
+  // a `name_template` that gives the review a MEANINGFUL name ("Review: <name>")
+  // instead of a numeric suffix. Both types carry the next/prev chain.
+  function makeCrossSchema(nameTemplate?: string): Schema {
+    return {
+      version: 2,
+      traits: {
+        chained: {
+          fields: {
+            next: { prompt: 'relation', source: ['draft', 'review'] },
+            prev: { prompt: 'relation', source: ['draft', 'review'] },
+          },
+        },
+        spawnsReview: {
+          recurrence: {
+            on: 'status = done',
+            template: 'spawn-review',
+            ...(nameTemplate ? { name_template: nameTemplate } : {}),
+            set: { due: 'due + 3d' },
+          },
+        },
+      },
+      types: {
+        draft: {
+          output_dir: 'drafts',
+          traits: ['chained', 'spawnsReview'],
+          fields: {
+            name: { prompt: 'text', required: true },
+            status: { prompt: 'select', options: ['todo', 'doing', 'done'], default: 'todo' },
+            due: { prompt: 'date' },
+          },
+        },
+        review: {
+          output_dir: 'reviews',
+          traits: ['chained'],
+          fields: {
+            name: { prompt: 'text', required: true },
+            status: { prompt: 'select', options: ['todo', 'doing', 'done'], default: 'todo' },
+            due: { prompt: 'date' },
+          },
+        },
+      },
+    };
+  }
+
+  async function writeReviewTemplate(vaultDir: string): Promise<void> {
+    const dir = join(vaultDir, '.bwrb', 'templates', 'review');
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, 'spawn-review.md'),
+      `---
+type: template
+template-for: review
+name: spawn-review
+defaults:
+  status: todo
+---
+
+# {name}
+`
+    );
+  }
+
+  async function listDir(vaultDir: string, sub: string): Promise<string[]> {
+    const dir = join(vaultDir, sub);
+    if (!existsSync(dir)) return [];
+    return (await readdir(dir)).filter((f) => f.endsWith('.md')).sort();
+  }
+
+  async function setupCrossVault(nameTemplate?: string): Promise<string> {
+    const vaultDir = await setupVault(makeCrossSchema(nameTemplate));
+    await writeReviewTemplate(vaultDir);
+    await mkdir(join(vaultDir, 'drafts'), { recursive: true });
+    await mkdir(join(vaultDir, 'reviews'), { recursive: true });
+    return vaultDir;
+  }
+
+  let vaultDir: string;
+  afterEach(async () => {
+    if (vaultDir) await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('names the cross-type successor from name_template (Review: {name})', async () => {
+    vaultDir = await setupCrossVault('Review: {name}');
+    const draftPath = join(vaultDir, 'drafts', 'Chapter One.md');
+    await writeFile(
+      draftPath,
+      `---
+type: draft
+name: Chapter One
+status: doing
+due: 2026-04-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, draftPath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+
+    const reviews = await listDir(vaultDir, 'reviews');
+    expect(reviews).toHaveLength(1);
+    // The colon is filesystem-illegal, so the sanitized basename drops it:
+    // "Review: Chapter One" -> "Review Chapter One".
+    expect(reviews[0]).toBe('Review Chapter One.md');
+
+    // Offset still applied; chain links resolve to the templated name.
+    const succFm = await readFrontmatter(join(vaultDir, 'reviews', reviews[0]!));
+    expect(succFm['due']).toBe('2026-04-04');
+    expect(succFm['name']).toBe('Review Chapter One');
+    expect(String(succFm['prev'])).toContain('Chapter One');
+
+    const draftFm = await readFrontmatter(draftPath);
+    expect(String(draftFm['next'])).toContain('Review Chapter One');
+
+    // Audit clean of the name-collision symptoms.
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const issues = results.flatMap((r) => r.issues);
+    expect(issues.some((i) => i.code === 'self-reference')).toBe(false);
+    expect(issues.some((i) => i.code === 'type-mismatch')).toBe(false);
+    expect(issues.some((i) => i.code === 'ambiguous-link-target')).toBe(false);
+  });
+
+  it('without name_template, keeps the numeric-suffix behavior (#632)', async () => {
+    vaultDir = await setupCrossVault(); // no name_template
+    const draftPath = join(vaultDir, 'drafts', 'Chapter One.md');
+    await writeFile(
+      draftPath,
+      `---
+type: draft
+name: Chapter One
+status: doing
+due: 2026-04-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, draftPath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+
+    const reviews = await listDir(vaultDir, 'reviews');
+    expect(reviews).toHaveLength(1);
+    const name = reviews[0]!.replace(/\.md$/, '');
+    expect(name).not.toBe('Chapter One');
+    expect(name.startsWith('Chapter One')).toBe(true); // carried name + numeric suffix
+  });
+
+  it('a templated name that still collides is disambiguated with a numeric suffix', async () => {
+    vaultDir = await setupCrossVault('Review: {name}');
+    // Pre-seed a review that already occupies the templated basename so the spawn
+    // must climb past it — uniqueness (#632) applies ON TOP of the template.
+    await writeFile(
+      join(vaultDir, 'reviews', 'Review Chapter One.md'),
+      `---
+type: review
+name: Review Chapter One
+status: todo
+due: 2026-01-01
+---
+`
+    );
+    const draftPath = join(vaultDir, 'drafts', 'Chapter One.md');
+    await writeFile(
+      draftPath,
+      `---
+type: draft
+name: Chapter One
+status: doing
+due: 2026-04-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, draftPath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+
+    const reviews = await listDir(vaultDir, 'reviews');
+    expect(reviews).toContain('Review Chapter One.md'); // pre-existing untouched
+    expect(reviews).toContain('Review Chapter One 2.md'); // spawn climbed past it
+
+    // Every basename across the vault is unique.
+    const all = [
+      ...(await listDir(vaultDir, 'drafts')),
+      ...(await listDir(vaultDir, 'reviews')),
+    ].map((f) => f.replace(/\.md$/, ''));
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  it('fast path and backstop produce the SAME templated successor name', async () => {
+    vaultDir = await setupCrossVault('Review: {name}');
+    const schema = await loadSchema(vaultDir);
+
+    // Fast path on "Alpha".
+    const fastPath = join(vaultDir, 'drafts', 'Alpha.md');
+    await writeFile(
+      fastPath,
+      `---
+type: draft
+name: Alpha
+status: doing
+due: 2026-04-01
+---
+`
+    );
+    await editNoteFromJson(schema, vaultDir, fastPath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+
+    // Backstop on "Beta" (hand-completed: status=done, empty next).
+    const handPath = join(vaultDir, 'drafts', 'Beta.md');
+    await writeFile(
+      handPath,
+      `---
+type: draft
+name: Beta
+status: done
+due: 2026-04-01
+---
+`
+    );
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    await runAutoFix(results, schema, vaultDir, { dryRun: false });
+
+    const reviews = await listDir(vaultDir, 'reviews');
+    // Both successors got the templated form (sanitized, colon dropped).
+    expect(reviews).toContain('Review Alpha.md');
+    expect(reviews).toContain('Review Beta.md');
+  });
+
+  it('is idempotent: re-completing does NOT spawn a duplicate templated review', async () => {
+    vaultDir = await setupCrossVault('Review: {name}');
+    const draftPath = join(vaultDir, 'drafts', 'Chapter One.md');
+    await writeFile(
+      draftPath,
+      `---
+type: draft
+name: Chapter One
+status: doing
+due: 2026-04-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, draftPath, JSON.stringify({ status: 'done' }), {
+      jsonMode: false,
+    });
+    expect(await listDir(vaultDir, 'reviews')).toHaveLength(1);
+
+    await editNoteFromJson(
+      schema,
+      vaultDir,
+      draftPath,
+      JSON.stringify({ status: 'done', due: '2026-04-01' }),
+      { jsonMode: false }
+    );
+    expect(await listDir(vaultDir, 'reviews')).toHaveLength(1);
+  });
+
+  it('flags an empty name_template as a config error (invalid-recurrence)', async () => {
+    vaultDir = await setupVault(makeCrossSchema('   '));
+    await mkdir(join(vaultDir, 'drafts'), { recursive: true });
+    await writeFile(
+      join(vaultDir, 'drafts', 'D.md'),
+      `---
+type: draft
+name: D
+status: todo
+due: 2026-01-01
+---
+`
+    );
+    const schema = await loadSchema(vaultDir);
+    const issues = validateRecurrenceRule(schema, 'draft');
+    expect(issues.some((i) => /name_template/.test(i.message))).toBe(true);
+  });
+});
+
 describe('recurrence: multi-spawn template (#630)', () => {
   let vaultDir: string;
   afterEach(async () => {

--- a/tests/ts/lib/schema-schema-drift.test.ts
+++ b/tests/ts/lib/schema-schema-drift.test.ts
@@ -217,6 +217,15 @@ describe('schema.schema.json drift guards', () => {
     expect(recurrence.properties.set.additionalProperties.type).toBe('string');
   });
 
+  // --- #679: optional successor name template on the recurrence block ---
+  it('exposes recurrence.name_template as an optional string (#679)', () => {
+    const recurrence = metaSchema.definitions.recurrence;
+    expect(recurrence.properties.name_template).toBeDefined();
+    expect(recurrence.properties.name_template.type).toBe('string');
+    // Optional: never added to `required`.
+    expect(recurrence.required).not.toContain('name_template');
+  });
+
   // --- #626 core: type definitions use the flat v2 `fields` contract ---
   describe('type definitions match the flat v2 loader contract (#626)', () => {
     it('a type composes traits via a string array', () => {


### PR DESCRIPTION
## Summary

The event-driven recurrence system spawns a successor on a field transition. For **cross-type** recurrence (the rule's `template` targets a different type, e.g. finish a `draft` → spawn a `review`), #632 gives the successor a vault-global-unique basename via a **numeric suffix** (`Chapter One 2`). That's functional but ugly and decouples the name from a meaningful title.

This adds an optional **`name_template`** to the `recurrence` config so a successor can be named meaningfully — e.g. `Review: {name}` → `Review Chapter One` — instead of carrying a numeric suffix.

## What changed

- **Config field:** `recurrence.name_template` (optional string) on the `recurring` trait, in both the Zod schema (`src/types/schema.ts`) and `schema.schema.json` (+ the published `docs-site/public/schema.json` copy).
- **Interpolation reuses the existing engine** (`resolveFilenamePattern`), so it supports the **same tokens** as filename patterns: `{name}` (predecessor's name), `{date}` / `{date:FORMAT}` (today), and any predecessor field `{field}`. The result is sanitized for a filename (illegal `:` dropped, so `Review: Chapter One` files as `Review Chapter One`).
- **Uniqueness (#632) still applies on top:** the templated name is fed through `resolveSuccessorName`, so a templated name that *also* collides gets the numeric-suffix disambiguation — links stay unambiguous.
- **Unset → unchanged:** without `name_template`, the carried-name + numeric-suffix behavior is exactly as before. An unresolvable token falls back to the carried name rather than failing the spawn.
- **Validation:** `validateRecurrenceRule` rejects an empty `name_template` as a deterministic config error (surfaced by `bwrb audit` as `invalid-recurrence`).
- **Docs:** `automation/task-system.md` (new "Naming a cross-type successor" section) and `reference/schema.md` (recurrence property table).

## Tests

New `recurrence: successor name template (#679)` suite covers: templated cross-type name; no-template numeric-suffix behavior unchanged; templated-name collision still disambiguated; fast-path == backstop produce the same templated name; idempotency; empty-template config error. Drift-guard test asserts the new schema field. Full suite green (2623 passed).

Verified end-to-end via the real CLI: `bwrb edit … --json '{"status":"done"}'` spawns `reviews/Review Chapter One.md`, `next`/`prev` link correctly, offset applied, `bwrb audit --all` clean.

## Gate

`pnpm qa` ✅ · `pnpm knip` ✅ · `pnpm docs:build` ✅

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)