### PR TITLE
fix(audit): make invalid-list-element coerce idempotent (#700)

### DIFF
--- a/docs/product/audit-fix-policy.md
+++ b/docs/product/audit-fix-policy.md
@@ -51,7 +51,7 @@ For list fields, `invalid-list-element` may auto-fix only when deterministic:
 
 - Remove `null` / empty-string elements if the list remains valid
 - Flatten a single nested list only when exactly one level deep and all elements are valid
-- Apply safe scalar coercions per `wrong-scalar-type` when unambiguous
+- Coerce a wrong-typed scalar element (a bare `number` or `boolean`, e.g. `42` or `true`) to its string form in place, leaving the rest of the array intact. The coerced element is written as a **quoted** YAML string (`- "42"`, not bare `- 42`) and re-read as a string, so it survives the YAML round-trip and a re-audit finds nothing to fix — the coerce converges in one pass (idempotent, the #700 trap). The fix re-derives the element from the live array and only acts while it is still a number/boolean, so a re-applied or stale issue is a safe no-op.
 
 A **valid numeric element of a `multiple` date field** (e.g. an unquoted `2026` at year granularity) is reported as `wrong-scalar-type` with a `listIndex` and is auto-fixable per-element (#673): the fix quotes that single element in place (`2026` → `"2026"`), preserving array order and all other elements — it never collapses the array to one scalar. Quoting is index-safe (each element is re-derived from the live array, like the #683 blank removal) and idempotent: the quoted string is written and re-read as a string, so the value survives the YAML round-trip and a second pass finds nothing (avoiding the #700 non-idempotency trap). An **invalid** numeric date element (not a valid date at the field's granularity) is left as `invalid-date-format` for manual correction and is never auto-quoted.
 

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -1514,7 +1514,25 @@ export async function runAutoFix(
           if (listIndex < 0 || listIndex >= current.length) return false;
 
           if (action === 'coerce') {
-            current[listIndex] = String(current[listIndex]);
+            // Stringify a wrong-typed scalar element (a number or boolean) so the
+            // list becomes all-strings. Re-derive from the LIVE array and only act
+            // when the element is still a number/boolean — if it was already
+            // coerced (e.g. a stale duplicate issue, or a prior pass), this is a
+            // no-op and the file is left untouched.
+            //
+            // Idempotency / round-trip stability (#700): the coerced value is the
+            // JS string `String(42)` → `"42"`. `serializeFrontmatter` writes it via
+            // yaml.stringify, which force-quotes a numeric/boolean-looking string
+            // (`- "42"`, not bare `- 42`), and gray-matter re-reads a quoted scalar
+            // as a string. So a second audit pass finds an all-string list and does
+            // NOT re-flag — the fix converges in one pass. Coercing a value that is
+            // no longer a number/boolean would risk re-quoting a real string, so we
+            // guard against it.
+            const element = current[listIndex];
+            if (typeof element !== 'number' && typeof element !== 'boolean') {
+              return false;
+            }
+            current[listIndex] = String(element);
             frontmatter[issue.field!] = current;
             return true;
           }

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -5256,6 +5256,120 @@ effort: "3"
       expect(content).not.toContain('archived: "true"');
       expect(content).not.toContain('effort: "3"');
     });
+
+    it('coerces a numeric list element to a quoted string that survives re-audit (#700)', async () => {
+      await mkdir(join(tempVaultDir, 'Objectives/Tasks'), { recursive: true });
+      const taskPath = join(tempVaultDir, 'Objectives/Tasks', 'Numeric Tag.md');
+      await writeFile(
+        taskPath,
+        `---
+type: task
+status: backlog
+tags:
+  - alpha
+  - 42
+  - beta
+---
+`
+      );
+
+      // First pass: coerce the numeric element.
+      const fix = await runCLI(['audit', 'task', '--fix', '--auto', '--execute'], tempVaultDir);
+      expect(fix.stdout).toContain('Fixed tags[1] (coerce)');
+
+      const { readFile } = await import('fs/promises');
+      const content = await readFile(taskPath, 'utf-8');
+      // The coerced value must serialize as a QUOTED string so it round-trips as
+      // a string, not as bare `42` (which would re-flag forever — the #700 trap).
+      expect(content).toContain('- "42"');
+      expect(content).not.toMatch(/^\s*-\s*42\s*$/m);
+
+      // Second pass: a re-audit must find the element clean — no re-flag. The fix
+      // converges in ONE pass (idempotent).
+      const reaudit = await runCLI(['audit', 'task', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(reaudit.stdout);
+      const file = output.files.find((f: { path: string }) => f.path.includes('Numeric Tag.md'));
+      const listIssues = file
+        ? file.issues.filter((i: { code: string }) => i.code === 'invalid-list-element')
+        : [];
+      expect(listIssues).toHaveLength(0);
+
+      // Re-running the fix must be a no-op (nothing left to coerce).
+      const fixAgain = await runCLI(['audit', 'task', '--fix', '--auto', '--execute'], tempVaultDir);
+      expect(fixAgain.stdout).not.toContain('coerce');
+      const contentAfter = await readFile(taskPath, 'utf-8');
+      expect(contentAfter).toBe(content);
+    });
+
+    it('coerces multiple numeric list elements idempotently in one pass (#700)', async () => {
+      await mkdir(join(tempVaultDir, 'Objectives/Tasks'), { recursive: true });
+      const taskPath = join(tempVaultDir, 'Objectives/Tasks', 'Multi Numeric.md');
+      await writeFile(
+        taskPath,
+        `---
+type: task
+status: backlog
+tags:
+  - 1
+  - alpha
+  - 2
+  - 3
+---
+`
+      );
+
+      const fix = await runCLI(['audit', 'task', '--fix', '--auto', '--execute'], tempVaultDir);
+      expect(fix.stdout).toContain('Fixed tags[0] (coerce)');
+      expect(fix.stdout).toContain('Fixed tags[2] (coerce)');
+      expect(fix.stdout).toContain('Fixed tags[3] (coerce)');
+
+      const { readFile } = await import('fs/promises');
+      const content = await readFile(taskPath, 'utf-8');
+      // Every numeric element is now a quoted string; the distinct 'alpha' is kept.
+      expect(content).toContain('- "1"');
+      expect(content).toContain('- alpha');
+      expect(content).toContain('- "2"');
+      expect(content).toContain('- "3"');
+
+      const reaudit = await runCLI(['audit', 'task', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(reaudit.stdout);
+      const file = output.files.find((f: { path: string }) => f.path.includes('Multi Numeric.md'));
+      const listIssues = file
+        ? file.issues.filter((i: { code: string }) => i.code === 'invalid-list-element')
+        : [];
+      expect(listIssues).toHaveLength(0);
+    });
+
+    it('coerces a boolean list element to a quoted string that survives re-audit (#700)', async () => {
+      await mkdir(join(tempVaultDir, 'Objectives/Tasks'), { recursive: true });
+      const taskPath = join(tempVaultDir, 'Objectives/Tasks', 'Bool Tag.md');
+      await writeFile(
+        taskPath,
+        `---
+type: task
+status: backlog
+tags:
+  - alpha
+  - true
+---
+`
+      );
+
+      const fix = await runCLI(['audit', 'task', '--fix', '--auto', '--execute'], tempVaultDir);
+      expect(fix.stdout).toContain('Fixed tags[1] (coerce)');
+
+      const { readFile } = await import('fs/promises');
+      const content = await readFile(taskPath, 'utf-8');
+      expect(content).toContain('- "true"');
+
+      const reaudit = await runCLI(['audit', 'task', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(reaudit.stdout);
+      const file = output.files.find((f: { path: string }) => f.path.includes('Bool Tag.md'));
+      const listIssues = file
+        ? file.issues.filter((i: { code: string }) => i.code === 'invalid-list-element')
+        : [];
+      expect(listIssues).toHaveLength(0);
+    });
   });
 
   describe('partial date granularity', () => {


### PR DESCRIPTION
## Summary

The `invalid-list-element` **coerce** action stringifies a wrong-typed scalar list element (a bare number/boolean, e.g. `42`). Issue #700 reported this as non-idempotent — `"42"` re-serializing to bare `42`, re-flagging forever.

Root cause / round-trip: the coerced value is the JS string `String(42)` → `"42"`. `serializeFrontmatter` writes it via `yaml.stringify`, which **force-quotes** a numeric/boolean-looking string (`- "42"`, not bare `- 42`), and gray-matter re-reads a quoted scalar as a string. So a re-audit sees an all-string list and does **not** re-flag — the coerce converges in **one pass**.

## Fix

- **Harden the coerce site** (`src/lib/audit/fix.ts`) to *guarantee* idempotency instead of relying on it implicitly: re-derive the element from the live array and only stringify while it is still a `number`/`boolean`. A re-applied or stale issue is now a safe no-op (it can never re-quote a real string). This matches the field semantics — `invalid-list-element` enforces "every element is a string"; the stable final form is the **quoted string** `"42"`.
- Document the round-trip stability inline and in `docs/product/audit-fix-policy.md`.
- **Regression tests** (`tests/ts/commands/audit.test.ts`): for single-numeric, multiple-numeric (index-safe), and boolean list elements — assert `--fix --auto --execute` writes a quoted string, a re-audit reports **zero** `invalid-list-element` issues, and a second fix is a no-op.

No overlap/regression with the #673 per-element date-list quoting (its idempotency test still passes).

## Gate

- `pnpm qa`: ✅ pass (typecheck, lint, schema:check, docs:lint, docs:doctor, build, 2775 tests)
- `pnpm knip`: ✅ clean

Closes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)