### PR TITLE
chore(knip): remove blanket src/lib/migration ignore, drop dead exports

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -16,9 +16,7 @@
     // Test helpers export public API for test files
     "tests/ts/lib/pty-helpers.ts",
     // Shared test schemas export public API for test files
-    "tests/ts/fixtures/schemas.ts",
-    // Migration utilities are public API for migration commands
-    "src/lib/migration/*.ts"
+    "tests/ts/fixtures/schemas.ts"
   ],
 
   // Ignore specific issue types in files with intentional re-exports

--- a/src/lib/migration/diff.ts
+++ b/src/lib/migration/diff.ts
@@ -298,32 +298,6 @@ function classifyChanges(
 }
 
 /**
- * Get a human-readable description of a migration operation.
- */
-export function describeMigrationOp(op: MigrationOp): string {
-  switch (op.op) {
-    case 'add-field':
-      return op.default !== undefined
-        ? `Add field '${op.field}' to type '${op.targetType}' (default: ${JSON.stringify(op.default)})`
-        : `Add field '${op.field}' to type '${op.targetType}' (no default)`;
-    case 'remove-field':
-      return `Remove field '${op.field}' from type '${op.targetType}'`;
-    case 'rename-field':
-      return `Rename field '${op.from}' to '${op.to}' on type '${op.targetType}'`;
-    case 'add-type':
-      return `Add type '${op.typeName}'`;
-    case 'remove-type':
-      return `Remove type '${op.typeName}'`;
-    case 'rename-type':
-      return `Rename type '${op.from}' to '${op.to}'`;
-    case 'reparent-type':
-      return `Change parent of '${op.typeName}' from '${op.from ?? 'root'}' to '${op.to ?? 'root'}'`;
-    case 'normalize-links':
-      return `Normalize all links from '${op.fromFormat}' to '${op.toFormat}'`;
-  }
-}
-
-/**
  * Suggest a version bump based on the migration plan.
  * - Major: breaking changes (removals, renames)
  * - Minor: additions
@@ -360,13 +334,6 @@ function parseVersion(version: string): [number, number, number] {
     parseInt(match[2] ?? '0', 10),
     parseInt(match[3] ?? '0', 10),
   ];
-}
-
-/**
- * Validate a version string.
- */
-export function isValidVersion(version: string): boolean {
-  return /^\d+\.\d+\.\d+/.test(version);
 }
 
 /**

--- a/src/lib/migration/history.ts
+++ b/src/lib/migration/history.ts
@@ -38,7 +38,7 @@ export async function loadMigrationHistory(vaultPath: string): Promise<Migration
  * Save migration history to .bwrb/migrations.json
  * Uses atomic write (temp file + rename).
  */
-export async function saveMigrationHistory(
+async function saveMigrationHistory(
   vaultPath: string,
   history: MigrationHistory
 ): Promise<void> {
@@ -72,15 +72,3 @@ export async function recordMigration(
   history.applied.push(record);
   await saveMigrationHistory(vaultPath, history);
 }
-
-/**
- * Get the latest applied migration, if any.
- */
-export async function getLatestMigration(
-  vaultPath: string
-): Promise<AppliedMigration | undefined> {
-  const history = await loadMigrationHistory(vaultPath);
-  return history.applied.at(-1);
-}
-
-

--- a/src/lib/migration/snapshot.ts
+++ b/src/lib/migration/snapshot.ts
@@ -66,12 +66,3 @@ export async function hasSchemaSnapshot(vaultPath: string): Promise<boolean> {
     return false;
   }
 }
-
-/**
- * Get the schema version from the last snapshot.
- * Returns undefined if no snapshot exists.
- */
-export async function getSnapshotVersion(vaultPath: string): Promise<string | undefined> {
-  const snapshot = await loadSchemaSnapshot(vaultPath);
-  return snapshot?.schemaVersion;
-}


### PR DESCRIPTION
## Summary

knip's config blanket-ignored `src/lib/migration/*.ts` (commented "Migration utilities are public API for migration commands"). That blanket exemption is why `formatMigrationResult` could sit unreachable from the CLI without knip flagging it (#650).

This removes the blanket glob and lets knip analyze the module. With the glob gone, knip flagged 5 exports — all of which turned out to be dead code or unnecessarily exported, not real public API:

| Export | File | Resolution |
| --- | --- | --- |
| `describeMigrationOp` | `src/lib/migration/diff.ts` | unreferenced anywhere → **removed** |
| `isValidVersion` | `src/lib/migration/diff.ts` | unreferenced anywhere → **removed** |
| `getLatestMigration` | `src/lib/migration/history.ts` | unreferenced anywhere → **removed** |
| `getSnapshotVersion` | `src/lib/migration/snapshot.ts` | unreferenced anywhere → **removed** |
| `saveMigrationHistory` | `src/lib/migration/history.ts` | used only internally by `recordMigration` → **de-exported** (kept as a module-private function) |

No narrow per-symbol keep entries were needed: nothing in the module is genuinely public-API-but-unreferenced (the actually-consumed helpers — `loadMigrationHistory`, `recordMigration`, `diffSchemas`, `formatDiffForDisplay`, `formatDiffForJson`, `suggestVersionBump`, snapshot load/save/has, `formatMigrationResult`, etc. — are all imported by commands and/or tests, so knip is happy).

`formatMigrationResult` is **not** flagged (confirms #650 wired it into the migrate command).

## Future dead helpers are now caught

Verified by experiment: added a throwaway `export function __knipCanaryUnusedHelper() {}` to `src/lib/migration/diff.ts`, ran `pnpm knip`, and it was flagged as an unused export. Removed the canary. A future genuinely-dead helper added to this module will now be caught.

## Testing

- `pnpm knip` — green (without the blanket ignore)
- `pnpm qa` — green (typecheck, lint, schema:check, docs:lint, docs:doctor, build, 2633 tests pass)

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)