### PR TITLE
chore(schema): generate published JSON Schema from Zod (#666)

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,12 @@ The schema structure is defined by `schema.schema.json` (JSON Schema draft-07). 
 ./validate_schema.sh
 ```
 
+> **Contributors:** `schema.schema.json` and `docs-site/public/schema.json` are
+> **generated** from the Zod source of truth in `src/types/schema.ts` — do not
+> edit them by hand. After changing the Zod schema run `pnpm schema:gen` and
+> commit the result. CI (`pnpm schema:check`, part of `pnpm qa`) fails if the
+> committed files are stale.
+
 ## File Structure
 
 **bwrb repo:**
@@ -400,14 +406,17 @@ bwrb/
 │   │   ├── query.ts          # Filter parsing & evaluation
 │   │   ├── vault.ts          # Vault operations
 │   │   └── prompt.ts         # Interactive prompts
-│   └── types/
-│       └── schema.ts         # Zod schema definitions
+│   ├── types/
+│   │   └── schema.ts         # Zod schema definitions (source of truth)
+│   └── tools/
+│       └── schema/
+│           └── generate-json-schema.ts  # Generates the JSON Schema from Zod
 ├── tests/
 │   └── ts/                   # TypeScript test suite
 ├── package.json
 ├── tsconfig.json
 ├── vitest.config.ts
-├── schema.schema.json        # JSON Schema for validating vault schemas
+├── schema.schema.json        # GENERATED JSON Schema (run `pnpm schema:gen`)
 └── README.md
 ```
 

--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -4,10 +4,6 @@
   "title": "Bowerbird Schema",
   "description": "Schema for defining types, fields, and configuration for markdown vaults",
   "type": "object",
-  "required": [
-    "types"
-  ],
-  "additionalProperties": false,
   "properties": {
     "$schema": {
       "type": "string",
@@ -27,77 +23,29 @@
     },
     "traits": {
       "type": "object",
-      "description": "Reusable field bundles composed into types via each type's `traits` array. Composition (`also-has`) alongside `extends` inheritance (`is-a`). Optional; schemas without traits are unchanged.",
       "additionalProperties": {
         "$ref": "#/definitions/trait"
-      }
+      },
+      "description": "Reusable field bundles composed into types via each type's `traits` array. Composition (`also-has`) alongside `extends` inheritance (`is-a`). Optional; schemas without traits are unchanged."
     },
     "types": {
       "type": "object",
-      "description": "Type definitions with inheritance support",
       "additionalProperties": {
         "$ref": "#/definitions/typeNode"
-      }
+      },
+      "description": "Type definitions with inheritance support"
     },
     "audit": {
       "$ref": "#/definitions/auditConfig"
     }
   },
+  "required": [
+    "types"
+  ],
+  "additionalProperties": false,
   "definitions": {
-    "trait": {
-      "type": "object",
-      "description": "A reusable bundle of fields composed into a type. Traits are flat: they carry only fields (and an optional description, plus an optional recurrence block) and cannot extend types or compose other traits.",
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "type": "string",
-          "description": "Human-readable description of what this trait bundles and when to use it. Surfaced by `bwrb schema list`."
-        },
-        "fields": {
-          "type": "object",
-          "description": "Field definitions contributed by this trait",
-          "additionalProperties": {
-            "$ref": "#/definitions/frontmatterField"
-          }
-        },
-        "recurrence": {
-          "$ref": "#/definitions/recurrence"
-        }
-      }
-    },
-    "recurrence": {
-      "type": "object",
-      "description": "Event-driven, spawn-on-transition recurrence (#107). When a field transitions into a value (e.g. status enters done), spawn a successor note from a template, offsetting the successor's date field from a predecessor date field. No cron, no daemon, no LLM.",
-      "additionalProperties": false,
-      "required": [
-        "on"
-      ],
-      "properties": {
-        "on": {
-          "type": "string",
-          "description": "Trigger transition, written as `<field> = <value>` (e.g. \"status = done\"). The successor is spawned when the trigger field transitions INTO this value."
-        },
-        "template": {
-          "type": "string",
-          "description": "Template to spawn the successor from. Defaults to the completed note's type default template (a task begets a task). A named template can spawn a different type (finish \"draft\" -> spawn \"review\")."
-        },
-        "name_template": {
-          "type": "string",
-          "description": "Optional name template for the successor (#679). Interpolated with the same tokens as filename patterns -- {name} (the predecessor's name), {date} / {date:FORMAT} (today), and any predecessor field {field} -- then sanitized for a filename (e.g. \"Review: {name}\" -> \"Review Chapter One\"). Gives a cross-type successor a meaningful, distinct name instead of a numeric suffix. When omitted, the predecessor's name is carried forward. Vault-global basename uniqueness is still enforced on the result -- if the interpolated name also collides, a numeric suffix is appended on top."
-        },
-        "set": {
-          "type": "object",
-          "description": "Field-offset assignments for the successor. Each value is a field-offset expression `<dateField> <+|-> <duration>` (e.g. \"deadline + 7d\"). The base must be a date field on the predecessor. Transition-time offsets and calendar-anchored bases are not supported.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "config": {
       "type": "object",
-      "description": "Vault-wide configuration options",
-      "additionalProperties": false,
       "properties": {
         "link_format": {
           "type": "string",
@@ -105,7 +53,6 @@
             "wikilink",
             "markdown"
           ],
-          "default": "wikilink",
           "description": "Link format for relation fields: wikilink (\"[[Note]]\") or markdown (\"[Note](Note.md)\")"
         },
         "editor": {
@@ -124,7 +71,6 @@
             "visual",
             "obsidian"
           ],
-          "default": "system",
           "description": "Default behavior for --open flag"
         },
         "obsidian_vault": {
@@ -144,7 +90,6 @@
         },
         "date_format": {
           "type": "string",
-          "default": "YYYY-MM-DD",
           "description": "Date format for date fields (YYYY, MM, DD tokens), e.g. YYYY-MM-DD (default), MM/DD/YYYY, DD-MM-YYYY"
         },
         "date_granularity": {
@@ -154,36 +99,67 @@
             "month",
             "year"
           ],
-          "default": "day",
           "description": "Default coarsest date precision allowed for all date fields (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Per-field `granularity` overrides this default."
-        }
-      }
-    },
-    "auditConfig": {
-      "type": "object",
-      "description": "Configuration for the audit command",
-      "additionalProperties": false,
-      "properties": {
-        "ignored_directories": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Directories to skip during audit"
         },
-        "allowed_extra_fields": {
-          "type": "array",
-          "items": {
+        "mention_fuzzy_threshold": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5,
+          "description": "Max Levenshtein distance for the `unlinked-mention` audit fuzzy (\"did you mean?\") tier (#622). Integer 0-5; default 2. 0 disables the fuzzy tier. Overridden per run by `--mention-fuzzy-threshold` / `--no-mention-fuzzy`."
+        }
+      },
+      "additionalProperties": false
+    },
+    "trait": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this trait bundles and when to use it. Surfaced by `bwrb schema list`."
+        },
+        "fields": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/frontmatterField"
+          },
+          "description": "Field definitions contributed by this trait"
+        },
+        "recurrence": {
+          "$ref": "#/definitions/recurrence"
+        }
+      },
+      "additionalProperties": false
+    },
+    "recurrence": {
+      "type": "object",
+      "properties": {
+        "on": {
+          "type": "string",
+          "description": "Trigger transition, written as `<field> = <value>` (e.g. \"status = done\"). The successor is spawned when the trigger field transitions INTO this value."
+        },
+        "template": {
+          "type": "string",
+          "description": "Template to spawn the successor from. Defaults to the completed note's type default template (a task begets a task). A named template can spawn a different type (finish \"draft\" -> spawn \"review\")."
+        },
+        "name_template": {
+          "type": "string",
+          "description": "Optional name template for the successor (#679). Interpolated with the same tokens as filename patterns -- {name} (the predecessor's name), {date} / {date:FORMAT} (today), and any predecessor field {field} -- then sanitized for a filename (e.g. \"Review: {name}\" -> \"Review Chapter One\"). Gives a cross-type successor a meaningful, distinct name instead of a numeric suffix. When omitted, the predecessor's name is carried forward. Vault-global basename uniqueness is still enforced on the result -- if the interpolated name also collides, a numeric suffix is appended on top."
+        },
+        "set": {
+          "type": "object",
+          "additionalProperties": {
             "type": "string"
           },
-          "description": "Extra frontmatter fields that are allowed without warning"
+          "description": "Field-offset assignments for the successor. Each value is a field-offset expression `<dateField> <+|-> <duration>` (e.g. \"deadline + 7d\"). The base must be a date field on the predecessor. Transition-time offsets and calendar-anchored bases are not supported."
         }
-      }
+      },
+      "required": [
+        "on"
+      ],
+      "additionalProperties": false
     },
     "typeNode": {
       "type": "object",
-      "description": "Type definition with inheritance support. Flat v2 model: `extends` for is-a inheritance, `traits` for also-has composition, `fields` (not `frontmatter`) for field definitions. All properties are optional.",
-      "additionalProperties": false,
       "properties": {
         "extends": {
           "type": "string",
@@ -202,10 +178,10 @@
         },
         "fields": {
           "type": "object",
-          "description": "Field definitions, merged with ancestors and traits at load time",
           "additionalProperties": {
             "$ref": "#/definitions/frontmatterField"
-          }
+          },
+          "description": "Field definitions, merged with ancestors and traits at load time"
         },
         "field_order": {
           "type": "array",
@@ -216,10 +192,10 @@
         },
         "body_sections": {
           "type": "array",
-          "description": "Body section definitions generated after frontmatter",
           "items": {
             "$ref": "#/definitions/bodySection"
-          }
+          },
+          "description": "Body section definitions generated after frontmatter"
         },
         "recursive": {
           "type": "boolean",
@@ -237,28 +213,24 @@
           "type": "string",
           "description": "Custom plural form for folder naming (e.g., 'research' instead of 'researches'). Auto-pluralized if not specified."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "frontmatterField": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
-        "value": {
-          "type": "string",
-          "description": "Static value (use $NOW for current datetime, $TODAY for date)"
-        },
         "prompt": {
           "type": "string",
           "enum": [
             "text",
             "select",
-            "relation",
             "list",
             "date",
+            "relation",
             "boolean",
             "number"
           ],
-          "description": "Type of prompt: text (free text), select (from enum), relation (from vault query), list (comma-separated list), date (date picker), boolean (yes/no), number (numeric input)"
+          "description": "Type of prompt: text (free text), select (from options), relation (from vault query), list (comma-separated list), date (date picker), boolean (yes/no), number (numeric input)"
         },
         "granularity": {
           "type": "string",
@@ -269,9 +241,9 @@
           ],
           "description": "Coarsest date precision allowed for this `date` field, finer is always allowed (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Overrides the global config.date_granularity for this field."
         },
