### PR TITLE
perf(levenshtein): two-row rolling buffer (O(min(n,m)) memory)

### DIFF
--- a/src/lib/levenshtein.ts
+++ b/src/lib/levenshtein.ts
@@ -7,40 +7,67 @@
  * matching should lowercase their inputs first.
  *
  * Used for fuzzy matching to suggest corrections for typos.
+ *
+ * Implementation note: uses a two-row (rolling buffer) dynamic-programming
+ * scheme instead of a full O(n·m) matrix, reducing memory to O(min(n, m)).
+ * The inner dimension iterates over the shorter string so the row buffers
+ * are no larger than `min(a.length, b.length) + 1`. Classic Levenshtein is
+ * symmetric, so swapping the operands does not change the result. Character
+ * comparison remains by UTF-16 code unit (`===` on single-character strings),
+ * identical to the previous full-matrix implementation.
  */
 export function levenshteinDistance(a: string, b: string): number {
-  const aLen = a.length;
-  const bLen = b.length;
-
-  // Create a 2D matrix with proper initialization
-  const matrix: number[][] = Array.from({ length: aLen + 1 }, () =>
-    Array.from({ length: bLen + 1 }, () => 0)
-  );
-
-  // Initialize first column
-  for (let i = 0; i <= aLen; i++) {
-    matrix[i]![0] = i;
+  // Iterate the shorter string in the inner loop so the row buffers are
+  // O(min(n, m)). Distance is symmetric, so swapping operands is safe.
+  let shorter = a;
+  let longer = b;
+  if (a.length > b.length) {
+    shorter = b;
+    longer = a;
   }
 
-  // Initialize first row
-  for (let j = 0; j <= bLen; j++) {
-    matrix[0]![j] = j;
+  const shortLen = shorter.length;
+  const longLen = longer.length;
+
+  // Fast path: an empty operand means the distance is the other's length.
+  if (shortLen === 0) {
+    return longLen;
   }
 
-  // Fill in the rest of the matrix
-  for (let i = 1; i <= aLen; i++) {
-    for (let j = 1; j <= bLen; j++) {
-      if (a[i - 1] === b[j - 1]) {
-        matrix[i]![j] = matrix[i - 1]![j - 1]!;
+  // `prevRow` holds distances for the previous outer-loop position; `currRow`
+  // is filled for the current one. Both are sized to the shorter string.
+  let prevRow = new Array<number>(shortLen + 1);
+  let currRow = new Array<number>(shortLen + 1);
+
+  // First row: transforming the empty prefix of `longer` into each prefix of
+  // `shorter` costs one insertion per character.
+  for (let j = 0; j <= shortLen; j++) {
+    prevRow[j] = j;
+  }
+
+  for (let i = 1; i <= longLen; i++) {
+    // First column: transforming each prefix of `longer` into the empty prefix
+    // of `shorter` costs one deletion per character.
+    currRow[0] = i;
+
+    const longChar = longer[i - 1];
+    for (let j = 1; j <= shortLen; j++) {
+      if (longChar === shorter[j - 1]) {
+        currRow[j] = prevRow[j - 1]!;
       } else {
-        matrix[i]![j] = Math.min(
-          matrix[i - 1]![j - 1]! + 1, // substitution
-          matrix[i]![j - 1]! + 1, // insertion
-          matrix[i - 1]![j]! + 1 // deletion
+        currRow[j] = Math.min(
+          prevRow[j - 1]! + 1, // substitution
+          currRow[j - 1]! + 1, // insertion
+          prevRow[j]! + 1 // deletion
         );
       }
     }
+
+    // Swap the buffers: the row we just filled becomes the previous row.
+    const tmp = prevRow;
+    prevRow = currRow;
+    currRow = tmp;
   }
 
-  return matrix[aLen]![bLen]!;
+  return prevRow[shortLen]!;
 }

--- a/tests/ts/lib/levenshtein.test.ts
+++ b/tests/ts/lib/levenshtein.test.ts
@@ -40,3 +40,139 @@ describe('levenshteinDistance', () => {
     expect(levenshteinDistance('Test', 'test')).toBe(1);
   });
 });
+
+/**
+ * Reference implementation: the original full O(n·m) matrix version this
+ * function replaced. The rolling-buffer implementation must return byte-for-byte
+ * identical distances for every input pair. Kept inline so the equivalence test
+ * is self-contained.
+ */
+function referenceLevenshtein(a: string, b: string): number {
+  const aLen = a.length;
+  const bLen = b.length;
+
+  const matrix: number[][] = Array.from({ length: aLen + 1 }, () =>
+    Array.from({ length: bLen + 1 }, () => 0)
+  );
+
+  for (let i = 0; i <= aLen; i++) {
+    matrix[i]![0] = i;
+  }
+  for (let j = 0; j <= bLen; j++) {
+    matrix[0]![j] = j;
+  }
+
+  for (let i = 1; i <= aLen; i++) {
+    for (let j = 1; j <= bLen; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        matrix[i]![j] = matrix[i - 1]![j - 1]!;
+      } else {
+        matrix[i]![j] = Math.min(
+          matrix[i - 1]![j - 1]! + 1,
+          matrix[i]![j - 1]! + 1,
+          matrix[i - 1]![j]! + 1
+        );
+      }
+    }
+  }
+
+  return matrix[aLen]![bLen]!;
+}
+
+describe('levenshteinDistance equivalence with full-matrix reference', () => {
+  it('matches the reference on curated edge cases', () => {
+    const pairs: Array<[string, string]> = [
+      ['', ''],
+      ['', 'a'],
+      ['a', ''],
+      ['abc', 'abc'],
+      ['kitten', 'sitting'],
+      ['ab', 'ba'], // transposition
+      ['Test', 'test'], // case
+      ['a', 'aaaaaaaaaa'], // very different lengths
+      ['flaw', 'lawn'],
+      ['gumbo', 'gambol'],
+      // unicode / surrogate pairs (emoji are UTF-16 surrogate pairs)
+      ['café', 'cafe'],
+      ['😀', '😀'],
+      ['😀😁', '😁😀'],
+      ['naïve', 'naive'],
+      ['日本語', '日本'],
+      ['👨‍👩‍👧', '👨‍👩‍👦'], // ZWJ sequences
+    ];
+    for (const [a, b] of pairs) {
+      expect(levenshteinDistance(a, b)).toBe(referenceLevenshtein(a, b));
+    }
+  });
+
+  it('matches the reference on many random pairs (fuzz)', () => {
+    // Deterministic PRNG so failures are reproducible.
+    let seed = 0x12345678;
+    const rand = (): number => {
+      // xorshift32
+      seed ^= seed << 13;
+      seed ^= seed >>> 17;
+      seed ^= seed << 5;
+      return ((seed >>> 0) % 100000) / 100000;
+    };
+
+    // Mix of ASCII, accented, CJK, and emoji (surrogate pairs) characters.
+    const alphabet = [
+      'a',
+      'b',
+      'c',
+      'A',
+      'B',
+      '1',
+      ' ',
+      '-',
+      'é',
+      'ñ',
+      '日',
+      '本',
+      '😀',
+      '😁',
+      '🎉',
+    ];
+
+    const makeString = (maxLen: number): string => {
+      const len = Math.floor(rand() * (maxLen + 1));
+      let s = '';
+      for (let i = 0; i < len; i++) {
+        s += alphabet[Math.floor(rand() * alphabet.length)];
+      }
+      return s;
+    };
+
+    for (let n = 0; n < 2000; n++) {
+      // Vary length ranges, including very asymmetric pairs.
+      const a = makeString(rand() < 0.2 ? 30 : 8);
+      const b = makeString(rand() < 0.2 ? 30 : 8);
+      const got = levenshteinDistance(a, b);
+      const want = referenceLevenshtein(a, b);
+      expect(got, `a=${JSON.stringify(a)} b=${JSON.stringify(b)}`).toBe(want);
+    }
+  });
+
+  it('is symmetric on random pairs (operand-swap invariance)', () => {
+    let seed = 0x0badf00d;
+    const rand = (): number => {
+      seed ^= seed << 13;
+      seed ^= seed >>> 17;
+      seed ^= seed << 5;
+      return ((seed >>> 0) % 100000) / 100000;
+    };
+    const chars = 'abcABC日😀'.match(/./gu) ?? [];
+    const make = (): string => {
+      const len = Math.floor(rand() * 12);
+      let s = '';
+      for (let i = 0; i < len; i++) s += chars[Math.floor(rand() * chars.length)];
+      return s;
+    };
+    for (let n = 0; n < 500; n++) {
+      const a = make();
+      const b = make();
+      expect(levenshteinDistance(a, b)).toBe(levenshteinDistance(b, a));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`levenshteinDistance` in `src/lib/levenshtein.ts` allocated the full O(n·m) 2D matrix. This replaces it with a two-row (rolling buffer) dynamic-programming scheme:

- The **shorter** operand drives the inner dimension, so the row buffers are sized to `min(a.length, b.length) + 1` → **O(min(n, m)) memory**.
- Levenshtein distance is symmetric, so swapping operands is safe.
- **Byte-for-byte identical results**: same unit cost model (insert/delete/substitute = 1) and the same UTF-16 code-unit (`===`) character comparison as before. No API change — signature, name, exports, and case-sensitivity are unchanged.

Pure internal optimization. Consumers (`search --fuzzy`, audit body detections, close-match #608, validation suggestions, discovery) are untouched.

## Tests

- Existing `tests/ts/lib/levenshtein.test.ts` (#604) passes unchanged.
- Added an **equivalence/fuzz** suite: an inlined full-matrix reference (the old implementation) is asserted equal to the new one across curated edge cases (empty, identical, transpositions, case, unicode/surrogate emoji, ZWJ sequences, very asymmetric lengths) and **2000 deterministic random pairs**, plus operand-swap symmetry checks.
- `pnpm qa` green (2636 passed, 4 skipped). `pnpm knip` clean.

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)