### PR TITLE
fix(search): honor --path in name/fuzzy modes, strict numeric parsing, path-glob conflict warning

### DIFF
--- a/docs-site/src/content/docs/reference/commands/search.md
+++ b/docs-site/src/content/docs/reference/commands/search.md
@@ -253,6 +253,11 @@ Uses shortest unambiguous form:
 - Unique basename: `[[My Note]]`
 - Ambiguous (multiple notes with same name): `[[Ideas/My Note]]`
 
+Disambiguation is always evaluated against the **whole vault**, even when
+`--path` scopes the search. A basename that is duplicated elsewhere in the vault
+stays path-qualified (`[[Ideas/My Note]]`) so the emitted link is unambiguous in
+Obsidian — even if only one copy falls inside the `--path` glob.
+
 ## App Mode Precedence
 
 1. `--app` flag (explicit)

--- a/docs-site/src/content/docs/reference/commands/search.md
+++ b/docs-site/src/content/docs/reference/commands/search.md
@@ -19,6 +19,22 @@ Search operates in three modes:
 - **Fuzzy search** (`--fuzzy`): Ranked approximate matching over note names and aliases, with scores
 - **Content search** (`--body`): Full-text search across note contents using ripgrep
 
+## Path Filtering
+
+`-p, --path <pattern>` scopes the candidate notes to a path glob (e.g.
+`"Projects/**"`) using the same normalization as `list` and the bulk commands.
+It applies in **all three modes**:
+
+- **Name search** — narrows resolution so the glob can disambiguate or exclude
+  matches by directory (e.g. `search Sample --path "Ideas/**"`).
+- **Fuzzy search** (`--fuzzy`) — ranks only candidates inside the glob.
+- **Content search** (`--body`) — prefilters files before the content scan, so
+  `--limit` applies to the path-scoped set.
+
+`--path-glob` is a **deprecated alias** for `--path`. If you pass both, `--path`
+wins and `--path-glob` is ignored — `search` prints a warning to stderr so the
+ignored value is never silent.
+
 ## Options
 
 ### Output
@@ -43,7 +59,7 @@ Search operates in three modes:
 | Option | Description |
 |--------|-------------|
 | `-t, --type <type>` | Restrict search to a type |
-| `-p, --path <pattern>` | Filter by file path glob pattern |
+| `-p, --path <pattern>` | Filter by file path glob pattern (applies in **all** modes — name, `--fuzzy`, and `--body`) |
 | `-w, --where <expr>` | Filter results by frontmatter expression (repeatable) |
 | `-b, --body` | Enable content search mode |
 | `--fuzzy` | Enable fuzzy ranked matching over names and aliases |
@@ -66,6 +82,12 @@ Search operates in three modes:
 | `-E, --regex` | Treat pattern as regex (default: literal) |
 | `-l, --limit <count>` | Maximum files to return (default: 100) |
 
+`--context` and `--limit` are strictly validated, consistent with `--fuzzy`'s
+`--threshold` / `--limit`: a malformed value (e.g. `--limit abc`, `--limit 2.7`,
+`--context -1`) is rejected with a clear error rather than being silently coerced.
+`--context` accepts `0` (equivalent to `--no-context`); `--limit` must be a
+positive integer.
+
 ## Output Formats
 
 | Format | Description |