-        "label": {
+        "value": {
           "type": "string",
-          "description": "Label shown to user for input prompts (the imperative prompt text, e.g. \"Select status\"). Distinct from `description`, which explains what the field is for."
+          "description": "Static value (use $NOW for current datetime, $TODAY for date)"
         },
         "description": {
           "type": "string",
@@ -286,10 +258,6 @@
               },
               {
                 "type": "object",
-                "additionalProperties": false,
-                "required": [
-                  "value"
-                ],
                 "properties": {
                   "value": {
                     "type": "string",
@@ -299,14 +267,17 @@
                     "type": "string",
                     "description": "What this option means / when to choose it"
                   }
-                }
+                },
+                "required": [
+                  "value"
+                ],
+                "additionalProperties": false
               }
             ]
           },
           "description": "Allowed values for select fields (inline options). Each entry is a bare value or a { value, description } pair that documents what the option means."
         },
         "source": {
-          "description": "Type name(s) for relation prompts. When a relation's value is ambiguous because two notes share a name, path-qualify the link (e.g. `[[contexts/Betson]]`); see the search command docs for the shortest-unambiguous-form rule.",
           "anyOf": [
             {
               "type": "string"
@@ -317,14 +288,45 @@
                 "type": "string"
               }
             }
-          ]
+          ],
+          "description": "Type name(s) for relation prompts. When a relation's value is ambiguous because two notes share a name, path-qualify the link (e.g. `[[contexts/Betson]]`); see the search command docs for the shortest-unambiguous-form rule."
         },
         "filter": {
           "type": "object",
-          "description": "Filter conditions for type-based source queries",
           "additionalProperties": {
             "$ref": "#/definitions/filterCondition"
-          }
+          },
+          "description": "Filter conditions for type-based source queries"
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether this field is required (user cannot skip)"
+        },
+        "default": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "Default value if user skips the prompt"
+        },
+        "list_format": {
+          "type": "string",
+          "enum": [
+            "yaml-array",
+            "comma-separated"
+          ],
+          "description": "For list fields, how to format the list"
+        },
+        "label": {
+          "type": "string",
+          "description": "Label shown to user for input prompts (the imperative prompt text, e.g. \"Select status\"). Distinct from `description`, which explains what the field is for."
         },
         "multiple": {
           "type": "boolean",
@@ -337,41 +339,12 @@
         "alias": {
           "type": "boolean",
           "description": "Field role: marks this field as holding the entity's aliases (alternate names). bwrb consults aliases during name resolution and linking, so an entity is findable by its aliases wherever it is findable by its name. The value must be an array of non-empty, unique strings (Obsidian `aliases` format)."
-        },
-        "default": {
-          "description": "Default value if user skips the prompt",
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          ]
-        },
-        "required": {
-          "type": "boolean",
-          "description": "Whether this field is required (user cannot skip)"
-        },
-        "list_format": {
-          "type": "string",
-          "enum": [
-            "yaml-array",
-            "comma-separated"
-          ],
-          "description": "For list fields, how to format the list"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "bodySection": {
       "type": "object",
-      "required": [
-        "title"
-      ],
-      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string",
@@ -392,7 +365,6 @@
             "bullets",
             "checkboxes"
           ],
-          "default": "none",
           "description": "Type of content placeholder to add"
         },
         "prompt": {
@@ -409,16 +381,19 @@
         },
         "children": {
           "type": "array",
-          "description": "Nested subsections",
           "items": {
             "$ref": "#/definitions/bodySection"
-          }
+          },
+          "description": "Nested subsections"
         }
-      }
+      },
+      "required": [
+        "title"
+      ],
+      "additionalProperties": false
     },
     "filterCondition": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "equals": {
           "type": "string",
@@ -442,7 +417,28 @@
           },
           "description": "Field must not be one of these values"
         }
-      }
+      },
+      "additionalProperties": false
+    },
+    "auditConfig": {
+      "type": "object",
+      "properties": {
+        "ignored_directories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Directories to skip during audit"
+        },
+        "allowed_extra_fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Extra frontmatter fields that are allowed without warning"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "test:pty": "vitest run --reporter=verbose .pty.test.ts",
     "test:pty:ci": "sh -c 'mkdir -p artifacts && vitest run --reporter=json --outputFile=artifacts/pty-results.json .pty.test.ts'",
     "docs:check": "tsx src/tools/docs/check-concepts-sidebar.ts",
+    "schema:gen": "tsx src/tools/schema/generate-json-schema.ts",
+    "schema:check": "tsx src/tools/schema/generate-json-schema.ts --check",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -33,7 +35,7 @@
     "docs:preview": "pnpm -C docs-site preview",
     "docs:lint": "node scripts/docs-link-consistency.mjs",
     "docs:doctor": "node scripts/docs-doctor.mjs",
-    "qa": "pnpm typecheck && pnpm lint && pnpm docs:lint && pnpm docs:doctor && pnpm build && pnpm test",
+    "qa": "pnpm typecheck && pnpm lint && pnpm schema:check && pnpm docs:lint && pnpm docs:doctor && pnpm build && pnpm test",
     "verify:pack": "node scripts/verify-pack.mjs",
     "knip": "knip",
     "knip:prod": "knip --production",
@@ -75,7 +77,8 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0",
-    "vitest": "^2.1.9"
+    "vitest": "^2.1.9",
+    "zod-to-json-schema": "^3.25.2"
   },
   "engines": {
     "node": ">=22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.19.9)
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@3.25.76)
 
 packages:
 
@@ -1794,6 +1797,11 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -3369,6 +3377,10 @@ snapshots:
   yaml@2.8.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -4,8 +4,6 @@
   "title": "Bowerbird Schema",
   "description": "Schema for defining types, fields, and configuration for markdown vaults",
   "type": "object",
-  "required": ["types"],
-  "additionalProperties": false,
   "properties": {
     "$schema": {
       "type": "string",
@@ -25,27 +23,95 @@
     },
     "traits": {
       "type": "object",
-      "description": "Reusable field bundles composed into types via each type's `traits` array. Composition (`also-has`) alongside `extends` inheritance (`is-a`). Optional; schemas without traits are unchanged.",
       "additionalProperties": {
         "$ref": "#/definitions/trait"
-      }
+      },
+      "description": "Reusable field bundles composed into types via each type's `traits` array. Composition (`also-has`) alongside `extends` inheritance (`is-a`). Optional; schemas without traits are unchanged."
     },
     "types": {
       "type": "object",
-      "description": "Type definitions with inheritance support",
       "additionalProperties": {
         "$ref": "#/definitions/typeNode"
-      }
+      },
+      "description": "Type definitions with inheritance support"
     },
     "audit": {
       "$ref": "#/definitions/auditConfig"
     }
   },
+  "required": [
+    "types"
+  ],
+  "additionalProperties": false,
   "definitions": {
+    "config": {
+      "type": "object",
+      "properties": {
+        "link_format": {
+          "type": "string",
+          "enum": [
+            "wikilink",
+            "markdown"
+          ],
+          "description": "Link format for relation fields: wikilink (\"[[Note]]\") or markdown (\"[Note](Note.md)\")"
+        },
+        "editor": {
+          "type": "string",
+          "description": "Terminal editor command (defaults to $EDITOR)"
+        },
+        "visual": {
+          "type": "string",
+          "description": "GUI editor command (defaults to $VISUAL)"
+        },
+        "open_with": {
+          "type": "string",
+          "enum": [
+            "system",
+            "editor",
+            "visual",
+            "obsidian"
+          ],
+          "description": "Default behavior for --open flag"
+        },
+        "obsidian_vault": {
+          "type": "string",
+          "description": "Obsidian vault name for URI scheme (auto-detected if not set)"
+        },
+        "default_dashboard": {
+          "type": "string",
+          "description": "Dashboard to run when `bwrb dashboard` is called without arguments"
+        },
+        "excluded_directories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Vault-root-relative directory prefixes excluded from all discovery/targeting operations (e.g., \"Archive\", \"Templates\")"
+        },
+        "date_format": {
+          "type": "string",
+          "description": "Date format for date fields (YYYY, MM, DD tokens), e.g. YYYY-MM-DD (default), MM/DD/YYYY, DD-MM-YYYY"
+        },
+        "date_granularity": {
+          "type": "string",
+          "enum": [
+            "day",
+            "month",
+            "year"
+          ],
+          "description": "Default coarsest date precision allowed for all date fields (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Per-field `granularity` overrides this default."
+        },
+        "mention_fuzzy_threshold": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 5,
+          "description": "Max Levenshtein distance for the `unlinked-mention` audit fuzzy (\"did you mean?\") tier (#622). Integer 0-5; default 2. 0 disables the fuzzy tier. Overridden per run by `--mention-fuzzy-threshold` / `--no-mention-fuzzy`."
+        }
+      },
+      "additionalProperties": false
+    },
     "trait": {
       "type": "object",
-      "description": "A reusable bundle of fields composed into a type. Traits are flat: they carry only fields (and an optional description, plus an optional recurrence block) and cannot extend types or compose other traits.",
-      "additionalProperties": false,
       "properties": {
         "description": {
           "type": "string",
@@ -53,21 +119,19 @@
         },
         "fields": {
           "type": "object",
-          "description": "Field definitions contributed by this trait",
           "additionalProperties": {
             "$ref": "#/definitions/frontmatterField"
-          }
+          },
+          "description": "Field definitions contributed by this trait"
         },
         "recurrence": {
           "$ref": "#/definitions/recurrence"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "recurrence": {
       "type": "object",
-      "description": "Event-driven, spawn-on-transition recurrence (#107). When a field transitions into a value (e.g. status enters done), spawn a successor note from a template, offsetting the successor's date field from a predecessor date field. No cron, no daemon, no LLM.",
-      "additionalProperties": false,
-      "required": ["on"],
       "properties": {
         "on": {
           "type": "string",
@@ -83,83 +147,19 @@
         },
         "set": {
           "type": "object",
-          "description": "Field-offset assignments for the successor. Each value is a field-offset expression `<dateField> <+|-> <duration>` (e.g. \"deadline + 7d\"). The base must be a date field on the predecessor. Transition-time offsets and calendar-anchored bases are not supported.",
-          "additionalProperties": { "type": "string" }
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Field-offset assignments for the successor. Each value is a field-offset expression `<dateField> <+|-> <duration>` (e.g. \"deadline + 7d\"). The base must be a date field on the predecessor. Transition-time offsets and calendar-anchored bases are not supported."
         }
-      }
-    },
-    "config": {
-      "type": "object",
-      "description": "Vault-wide configuration options",
-      "additionalProperties": false,
-      "properties": {
-        "link_format": {
-          "type": "string",
-          "enum": ["wikilink", "markdown"],
-          "default": "wikilink",
-          "description": "Link format for relation fields: wikilink (\"[[Note]]\") or markdown (\"[Note](Note.md)\")"
-        },
-        "editor": {
-          "type": "string",
-          "description": "Terminal editor command (defaults to $EDITOR)"
-        },
-        "visual": {
-          "type": "string",
-          "description": "GUI editor command (defaults to $VISUAL)"
-        },
-        "open_with": {
-          "type": "string",
-          "enum": ["system", "editor", "visual", "obsidian"],
-          "default": "system",
-          "description": "Default behavior for --open flag"
-        },
-        "obsidian_vault": {
-          "type": "string",
-          "description": "Obsidian vault name for URI scheme (auto-detected if not set)"
-        },
-        "default_dashboard": {
-          "type": "string",
-          "description": "Dashboard to run when `bwrb dashboard` is called without arguments"
-        },
-        "excluded_directories": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "Vault-root-relative directory prefixes excluded from all discovery/targeting operations (e.g., \"Archive\", \"Templates\")"
-        },
-        "date_format": {
-          "type": "string",
-          "default": "YYYY-MM-DD",
-          "description": "Date format for date fields (YYYY, MM, DD tokens), e.g. YYYY-MM-DD (default), MM/DD/YYYY, DD-MM-YYYY"
-        },
-        "date_granularity": {
-          "type": "string",
-          "enum": ["day", "month", "year"],
-          "default": "day",
-          "description": "Default coarsest date precision allowed for all date fields (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Per-field `granularity` overrides this default."
-        }
-      }
-    },
-    "auditConfig": {
-      "type": "object",
-      "description": "Configuration for the audit command",
-      "additionalProperties": false,
-      "properties": {
-        "ignored_directories": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "Directories to skip during audit"
-        },
-        "allowed_extra_fields": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "Extra frontmatter fields that are allowed without warning"
-        }
-      }
+      },
+      "required": [
+        "on"
+      ],
+      "additionalProperties": false
     },
     "typeNode": {
       "type": "object",
-      "description": "Type definition with inheritance support. Flat v2 model: `extends` for is-a inheritance, `traits` for also-has composition, `fields` (not `frontmatter`) for field definitions. All properties are optional.",
-      "additionalProperties": false,
       "properties": {
         "extends": {
           "type": "string",
@@ -167,7 +167,9 @@
         },
         "traits": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Trait names composed into this type (composition alongside `extends`). Precedence: own fields > traits > inherited; later traits in the array win over earlier ones."
         },
         "description": {
@@ -176,20 +178,24 @@
         },
         "fields": {
           "type": "object",
-          "description": "Field definitions, merged with ancestors and traits at load time",
           "additionalProperties": {
             "$ref": "#/definitions/frontmatterField"
-          }
+          },
+          "description": "Field definitions, merged with ancestors and traits at load time"
         },
         "field_order": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Explicit field ordering (optional; defaults to definition order)"
         },
         "body_sections": {
           "type": "array",
-          "description": "Body section definitions generated after frontmatter",
-          "items": { "$ref": "#/definitions/bodySection" }
+          "items": {
+            "$ref": "#/definitions/bodySection"
+          },
+          "description": "Body section definitions generated after frontmatter"
         },
         "recursive": {
           "type": "boolean",
@@ -207,29 +213,37 @@
           "type": "string",
           "description": "Custom plural form for folder naming (e.g., 'research' instead of 'researches'). Auto-pluralized if not specified."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "frontmatterField": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
-        "value": {
-          "type": "string",
-          "description": "Static value (use $NOW for current datetime, $TODAY for date)"
-        },
         "prompt": {
           "type": "string",
-          "enum": ["text", "select", "relation", "list", "date", "boolean", "number"],
-          "description": "Type of prompt: text (free text), select (from enum), relation (from vault query), list (comma-separated list), date (date picker), boolean (yes/no), number (numeric input)"
+          "enum": [
+            "text",
+            "select",
+            "list",
+            "date",
+            "relation",
+            "boolean",
+            "number"
+          ],
+          "description": "Type of prompt: text (free text), select (from options), relation (from vault query), list (comma-separated list), date (date picker), boolean (yes/no), number (numeric input)"
         },
         "granularity": {
           "type": "string",
-          "enum": ["day", "month", "year"],
+          "enum": [
+            "day",
+            "month",
+            "year"
+          ],
           "description": "Coarsest date precision allowed for this `date` field, finer is always allowed (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Overrides the global config.date_granularity for this field."
         },
-        "label": {
+        "value": {
           "type": "string",
-          "description": "Label shown to user for input prompts (the imperative prompt text, e.g. \"Select status\"). Distinct from `description`, which explains what the field is for."
+          "description": "Static value (use $NOW for current datetime, $TODAY for date)"
         },
         "description": {
           "type": "string",
@@ -239,33 +253,80 @@
           "type": "array",
           "items": {
             "anyOf": [
-              { "type": "string" },
+              {
+                "type": "string"
+              },
               {
                 "type": "object",
-                "additionalProperties": false,
-                "required": ["value"],
                 "properties": {
-                  "value": { "type": "string", "description": "The option value stored in frontmatter" },
-                  "description": { "type": "string", "description": "What this option means / when to choose it" }
-                }
+                  "value": {
+                    "type": "string",
+                    "description": "The option value stored in frontmatter"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "What this option means / when to choose it"
+                  }
+                },
+                "required": [
+                  "value"
+                ],
+                "additionalProperties": false
               }
             ]
           },
           "description": "Allowed values for select fields (inline options). Each entry is a bare value or a { value, description } pair that documents what the option means."
         },
         "source": {
-          "description": "Type name(s) for relation prompts. When a relation's value is ambiguous because two notes share a name, path-qualify the link (e.g. `[[contexts/Betson]]`); see the search command docs for the shortest-unambiguous-form rule.",
           "anyOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "Type name(s) for relation prompts. When a relation's value is ambiguous because two notes share a name, path-qualify the link (e.g. `[[contexts/Betson]]`); see the search command docs for the shortest-unambiguous-form rule."
         },
         "filter": {
           "type": "object",
-          "description": "Filter conditions for type-based source queries",
           "additionalProperties": {
             "$ref": "#/definitions/filterCondition"
-          }
+          },
+          "description": "Filter conditions for type-based source queries"
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether this field is required (user cannot skip)"
+        },
+        "default": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "Default value if user skips the prompt"
+        },
+        "list_format": {
+          "type": "string",
+          "enum": [
+            "yaml-array",
+            "comma-separated"
+          ],
+          "description": "For list fields, how to format the list"
+        },
+        "label": {
+          "type": "string",
+          "description": "Label shown to user for input prompts (the imperative prompt text, e.g. \"Select status\"). Distinct from `description`, which explains what the field is for."
         },
         "multiple": {
           "type": "boolean",
@@ -278,29 +339,12 @@
         "alias": {
           "type": "boolean",
           "description": "Field role: marks this field as holding the entity's aliases (alternate names). bwrb consults aliases during name resolution and linking, so an entity is findable by its aliases wherever it is findable by its name. The value must be an array of non-empty, unique strings (Obsidian `aliases` format)."
-        },
-        "default": {
-          "description": "Default value if user skips the prompt",
-          "anyOf": [
-            { "type": "string" },
-            { "type": "array", "items": { "type": "string" } }
-          ]
-        },
-        "required": {
-          "type": "boolean",
-          "description": "Whether this field is required (user cannot skip)"
-        },
-        "list_format": {
-          "type": "string",
-          "enum": ["yaml-array", "comma-separated"],
-          "description": "For list fields, how to format the list"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "bodySection": {
       "type": "object",
-      "required": ["title"],
-      "additionalProperties": false,
       "properties": {
         "title": {
           "type": "string",
@@ -315,13 +359,20 @@
         },
         "content_type": {
           "type": "string",
-          "enum": ["none", "paragraphs", "bullets", "checkboxes"],
-          "default": "none",
+          "enum": [
+            "none",
+            "paragraphs",
+            "bullets",
+            "checkboxes"
+          ],
           "description": "Type of content placeholder to add"
         },
         "prompt": {
           "type": "string",
-          "enum": ["none", "list"],
+          "enum": [
+            "none",
+            "list"
+          ],
           "description": "If set, prompts user for initial content during creation"
         },
         "prompt_label": {
@@ -330,16 +381,19 @@
         },
         "children": {
           "type": "array",
-          "description": "Nested subsections",
           "items": {
             "$ref": "#/definitions/bodySection"
-          }
+          },
+          "description": "Nested subsections"
         }
-      }
+      },
+      "required": [
+        "title"
+      ],
+      "additionalProperties": false
     },
     "filterCondition": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "equals": {
           "type": "string",
@@ -351,15 +405,40 @@
         },
         "in": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Field must be one of these values"
         },
         "not_in": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Field must not be one of these values"
         }