@@ -83,6 +105,9 @@ Search operates in three modes:
 ```bash
 # Find by name
 bwrb search "My Note"
+
+# Scope name resolution to a directory (disambiguates duplicate basenames)
+bwrb search "Sample" --path "Ideas/**"
 
 # Output as wikilink
 bwrb search "My Note" --output link

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -12,7 +12,7 @@ import { basename } from 'path';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts, resolveGlobalPickerMode } from '../lib/command.js';
 import { loadSchema, getTypeDefByPath, formatUnknownTypeError } from '../lib/schema.js';
-import { configurePromptMode, printError, printSuccess } from '../lib/prompt.js';
+import { configurePromptMode, printError, printSuccess, printWarning } from '../lib/prompt.js';
 import { printJson, jsonSuccess, jsonError, ExitCodes, exitWithResolutionError, warnDeprecated, type SearchOutputFormat } from '../lib/output.js';
 import { openNote, resolveAppMode } from './open.js';
 import { editNoteFromJson, editNoteInteractive } from '../lib/edit.js';
@@ -152,7 +152,7 @@ export const searchCommand = new Command('search')
   .option('-b, --body', 'Full-text content search (uses ripgrep)')
   .option('--text', 'DEPRECATED: use --body')
   .option('-t, --type <type>', 'Restrict search to a type (e.g., idea, objective/task)')
-  .option('-p, --path <pattern>', 'Filter by file path glob pattern (e.g., "Projects/**")')
+  .option('-p, --path <pattern>', 'Filter by file path glob pattern, e.g. "Projects/**" (works in name, --fuzzy, and --body modes)')
   .option('--path-glob <pattern>', 'DEPRECATED: use --path')
   .option('-w, --where <expression...>', 'Filter results by frontmatter expression')
   .option('-C, --context <lines>', 'Lines of context around matches (default: 2)')
@@ -167,7 +167,12 @@ export const searchCommand = new Command('search')
   .addHelpText('after', `
 Name Search (default):
   Searches by note name, basename, or path.
-  
+
+  -p, --path <pat>     Scope resolution to a path glob (e.g. "Projects/**").
+                       Applies in name, --fuzzy, and --body modes. If both
+                       --path and the deprecated --path-glob are passed, --path
+                       wins and --path-glob is ignored (with a warning).
+
   Output Formats (--output):
     name        Output just the note name (default)
     paths       Output vault-relative path with extension
@@ -264,10 +269,19 @@ Examples:
       options.body = true;
     }
 
-    // Handle deprecated --path-glob flag
-    if (options.pathGlob && !options.path) {
-      warnDeprecated('--path-glob', '--path');
-      options.path = options.pathGlob;
+    // Handle deprecated --path-glob flag.
+    // --path-glob is a deprecated alias for --path. If both are given, --path
+    // wins and --path-glob is ignored; warn so the user isn't surprised that
+    // their --path-glob value silently had no effect (#705).
+    if (options.pathGlob) {
+      if (options.path) {
+        printWarning(
+          `Warning: both --path and --path-glob were provided; --path-glob is a deprecated alias for --path, so --path ("${options.path}") wins and --path-glob ("${options.pathGlob}") is ignored.`
+        );
+      } else {
+        warnDeprecated('--path-glob', '--path');
+        options.path = options.pathGlob;
+      }
     }
 
     // Validate mutual exclusivity of --open and --edit
@@ -377,9 +391,43 @@ async function handleContentSearch(
     }
   }
 