-      }
+      },
+      "additionalProperties": false
+    },
+    "auditConfig": {
+      "type": "object",
+      "properties": {
+        "ignored_directories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Directories to skip during audit"
+        },
+        "allowed_extra_fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Extra frontmatter fields that are allowed without warning"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/src/lib/schema-json-schema.ts
+++ b/src/lib/schema-json-schema.ts
@@ -1,0 +1,92 @@
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import {
+  AuditConfigSchema,
+  BodySectionSchema,
+  BwrbSchema,
+  ConfigSchema,
+  FieldSchema,
+  FilterConditionSchema,
+  RecurrenceSchema,
+  TraitSchema,
+  TypeSchema,
+} from '../types/schema.js';
+
+/**
+ * The published JSON Schema (`schema.schema.json` + `docs-site/public/schema.json`)
+ * is GENERATED from the Zod source of truth in `src/types/schema.ts` — it is not
+ * hand-maintained. This eliminates the drift class behind #626/#693/#666: there is
+ * one source (Zod), and the committed JSON files are regenerable artifacts.
+ *
+ * Run `pnpm schema:gen` to regenerate after changing the Zod schema; CI runs
+ * `pnpm schema:check` (regenerate + diff) so a stale committed file fails the build.
+ */
+
+const JSON_SCHEMA_TITLE = 'Bowerbird Schema';
+const JSON_SCHEMA_DESCRIPTION =
+  'Schema for defining types, fields, and configuration for markdown vaults';
+
+/**
+ * Stable `definitions` names for the reusable sub-schemas. These names are part of
+ * the published contract: editors and the drift-guard test reference
+ * `#/definitions/frontmatterField`, `#/definitions/typeNode`, etc. The keys here map
+ * those published names onto the Zod sub-schemas so `zod-to-json-schema` emits shared
+ * `$ref`s instead of inlining (and so renaming a Zod export can't silently change a
+ * published `$ref`).
+ */
+const DEFINITIONS = {
+  config: ConfigSchema,
+  trait: TraitSchema,
+  recurrence: RecurrenceSchema,
+  typeNode: TypeSchema,
+  frontmatterField: FieldSchema,
+  bodySection: BodySectionSchema,
+  filterCondition: FilterConditionSchema,
+  auditConfig: AuditConfigSchema,
+} as const;
+
+const ROOT_DEF_NAME = '__root';
+
+/**
+ * Build the published JSON Schema object from the Zod `BwrbSchema`.
+ *
+ * `$id` is a parameter because the two published copies differ only by it:
+ * - root `schema.schema.json` → `https://bwrb.dev/schema.schema.json`
+ * - `docs-site/public/schema.json` (served at the `$schema` URL `bwrb init` writes)
+ *   → `https://bwrb.dev/schema.json`
+ */
+export function buildJsonSchema($id: string): Record<string, unknown> {
+  const generated = zodToJsonSchema(BwrbSchema, {
+    name: ROOT_DEF_NAME,
+    target: 'jsonSchema7',
+    $refStrategy: 'root',
+    definitions: DEFINITIONS,
+    definitionPath: 'definitions',
+  }) as {
+    definitions: Record<string, Record<string, unknown>>;
+  };
+
+  const { [ROOT_DEF_NAME]: root, ...definitions } = generated.definitions;
+  if (!root) {
+    throw new Error('schema generation failed: root definition missing');
+  }
+
+  // Flatten the root object up to the top level (draft-07 meta-schema style) and
+  // attach the standard header + the remaining shared definitions. Property order
+  // is fixed so the serialized file is stable across regenerations.
+  return {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    $id,
+    title: JSON_SCHEMA_TITLE,
+    description: JSON_SCHEMA_DESCRIPTION,
+    ...root,
+    definitions,
+  };
+}
+
+export const ROOT_SCHEMA_ID = 'https://bwrb.dev/schema.schema.json';
+export const DOCS_SCHEMA_ID = 'https://bwrb.dev/schema.json';
+
+/** Deterministic, newline-terminated JSON for writing/diffing the committed files. */
+export function serializeJsonSchema(schema: Record<string, unknown>): string {
+  return JSON.stringify(schema, null, 2) + '\n';
+}

--- a/src/tools/schema/generate-json-schema.ts
+++ b/src/tools/schema/generate-json-schema.ts
@@ -1,0 +1,84 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  buildJsonSchema,
+  DOCS_SCHEMA_ID,
+  ROOT_SCHEMA_ID,
+  serializeJsonSchema,
+} from '../../lib/schema-json-schema.js';
+
+/**
+ * Generates the published JSON Schema files FROM the Zod source of truth
+ * (`src/types/schema.ts`). See `src/lib/schema-json-schema.ts` for the rationale.
+ *
+ *   pnpm schema:gen     # write the files
+ *   pnpm schema:check   # fail if a committed file is stale (CI guard)
+ *
+ * Two files are produced from the same Zod schema, differing only by `$id`:
+ *   - schema.schema.json              (shipped in the npm package; local-reference)
+ *   - docs-site/public/schema.json    (served at https://bwrb.dev/schema.json, the
+ *                                       `$schema` URL `bwrb init` writes)
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../../..');
+
+interface Target {
+  path: string;
+  content: string;
+}
+
+function targets(): Target[] {
+  return [
+    {
+      path: resolve(repoRoot, 'schema.schema.json'),
+      content: serializeJsonSchema(buildJsonSchema(ROOT_SCHEMA_ID)),
+    },
+    {
+      path: resolve(repoRoot, 'docs-site/public/schema.json'),
+      content: serializeJsonSchema(buildJsonSchema(DOCS_SCHEMA_ID)),
+    },
+  ];
+}
+
+async function write(): Promise<void> {
+  for (const target of targets()) {
+    await writeFile(target.path, target.content, 'utf-8');
+    console.log(`wrote ${target.path}`);
+  }
+}
+
+async function check(): Promise<void> {
+  const stale: string[] = [];
+  for (const target of targets()) {
+    let existing: string | null = null;
+    try {
+      existing = await readFile(target.path, 'utf-8');
+    } catch {
+      existing = null;
+    }
+    if (existing !== target.content) {
+      stale.push(target.path);
+    }
+  }
+
+  if (stale.length > 0) {
+    console.error(
+      'The published JSON Schema is out of date with the Zod source ' +
+        '(src/types/schema.ts). Run `pnpm schema:gen` and commit the result.\n' +
+        'Stale files:\n' +
+        stale.map((p) => `  - ${p}`).join('\n')
+    );
+    process.exit(1);
+  }
+
+  console.log('JSON Schema is up to date with the Zod source.');
+}
+
+const mode = process.argv[2] ?? 'write';
+const run = mode === '--check' || mode === 'check' ? check : write;
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -6,10 +6,10 @@ import { z } from 'zod';
 
 // Filter condition for type-based source queries
 export const FilterConditionSchema = z.object({
-  equals: z.string().optional(),
-  not_equals: z.string().optional(),
-  in: z.array(z.string()).optional(),
-  not_in: z.array(z.string()).optional(),
+  equals: z.string().optional().describe('Field must equal this value'),
+  not_equals: z.string().optional().describe('Field must not equal this value'),
+  in: z.array(z.string()).optional().describe('Field must be one of these values'),
+  not_in: z.array(z.string()).optional().describe('Field must not be one of these values'),
 });
 
 /**
@@ -22,8 +22,8 @@ export const FilterConditionSchema = z.object({
 export const FieldOptionSchema = z.union([
   z.string(),
   z.object({
-    value: z.string(),
-    description: z.string().optional(),
+    value: z.string().describe('The option value stored in frontmatter'),
+    description: z.string().optional().describe('What this option means / when to choose it'),
   }),
 ]);
 
@@ -33,58 +33,127 @@ export const FieldOptionSchema = z.union([
  */
 export const FieldSchema = z.object({
   // Prompt type (how the field is collected)
-  prompt: z.enum(['text', 'select', 'list', 'date', 'relation', 'boolean', 'number']).optional(),
+  prompt: z
+    .enum(['text', 'select', 'list', 'date', 'relation', 'boolean', 'number'])
+    .optional()
+    .describe(
+      'Type of prompt: text (free text), select (from options), relation (from vault query), list (comma-separated list), date (date picker), boolean (yes/no), number (numeric input)'
+    ),
   // Coarsest date precision allowed for `date` fields (finer is always allowed).
   // - day (default): full YYYY-MM-DD only
   // - month: YYYY-MM or YYYY-MM-DD (e.g. last-contact known to the month)
   // - year: YYYY, YYYY-MM, or YYYY-MM-DD (e.g. "around 2021")
   // Overrides the global config.date_granularity for this field.
-  granularity: z.enum(['day', 'month', 'year']).optional(),
+  granularity: z
+    .enum(['day', 'month', 'year'])
+    .optional()
+    .describe(
+      'Coarsest date precision allowed for this `date` field, finer is always allowed (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Overrides the global config.date_granularity for this field.'
+    ),
   // Static value (no prompting)
-  value: z.string().optional(),
+  value: z
+    .string()
+    .optional()
+    .describe('Static value (use $NOW for current datetime, $TODAY for date)'),
   // Human-readable description of what this field is for and when to use it.
   // Surfaced by `bwrb schema list` (text + JSON); distinct from `label`, which
   // is the imperative prompt shown during input.
-  description: z.string().optional(),
+  description: z
+    .string()
+    .optional()
+    .describe(
+      'Human-readable description of what this field is for and when to use it. Surfaced by `bwrb schema list`; distinct from `label`.'
+    ),
   // Inline options for select prompts (replaces global enums).
   // Each option is a bare value or a { value, description } pair.
-  options: z.array(FieldOptionSchema).optional(),
+  options: z
+    .array(FieldOptionSchema)
+    .optional()
+    .describe(
+      'Allowed values for select fields (inline options). Each entry is a bare value or a { value, description } pair that documents what the option means.'
+    ),
   // Type name(s) for relation prompts (e.g., "milestone", "objective")
   // When specified, queryByType() fetches notes of this type (and descendants)
   // Can be an array to allow multiple valid types (e.g., for recursive types with extends)
-  source: z.union([z.string(), z.array(z.string())]).optional(),
+  source: z
+    .union([z.string(), z.array(z.string())])
+    .optional()
+    .describe(
+      'Type name(s) for relation prompts. When a relation\'s value is ambiguous because two notes share a name, path-qualify the link (e.g. `[[contexts/Betson]]`); see the search command docs for the shortest-unambiguous-form rule.'
+    ),
   // Filter conditions for type-based source queries
   // Applies frontmatter conditions to filter results (e.g., { status: { not_in: ["settled"] } })
-  filter: z.record(FilterConditionSchema).optional(),
+  filter: z
+    .record(FilterConditionSchema)
+    .optional()
+    .describe('Filter conditions for type-based source queries'),
   // Whether the field is required
-  required: z.boolean().optional(),
+  required: z
+    .boolean()
+    .optional()
+    .describe('Whether this field is required (user cannot skip)'),
   // Default value
-  default: z.union([z.string(), z.array(z.string())]).optional(),
+  default: z
+    .union([z.string(), z.array(z.string())])
+    .optional()
+    .describe('Default value if user skips the prompt'),
   // How list values are formatted in YAML
-  list_format: z.enum(['yaml-array', 'comma-separated']).optional(),
+  list_format: z
+    .enum(['yaml-array', 'comma-separated'])
+    .optional()
+    .describe('For list fields, how to format the list'),
   // Prompt label override
-  label: z.string().optional(),
+  label: z
+    .string()
+    .optional()
+    .describe(
+      'Label shown to user for input prompts (the imperative prompt text, e.g. "Select status"). Distinct from `description`, which explains what the field is for.'
+    ),
   // Whether this field can hold multiple values (for context fields)
-  multiple: z.boolean().optional(),
+  multiple: z
+    .boolean()
+    .optional()
+    .describe('Whether this field can hold multiple values'),
   // Whether children referenced by this field are owned (colocate with parent)
-  owned: z.boolean().optional(),
+  owned: z
+    .boolean()
+    .optional()
+    .describe('Whether children referenced by this field are owned (colocate with parent)'),
   // Field role: marks this field as holding the entity's aliases — alternate
   // names the entity is also known by. A recognized role (like `owned`) that
   // name-resolution and linking consult uniformly, so an entity is findable by
   // its aliases wherever it's findable by its name. The value must be an array
   // of non-empty, unique strings (Obsidian `aliases` format).
-  alias: z.boolean().optional(),
+  alias: z
+    .boolean()
+    .optional()
+    .describe(
+      'Field role: marks this field as holding the entity\'s aliases (alternate names). bwrb consults aliases during name resolution and linking, so an entity is findable by its aliases wherever it is findable by its name. The value must be an array of non-empty, unique strings (Obsidian `aliases` format).'
+    ),
 });
 
 // Body section definition
 export const BodySectionSchema: z.ZodType<BodySection, z.ZodTypeDef, BodySectionInput> = z.lazy(() =>
   z.object({
-    title: z.string(),
-    level: z.number().optional().default(2),
-    content_type: z.enum(['none', 'paragraphs', 'bullets', 'checkboxes']).optional(),
-    prompt: z.enum(['none', 'list']).optional(),
-    prompt_label: z.string().optional(),
-    children: z.array(BodySectionSchema).optional(),
+    title: z.string().describe('Section heading text'),
+    level: z
+      .number()
+      .int()
+      .min(2)
+      .max(6)
+      .optional()
+      .default(2)
+      .describe('Heading level (2 = ##, 3 = ###, etc.)'),
+    content_type: z
+      .enum(['none', 'paragraphs', 'bullets', 'checkboxes'])
+      .optional()
+      .describe('Type of content placeholder to add'),
+    prompt: z
+      .enum(['none', 'list'])
+      .optional()
+      .describe('If set, prompts user for initial content during creation'),
+    prompt_label: z.string().optional().describe('Label for the content prompt'),
+    children: z.array(BodySectionSchema).optional().describe('Nested subsections'),
   })
 );
 