-  // Parse options
-  const contextLines = options.noContext ? 0 : parseInt(options.context ?? '2', 10);
-  const limit = parseInt(options.limit ?? '100', 10);
+  // Parse options. Use the same strict integer parsing as the fuzzy path so
+  // malformed values (e.g. "abc", "2.7", "1e1") are rejected with a clear error
+  // instead of being silently coerced by parseInt's lenient parsing (#705).
+  // Commander maps --no-context to options.context === false (see the option
+  // definition). Treat that sentinel (and the legacy noContext flag) as 0 lines
+  // BEFORE strict parsing, so we never try to parse the boolean as an integer.
+  let contextLines = 2;
+  if (options.noContext || (options.context as unknown) === false) {
+    contextLines = 0;
+  } else if (options.context !== undefined) {
+    const parsed = parseStrictInteger(options.context);
+    if (parsed === null || parsed < 0) {
+      const error = `Invalid --context "${options.context}": must be a non-negative integer`;
+      if (jsonMode) {
+        printJson(jsonError(error));
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+      printError(error);
+      process.exit(1);
+    }
+    contextLines = parsed;
+  }
+
+  let limit = 100;
+  if (options.limit !== undefined) {
+    const parsed = parseStrictInteger(options.limit);
+    if (parsed === null || parsed < 1) {
+      const error = `Invalid --limit "${options.limit}": must be a positive integer`;
+      if (jsonMode) {
+        printJson(jsonError(error));
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+      printError(error);
+      process.exit(1);
+    }
+    limit = parsed;
+  }
 
   // Run content search.
   //
@@ -665,7 +713,8 @@ async function handleFuzzySearch(
     process.exit(1);
   }
 
-  const index = await buildNoteIndex(schema, vaultDir);
+  // Scope to --path when provided, consistent with name and content search (#705).
+  const index = await buildNoteIndex(schema, vaultDir, options.path);
   const matches = await fuzzySearch(index, query, schema, vaultDir, { threshold, limit });
 
   // --open / --edit: act on the matched note(s), reusing the exact open/edit +
@@ -839,8 +888,11 @@ async function handleNameSearch(
   // JSON mode implies non-interactive (but returns all matches instead of error)
   const effectivePickerMode: PickerMode = jsonMode ? 'none' : pickerMode;
 
-  // Build note index
-  const index = await buildNoteIndex(schema, vaultDir);
+  // Build note index, scoping to --path when provided. Name-mode --path is
+  // honored (not ignored) for consistency with content search: the same
+  // filterByPath glob normalization narrows the candidate set before every
+  // resolution step (path/basename/alias/fuzzy) runs against it (#705).
+  const index = await buildNoteIndex(schema, vaultDir, options.path);
 
   // Resolve query to file(s)
   const result = await resolveAndPick(index, query, {

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -31,6 +31,22 @@ export interface NoteIndex {
   byAlias: Map<string, ManagedFile[]>;
   /** All discovered files */
   allFiles: ManagedFile[];
+  /**
+   * Full-vault basename map used ONLY for wikilink disambiguation.
+   *
+   * When the index is path-filtered (`buildNoteIndex(..., pathFilter)`), the
+   * `byBasename` map above is scoped to the in-path notes so resolution honors
+   * `--path` (#705). But wikilink generation must NOT use that scoped map to
+   * decide whether a basename is globally unique: a basename duplicated across
+   * the vault but unique within the path glob would otherwise emit a bare
+   * `[[Duplicate]]` that can resolve to the wrong note in Obsidian.
+   *
+   * This map always reflects the UNFILTERED vault, so `getShortestWikilinkTarget`
+   * path-qualifies globally-duplicated basenames even under a path-scoped search.
+   * It is only populated when a path filter is applied; otherwise `byBasename`
+   * already covers the whole vault and disambiguation falls back to it.
+   */
+  fullByBasename?: Map<string, ManagedFile[]>;
 }
 
 export interface ResolutionResult {
@@ -66,11 +82,14 @@ export async function buildNoteIndex(
   vaultDir: string,
   pathFilter?: string
 ): Promise<NoteIndex> {
-  let files = await discoverFilesForNavigation(schema, vaultDir);
+  const allDiscovered = await discoverFilesForNavigation(schema, vaultDir);
 
-  if (pathFilter) {
-    files = filterByPath(files, pathFilter);
-  }
+  // When a path filter is active, resolution maps are built over the in-path
+  // subset only, but we ALSO retain a full-vault basename map (derived from the
+  // unfiltered discovery already in memory — no extra IO) so wikilink generation
+  // can detect globally-duplicated basenames and path-qualify them even though
+  // resolution is scoped to the glob (#705 regression fix).
+  const files = pathFilter ? filterByPath(allDiscovered, pathFilter) : allDiscovered;
 
   const byPath = new Map<string, ManagedFile>();
   const byBasename = new Map<string, ManagedFile[]>();
@@ -82,6 +101,20 @@ export async function buildNoteIndex(
     const existing = byBasename.get(name) || [];
     existing.push(file);
     byBasename.set(name, existing);
+  }
+
+  // Full-vault basename map for wikilink disambiguation. Only needed when the
+  // resolution maps above were scoped by a path filter; without a filter,
+  // `byBasename` already spans the whole vault.
+  let fullByBasename: Map<string, ManagedFile[]> | undefined;
+  if (pathFilter) {
+    fullByBasename = new Map<string, ManagedFile[]>();
+    for (const file of allDiscovered) {
+      const name = basename(file.relativePath, '.md');
+      const existing = fullByBasename.get(name) || [];
+      existing.push(file);
+      fullByBasename.set(name, existing);
+    }
   }
 
   // Index entity aliases as additional resolution keys, so notes are findable by
@@ -111,7 +144,13 @@ export async function buildNoteIndex(
     }
   }
 
-  return { byPath, byBasename, byAlias, allFiles: files };
+  return {
+    byPath,
+    byBasename,
+    byAlias,
+    allFiles: files,
+    ...(fullByBasename ? { fullByBasename } : {}),
+  };
 }
 
 // ============================================================================
@@ -243,7 +282,14 @@ export function resolveNoteQuery(index: NoteIndex, query: string): ResolutionRes
  */
 export function getShortestWikilinkTarget(index: NoteIndex, file: ManagedFile): string {
   const name = basename(file.relativePath, '.md');
-  const filesWithSameName = index.byBasename.get(name);
+  // Disambiguate against the FULL vault, not a path-filtered subset. When the
+  // index was scoped by `--path` (#705), `byBasename` only contains in-path
+  // notes; using it here would treat a globally-duplicated basename as unique
+  // and emit a bare `[[Duplicate]]` that resolves ambiguously in Obsidian.
+  // `fullByBasename` (when present) always spans the whole vault; otherwise the
+  // index is already unfiltered and `byBasename` is the full-vault map.
+  const disambiguationByBasename = index.fullByBasename ?? index.byBasename;
+  const filesWithSameName = disambiguationByBasename.get(name);
   
   // If basename is unique, use just the basename
   if (filesWithSameName && filesWithSameName.length === 1) {

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -12,6 +12,7 @@ import type { LoadedSchema } from '../types/schema.js';
 import {
   buildVaultNoteSnapshot,
   discoverFilesForNavigation,
+  filterByPath,
   findSimilarFiles,
   type ManagedFile
 } from './discovery.js';
@@ -53,9 +54,23 @@ export type { ManagedFile };
   *
   * Uses the same global discovery rules as the rest of the CLI (exclusions apply
   * consistently across list/search/open/edit/audit).
+  *
+  * When `pathFilter` is provided, the candidate file set is narrowed by the same
+  * glob normalization used by content search and bulk commands (`filterByPath`)
+  * BEFORE any maps are built. This scopes every downstream resolution (path,
+  * basename, alias, and fuzzy/partial matching) to the path-filtered set, so
+  * name-mode `search --path` behaves consistently with `search --body --path`.
   */
-export async function buildNoteIndex(schema: LoadedSchema, vaultDir: string): Promise<NoteIndex> {
-  const files = await discoverFilesForNavigation(schema, vaultDir);
+export async function buildNoteIndex(
+  schema: LoadedSchema,
+  vaultDir: string,
+  pathFilter?: string
+): Promise<NoteIndex> {
+  let files = await discoverFilesForNavigation(schema, vaultDir);
+
+  if (pathFilter) {
+    files = filterByPath(files, pathFilter);
+  }
 
   const byPath = new Map<string, ManagedFile>();
   const byBasename = new Map<string, ManagedFile[]>();

--- a/tests/ts/commands/search-fuzzy.test.ts
+++ b/tests/ts/commands/search-fuzzy.test.ts
@@ -92,6 +92,24 @@ aliases:
 `
   );
 
+  // Duplicate basename across two directories. Only Ideas/Duplicate Note.md is
+  // inside the `--path Ideas/**` glob used below, but the basename is NOT
+  // globally unique, so generated wikilinks must stay path-qualified (#705).
+  await writeFile(
+    join(vaultDir, 'Ideas', 'Duplicate Note.md'),
+    `---
+type: idea
+---
+`
+  );
+  await writeFile(
+    join(vaultDir, 'People', 'Duplicate Note.md'),
+    `---
+type: person
+---
+`
+  );
+
   return vaultDir;
 }
 
@@ -220,6 +238,44 @@ describe('search --fuzzy', () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout.split('\n')[0]).toBe('[[Steve Yegge]]');
+  });
+
+  // Regression (#705/#740): fuzzy --path scopes the index, but wikilink
+  // disambiguation must still consult the FULL vault so a globally-duplicated
+  // basename (unique only within the glob) is path-qualified, not bare.
+  it('--output link path-qualifies a globally-duplicated basename even when --path scopes one copy', async () => {
+    const result = await runCLI(
+      ['search', 'Duplicate Note', '--fuzzy', '--path', 'Ideas/**', '--output', 'link'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.split('\n')[0]).toBe('[[Ideas/Duplicate Note]]');
+  });
+
+  it('--output json path-qualifies the duplicate basename in the link field under --path', async () => {
+    const result = await runCLI(
+      ['search', 'Duplicate Note', '--fuzzy', '--path', 'Ideas/**', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(true);
+    const top = json.data[0];
+    expect(top.wikilink).toBe('[[Ideas/Duplicate Note]]');
+    // Result-set filtering (#705) is unchanged: only the in-path copy matches.
+    expect(top.path).toBe('Ideas/Duplicate Note.md');
+  });
+
+  it('control: fuzzy --path still emits the short link for a genuinely unique basename', async () => {
+    const result = await runCLI(
+      ['search', 'Deterministic Safety Net', '--fuzzy', '--path', 'Ideas/**', '--output', 'link'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.split('\n')[0]).toBe('[[Deterministic Safety Net]]');
   });
 
   it('--output content prints the full file (frontmatter + body)', async () => {

--- a/tests/ts/commands/search.test.ts
+++ b/tests/ts/commands/search.test.ts
@@ -139,6 +139,43 @@ describe('search command', () => {
       const json = JSON.parse(result.stdout);
       expect(json.success).toBe(true);
     });
+
+    // Name-mode --path is now honored (was previously ignored): the candidate
+    // set is scoped before resolution, so --path can disambiguate or exclude
+    // matches by directory (issue #705).
+    describe('name-mode --path is honored (issue #705)', () => {
+      it('should scope name resolution to the path glob', async () => {
+        // "Sample" is ambiguous across Ideas/ and Objectives/Tasks/. Scoping to
+        // Ideas/ makes it resolve unambiguously to the idea.
+        const result = await runCLI([
+          'search', 'Sample', '--path', 'Ideas/**', '--picker', 'none', '--output', 'paths',
+        ], vaultDir);
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toBe('Ideas/Sample Idea.md');
+      });
+
+      it('should exclude matches outside the path glob', async () => {
+        // Scoping the same ambiguous query to Objectives/ resolves to the task.
+        const result = await runCLI([
+          'search', 'Sample', '--path', 'Objectives/**', '--picker', 'none', '--output', 'paths',
+        ], vaultDir);
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toBe('Objectives/Tasks/Sample Task.md');
+      });
+
+      it('should report no matches when the query is outside the path glob', async () => {
+        // "Another Idea" only exists under Ideas/ and shares no substring with
+        // any note under Objectives/, so scoping there yields no resolution.
+        const result = await runCLI([
+          'search', 'Another Idea', '--path', 'Objectives/**', '--picker', 'none',
+        ], vaultDir);
+
+        expect(result.exitCode).not.toBe(0);
+        expect(result.stderr).toContain('No matching notes found');
+      });
+    });
   });
 
   describe('deprecated --path-glob flag', () => {
@@ -150,6 +187,29 @@ describe('search command', () => {
       expect(json.success).toBe(true);
       expect(result.stderr).toContain('Warning');
       expect(result.stderr).toContain('--path');
+    });
+
+    // Passing both --path and the deprecated --path-glob used to silently ignore
+    // --path-glob with no signal. We now warn that --path wins (issue #705).
+    it('should warn when both --path and --path-glob are provided, and --path wins', async () => {
+      const result = await runCLI([
+        'search', 'status', '--body',
+        '--path', 'Ideas/*',
+        '--path-glob', 'Objectives/**',
+        '--output', 'json',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain('Warning');
+      expect(result.stderr).toContain('--path-glob');
+      expect(result.stderr).toContain('ignored');
+
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      // --path ("Ideas/*") wins; nothing from Objectives/ leaks in.
+      for (const item of json.data) {
+        expect(item.path).toMatch(/^Ideas\//);
+      }
     });
   });
 
@@ -563,6 +623,73 @@ Some content
       const json = JSON.parse(result.stdout);
       expect(json.success).toBe(true);
       expect(json.data.length).toBeLessThanOrEqual(1);
+    });
+
+    describe('strict numeric parsing (issue #705)', () => {
+      it('should reject a malformed --limit instead of coercing it', async () => {
+        const result = await runCLI([
+          'search', 'type', '--body', '--limit', 'abc', '--output', 'json',
+        ], vaultDir);
+
+        expect(result.exitCode).not.toBe(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.success).toBe(false);
+        expect(json.error).toContain('--limit');
+      });
+
+      it('should reject a non-integer --limit (e.g. 2.7)', async () => {
+        const result = await runCLI([
+          'search', 'type', '--body', '--limit', '2.7', '--output', 'json',
+        ], vaultDir);
+
+        expect(result.exitCode).not.toBe(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.success).toBe(false);
+        expect(json.error).toContain('--limit');
+      });
+
+      it('should reject a zero/negative --limit', async () => {
+        const result = await runCLI([
+          'search', 'type', '--body', '--limit', '0', '--output', 'json',
+        ], vaultDir);
+
+        expect(result.exitCode).not.toBe(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.success).toBe(false);
+        expect(json.error).toContain('--limit');
+      });
+
+      it('should reject a malformed --context instead of coercing it', async () => {
+        const result = await runCLI([
+          'search', 'type', '--body', '--context', 'abc', '--output', 'json',
+        ], vaultDir);
+
+        expect(result.exitCode).not.toBe(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.success).toBe(false);
+        expect(json.error).toContain('--context');
+      });
+
+      it('should reject a negative --context', async () => {
+        const result = await runCLI([
+          'search', 'type', '--body', '--context', '-1', '--output', 'json',
+        ], vaultDir);
+
+        expect(result.exitCode).not.toBe(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.success).toBe(false);
+        expect(json.error).toContain('--context');
+      });
+
+      it('should still accept a valid --context of 0', async () => {
+        const result = await runCLI([
+          'search', 'type', '--body', '--context', '0', '--output', 'json',
+        ], vaultDir);
+
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.success).toBe(true);
+      });
     });
 
     it('should show updated help with content search options', async () => {

--- a/tests/ts/commands/search.test.ts
+++ b/tests/ts/commands/search.test.ts
@@ -252,6 +252,51 @@ status: backlog
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('Ambiguous');
     });
+
+    // Regression (#705/#740): when --path scopes the name-search index, a
+    // basename that is globally duplicated but unique WITHIN the path glob must
+    // still be path-qualified in generated wikilinks. Disambiguation has to
+    // consult the FULL vault, not the path-filtered result set; otherwise the
+    // emitted link is ambiguous in Obsidian and can resolve to the wrong note.
+    describe('path-scoped search still disambiguates wikilinks against the full vault (#705)', () => {
+      it('emits the globally-qualified link for --output link when --path scopes one duplicate', async () => {
+        // Only Ideas/Duplicate.md is in scope, but Objectives/Tasks/Duplicate.md
+        // also exists globally, so the basename "Duplicate" is NOT globally unique.
+        const result = await runCLI(
+          ['search', 'Duplicate', '--path', 'Ideas/**', '--picker', 'none', '--output', 'link'],
+          tempVaultDir,
+        );
+
+        expect(result.exitCode).toBe(0);
+        // Must be path-qualified, NOT the bare [[Duplicate]].
+        expect(result.stdout.trim()).toBe('[[Ideas/Duplicate]]');
+      });
+
+      it('emits the globally-qualified link in the JSON link field under --path', async () => {
+        const result = await runCLI(
+          ['search', 'Duplicate', '--path', 'Ideas/**', '--picker', 'none', '--output', 'json'],
+          tempVaultDir,
+        );
+
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.success).toBe(true);
+        expect(json.data).toHaveLength(1);
+        expect(json.data[0].wikilink).toBe('[[Ideas/Duplicate]]');
+        // Result-set filtering (#705) is unchanged: only the in-path note matches.
+        expect(json.data[0].path).toBe('Ideas/Duplicate.md');
+      });
+
+      it('control: a genuinely unique basename still uses the short link form under --path', async () => {
+        const result = await runCLI(
+          ['search', 'Sample Idea', '--path', 'Ideas/**', '--picker', 'none', '--output', 'link'],
+          tempVaultDir,
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout.trim()).toBe('[[Sample Idea]]');
+      });
+    });
   });
 
   describe('discovery consistency with list command (issue #149)', () => {


### PR DESCRIPTION
Closes #705

Three tight polish fixes in `search` (follow-ups noticed while fixing #675). No refactor of unrelated search logic.

## Sub-item 1 — name-mode `--path` was ignored → **honored**
Path filtering previously only applied to `--body` content search. **Decision: honor `--path` in name mode (and `--fuzzy`) rather than document-and-warn** — it's the consistent UX and cheap to do.

`buildNoteIndex(schema, vaultDir, pathFilter?)` now narrows the discovered file set with the existing `filterByPath` glob normalization **before** any maps are built, so path/basename/alias/fuzzy resolution all scope to the same path-filtered set. `handleNameSearch` and `handleFuzzySearch` pass `options.path` through.

## Sub-item 2 — lenient numeric parsing → **strict**
`handleContentSearch` used `parseInt(options.context ?? '2')` / `parseInt(options.limit ?? '100')`, silently coercing malformed values (`--limit abc` → `NaN`, `--limit 2.7` → `2`). It now uses `parseStrictInteger` (the same helper the fuzzy path uses for `--threshold`/`--limit`), rejecting bad values with a clear error. The Commander `--no-context` sentinel (`context === false`) is handled before strict parsing; `--context 0` stays valid.

## Sub-item 3 — `--path` + `--path-glob` silently dropped one → **warns**
Normalization was `if (pathGlob && !path)`, so passing both silently ignored `--path-glob`. It now prints a warning to stderr that `--path` wins and `--path-glob` is ignored (stdout/JSON stays clean).

## Tests & docs
- Added coverage: name-mode `--path` honored (disambiguate / exclude / no-match), strict rejection of malformed `--limit`/`--context` (and `--context 0` still valid), `--path`+`--path-glob` conflict warning.
- Updated `docs-site/.../reference/commands/search.md`: new Path Filtering section, flag-scope note, strict-validation note, name-mode example.

## Gate (local, foreground)
- `pnpm qa`: **pass** (typecheck, lint, schema:check, docs:lint, docs:doctor, build, 2789 tests)
- `pnpm knip`: **pass**

No `src/types/schema.ts` changes, so `schema.schema.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)