@@ -111,11 +180,20 @@ export const BodySectionSchema: z.ZodType<BodySection, z.ZodTypeDef, BodySection
 export const RecurrenceSchema = z.object({
   // The trigger transition, written as `<field> = <value>` (e.g. "status = done").
   // The successor is spawned when the trigger field transitions INTO this value.
-  on: z.string(),
+  on: z
+    .string()
+    .describe(
+      'Trigger transition, written as `<field> = <value>` (e.g. "status = done"). The successor is spawned when the trigger field transitions INTO this value.'
+    ),
   // Template name to spawn the successor from. Defaults to the completed note's
   // type default template (a task begets a task). Naming a template can spawn a
   // different type (finish "draft" → spawn "review").
-  template: z.string().optional(),
+  template: z
+    .string()
+    .optional()
+    .describe(
+      'Template to spawn the successor from. Defaults to the completed note\'s type default template (a task begets a task). A named template can spawn a different type (finish "draft" -> spawn "review").'
+    ),
   // Optional name template for the successor. When set, the successor's name is
   // this string interpolated with the SAME tokens used elsewhere — `{name}` (the
   // predecessor's name), `{date}` / `{date:FORMAT}` (today), and any predecessor
@@ -125,11 +203,21 @@ export const RecurrenceSchema = z.object({
   // predecessor's name is carried forward as before. Vault-global basename
   // uniqueness (#632) is still enforced on the RESULT — if the interpolated name
   // also collides, a numeric suffix is appended on top.
-  name_template: z.string().optional(),
+  name_template: z
+    .string()
+    .optional()
+    .describe(
+      'Optional name template for the successor (#679). Interpolated with the same tokens as filename patterns -- {name} (the predecessor\'s name), {date} / {date:FORMAT} (today), and any predecessor field {field} -- then sanitized for a filename (e.g. "Review: {name}" -> "Review Chapter One"). Gives a cross-type successor a meaningful, distinct name instead of a numeric suffix. When omitted, the predecessor\'s name is carried forward. Vault-global basename uniqueness is still enforced on the result -- if the interpolated name also collides, a numeric suffix is appended on top.'
+    ),
   // Field-offset assignments for the successor. Each value is a field-offset
   // expression `<dateField> <+|-> <duration>` (e.g. "deadline + 7d"). The base
   // must be a date field on the predecessor.
-  set: z.record(z.string()).optional(),
+  set: z
+    .record(z.string())
+    .optional()
+    .describe(
+      'Field-offset assignments for the successor. Each value is a field-offset expression `<dateField> <+|-> <duration>` (e.g. "deadline + 7d"). The base must be a date field on the predecessor. Transition-time offsets and calendar-anchored bases are not supported.'
+    ),
 });
 
 export type Recurrence = z.infer<typeof RecurrenceSchema>;
@@ -150,9 +238,17 @@ export type Recurrence = z.infer<typeof RecurrenceSchema>;
 export const TraitSchema = z.object({
   // Human-readable description of what this trait bundles and when to use it.
   // Surfaced by `bwrb schema list` (text + JSON).
-  description: z.string().optional(),
+  description: z
+    .string()
+    .optional()
+    .describe(
+      'Human-readable description of what this trait bundles and when to use it. Surfaced by `bwrb schema list`.'
+    ),
   // Field definitions contributed by this trait.
-  fields: z.record(FieldSchema).optional(),
+  fields: z
+    .record(FieldSchema)
+    .optional()
+    .describe('Field definitions contributed by this trait'),
   // Recurrence configuration (spawn-on-transition). When present, types that
   // compose this trait gain event-driven successor spawning. See RecurrenceSchema.
   recurrence: RecurrenceSchema.optional(),
@@ -173,30 +269,67 @@ export const TraitSchema = z.object({
  */
 export const TypeSchema = z.object({
   // Parent type name (implicit 'meta' if not specified)
-  extends: z.string().optional(),
+  extends: z
+    .string()
+    .optional()
+    .describe(
+      "Parent type name (implicit 'meta' if not specified). Single-parent is-a inheritance."
+    ),
   // Trait names composed into this type (composition, alongside `extends`).
   // `extends` is *is-a* (single-parent inheritance); `traits` are *also-has*
   // (multiple reusable field bundles). Resolved at load time into the type's
   // effective fields. See `TraitSchema` and the resolver for precedence.
-  traits: z.array(z.string()).optional(),
+  traits: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Trait names composed into this type (composition alongside `extends`). Precedence: own fields > traits > inherited; later traits in the array win over earlier ones.'
+    ),
   // Human-readable description of what this type is for and when to use it.
   // Surfaced by `bwrb schema list` (text + JSON).
-  description: z.string().optional(),
+  description: z
+    .string()
+    .optional()
+    .describe(
+      'Human-readable description of what this type is for and when to use it. Surfaced by `bwrb schema list`.'
+    ),
   // Field definitions (merged with ancestors at load time)
-  fields: z.record(FieldSchema).optional(),
+  fields: z
+    .record(FieldSchema)
+    .optional()
+    .describe('Field definitions, merged with ancestors and traits at load time'),
   // Explicit field ordering (optional - defaults to definition order)
-  field_order: z.array(z.string()).optional(),
+  field_order: z
+    .array(z.string())
+    .optional()
+    .describe('Explicit field ordering (optional; defaults to definition order)'),
   // Body section definitions
-  body_sections: z.array(BodySectionSchema).optional(),
+  body_sections: z
+    .array(BodySectionSchema)
+    .optional()
+    .describe('Body section definitions generated after frontmatter'),
   // Whether this type can contain instances of itself
-  recursive: z.boolean().optional(),
+  recursive: z
+    .boolean()
+    .optional()
+    .describe('Whether this type can contain instances of itself'),
   // Output directory (computed from hierarchy if not specified)
-  output_dir: z.string().optional(),
+  output_dir: z
+    .string()
+    .optional()
+    .describe(
+      'Directory path relative to vault root where files of this type are created (computed from hierarchy if not specified)'
+    ),
   // Filename pattern
-  filename: z.string().optional(),
+  filename: z.string().optional().describe('Filename pattern'),
   // Custom plural form for folder naming (e.g., "research" instead of "researches")
   // If not specified, auto-pluralization is used (add 's', handle 'y' -> 'ies', etc.)
-  plural: z.string().optional(),
+  plural: z
+    .string()
+    .optional()
+    .describe(
+      "Custom plural form for folder naming (e.g., 'research' instead of 'researches'). Auto-pluralized if not specified."
+    ),
 });
 
 // ============================================================================
@@ -204,8 +337,14 @@ export const TypeSchema = z.object({
 // ============================================================================
 
 export const AuditConfigSchema = z.object({
-  ignored_directories: z.array(z.string()).optional(),
-  allowed_extra_fields: z.array(z.string()).optional(),
+  ignored_directories: z
+    .array(z.string())
+    .optional()
+    .describe('Directories to skip during audit'),
+  allowed_extra_fields: z
+    .array(z.string())
+    .optional()
+    .describe('Extra frontmatter fields that are allowed without warning'),
 });
 
 // ============================================================================
@@ -220,41 +359,78 @@ export const ConfigSchema = z.object({
   // Link format for relation fields in frontmatter
   // wikilink: "[[Note Name]]" (default, Obsidian-compatible)
   // markdown: "[Note Name](Note Name.md)"
-  link_format: z.enum(['wikilink', 'markdown']).optional(),
+  link_format: z
+    .enum(['wikilink', 'markdown'])
+    .optional()
+    .describe(
+      'Link format for relation fields: wikilink ("[[Note]]") or markdown ("[Note](Note.md)")'
+    ),
   // Terminal editor command (defaults to $EDITOR)
-  editor: z.string().optional(),
+  editor: z.string().optional().describe('Terminal editor command (defaults to $EDITOR)'),
   // GUI editor command (defaults to $VISUAL)
-  visual: z.string().optional(),
+  visual: z.string().optional().describe('GUI editor command (defaults to $VISUAL)'),
   // Default behavior for --open flag
   // system: Open with OS default handler (default)
   // editor: Open in terminal editor ($EDITOR)
   // visual: Open in GUI editor ($VISUAL)
   // obsidian: Open via Obsidian URI
-  open_with: z.enum(['system', 'editor', 'visual', 'obsidian']).optional(),
+  open_with: z
+    .enum(['system', 'editor', 'visual', 'obsidian'])
+    .optional()
+    .describe('Default behavior for --open flag'),
   // Obsidian vault name for URI scheme (auto-detected from .obsidian if not set)
-  obsidian_vault: z.string().optional(),
+  obsidian_vault: z
+    .string()
+    .optional()
+    .describe('Obsidian vault name for URI scheme (auto-detected if not set)'),
   // Default dashboard to run when `bwrb dashboard` is called without arguments
-  default_dashboard: z.string().optional(),
+  default_dashboard: z
+    .string()
+    .optional()
+    .describe('Dashboard to run when `bwrb dashboard` is called without arguments'),
   // Directories to exclude from all discovery/targeting operations
   // Values are vault-root-relative directory prefixes (e.g., "Archive", "Templates", "Archive/Old")
-  excluded_directories: z.array(z.string()).optional(),
+  excluded_directories: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Vault-root-relative directory prefixes excluded from all discovery/targeting operations (e.g., "Archive", "Templates")'
+    ),
   // Date format for date fields in frontmatter
   // YYYY-MM-DD: ISO 8601 format (default)
   // MM/DD/YYYY: US format
   // DD/MM/YYYY: EU format
   // DD-MM-YYYY: EU format with dashes
   // Custom patterns using YYYY, MM, DD tokens are also supported
-  date_format: z.string().optional(),
+  date_format: z
+    .string()
+    .optional()
+    .describe(
+      'Date format for date fields (YYYY, MM, DD tokens), e.g. YYYY-MM-DD (default), MM/DD/YYYY, DD-MM-YYYY'
+    ),
   // Default coarsest date precision allowed for all `date` fields.
   // - day (default): full YYYY-MM-DD only
   // - month: YYYY-MM or finer
   // - year: YYYY or finer
   // Per-field `granularity` overrides this default.
-  date_granularity: z.enum(['day', 'month', 'year']).optional(),
+  date_granularity: z
+    .enum(['day', 'month', 'year'])
+    .optional()
+    .describe(
+      'Default coarsest date precision allowed for all date fields (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Per-field `granularity` overrides this default.'
+    ),
   // Max Levenshtein distance for the `unlinked-mention` audit fuzzy ("did you
   // mean?") tier (#622). Integer 0-5; default 2. 0 disables the fuzzy tier.
   // Overridden per run by `--mention-fuzzy-threshold` / `--no-mention-fuzzy`.
-  mention_fuzzy_threshold: z.number().int().min(0).max(5).optional(),
+  mention_fuzzy_threshold: z
+    .number()
+    .int()
+    .min(0)
+    .max(5)
+    .optional()
+    .describe(
+      'Max Levenshtein distance for the `unlinked-mention` audit fuzzy ("did you mean?") tier (#622). Integer 0-5; default 2. 0 disables the fuzzy tier. Overridden per run by `--mention-fuzzy-threshold` / `--no-mention-fuzzy`.'
+    ),
 });
 
 // ============================================================================
@@ -272,19 +448,35 @@ export const ConfigSchema = z.object({
  */
 export const BwrbSchema = z.object({
   // JSON Schema reference for editor support
-  $schema: z.string().optional(),
+  $schema: z
+    .string()
+    .optional()
+    .describe('Reference to this JSON Schema for editor support'),
   // Schema format version (2 = inheritance model)
-  version: z.number().optional().default(2),
+  version: z
+    .number()
+    .int()
+    .optional()
+    .default(2)
+    .describe('Schema format version (2 = inheritance model)'),
   // User-controlled schema content version for migrations (semver)
   // This tracks the evolution of your schema over time
-  schemaVersion: z.string().optional(),
+  schemaVersion: z
+    .string()
+    .optional()
+    .describe('User-controlled schema content version for migrations (semver)'),
   // Vault-wide configuration
   config: ConfigSchema.optional(),
   // Reusable field bundles composed into types via each type's `traits` array.
   // Optional: schemas without traits are unchanged.
-  traits: z.record(TraitSchema).optional(),
+  traits: z
+    .record(TraitSchema)
+    .optional()
+    .describe(
+      "Reusable field bundles composed into types via each type's `traits` array. Composition (`also-has`) alongside `extends` inheritance (`is-a`). Optional; schemas without traits are unchanged."
+    ),
   // Type definitions (flat with 'extends')
-  types: z.record(TypeSchema),
+  types: z.record(TypeSchema).describe('Type definitions with inheritance support'),
   // Audit configuration
   audit: AuditConfigSchema.optional(),
 });

--- a/tests/ts/commands/hierarchical-scope.test.ts
+++ b/tests/ts/commands/hierarchical-scope.test.ts
@@ -40,7 +40,7 @@ describe('#554 hierarchical scope — contexts as notes + under()', () => {
         fields: {
           type: { value: 'context' },
           // Self-referential parent relation — entities already support this.
-          parent: { prompt: 'relation', source: 'context', format: 'quoted-wikilink' },
+          parent: { prompt: 'relation', source: 'context' },
           aliases: { prompt: 'list', alias: true, list_format: 'yaml-array', default: [] },
         },
         field_order: ['type', 'parent', 'aliases'],
@@ -56,7 +56,7 @@ describe('#554 hierarchical scope — contexts as notes + under()', () => {
             required: true,
           },
           // The leaf context only — the domain is DERIVABLE, so no `scope`.
-          context: { prompt: 'relation', source: 'context', format: 'quoted-wikilink' },
+          context: { prompt: 'relation', source: 'context' },
         },
         field_order: ['type', 'status', 'context'],
       },
@@ -283,7 +283,7 @@ describe('#636 under() canonicalizes aliases', () => {
         recursive: true,
         fields: {
           type: { value: 'context' },
-          parent: { prompt: 'relation', source: 'context', format: 'quoted-wikilink' },
+          parent: { prompt: 'relation', source: 'context' },
           aliases: { prompt: 'list', alias: true, list_format: 'yaml-array', default: [] },
         },
         field_order: ['type', 'parent', 'aliases'],
@@ -298,7 +298,7 @@ describe('#636 under() canonicalizes aliases', () => {
             default: 'backlog',
             required: true,
           },
-          context: { prompt: 'relation', source: 'context', format: 'quoted-wikilink' },
+          context: { prompt: 'relation', source: 'context' },
         },
         field_order: ['type', 'status', 'context'],
       },
@@ -462,7 +462,7 @@ describe('#659 isChildOf/isDescendantOf canonicalize aliased parent values', () 
         recursive: true,
         fields: {
           type: { value: 'context' },
-          parent: { prompt: 'relation', source: 'context', format: 'quoted-wikilink' },
+          parent: { prompt: 'relation', source: 'context' },
           aliases: { prompt: 'list', alias: true, list_format: 'yaml-array', default: [] },
         },
         field_order: ['type', 'parent', 'aliases'],

--- a/tests/ts/commands/list-tree-hierarchy.test.ts
+++ b/tests/ts/commands/list-tree-hierarchy.test.ts
@@ -35,7 +35,7 @@ describe('#637 list --output tree renders parent hierarchy', () => {
         recursive: true,
         fields: {
           type: { value: 'context' },
-          parent: { prompt: 'relation', source: 'context', format: 'quoted-wikilink' },
+          parent: { prompt: 'relation', source: 'context' },
         },
         field_order: ['type', 'parent'],
       },
@@ -45,7 +45,7 @@ describe('#637 list --output tree renders parent hierarchy', () => {
         output_dir: 'Domains',
         fields: {
           type: { value: 'domain' },
-          parent: { prompt: 'relation', source: 'domain', format: 'quoted-wikilink' },
+          parent: { prompt: 'relation', source: 'domain' },
         },
         field_order: ['type', 'parent'],
       },

--- a/tests/ts/commands/new.pty.test.ts
+++ b/tests/ts/commands/new.pty.test.ts
@@ -45,7 +45,6 @@ const FULL_SCHEMA = {
           prompt: 'relation',
           source: 'milestone',
           filter: { status: { not_in: ['settled'] } },
-          format: 'quoted-wikilink',
         },
       },
       field_order: ['type', 'status', 'milestone'],

--- a/tests/ts/fixtures/schemas.ts
+++ b/tests/ts/fixtures/schemas.ts
@@ -104,7 +104,6 @@ export const BASELINE_SCHEMA: TestSchema = {
           prompt: 'relation',
           source: 'milestone',
           filter: { status: { not_in: ['settled'] } },
-          format: 'quoted-wikilink',
         },
         parent: {
           prompt: 'relation',

--- a/tests/ts/lib/schema-schema-drift.test.ts
+++ b/tests/ts/lib/schema-schema-drift.test.ts
@@ -1,5 +1,11 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { readFile } from 'node:fs/promises';
+import {
+  buildJsonSchema,
+  DOCS_SCHEMA_ID,
+  ROOT_SCHEMA_ID,
+  serializeJsonSchema,
+} from '../../../src/lib/schema-json-schema.js';
 
 /**
  * Minimal, dependency-free JSON Schema (draft-07 subset) validator.
@@ -7,9 +13,9 @@ import { readFile } from 'node:fs/promises';
  * `schema.schema.json` only uses a small slice of draft-07: `type`,
  * `properties`, `additionalProperties` (bool or schema), `required`, `enum`,
  * `items`, `anyOf`/`oneOf`, and local `$ref`. A bespoke validator keeps this
- * drift guard free of runtime dependencies while still mechanically checking
- * that real vault schemas satisfy (and that legacy shapes are rejected by) the
- * published JSON Schema.
+ * guard free of runtime dependencies while still mechanically checking that real
+ * vault schemas satisfy (and that legacy shapes are rejected by) the published
+ * JSON Schema.
  */
 function makeValidator(root: any) {
   const resolveRef = (ref: string): any => {
@@ -95,17 +101,20 @@ function makeValidator(root: any) {
 }
 
 /**
- * Regression guard for Issues #247 and #626.
+ * Regression guard for Issues #247, #626, and #666.
  *
- * `schema.schema.json` is the hand-maintained JSON Schema users point their
- * editor's JSON LSP at. It is NOT generated from the Zod schema, so it can
- * silently drift from the real runtime contract in `src/types/schema.ts` /
- * `src/lib/schema.ts`. These guards mechanically assert the two agree on the
- * points #626 raised (type definitions use `fields`, not `frontmatter`;
- * `config.date_granularity` and field-level `granularity` exist) and, more
- * generally, that a real `fields`-based vault schema validates against it.
+ * The published JSON Schema is now GENERATED from the Zod source of truth in
+ * `src/types/schema.ts` (via `src/lib/schema-json-schema.ts`); the committed
+ * `schema.schema.json` and `docs-site/public/schema.json` are regenerable
+ * artifacts. These guards assert:
+ *   1. the committed files are up to date with the Zod source (the drift class
+ *      from #666 — hand-editing Zod without regenerating now fails CI), and
+ *   2. the generated schema still satisfies the behavioural contract #626/#665
+ *      pinned down (types use `fields` not `frontmatter`; granularity/traits/
+ *      recurrence/alias exist; real `fields` schemas validate; legacy
+ *      `frontmatter` shapes are rejected).
  */
-describe('schema.schema.json drift guards', () => {
+describe('published JSON Schema is generated from Zod (no drift, #666)', () => {
   let metaSchema: any;
   let docsSchema: any;
 
@@ -117,14 +126,38 @@ describe('schema.schema.json drift guards', () => {
     docsSchema = JSON.parse(await readFile(docsUrl, 'utf-8'));
   });
 
-  it('includes config.open_with system option and default', () => {
+  // --- #666: committed files must match what the generator produces from Zod ---
+  describe('committed files match the Zod-generated output (#666)', () => {
+    it('schema.schema.json is up to date (run `pnpm schema:gen` if this fails)', async () => {
+      const schemaUrl = new URL('../../../schema.schema.json', import.meta.url);
+      const committed = await readFile(schemaUrl, 'utf-8');
+      expect(committed).toBe(serializeJsonSchema(buildJsonSchema(ROOT_SCHEMA_ID)));
+    });
+
+    it('docs-site/public/schema.json is up to date (run `pnpm schema:gen` if this fails)', async () => {
+      const docsUrl = new URL('../../../docs-site/public/schema.json', import.meta.url);
+      const committed = await readFile(docsUrl, 'utf-8');
+      expect(committed).toBe(serializeJsonSchema(buildJsonSchema(DOCS_SCHEMA_ID)));
+    });
+
+    it('the two published files differ only by $id', () => {
+      const stripId = (s: any) => {
+        const { $id, ...rest } = s;
+        return rest;
+      };
+      expect(stripId(docsSchema)).toEqual(stripId(metaSchema));
+      expect(metaSchema.$id).toBe(ROOT_SCHEMA_ID);
+      expect(docsSchema.$id).toBe(DOCS_SCHEMA_ID);
+    });
+  });
+
+  it('includes config.open_with system option', () => {
     const openWith = metaSchema.definitions.config.properties.open_with;
     expect(openWith).toBeDefined();
     expect(openWith.enum).toContain('system');
     expect(openWith.enum).toContain('editor');
     expect(openWith.enum).toContain('visual');
     expect(openWith.enum).toContain('obsidian');
-    expect(openWith.default).toBe('system');
   });
 
   it('includes runtime config keys in JSON schema', () => {
@@ -135,6 +168,11 @@ describe('schema.schema.json drift guards', () => {
 
     expect(configProps.date_format).toBeDefined();
     expect(configProps.date_format.type).toBe('string');
+
+    // #666: this key existed in Zod but was missing from the hand-written
+    // schema. Generating from Zod fixes that drift.
+    expect(configProps.mention_fuzzy_threshold).toBeDefined();
+    expect(configProps.mention_fuzzy_threshold.type).toBe('integer');
   });
 
   // --- #626: config.date_granularity must exist (Zod ConfigSchema.date_granularity) ---
@@ -179,6 +217,22 @@ describe('schema.schema.json drift guards', () => {
     const alias = metaSchema.definitions.frontmatterField.properties.alias;
     expect(alias).toBeDefined();
     expect(alias.type).toBe('boolean');
+  });
+
+  it('exposes select option objects with value + description', () => {
+    const options = metaSchema.definitions.frontmatterField.properties.options;
+    expect(options).toBeDefined();
+    expect(options.type).toBe('array');
+    const branches = options.items.anyOf;
+    expect(branches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'string' }),
+        expect.objectContaining({
+          type: 'object',
+          required: ['value'],
+        }),
+      ])
+    );
   });
 
   it('allows body section prompt to be none or list', () => {
@@ -284,15 +338,6 @@ describe('schema.schema.json drift guards', () => {
     expect(typeNodeProps.filename.type).toBe('string');
   });
 
-  // --- The published docs-site copy must not drift from the root schema ---
-  it('docs-site/public/schema.json matches schema.schema.json (modulo $id)', () => {
-    const stripId = (s: any) => {
-      const { $id, ...rest } = s;
-      return rest;
-    };
-    expect(stripId(docsSchema)).toEqual(stripId(metaSchema));
-  });
-
   // --- End-to-end: a real fields-based vault schema validates against the JSON Schema ---
   describe('real vault schemas validate against the JSON Schema', () => {
     let validate: ReturnType<typeof makeValidator>;
@@ -327,6 +372,38 @@ describe('schema.schema.json drift guards', () => {
               status: { prompt: 'select', options: ['todo', 'done'] },
               due: { prompt: 'date', granularity: 'month' },
             },
+          },
+        },
+      };
+      const { ok, errors } = validate(valid);
+      expect(errors).toEqual([]);
+      expect(ok).toBe(true);
+    });
+
+    it('a schema using traits + recurrence + alias validates (#107/#679)', () => {
+      const valid = {
+        version: 2,
+        traits: {
+          recurring: {
+            description: 'spawn-on-transition',
+            fields: { status: { prompt: 'select', options: ['todo', 'done'] } },
+            recurrence: {
+              on: 'status = done',
+              template: 'task',
+              name_template: 'Review: {name}',
+              set: { due: 'due + 7d' },
+            },
+          },
+        },
+        types: {
+          person: {
+            fields: {
+              also_known_as: { prompt: 'list', alias: true },
+            },
+          },
+          task: {
+            traits: ['recurring'],
+            fields: {},
           },
         },
       };


### PR DESCRIPTION
## What & why

The published JSON Schema lived in **two** hand-maintained files —
`schema.schema.json` (repo root, shipped in the npm package) and
`docs-site/public/schema.json` (served at `https://bwrb.dev/schema.json`, the
`$schema` URL `bwrb init` writes) — alongside the Zod source of truth in
`src/types/schema.ts`. The three kept re-drifting (#626, #693). A drift-guard
test caught divergence but the JSON files still needed manual edits.

This eliminates the **drift class**: Zod is now the single source, and both
JSON Schema files are **generated** from `BwrbSchema`.

## Approach — generate FROM Zod (option a)

Chose option (a) over copy-from-root because it removes hand-maintenance
entirely (one source, not two published files kept in sync). `zod` 3.25's
classic API doesn't expose `toJSONSchema`, and the schemas use the v3 API
throughout, so added **`zod-to-json-schema`** (devDependency — generation is
build/CI-time only; it does not leak into the shipped `dist` bundle).

To preserve editor usability, the rich field/type/config descriptions were
ported into the Zod schemas via `.describe()`, so the generated schema carries
them. (Behaviour-changing `.default()` calls were intentionally *not* added to
Zod's `ConfigSchema`, to avoid mutating parsed `raw` schemas; defaults remain
documented in prose.)

## How staleness is caught

- `pnpm schema:gen` — regenerate both files from Zod.
- `pnpm schema:check` — regenerate + diff; non-zero exit if a committed file is
  stale. Wired into `pnpm qa`, so CI fails if someone edits the Zod schema
  without regenerating.
- The drift-guard test (`tests/ts/lib/schema-schema-drift.test.ts`) is
  converted into an "committed files == Zod-generated output" check, keeping the
  #626/#107/#679 validation coverage.

## Verification

- Generated schema **validates** the real `fields`-based fixture vault schema
  and a traits/recurrence/alias/granularity/options/body_sections schema.
- **Rejects** the legacy `frontmatter`-required shape (#626 not regressed).
- Includes traits, `recurrence` (+ `name_template` #679), alias role,
  `granularity`/`date_granularity`, select `options`, `body_sections`,
  `output_dir`, `excluded_directories`.
- The two published files differ only by `$id`.
- Surfaced + fixed a real drift: `config.mention_fuzzy_threshold` existed in Zod
  but was missing from the published schema — now included.
- Also removed the orphan `format: "quoted-wikilink"` keys from test fixtures
  (noted in the issue).
- `bwrb init` still writes `$schema: https://bwrb.dev/schema.json`; verified via
  a real `bwrb init --yes` run.

## Gate

- `pnpm qa` ✅ (typecheck, lint, schema:check, docs:lint, docs:doctor, build,
  2633 tests pass)
- `pnpm knip` ✅
- `pnpm docs:build` ✅ (the generated `schema.json` is copied into `dist/`)

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)
