### PR TITLE
fix(validation): unify whitespace-only emptiness across scalar types (#707)

### DIFF
--- a/docs/product/audit-fix-policy.md
+++ b/docs/product/audit-fix-policy.md
@@ -15,11 +15,11 @@ If the field is absent entirely, report `missing-required`.
 
 ## Optional Field Emptiness
 
-An **optional** scalar field set to the literal empty string (`""`), `null`, or absent entirely is treated as "unset" — never an error. Audit and the write path agree here: `validateFrontmatter` computes emptiness with `value !== ''` (an exact check, **not** trimmed), so it accepts `''`, and audit must not flag what writing would have accepted.
+An **optional** scalar field is treated as "unset" — never an error — when its value is blank: `null`, `undefined`, absent entirely, the empty string (`""`), **or a whitespace-only string** (e.g. `"   "`). This single rule applies uniformly to every scalar type (`number`, `boolean`, `date`, `string`). The write path and the audit path share one emptiness predicate (`isBlankScalar`, which trims), so `validateFrontmatter` accepts a blank optional value and audit must not flag what writing would have accepted (#707).
 
-In particular, an empty optional `number` (e.g. `count: ""`) is *not* reported as `wrong-scalar-type`; it is simply unset (#664, mirroring #614).
+In particular, a blank optional `number` (e.g. `count: ""` or `count: "   "`), a blank optional `boolean`, and a blank optional `date` (e.g. `deadline: "   "`) are all *not* reported as `wrong-scalar-type` / `invalid-date-format`; they are simply unset. This is the **trim-everywhere** policy unifying the earlier per-type rules from #614 (dates) and #664 (numbers/booleans).
 
-A **whitespace-only** value (e.g. `count: "   "`) is *not* unset. Because the check is exact rather than trimmed, audit skips only the literal empty string, so a whitespace-only optional `number` or `boolean` is flagged `wrong-scalar-type` — consistent with the write path, which rejects it. This write/audit parity is intentional. A genuinely non-numeric value (e.g. `count: "abc"`) is likewise flagged.
+A genuinely non-empty bad value (e.g. `count: "abc"`, `deadline: "not-a-date"`) is *not* blank and is still flagged on both write and audit. A blank **required** field is reported once as `empty-string-required` (or `missing-required` if absent), never as a scalar-type error.
 
 ## Auto-Coercion Policy (Unambiguous Only)
 

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -36,6 +36,7 @@ import {
   isAcceptableDate,
 } from './fix-policy.js';
 import { extractYamlNodeValue, isEffectivelyEmpty } from './value-utils.js';
+import { isBlankScalar } from '../emptiness.js';
 import { isMap } from 'yaml';
 import type { Pair, Scalar, YAMLMap } from 'yaml';
 import { isDeepStrictEqual } from 'node:util';
@@ -544,21 +545,19 @@ export async function auditFile(
     } else if (
       expectedScalarType !== 'string' &&
       typeof value === 'string' &&
-      value === ''
+      isBlankScalar(value)
     ) {
-      // A literal empty string is "unset", not an invalid scalar. This mirrors
-      // the write path exactly: validateFrontmatter computes emptiness with
-      // `value !== ''` (NOT trimmed) and accepts `''`, so we skip only `''`
-      // here too. A whitespace-only value (e.g. "   ") is NOT skipped — the
-      // write path rejects it as a wrong-type scalar, so audit must flag it as
-      // `wrong-scalar-type` to keep write and audit in agreement (parity).
-      // Other optional fields behave the same (e.g. empty selects/dates are
-      // skipped — see the date block below). A *required* empty value is
+      // A blank string — empty OR whitespace-only — is "unset", not an invalid
+      // scalar. This mirrors the write path exactly: validateFrontmatter now
+      // treats any blank optional value as unset via the shared `isBlankScalar`
+      // helper (#707), so a blank optional number/boolean is accepted on write
+      // and must likewise be skipped here to keep write and audit in agreement
+      // (parity from #664). Other optional fields behave the same (empty/blank
+      // selects and dates are skipped — see the date block below, all routed
+      // through the same trim-everywhere rule). A *required* blank value is
       // reported once as `empty-string-required` by the required-field loop
-      // above. Skipping here avoids both double-reporting and flagging an unset
-      // optional number as `wrong-scalar-type` (#664, mirroring #614). A
-      // genuinely non-numeric value (e.g. "abc") is not empty and so is still
-      // flagged by the coercion check below.
+      // above. A genuinely non-numeric value (e.g. "abc") is not blank and so is
+      // still flagged by the coercion check below.
     } else {
       if (Array.isArray(value)) {
         const listCoercion = getScalarFromList(value, expectedScalarType);
@@ -634,13 +633,15 @@ export async function auditFile(
       const checkDateElement = (element: unknown, listIndex?: number) => {
         if (typeof element !== 'string' && typeof element !== 'number') return;
 
-        // An empty/blank string is "unset", not an invalid date. This mirrors the
-        // write path (validateFrontmatter treats `''` as no value) and how other
-        // optional fields behave (e.g. empty selects are skipped). A *required*
-        // empty date is reported once as `empty-string-required`; an empty list
-        // element is reported once as `invalid-list-element`. Skipping here keeps
-        // write and audit in agreement and avoids double-reporting (#614).
-        if (typeof element === 'string' && element.trim().length === 0) return;
+        // A blank string — empty OR whitespace-only — is "unset", not an invalid
+        // date. This uses the same shared `isBlankScalar` rule as the write path
+        // (validateFrontmatter treats any blank optional value as no value) and
+        // as the number/boolean guard above, so all scalar types skip blanks
+        // identically (#614, unified in #707). A *required* blank date is
+        // reported once as `empty-string-required`; an empty list element is
+        // reported once as `invalid-list-element`. Skipping here keeps write and
+        // audit in agreement and avoids double-reporting.
+        if (typeof element === 'string' && isBlankScalar(element)) return;
 
         // A bare year (e.g. 2026) is parsed as a number by YAML; treat it as a
         // partial date string for validation.

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -34,6 +34,7 @@ import {
   normalizeDateFields,
   applyDefaults,
 } from './validation.js';
+import { isBlankScalar } from './emptiness.js';
 import { validateParentNoCycle } from './hierarchy.js';
 import {
   printJson,
@@ -162,16 +163,38 @@ export async function editNoteFromJson(
   // Normalize date-like fields to canonical YYYY-MM-DD strings
   const normalizedFrontmatter = normalizeDateFields(schema, typePath, mergedFrontmatter);
 
-  // Materialize defaults BEFORE validating/writing, mirroring the `new` path
-  // (json-mode.ts). Without this, a blank (incl. whitespace-only) REQUIRED field
-  // that HAS a default would pass validation — `validateFrontmatter` treats it as
-  // "unset → satisfied by the default" (#707) — but the blank value would be
-  // PERSISTED, so a subsequent `audit` flags it `empty-string-required`: write
-  // says OK, audit says broken. `applyDefaults` only fills blanks (it never
-  // overwrites a real user value) and only where a `default`/`value` is declared,
-  // so optional fields with no default stay unset (trim-everywhere preserved) and
-  // required fields with no default remain blank → still rejected below.
-  const resolvedFrontmatter = applyDefaults(schema, typePath, normalizedFrontmatter);
+  // Materialize defaults BEFORE validating/writing — but ONLY for the parity
+  // case, SURGICALLY scoped to the keys the user blanked in THIS patch.
+  //
+  // The write↔audit parity bug (#707): a blank (incl. whitespace-only) value for
+  // a key whose field HAS a `default`/`value` passes validation —
+  // `validateFrontmatter` treats it as "unset → satisfied by the default" — but
+  // the blank would be PERSISTED, so `audit` then flags `empty-string-required`:
+  // write says OK, audit says broken. Materializing the default for that key makes
+  // write and audit agree.
+  //
+  // A BLANKET `applyDefaults` over the whole merged frontmatter over-corrects in
+  // two ways, so we scope instead:
+  //   1. Explicit removal (`{"field": null}`) is the documented way to delete a
+  //      field. `mergeFrontmatter` deletes it; a blanket default would write it
+  //      straight back. We EXCLUDE null (isBlankScalar is true for null, so we
+  //      filter on a blank STRING specifically) → removal is preserved.
+  //   2. An edit must not materialize defaults for fields the user never touched.
+  //      Scoping to user-patch keys leaves untouched fields alone.
+  //
+  // Keys the user blanked but whose field has NO default stay blank: optional →
+  // unset (trim-everywhere preserved), required → still rejected at validation.
+  const blankPatchKeys = new Set(
+    Object.keys(patchData).filter(
+      (key) => typeof patchData[key] === 'string' && isBlankScalar(patchData[key])
+    )
+  );
+  const resolvedFrontmatter = applyDefaults(
+    schema,
+    typePath,
+    normalizedFrontmatter,
+    blankPatchKeys
+  );
 
   // Validate merged result
   const validation = validateFrontmatter(schema, typePath, resolvedFrontmatter);

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -160,9 +160,6 @@ export async function editNoteFromJson(
   const mergedFrontmatter = mergeFrontmatter(frontmatter, patchData);
   const updatedFields = Object.keys(patchData).filter(k => patchData[k] !== undefined);
 
-  // Normalize date-like fields to canonical YYYY-MM-DD strings
-  const normalizedFrontmatter = normalizeDateFields(schema, typePath, mergedFrontmatter);
-
   // Materialize defaults BEFORE validating/writing — but ONLY for the parity
   // case, SURGICALLY scoped to the keys the user blanked in THIS patch.
   //
@@ -189,12 +186,23 @@ export async function editNoteFromJson(
       (key) => typeof patchData[key] === 'string' && isBlankScalar(patchData[key])
     )
   );
-  const resolvedFrontmatter = applyDefaults(
+  const defaultedFrontmatter = applyDefaults(
     schema,
     typePath,
-    normalizedFrontmatter,
+    mergedFrontmatter,
     blankPatchKeys
   );
+
+  // Normalize date-like fields to canonical YYYY-MM-DD strings — AFTER defaults
+  // are materialized (#707). A materialized date default can be non-canonical
+  // (e.g. `default: "12/25/2026"`); `validateFrontmatter` accepts the slash form,
+  // so without normalizing it here the raw default would be PERSISTED and `audit`
+  // would then flag `invalid-date-format`. Running the single date-normalization
+  // pass after `applyDefaults` canonicalizes BOTH user-supplied date values and
+  // any date default we just filled in, so write and audit agree on the stored
+  // form. (Mirrors `new`/json-mode, which materializes defaults before building
+  // the note.)
+  const resolvedFrontmatter = normalizeDateFields(schema, typePath, defaultedFrontmatter);
 
   // Validate merged result
   const validation = validateFrontmatter(schema, typePath, resolvedFrontmatter);

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -32,6 +32,7 @@ import {
   validateFrontmatter,
   validateContextFields,
   normalizeDateFields,
+  applyDefaults,
 } from './validation.js';
 import { validateParentNoCycle } from './hierarchy.js';
 import {
@@ -161,8 +162,19 @@ export async function editNoteFromJson(
   // Normalize date-like fields to canonical YYYY-MM-DD strings
   const normalizedFrontmatter = normalizeDateFields(schema, typePath, mergedFrontmatter);
 
+  // Materialize defaults BEFORE validating/writing, mirroring the `new` path
+  // (json-mode.ts). Without this, a blank (incl. whitespace-only) REQUIRED field
+  // that HAS a default would pass validation — `validateFrontmatter` treats it as
+  // "unset → satisfied by the default" (#707) — but the blank value would be
+  // PERSISTED, so a subsequent `audit` flags it `empty-string-required`: write
+  // says OK, audit says broken. `applyDefaults` only fills blanks (it never
+  // overwrites a real user value) and only where a `default`/`value` is declared,
+  // so optional fields with no default stay unset (trim-everywhere preserved) and
+  // required fields with no default remain blank → still rejected below.
+  const resolvedFrontmatter = applyDefaults(schema, typePath, normalizedFrontmatter);
+
   // Validate merged result
-  const validation = validateFrontmatter(schema, typePath, normalizedFrontmatter);
+  const validation = validateFrontmatter(schema, typePath, resolvedFrontmatter);
   if (!validation.valid) {
     if (jsonMode) {
       printJson({
@@ -183,7 +195,7 @@ export async function editNoteFromJson(
   }
 
   // Validate context fields (source type constraints)
-  const contextValidation = await validateContextFields(schema, vaultDir, typePath, normalizedFrontmatter);
+  const contextValidation = await validateContextFields(schema, vaultDir, typePath, resolvedFrontmatter);
   if (!contextValidation.valid) {
     if (jsonMode) {
       printJson({
@@ -204,13 +216,13 @@ export async function editNoteFromJson(
   }
 
   // Validate parent field doesn't create a cycle (for recursive types)
-  if (typeDef.recursive && normalizedFrontmatter['parent']) {
+  if (typeDef.recursive && resolvedFrontmatter['parent']) {
     const noteName = filePath.split('/').pop()?.replace(/\.md$/, '') ?? '';
     const cycleError = await validateParentNoCycle(
       schema,
       vaultDir,
       noteName,
-      normalizedFrontmatter['parent'] as string
+      resolvedFrontmatter['parent'] as string
     );
     if (cycleError) {
       if (jsonMode) {
@@ -230,7 +242,7 @@ export async function editNoteFromJson(
 
   // Get field order
   const fieldOrder = getFrontmatterOrder(typeDef);
-  const orderedFields = fieldOrder.length > 0 ? fieldOrder : Object.keys(normalizedFrontmatter);
+  const orderedFields = fieldOrder.length > 0 ? fieldOrder : Object.keys(resolvedFrontmatter);
 
   // Recurrence fast path (atomicity, #107): VALIDATE + COMPUTE the successor
   // BEFORE mutating the predecessor. If this completion would spawn a successor
@@ -243,12 +255,12 @@ export async function editNoteFromJson(
     typeDef.name,
     filePath,
     frontmatter,
-    normalizedFrontmatter,
+    resolvedFrontmatter,
     body
   );
 
   // Write updated note (predecessor status change is now safe to commit).
-  await writeNote(filePath, normalizedFrontmatter, body, orderedFields);
+  await writeNote(filePath, resolvedFrontmatter, body, orderedFields);
 
   // Commit the prepared spawn (create successor + back-link `next`). Identical
   // result to the audit backstop, which shares the same engine.

--- a/src/lib/emptiness.ts
+++ b/src/lib/emptiness.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared emptiness predicate for optional scalar field values.
+ *
+ * bwrb treats a blank optional value as "unset" *uniformly* — a `null`,
+ * `undefined`, an empty string, or a whitespace-only string (e.g. `"   "`) all
+ * mean "no value provided". This is the single source of truth so the write
+ * path (`validateFrontmatter`, `normalizeDateFields`, `applyDefaults`) and the
+ * audit path (`detection.ts` scalar/date guards) can never drift apart again
+ * (#707). Trimming matches every other emptiness check in the codebase
+ * (`isEmptyRequiredValue`, `isEffectivelyEmpty`, select-option and date-element
+ * guards), so an optional date, number, boolean, or string with a whitespace-
+ * only value is skipped identically on both write and audit.
+ *
+ * This deliberately does NOT treat `0` or `false` as empty — those are
+ * legitimate scalar values, not "unset".
+ */
+export function isBlankScalar(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === 'string') return value.trim().length === 0;
+  return false;
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -313,22 +313,32 @@ export function validateFrontmatter(
 /**
  * Apply defaults to frontmatter for missing fields.
  * Also injects the 'type' field with the type name.
+ *
+ * When `keyScope` is provided, ONLY those field names are considered for default
+ * materialization (and the `type` field is left untouched). The `edit` write path
+ * uses this to restore the #707 write↔audit parity case SURGICALLY: it scopes
+ * defaults to just the keys the user blanked in their patch, so an explicit
+ * `null` removal is not re-defaulted and untouched fields are never materialized.
+ * Without a scope, every declared field is considered (the `new` behavior).
  */
 export function applyDefaults(
   schema: LoadedSchema,
   typeName: string,
-  frontmatter: Record<string, unknown>
+  frontmatter: Record<string, unknown>,
+  keyScope?: ReadonlySet<string>
 ): Record<string, unknown> {
   const result = { ...frontmatter };
   const fields = getFieldsForType(schema, typeName);
 
-  // Always inject the type field with the type name
+  // Always inject the type field with the type name (unscoped path only).
   // In the new inheritance model, type is auto-injected, not a field definition
-  if (!result['type']) {
+  if (keyScope === undefined && !result['type']) {
     result['type'] = typeName;
   }
 
   for (const [fieldName, field] of Object.entries(fields)) {
+    if (keyScope !== undefined && !keyScope.has(fieldName)) continue;
+
     const value = result[fieldName];
     // Blank optional values (incl. whitespace-only) are "unset", so defaults and
     // static values fill them in just like a missing field (#707).

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -245,24 +245,31 @@ export function validateFrontmatter(
   for (const [fieldName, field] of Object.entries(fields)) {
     const value = frontmatter[fieldName];
 
-    // The blank-as-unset shortcut (#707) applies only to SCALAR (`multiple`
-    // falsy) fields. For a `multiple: true` field a whitespace-only scalar string
-    // is NOT a valid "unset": it is the wrong SHAPE (a scalar where a list is
-    // expected) and has no sensible list interpretation. Audit flags any non-array
-    // scalar on a list field as `wrong-scalar-type`, including a whitespace blank
-    // (it does NOT route list fields through `isBlankScalar`). If we let
-    // `isBlankScalar` treat `dates: "   "` as unset here, write would SKIP every
-    // shape/type check and silently PERSIST the blank scalar, while audit still
-    // flagged it — the write↔audit parity break this PR exists to close.
+    // The blank-as-unset shortcut (#707) applies only to genuinely SCALAR fields.
+    // A field is LIST-SHAPED if `field.multiple === true` OR `field.prompt ===
+    // 'list'` — this is the exact predicate audit uses to decide "expects an
+    // array" (see `expectsList` in `src/lib/audit/detection.ts` and
+    // `src/lib/audit/fix.ts`), and it covers the alias role too (the ALIAS schema
+    // pattern declares `aliases` as `prompt: 'list'`). For a list-shaped field a
+    // whitespace-only scalar string is NOT a valid "unset": it is the wrong SHAPE
+    // (a scalar where a list is expected) and has no sensible list interpretation.
+    // Audit flags any non-array scalar on a list field as `wrong-scalar-type`,
+    // including a whitespace blank (it does NOT route list fields through
+    // `isBlankScalar`). If we let `isBlankScalar` treat `dates: "   "` or
+    // `aliases: "   "` as unset here, write would SKIP every shape/type check and
+    // silently PERSIST the blank scalar, while audit still flagged it — the
+    // write↔audit parity break this PR exists to close.
     //
-    // So we do NOT short-circuit blank scalars on `multiple` fields; they fall
-    // through to the type check below, where a blank scalar on (e.g.) a
-    // `multiple` date field is rejected as an invalid value — keeping write and
-    // audit in agreement (both reject). A genuine non-array scalar that DOES carry
-    // a value (e.g. `labels: "urgent"`) is unaffected: it was never blank, so its
-    // long-standing accept-on-write / autofix-on-audit behavior is preserved.
-    // `null`/`undefined`/absent and empty arrays remain "unset" exactly as before.
-    const treatBlankAsUnset = field.multiple !== true;
+    // So we do NOT short-circuit blank scalars on list-shaped fields; they fall
+    // through to the type check below, where a blank scalar on (e.g.) a `multiple`
+    // date field or a `prompt: 'list'` alias field is rejected as an invalid value
+    // — keeping write and audit in agreement (both reject). A genuine non-array
+    // scalar that DOES carry a value (e.g. `labels: "urgent"`) is unaffected: it
+    // was never blank, so its long-standing accept-on-write / autofix-on-audit
+    // behavior is preserved. `null`/`undefined`/absent and empty arrays remain
+    // "unset" exactly as before.
+    const isListShapedField = field.multiple === true || field.prompt === 'list';
+    const treatBlankAsUnset = !isListShapedField;
     const hasValue = treatBlankAsUnset ? !isBlankScalar(value) : value !== undefined && value !== null;
 
     // Check required fields

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -221,9 +221,26 @@ export function validateFrontmatter(
   // Check for required fields
   for (const [fieldName, field] of Object.entries(fields)) {
     const value = frontmatter[fieldName];
-    // A blank optional value (null/undefined/empty/whitespace-only) counts as
-    // "unset" uniformly across all scalar types (#707), matching the audit path.
-    const hasValue = !isBlankScalar(value);
+
+    // The blank-as-unset shortcut (#707) applies only to SCALAR (`multiple`
+    // falsy) fields. For a `multiple: true` field a whitespace-only scalar string
+    // is NOT a valid "unset": it is the wrong SHAPE (a scalar where a list is
+    // expected) and has no sensible list interpretation. Audit flags any non-array
+    // scalar on a list field as `wrong-scalar-type`, including a whitespace blank
+    // (it does NOT route list fields through `isBlankScalar`). If we let
+    // `isBlankScalar` treat `dates: "   "` as unset here, write would SKIP every
+    // shape/type check and silently PERSIST the blank scalar, while audit still
+    // flagged it — the write↔audit parity break this PR exists to close.
+    //
+    // So we do NOT short-circuit blank scalars on `multiple` fields; they fall
+    // through to the type check below, where a blank scalar on (e.g.) a
+    // `multiple` date field is rejected as an invalid value — keeping write and
+    // audit in agreement (both reject). A genuine non-array scalar that DOES carry
+    // a value (e.g. `labels: "urgent"`) is unaffected: it was never blank, so its
+    // long-standing accept-on-write / autofix-on-audit behavior is preserved.
+    // `null`/`undefined`/absent and empty arrays remain "unset" exactly as before.
+    const treatBlankAsUnset = field.multiple !== true;
+    const hasValue = treatBlankAsUnset ? !isBlankScalar(value) : value !== undefined && value !== null;
 
     // Check required fields
     if (field.required && !hasValue && field.default === undefined) {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -132,30 +132,53 @@ export function normalizeDateFields(
     if (!(fieldName in normalized)) continue;
 
     const value = normalized[fieldName];
-    // A blank optional value (null/undefined/empty/whitespace-only) is "unset";
-    // leave it untouched so it isn't normalized into a bogus date (#707).
-    if (isBlankScalar(value)) continue;
+    const granularity = resolveDateGranularity(field, schema.config);
 
-    // Handle any residual Date objects (defense-in-depth).
-    // Use UTC components since YAML dates are stored as midnight UTC.
-    if (value instanceof Date) {
-      normalized[fieldName] = formatUtcDate(value);
+    // A `multiple: true` date field holds an array; canonicalize each element
+    // against the field's granularity so list-date values (default-materialized
+    // OR user-supplied) are written in the same ISO form `audit` validates and
+    // `#673`-style per-element quoting expects. Mirrors the per-element validation
+    // in `validateFieldType` (#707).
+    if (field.multiple && Array.isArray(value)) {
+      normalized[fieldName] = value.map((element) =>
+        normalizeDateValue(element, granularity)
+      );
       continue;
     }
 
-    // A bare year (e.g. 2026) may arrive as a number from YAML/JSON; coerce so
-    // it can be normalized against the field's granularity.
-    const dateValue = typeof value === 'number' ? String(value) : value;
-    if (typeof dateValue !== 'string') continue;
-
-    const granularity = resolveDateGranularity(field, schema.config);
-    const result = normalizeToIsoDate(dateValue, granularity);
-    if (result.valid) {
-      normalized[fieldName] = result.value;
-    }
+    normalized[fieldName] = normalizeDateValue(value, granularity);
   }
 
   return normalized;
+}
+
+/**
+ * Canonicalize a single date value to its ISO stored form against the supplied
+ * granularity. Shared by scalar date fields and per-element normalization of
+ * `multiple: true` date arrays so the two paths stay in lockstep (#707).
+ *
+ * Returns the input untouched when it is blank/unset, a residual `Date`
+ * (formatted from UTC), a non-coercible non-string, or fails normalization — in
+ * the last case the validation layer surfaces a clear error.
+ */
+function normalizeDateValue(value: unknown, granularity: DatePrecision): unknown {
+  // A blank value (null/undefined/empty/whitespace-only) is "unset"; leave it
+  // untouched so it isn't normalized into a bogus date (#707).
+  if (isBlankScalar(value)) return value;
+
+  // Handle any residual Date objects (defense-in-depth).
+  // Use UTC components since YAML dates are stored as midnight UTC.
+  if (value instanceof Date) {
+    return formatUtcDate(value);
+  }
+
+  // A bare year (e.g. 2026) may arrive as a number from YAML/JSON; coerce so
+  // it can be normalized against the field's granularity.
+  const dateValue = typeof value === 'number' ? String(value) : value;
+  if (typeof dateValue !== 'string') return value;
+
+  const result = normalizeToIsoDate(dateValue, granularity);
+  return result.valid ? result.value : value;
 }
 
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -245,35 +245,53 @@ export function validateFrontmatter(
   for (const [fieldName, field] of Object.entries(fields)) {
     const value = frontmatter[fieldName];
 
-    // The blank-as-unset shortcut (#707) applies only to genuinely SCALAR fields.
-    // A field is LIST-SHAPED if `field.multiple === true` OR `field.prompt ===
-    // 'list'` — this is the exact predicate audit uses to decide "expects an
-    // array" (see `expectsList` in `src/lib/audit/detection.ts` and
-    // `src/lib/audit/fix.ts`), and it covers the alias role too (the ALIAS schema
-    // pattern declares `aliases` as `prompt: 'list'`). For a list-shaped field a
-    // whitespace-only scalar string is NOT a valid "unset": it is the wrong SHAPE
-    // (a scalar where a list is expected) and has no sensible list interpretation.
-    // Audit flags any non-array scalar on a list field as `wrong-scalar-type`,
-    // including a whitespace blank (it does NOT route list fields through
-    // `isBlankScalar`). If we let `isBlankScalar` treat `dates: "   "` or
-    // `aliases: "   "` as unset here, write would SKIP every shape/type check and
-    // silently PERSIST the blank scalar, while audit still flagged it — the
-    // write↔audit parity break this PR exists to close.
+    // The blank-as-unset handling (#707) splits into two questions, because a
+    // blank value plays a different role in the REQUIRED check vs the TYPE check.
     //
-    // So we do NOT short-circuit blank scalars on list-shaped fields; they fall
-    // through to the type check below, where a blank scalar on (e.g.) a `multiple`
-    // date field or a `prompt: 'list'` alias field is rejected as an invalid value
-    // — keeping write and audit in agreement (both reject). A genuine non-array
-    // scalar that DOES carry a value (e.g. `labels: "urgent"`) is unaffected: it
-    // was never blank, so its long-standing accept-on-write / autofix-on-audit
-    // behavior is preserved. `null`/`undefined`/absent and empty arrays remain
-    // "unset" exactly as before.
+    // A field is LIST-SHAPED if `field.multiple === true` OR `field.prompt ===
+    // 'list'` — the exact predicate audit uses to decide "expects an array" (see
+    // `expectsList` in `src/lib/audit/detection.ts` and `src/lib/audit/fix.ts`).
+    //
+    // (1) Is the value MISSING for the required check? — mirrors audit's
+    //     `isEmptyRequiredValue`: `null`/`undefined`/blank-string for any field,
+    //     PLUS an empty array `[]` for a list-shaped field. So a REQUIRED list
+    //     field given `""`/`"   "`/`[]` is reported as required-missing (audit
+    //     emits `empty-string-required`); an OPTIONAL one is simply skipped here.
+    //     This restores the required-emptiness check that an earlier round
+    //     regressed by routing list fields around `isBlankScalar` entirely.
+    //
+    // (2) Is there a value to TYPE-CHECK? — this is where scalar and list shapes
+    //     diverge:
+    //       - scalar field: a blank scalar string is "unset" and skips the type
+    //         check (the PR's main change — `dates: "   "` on an optional scalar
+    //         is accepted). Only a NON-blank scalar is type-checked.
+    //       - list-shaped field: a blank scalar string is NOT unset — it is the
+    //         wrong SHAPE (a scalar where a list is expected) and must reach
+    //         `validateFieldType`, which rejects it for a `multiple` date field
+    //         (bad date) and for an alias field (`invalid_alias`), matching
+    //         audit's `wrong-scalar-type` flag. Only `null`/`undefined`/`[]` are
+    //         genuinely unset for a list field and skip the type check.
+    //
+    // A non-blank scalar on a non-alias list field (e.g. `labels: 'urgent'`) is
+    // unaffected: it was never blank, so it flows to type validation and keeps its
+    // long-standing soft-coercion (audit autofixes it as `wrong-scalar-type`) —
+    // intentionally out of scope here.
     const isListShapedField = field.multiple === true || field.prompt === 'list';
-    const treatBlankAsUnset = !isListShapedField;
-    const hasValue = treatBlankAsUnset ? !isBlankScalar(value) : value !== undefined && value !== null;
+    const isNullish = value === undefined || value === null;
+    const isEmptyArray = Array.isArray(value) && value.length === 0;
+
+    // (1) Required-check emptiness (audit's `isEmptyRequiredValue` semantics).
+    const isMissingForRequired = isListShapedField
+      ? isBlankScalar(value) || isEmptyArray
+      : isBlankScalar(value);
+
+    // (2) Whether there is a value worth type-/option-checking. A blank scalar
+    // string is unset for SCALAR fields only; for LIST-shaped fields it is the
+    // wrong shape and must be type-checked.
+    const hasValue = isListShapedField ? !(isNullish || isEmptyArray) : !isBlankScalar(value);
 
     // Check required fields
-    if (field.required && !hasValue && field.default === undefined) {
+    if (field.required && isMissingForRequired && field.default === undefined) {
       const expected = getFieldExpected(schema, field);
       errors.push({
         type: 'required_field_missing',

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -4,6 +4,7 @@ import { isBwrbBuiltinFrontmatterField } from './frontmatter/systemFields.js';
 import { queryByType } from './vault.js';
 import { extractWikilinkTarget } from './links.js';
 import { levenshteinDistance } from './levenshtein.js';
+import { isBlankScalar } from './emptiness.js';
 import {
   expandStaticValue,
   parseDate,
@@ -131,7 +132,9 @@ export function normalizeDateFields(
     if (!(fieldName in normalized)) continue;
 
     const value = normalized[fieldName];
-    if (value === undefined || value === null || value === '') continue;
+    // A blank optional value (null/undefined/empty/whitespace-only) is "unset";
+    // leave it untouched so it isn't normalized into a bogus date (#707).
+    if (isBlankScalar(value)) continue;
 
     // Handle any residual Date objects (defense-in-depth).
     // Use UTC components since YAML dates are stored as midnight UTC.
@@ -218,7 +221,9 @@ export function validateFrontmatter(
   // Check for required fields
   for (const [fieldName, field] of Object.entries(fields)) {
     const value = frontmatter[fieldName];
-    const hasValue = value !== undefined && value !== null && value !== '';
+    // A blank optional value (null/undefined/empty/whitespace-only) counts as
+    // "unset" uniformly across all scalar types (#707), matching the audit path.
+    const hasValue = !isBlankScalar(value);
 
     // Check required fields
     if (field.required && !hasValue && field.default === undefined) {
@@ -325,7 +330,9 @@ export function applyDefaults(
 
   for (const [fieldName, field] of Object.entries(fields)) {
     const value = result[fieldName];
-    const hasValue = value !== undefined && value !== null && value !== '';
+    // Blank optional values (incl. whitespace-only) are "unset", so defaults and
+    // static values fill them in just like a missing field (#707).
+    const hasValue = !isBlankScalar(value);
 
     if (!hasValue && field.default !== undefined) {
       result[fieldName] = field.default;
@@ -424,9 +431,10 @@ function validateFieldType(
     if (field.multiple && Array.isArray(value)) {
       for (let index = 0; index < value.length; index++) {
         const element = value[index];
-        // Skip structural gaps (null/empty); those are reported separately.
-        if (element === null || element === undefined) continue;
-        if (typeof element === 'string' && element.trim().length === 0) continue;
+        // Skip blank/structural gaps (null/empty/whitespace-only); those are
+        // reported separately. Shared `isBlankScalar` rule keeps this in step
+        // with the scalar paths (#707).
+        if (isBlankScalar(element)) continue;
         const elementError = validateDateValue(fieldName, element, granularity, index);
         if (elementError) return elementError;
       }
@@ -744,9 +752,10 @@ export async function validateContextFields(
     if (!field.source) continue;
 
     const value = frontmatter[fieldName];
-    
-    // Skip empty/null values (required field check is separate)
-    if (value === undefined || value === null || value === '') continue;
+
+    // Skip blank values, incl. whitespace-only (required field check is
+    // separate). Arrays fall through to per-element handling below (#707).
+    if (isBlankScalar(value)) continue;
 
     // Validate each value (handle both single and array values)
     const values = Array.isArray(value) ? value : [value];

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -5026,13 +5026,14 @@ effort: ""
       }
     });
 
-    it('should flag a blank (whitespace) optional number as wrong-scalar-type (write/audit parity)', async () => {
-      // Parity with the write path: validateFrontmatter computes emptiness with
-      // `value !== ''` (NOT trimmed), so a whitespace-only value like "   " is
-      // NOT treated as unset and is rejected as a wrong-type scalar. Audit must
-      // agree and flag it as wrong-scalar-type. Only the literal empty string
-      // ("") is skipped as "unset" (see the #664 test above). This keeps audit
-      // and `new --json`/`edit` in agreement on whitespace-only scalars.
+    it('should not flag a blank (whitespace) optional number as wrong-scalar-type (#707)', async () => {
+      // #707 unifies whitespace handling to trim-everywhere: a whitespace-only
+      // value like "   " is "unset" the same as "" across ALL scalar types, on
+      // both write and audit. validateFrontmatter now treats blank optional
+      // values as unset via the shared `isBlankScalar` helper, so audit must
+      // agree and NOT flag a blank optional number. Mirrors the optional-date
+      // behaviour (see the blank-date test above), so dates and numbers handle
+      // whitespace-only values identically.
       await writeFile(
         join(tempVaultDir, 'Ideas', 'Blank Effort.md'),
         `---
@@ -5047,13 +5048,51 @@ effort: "   "
       const output = JSON.parse(result.stdout);
       const file = output.files.find((f: { path: string }) => f.path.includes('Blank Effort.md'));
 
-      expect(file).toBeDefined();
-      const numberIssue = file.issues.find(
-        (i: { code: string; field?: string }) =>
-          i.code === 'wrong-scalar-type' && i.field === 'effort'
+      if (file) {
+        const numberIssue = file.issues.find(
+          (i: { code: string; field?: string }) =>
+            i.code === 'wrong-scalar-type' && i.field === 'effort'
+        );
+        expect(numberIssue).toBeUndefined();
+      }
+    });
+
+    it('should not flag an empty or blank optional boolean as wrong-scalar-type (#707)', async () => {
+      // Booleans must follow the same unified trim-everywhere rule as dates and
+      // numbers (#707): both an empty string and a whitespace-only string are
+      // "unset" and skipped on write and audit alike.
+      await writeFile(
+        join(tempVaultDir, 'Ideas', 'Empty Archived.md'),
+        `---
+type: idea
+status: raw
+archived: ""
+---
+`
       );
-      expect(numberIssue).toBeDefined();
-      expect(numberIssue.expected).toBe('number');
+      await writeFile(
+        join(tempVaultDir, 'Ideas', 'Blank Archived.md'),
+        `---
+type: idea
+status: raw
+archived: "   "
+---
+`
+      );
+
+      const result = await runCLI(['audit', 'idea', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(result.stdout);
+
+      for (const name of ['Empty Archived.md', 'Blank Archived.md']) {
+        const file = output.files.find((f: { path: string }) => f.path.includes(name));
+        if (file) {
+          const boolIssue = file.issues.find(
+            (i: { code: string; field?: string }) =>
+              i.code === 'wrong-scalar-type' && i.field === 'archived'
+          );
+          expect(boolIssue).toBeUndefined();
+        }
+      }
     });
 
     it('should still flag a non-numeric optional number value', async () => {

--- a/tests/ts/lib/edit-blank-list-prompt-parity.test.ts
+++ b/tests/ts/lib/edit-blank-list-prompt-parity.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+
+import { loadSchema } from '../../../src/lib/schema.js';
+import { editNoteFromJson } from '../../../src/lib/edit.js';
+import { validateFrontmatter } from '../../../src/lib/validation.js';
+import { parseNote } from '../../../src/lib/frontmatter.js';
+import { runAudit } from '../../../src/lib/audit/detection.js';
+import type { Schema } from '../../../src/types/schema.js';
+
+/**
+ * Regression coverage for the #707 write↔audit parity break on `prompt: 'list'`
+ * fields that are NOT `multiple: true` (the alias-role shape).
+ *
+ * A prior round restricted the blank-as-unset scalar shortcut (`isBlankScalar`)
+ * to exclude only `multiple: true` fields. But a field declared as
+ * `prompt: 'list'` WITHOUT `multiple` is ALSO list-shaped — this is exactly the
+ * ALIAS-role schema pattern (`aliases: { prompt: 'list', alias: true }`). For
+ * such a field a whitespace-only scalar like `aliases: '   '` made `hasValue`
+ * false, so `validateFieldType` never ran and the non-array scalar string was
+ * accepted and PERSISTED on write — while `audit` treats `prompt: 'list'` as
+ * list-shaped (`expectsList = field.prompt === 'list' || field.multiple === true`
+ * in `src/lib/audit/detection.ts`) and flagged the SAME value as
+ * `wrong-scalar-type`. Write accepted, audit flagged: parity violated.
+ *
+ * Ground truth: the blank-as-unset shortcut must apply ONLY to genuinely SCALAR
+ * fields. A field is list-shaped when `field.multiple === true` OR
+ * `field.prompt === 'list'`. The fix uses that same predicate, so a blank scalar
+ * on a `prompt: 'list'` alias field is rejected at write (alias-array
+ * validation), matching audit's `wrong-scalar-type` flag. Both reject/flag.
+ */
+
+const SCHEMA: Schema = {
+  version: 2,
+  types: {
+    person: {
+      output_dir: 'people',
+      fields: {
+        name: { prompt: 'text', required: true },
+        // The alias role: `prompt: 'list'` WITHOUT `multiple` (list-shaped).
+        aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
+      },
+    },
+  },
+};
+
+async function setupVault(): Promise<string> {
+  const vaultDir = await mkdtemp(join(tmpdir(), 'edit-blank-list-prompt-'));
+  await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+  await writeFile(join(vaultDir, '.bwrb', 'schema.json'), JSON.stringify(SCHEMA, null, 2));
+  await mkdir(join(vaultDir, 'people'), { recursive: true });
+  return vaultDir;
+}
+
+async function readFrontmatter(filePath: string): Promise<Record<string, unknown>> {
+  const { frontmatter } = await parseNote(filePath);
+  return frontmatter;
+}
+
+function auditIssues(
+  results: Awaited<ReturnType<typeof runAudit>>,
+  fileName: string
+): { code: string; field?: string }[] {
+  const result = results.find((r) => r.relativePath.endsWith(fileName));
+  return (result?.issues ?? []).map((i) => ({ code: i.code, field: i.field }));
+}
+
+describe("whitespace scalar on prompt:'list' (alias) field: write↔audit parity (#707)", () => {
+  let vaultDir: string;
+  beforeEach(async () => {
+    vaultDir = await setupVault();
+  });
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it("validateFrontmatter REJECTS a whitespace scalar on a prompt:'list' alias field (matches audit flag)", async () => {
+    const schema = await loadSchema(vaultDir);
+    const result = validateFrontmatter(schema, 'person', {
+      type: 'person',
+      name: 'x',
+      aliases: '   ',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === 'aliases')).toBe(true);
+  });
+
+  it('edit --json: a whitespace scalar for an optional alias list field is rejected; nothing persisted', async () => {
+    const personPath = join(vaultDir, 'people', 'Steve.md');
+    await writeFile(
+      personPath,
+      `---
+type: person
+name: Steve
+aliases:
+  - Stevey
+---
+
+# Steve
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    // Write must REJECT — audit would flag this same value as wrong-scalar-type.
+    await expect(
+      editNoteFromJson(schema, vaultDir, personPath, JSON.stringify({ aliases: '   ' }), {
+        jsonMode: false,
+      })
+    ).rejects.toThrow(/aliases/);
+
+    // The original list value is untouched on disk.
+    const fm = await readFrontmatter(personPath);
+    expect(fm['aliases']).toEqual(['Stevey']);
+  });
+
+  it("parity: a persisted blank scalar on a prompt:'list' field is flagged wrong-scalar-type by audit", async () => {
+    // Demonstrates the audit side of the parity: a note carrying a blank scalar on
+    // a prompt:'list' alias field is flagged wrong-scalar-type. Since write now
+    // REJECTS the same value (test above), the "write accepts, audit flags"
+    // disparity is gone.
+    const personPath = join(vaultDir, 'people', 'Bad.md');
+    await writeFile(personPath, `---\ntype: person\nname: Bad\naliases: "   "\n---\n`);
+
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const issues = auditIssues(results, 'Bad.md');
+    expect(issues.some((i) => i.code === 'wrong-scalar-type' && i.field === 'aliases')).toBe(true);
+
+    // And write rejects that exact value — confirming agreement.
+    const result = validateFrontmatter(schema, 'person', {
+      type: 'person',
+      name: 'Bad',
+      aliases: '   ',
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('control: a proper alias ARRAY value passes write and audit, and persists', async () => {
+    const personPath = join(vaultDir, 'people', 'Good.md');
+    await writeFile(
+      personPath,
+      `---
+type: person
+name: Good
+---
+
+# Good
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(
+      schema,
+      vaultDir,
+      personPath,
+      JSON.stringify({ aliases: ['Stevey', 'Steve Yegge'] }),
+      { jsonMode: false }
+    );
+
+    const fm = await readFrontmatter(personPath);
+    expect(fm['aliases']).toEqual(['Stevey', 'Steve Yegge']);
+
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const issues = auditIssues(results, 'Good.md');
+    expect(issues.some((i) => i.code === 'wrong-scalar-type')).toBe(false);
+  });
+
+  it('control: blank scalar on a genuinely SCALAR field is still treated as unset (#707 preserved)', async () => {
+    // The PR's main change — trim-everywhere blank-as-unset for SCALAR fields —
+    // must be preserved. `note` here is an optional non-list text field.
+    const scalarSchema: Schema = {
+      version: 2,
+      types: {
+        person: {
+          output_dir: 'people',
+          fields: {
+            name: { prompt: 'text', required: true },
+            note: { prompt: 'text' },
+          },
+        },
+      },
+    };
+    const v = await mkdtemp(join(tmpdir(), 'edit-scalar-blank-control-'));
+    await mkdir(join(v, '.bwrb'), { recursive: true });
+    await writeFile(join(v, '.bwrb', 'schema.json'), JSON.stringify(scalarSchema, null, 2));
+    await mkdir(join(v, 'people'), { recursive: true });
+
+    const personPath = join(v, 'people', 'Scalar.md');
+    await writeFile(personPath, `---\ntype: person\nname: Scalar\nnote: hello\n---\n\n# Scalar\n`);
+
+    const schema = await loadSchema(v);
+    // Blanking an optional scalar field is accepted (unset), NOT rejected.
+    await editNoteFromJson(schema, v, personPath, JSON.stringify({ note: '   ' }), {
+      jsonMode: false,
+    });
+    const fm = await readFrontmatter(personPath);
+    expect(fm['note'] === undefined || String(fm['note']).trim() === '').toBe(true);
+
+    await rm(v, { recursive: true, force: true });
+  });
+
+  it('control: an absent / empty-array alias value remains unset (no false rejection)', async () => {
+    const schema = await loadSchema(vaultDir);
+    // Absent alias field — unset, valid.
+    const absent = validateFrontmatter(schema, 'person', { type: 'person', name: 'x' });
+    expect(absent.errors.some((e) => e.field === 'aliases')).toBe(false);
+    // Empty array — unset, valid (no wrong-shape rejection).
+    const empty = validateFrontmatter(schema, 'person', {
+      type: 'person',
+      name: 'x',
+      aliases: [],
+    });
+    expect(empty.errors.some((e) => e.field === 'aliases')).toBe(false);
+  });
+});

--- a/tests/ts/lib/edit-blank-multiple-parity.test.ts
+++ b/tests/ts/lib/edit-blank-multiple-parity.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+
+import { loadSchema } from '../../../src/lib/schema.js';
+import { editNoteFromJson } from '../../../src/lib/edit.js';
+import { validateFrontmatter } from '../../../src/lib/validation.js';
+import { parseNote } from '../../../src/lib/frontmatter.js';
+import { runAudit } from '../../../src/lib/audit/detection.js';
+import type { Schema } from '../../../src/types/schema.js';
+
+/**
+ * Regression coverage for the #707 write↔audit parity break on `multiple` (list)
+ * fields.
+ *
+ * The trim-everywhere blank-as-unset shortcut (`isBlankScalar`) was applied
+ * BEFORE validation for EVERY field shape, not just scalars. A whitespace-only
+ * scalar string for an optional `multiple: true` field was therefore treated as
+ * "unset" and SKIPPED the list/option/date checks: `dates: "   "` on a
+ * `prompt: "date", multiple: true` field passed write and was PERSISTED as a
+ * scalar string, while `audit` still reported `wrong-scalar-type` (it expects a
+ * list). Write accepted, audit flagged: parity violated.
+ *
+ * Ground truth: audit flags ANY non-array scalar on a `multiple` field as
+ * `wrong-scalar-type` (it never routes list fields through `isBlankScalar`). The
+ * fix stops the blank-as-unset shortcut from firing on `multiple` fields, so a
+ * blank scalar is rejected at write the same way a genuinely invalid value would
+ * be — write and audit now AGREE (both reject/flag). A non-blank scalar that
+ * carries a value (e.g. `labels: "urgent"`) keeps its long-standing
+ * accept-on-write / autofix-on-audit behavior.
+ */
+
+const SCHEMA: Schema = {
+  version: 2,
+  types: {
+    event: {
+      output_dir: 'events',
+      fields: {
+        name: { prompt: 'text', required: true },
+        // Optional list of dates: a `date` prompt with `multiple: true`.
+        dates: { prompt: 'date', multiple: true },
+        // Optional multi-select.
+        labels: { prompt: 'select', options: ['urgent', 'blocked'], multiple: true },
+      },
+    },
+  },
+};
+
+async function setupVault(): Promise<string> {
+  const vaultDir = await mkdtemp(join(tmpdir(), 'edit-blank-multiple-'));
+  await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+  await writeFile(join(vaultDir, '.bwrb', 'schema.json'), JSON.stringify(SCHEMA, null, 2));
+  await mkdir(join(vaultDir, 'events'), { recursive: true });
+  return vaultDir;
+}
+
+async function readFrontmatter(filePath: string): Promise<Record<string, unknown>> {
+  const { frontmatter } = await parseNote(filePath);
+  return frontmatter;
+}
+
+function auditIssues(
+  results: Awaited<ReturnType<typeof runAudit>>,
+  fileName: string
+): { code: string; field?: string }[] {
+  const result = results.find((r) => r.relativePath.endsWith(fileName));
+  return (result?.issues ?? []).map((i) => ({ code: i.code, field: i.field }));
+}
+
+describe('whitespace scalar on multiple field: write↔audit parity (#707)', () => {
+  let vaultDir: string;
+  beforeEach(async () => {
+    vaultDir = await setupVault();
+  });
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('validateFrontmatter REJECTS a whitespace scalar on a multiple date field (matches audit flag)', async () => {
+    const schema = await loadSchema(vaultDir);
+    const result = validateFrontmatter(schema, 'event', {
+      type: 'event',
+      name: 'x',
+      dates: '   ',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === 'dates')).toBe(true);
+  });
+
+  it('edit --json: a whitespace scalar for an optional multiple field is rejected; nothing persisted', async () => {
+    const eventPath = join(vaultDir, 'events', 'Show.md');
+    await writeFile(
+      eventPath,
+      `---
+type: event
+name: Show
+dates:
+  - 2026-01-02
+---
+
+# Show
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    // Write must REJECT — audit would flag this same value as wrong-scalar-type.
+    await expect(
+      editNoteFromJson(schema, vaultDir, eventPath, JSON.stringify({ dates: '   ' }), {
+        jsonMode: false,
+      })
+    ).rejects.toThrow(/dates/);
+
+    // The original list value is untouched on disk.
+    const fm = await readFrontmatter(eventPath);
+    expect(fm['dates']).toEqual(['2026-01-02']);
+  });
+
+  it('parity: had the blank scalar been persisted, audit would have flagged wrong-scalar-type', async () => {
+    // Demonstrates the audit side of the parity: a note carrying a blank scalar on
+    // a multiple field is flagged wrong-scalar-type. Since write now REJECTS the
+    // same value (test above), the "write accepts, audit flags" disparity is gone.
+    const eventPath = join(vaultDir, 'events', 'Bad.md');
+    await writeFile(eventPath, `---\ntype: event\nname: Bad\ndates: "   "\n---\n`);
+
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const issues = auditIssues(results, 'Bad.md');
+    expect(issues.some((i) => i.code === 'wrong-scalar-type' && i.field === 'dates')).toBe(true);
+
+    // And write rejects that exact value — confirming agreement.
+    const result = validateFrontmatter(schema, 'event', {
+      type: 'event',
+      name: 'Bad',
+      dates: '   ',
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('control: a proper list value on a multiple field passes write and audit', async () => {
+    const eventPath = join(vaultDir, 'events', 'Good.md');
+    await writeFile(
+      eventPath,
+      `---
+type: event
+name: Good
+---
+
+# Good
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(
+      schema,
+      vaultDir,
+      eventPath,
+      JSON.stringify({ dates: ['2026-01-02', '2026-02-03'] }),
+      { jsonMode: false }
+    );
+
+    const fm = await readFrontmatter(eventPath);
+    expect(fm['dates']).toEqual(['2026-01-02', '2026-02-03']);
+
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const issues = auditIssues(results, 'Good.md');
+    expect(issues.some((i) => i.code === 'wrong-scalar-type')).toBe(false);
+  });
+
+  it('control: blank scalar on a NON-multiple (scalar) field is still treated as unset (#707 preserved)', async () => {
+    // The PR's main change — trim-everywhere blank-as-unset for SCALAR fields —
+    // must be preserved. `labels` here is forced scalar by using a non-multiple
+    // optional text field.
+    const scalarSchema: Schema = {
+      version: 2,
+      types: {
+        event: {
+          output_dir: 'events',
+          fields: {
+            name: { prompt: 'text', required: true },
+            note: { prompt: 'text' },
+          },
+        },
+      },
+    };
+    const v = await mkdtemp(join(tmpdir(), 'edit-scalar-blank-'));
+    await mkdir(join(v, '.bwrb'), { recursive: true });
+    await writeFile(join(v, '.bwrb', 'schema.json'), JSON.stringify(scalarSchema, null, 2));
+    await mkdir(join(v, 'events'), { recursive: true });
+
+    const eventPath = join(v, 'events', 'Scalar.md');
+    await writeFile(eventPath, `---\ntype: event\nname: Scalar\nnote: hello\n---\n\n# Scalar\n`);
+
+    const schema = await loadSchema(v);
+    // Blanking an optional scalar field is accepted (unset), NOT rejected.
+    await editNoteFromJson(schema, v, eventPath, JSON.stringify({ note: '   ' }), {
+      jsonMode: false,
+    });
+    const fm = await readFrontmatter(eventPath);
+    expect(fm['note'] === undefined || String(fm['note']).trim() === '').toBe(true);
+
+    await rm(v, { recursive: true, force: true });
+  });
+});

--- a/tests/ts/lib/edit-blank-required-defaults.test.ts
+++ b/tests/ts/lib/edit-blank-required-defaults.test.ts
@@ -23,7 +23,8 @@ import type { Schema } from '../../../src/types/schema.js';
  */
 
 // `status` is a REQUIRED select WITH a default; `priority` is an OPTIONAL select
-// WITH a default; `owner` is a REQUIRED text field with NO default.
+// WITH a default; `owner` is a REQUIRED text field with NO default; `deadline` is
+// an OPTIONAL date field whose default is in NON-canonical slash form.
 const SCHEMA: Schema = {
   version: 2,
   types: {
@@ -33,6 +34,7 @@ const SCHEMA: Schema = {
         name: { prompt: 'text', required: true },
         status: { prompt: 'select', options: ['todo', 'doing', 'done'], required: true, default: 'todo' },
         priority: { prompt: 'select', options: ['low', 'high'], default: 'low' },
+        deadline: { prompt: 'date', default: '12/25/2026' },
       },
     },
     record: {
@@ -242,5 +244,40 @@ note: something
     expect(codes).not.toContain('empty-string-required');
 
     await rm(v, { recursive: true, force: true });
+  });
+
+  it('blanking a date field with a NON-canonical default persists the CANONICAL date; audit stays clean (#707)', async () => {
+    // Defect: `editNoteFromJson` ran `normalizeDateFields` on the merged
+    // frontmatter FIRST, then `applyDefaults` wrote the RAW default afterward, so
+    // a slash-format date default (`12/25/2026`) was persisted un-normalized.
+    // `validateFrontmatter` accepts the slash form, so the edit succeeded — but
+    // the next `audit` flagged `invalid-date-format`. The fix materializes the
+    // default BEFORE the single date-normalization pass, canonicalizing it.
+    const taskPath = join(vaultDir, 'tasks', 'Deadline.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Deadline
+status: doing
+deadline: 2026-01-01
+---
+
+# Deadline
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, taskPath, JSON.stringify({ deadline: '   ' }), {
+      jsonMode: false,
+    });
+
+    // The materialized default is the CANONICAL ISO form, not the raw slash date.
+    const fm = await readFrontmatter(taskPath);
+    expect(fm['deadline']).toBe('2026-12-25');
+
+    // Parity: audit finds no invalid-date-format for the materialized default.
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    expect(auditIssues(results, 'Deadline.md')).not.toContain('invalid-date-format');
   });
 });

--- a/tests/ts/lib/edit-blank-required-defaults.test.ts
+++ b/tests/ts/lib/edit-blank-required-defaults.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+
+import { loadSchema } from '../../../src/lib/schema.js';
+import { editNoteFromJson } from '../../../src/lib/edit.js';
+import { parseNote } from '../../../src/lib/frontmatter.js';
+import { runAudit } from '../../../src/lib/audit/detection.js';
+import type { Schema } from '../../../src/types/schema.js';
+
+/**
+ * Regression coverage for the #707 write↔audit parity break on the `edit` path.
+ *
+ * The trim-everywhere change made `validateFrontmatter` treat a whitespace-only
+ * value for a REQUIRED field that HAS a default as "unset → satisfied by the
+ * default" (VALID). That is only correct if the default is actually MATERIALIZED
+ * on write. `editNoteFromJson` previously wrote the merged frontmatter WITHOUT
+ * `applyDefaults`, so `edit --json '{"status":"   "}'` SUCCEEDED while persisting
+ * a blank required value — which `audit` then flagged as `empty-string-required`.
+ * Write said OK, audit said broken: parity violated. The fix applies defaults on
+ * the edit write path, mirroring `new`.
+ */
+
+// `status` is a REQUIRED select WITH a default; `priority` is an OPTIONAL select
+// WITH a default; `owner` is a REQUIRED text field with NO default.
+const SCHEMA: Schema = {
+  version: 2,
+  types: {
+    task: {
+      output_dir: 'tasks',
+      fields: {
+        name: { prompt: 'text', required: true },
+        status: { prompt: 'select', options: ['todo', 'doing', 'done'], required: true, default: 'todo' },
+        priority: { prompt: 'select', options: ['low', 'high'], default: 'low' },
+      },
+    },
+    record: {
+      output_dir: 'records',
+      fields: {
+        name: { prompt: 'text', required: true },
+        owner: { prompt: 'text', required: true },
+      },
+    },
+  },
+};
+
+async function setupVault(): Promise<string> {
+  const vaultDir = await mkdtemp(join(tmpdir(), 'edit-blank-required-'));
+  await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+  await writeFile(join(vaultDir, '.bwrb', 'schema.json'), JSON.stringify(SCHEMA, null, 2));
+  await mkdir(join(vaultDir, 'tasks'), { recursive: true });
+  await mkdir(join(vaultDir, 'records'), { recursive: true });
+  return vaultDir;
+}
+
+async function readFrontmatter(filePath: string): Promise<Record<string, unknown>> {
+  const { frontmatter } = await parseNote(filePath);
+  return frontmatter;
+}
+
+function auditIssues(
+  results: Awaited<ReturnType<typeof runAudit>>,
+  fileName: string
+): string[] {
+  const result = results.find((r) => r.relativePath.endsWith(fileName));
+  return (result?.issues ?? []).map((i) => i.code);
+}
+
+describe('edit --json: blank required-with-default parity (#707)', () => {
+  let vaultDir: string;
+  beforeEach(async () => {
+    vaultDir = await setupVault();
+  });
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('blanking a required-with-default field persists the default; audit stays clean', async () => {
+    const taskPath = join(vaultDir, 'tasks', 'Build.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Build
+status: doing
+priority: high
+---
+
+# Build
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, taskPath, JSON.stringify({ status: '   ' }), {
+      jsonMode: false,
+    });
+
+    // The default was MATERIALIZED, not a blank value left on disk.
+    const fm = await readFrontmatter(taskPath);
+    expect(fm['status']).toBe('todo');
+    // Untouched real value is preserved (applyDefaults only fills blanks).
+    expect(fm['priority']).toBe('high');
+
+    // Parity: audit finds no empty-string-required for the blanked field.
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    expect(auditIssues(results, 'Build.md')).not.toContain('empty-string-required');
+  });
+
+  it('blanking a required field WITHOUT a default is rejected at write', async () => {
+    const recordPath = join(vaultDir, 'records', 'Doc.md');
+    await writeFile(
+      recordPath,
+      `---
+type: record
+name: Doc
+owner: Alice
+---
+
+# Doc
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    await expect(
+      editNoteFromJson(schema, vaultDir, recordPath, JSON.stringify({ owner: '   ' }), {
+        jsonMode: false,
+      })
+    ).rejects.toThrow(/owner/);
+
+    // Nothing persisted: the original value is untouched.
+    const fm = await readFrontmatter(recordPath);
+    expect(fm['owner']).toBe('Alice');
+  });
+
+  it('control: blanking an OPTIONAL field with no default clears it to unset on both write and audit', async () => {
+    // `priority` HAS a default, so blanking it would be filled. Use an optional
+    // field WITHOUT a default to confirm trim-everywhere "unset" is preserved.
+    const optionalSchema: Schema = {
+      version: 2,
+      types: {
+        task: {
+          output_dir: 'tasks',
+          fields: {
+            name: { prompt: 'text', required: true },
+            note: { prompt: 'text' },
+          },
+        },
+      },
+    };
+    const v = await mkdtemp(join(tmpdir(), 'edit-optional-'));
+    await mkdir(join(v, '.bwrb'), { recursive: true });
+    await writeFile(join(v, '.bwrb', 'schema.json'), JSON.stringify(optionalSchema, null, 2));
+    await mkdir(join(v, 'tasks'), { recursive: true });
+
+    const taskPath = join(v, 'tasks', 'Opt.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Opt
+note: something
+---
+
+# Opt
+`
+    );
+
+    const schema = await loadSchema(v);
+    await editNoteFromJson(schema, v, taskPath, JSON.stringify({ note: '   ' }), {
+      jsonMode: false,
+    });
+
+    // Blank optional value is treated as unset; no default is forced in.
+    const fm = await readFrontmatter(taskPath);
+    expect(fm['note'] === undefined || String(fm['note']).trim() === '').toBe(true);
+
+    // Audit treats the blank optional as unset → no empty/required complaint.
+    const results = await runAudit(schema, v, { strict: false, vaultDir: v, schema });
+    const codes = auditIssues(results, 'Opt.md');
+    expect(codes).not.toContain('empty-string-required');
+
+    await rm(v, { recursive: true, force: true });
+  });
+});

--- a/tests/ts/lib/edit-blank-required-defaults.test.ts
+++ b/tests/ts/lib/edit-blank-required-defaults.test.ts
@@ -35,6 +35,7 @@ const SCHEMA: Schema = {
         status: { prompt: 'select', options: ['todo', 'doing', 'done'], required: true, default: 'todo' },
         priority: { prompt: 'select', options: ['low', 'high'], default: 'low' },
         deadline: { prompt: 'date', default: '12/25/2026' },
+        dates: { prompt: 'date', multiple: true, default: ['12/25/2026'] },
       },
     },
     record: {
@@ -279,5 +280,77 @@ deadline: 2026-01-01
     // Parity: audit finds no invalid-date-format for the materialized default.
     const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
     expect(auditIssues(results, 'Deadline.md')).not.toContain('invalid-date-format');
+  });
+
+  it('blanking a multiple:true date field with a NON-canonical default array persists CANONICAL per-element dates; audit stays clean (#707)', async () => {
+    // Defect: the scoped `applyDefaults` materialized the `multiple: true` date
+    // default array (`["12/25/2026"]`), but `normalizeDateFields` only
+    // canonicalized SCALAR date fields — it never iterated the elements of a
+    // date ARRAY. So `dates: ["12/25/2026"]` was persisted un-normalized and the
+    // next `audit` flagged `invalid-date-format`, reopening the write↔audit gap.
+    // The fix canonicalizes each element of a `multiple: true` date default.
+    const taskPath = join(vaultDir, 'tasks', 'Dates.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Dates
+status: doing
+dates:
+  - 2026-01-01
+---
+
+# Dates
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, taskPath, JSON.stringify({ dates: '   ' }), {
+      jsonMode: false,
+    });
+
+    // Each materialized element is the CANONICAL ISO form, not the raw slash date.
+    const fm = await readFrontmatter(taskPath);
+    expect(fm['dates']).toEqual(['2026-12-25']);
+
+    // Parity: audit finds no invalid-date-format for the materialized default.
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    expect(auditIssues(results, 'Dates.md')).not.toContain('invalid-date-format');
+  });
+
+  it('a user-supplied multiple:true date value in non-canonical form is normalized per-element on write (parity with scalar)', async () => {
+    // A non-canonical-but-accepted list-date value the user supplies directly
+    // must be written in the same canonical ISO form `audit` validates — keeping
+    // `multiple` date normalization in lockstep with scalar date normalization.
+    const taskPath = join(vaultDir, 'tasks', 'UserDates.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: UserDates
+status: doing
+dates:
+  - 2026-01-01
+---
+
+# UserDates
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(
+      schema,
+      vaultDir,
+      taskPath,
+      JSON.stringify({ dates: ['12/25/2026', '2026-02-03'] }),
+      { jsonMode: false }
+    );
+
+    // Slash form canonicalized; already-canonical element left intact.
+    const fm = await readFrontmatter(taskPath);
+    expect(fm['dates']).toEqual(['2026-12-25', '2026-02-03']);
+
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    expect(auditIssues(results, 'UserDates.md')).not.toContain('invalid-date-format');
   });
 });

--- a/tests/ts/lib/edit-blank-required-defaults.test.ts
+++ b/tests/ts/lib/edit-blank-required-defaults.test.ts
@@ -133,6 +133,67 @@ owner: Alice
     expect(fm['owner']).toBe('Alice');
   });
 
+  it('explicit null removal of a defaulted field stays removed (default NOT re-applied)', async () => {
+    // Regression: a blanket applyDefaults over the merged frontmatter would write
+    // `status`'s default back in immediately after `mergeFrontmatter` deleted it,
+    // silently undoing the documented `{"field": null}` removal. The surgical fix
+    // scopes defaults to blank-STRING patch keys only, so null is left removed.
+    const taskPath = join(vaultDir, 'tasks', 'Drop.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Drop
+status: doing
+priority: high
+---
+
+# Drop
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, taskPath, JSON.stringify({ status: null }), {
+      jsonMode: false,
+    });
+
+    // The field is GONE, not re-defaulted to 'todo'.
+    const fm = await readFrontmatter(taskPath);
+    expect('status' in fm).toBe(false);
+    // Untouched field is preserved.
+    expect(fm['priority']).toBe('high');
+  });
+
+  it('editing one field does NOT materialize an unrelated untouched defaulted field', async () => {
+    // `priority` is OPTIONAL with a default but is absent from the note and is NOT
+    // referenced by the patch. A blanket applyDefaults would fill it in; the
+    // surgical, patch-scoped fix must leave it absent.
+    const taskPath = join(vaultDir, 'tasks', 'Touch.md');
+    await writeFile(
+      taskPath,
+      `---
+type: task
+name: Touch
+status: doing
+---
+
+# Touch
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    await editNoteFromJson(schema, vaultDir, taskPath, JSON.stringify({ name: 'Touched' }), {
+      jsonMode: false,
+    });
+
+    const fm = await readFrontmatter(taskPath);
+    expect(fm['name']).toBe('Touched');
+    // The user never referenced `priority`; its default must NOT be materialized.
+    expect('priority' in fm).toBe(false);
+    // The edited field's own value is intact.
+    expect(fm['status']).toBe('doing');
+  });
+
   it('control: blanking an OPTIONAL field with no default clears it to unset on both write and audit', async () => {
     // `priority` HAS a default, so blanking it would be filled. Use an optional
     // field WITHOUT a default to confirm trim-everywhere "unset" is preserved.

--- a/tests/ts/lib/required-blank-list-parity.test.ts
+++ b/tests/ts/lib/required-blank-list-parity.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+
+import { loadSchema } from '../../../src/lib/schema.js';
+import { validateFrontmatter } from '../../../src/lib/validation.js';
+import { runAudit } from '../../../src/lib/audit/detection.js';
+import type { Schema } from '../../../src/types/schema.js';
+
+/**
+ * Regression coverage for the #707 REQUIRED-emptiness regression on list-shaped
+ * fields (`prompt: 'list'` or `multiple: true`).
+ *
+ * A prior round of #707 excluded ALL list-shaped fields from the blank-as-unset
+ * shortcut so a non-blank scalar (e.g. `labels: 'urgent'`) would still reach
+ * type validation. That over-corrected: a BLANK value (`''` / whitespace /
+ * empty array) on a REQUIRED list field stopped being treated as "missing", so
+ * `validateFrontmatter` accepted it (`validateFieldType` leniently accepts a
+ * string for `prompt: 'list'`) and write PERSISTED an empty required value —
+ * while audit still reported `empty-string-required`. Write accepted, audit
+ * flagged: parity violated.
+ *
+ * Ground truth: a blank value on a list-shaped field is EMPTY for the required
+ * check (required -> required_field_missing; optional -> unset, no error),
+ * exactly as audit's `isEmptyRequiredValue` classifies it. A NON-blank scalar on
+ * a non-alias list field still flows to type validation (soft-coerce, out of
+ * scope). Alias fields keep their stricter array contract (covered separately in
+ * edit-blank-list-prompt-parity.test.ts).
+ */
+
+const SCHEMA: Schema = {
+  version: 2,
+  types: {
+    widget: {
+      output_dir: 'Widgets',
+      fields: {
+        type: { value: 'widget' },
+        // Required list-shaped fields, both flavors.
+        reqlist: { prompt: 'list', required: true },
+        reqmulti: { prompt: 'select', multiple: true, required: true, options: ['a', 'b'] },
+        // Optional list-shaped field.
+        optlist: { prompt: 'list' },
+      },
+      field_order: ['type', 'reqlist', 'reqmulti', 'optlist'],
+    },
+  },
+};
+
+async function setupVault(): Promise<string> {
+  const vaultDir = await mkdtemp(join(tmpdir(), 'required-blank-list-'));
+  await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+  await writeFile(join(vaultDir, '.bwrb', 'schema.json'), JSON.stringify(SCHEMA, null, 2));
+  await mkdir(join(vaultDir, 'Widgets'), { recursive: true });
+  return vaultDir;
+}
+
+function auditCodes(
+  results: Awaited<ReturnType<typeof runAudit>>,
+  fileName: string
+): { code: string; field?: string }[] {
+  const result = results.find((r) => r.relativePath.endsWith(fileName));
+  return (result?.issues ?? []).map((i) => ({ code: i.code, field: i.field }));
+}
+
+describe('required blank list-field emptiness: write↔audit parity (#707)', () => {
+  let vaultDir: string;
+  beforeEach(async () => {
+    vaultDir = await setupVault();
+  });
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  // --- write side: validateFrontmatter ---
+
+  for (const [label, blank] of [
+    ['empty string', ''],
+    ['whitespace-only', '   '],
+  ] as const) {
+    it(`REJECTS a ${label} value on a required prompt:'list' field (required-missing)`, async () => {
+      const schema = await loadSchema(vaultDir);
+      const result = validateFrontmatter(schema, 'widget', {
+        type: 'widget',
+        reqlist: blank,
+        reqmulti: ['a'],
+      });
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) => e.field === 'reqlist' && e.type === 'required_field_missing'
+        )
+      ).toBe(true);
+    });
+  }
+
+  it("REJECTS an empty array on a required multiple field (required-missing)", async () => {
+    const schema = await loadSchema(vaultDir);
+    const result = validateFrontmatter(schema, 'widget', {
+      type: 'widget',
+      reqlist: ['x'],
+      reqmulti: [],
+    });
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(
+        (e) => e.field === 'reqmulti' && e.type === 'required_field_missing'
+      )
+    ).toBe(true);
+  });
+
+  it('passes a required list field with a valid non-empty array', async () => {
+    const schema = await loadSchema(vaultDir);
+    const result = validateFrontmatter(schema, 'widget', {
+      type: 'widget',
+      reqlist: ['alpha'],
+      reqmulti: ['a'],
+    });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  for (const [label, value] of [
+    ['empty string', ''],
+    ['whitespace-only', '   '],
+    ['empty array', [] as unknown],
+  ] as const) {
+    it(`treats a ${label} value on an OPTIONAL list field as unset (no error)`, async () => {
+      const schema = await loadSchema(vaultDir);
+      const result = validateFrontmatter(schema, 'widget', {
+        type: 'widget',
+        reqlist: ['x'],
+        reqmulti: ['a'],
+        optlist: value,
+      });
+      expect(result.errors.some((e) => e.field === 'optlist')).toBe(false);
+    });
+  }
+
+  it('treats an ABSENT optional list field as unset (no error)', async () => {
+    const schema = await loadSchema(vaultDir);
+    const result = validateFrontmatter(schema, 'widget', {
+      type: 'widget',
+      reqlist: ['x'],
+      reqmulti: ['a'],
+    });
+    expect(result.errors.some((e) => e.field === 'optlist')).toBe(false);
+  });
+
+  // --- audit side: parity ---
+
+  it("parity: audit flags empty-string-required on a required prompt:'list' field with a blank value", async () => {
+    const path = join(vaultDir, 'Widgets', 'ReqBlank.md');
+    await writeFile(path, `---\ntype: widget\nreqlist: "   "\nreqmulti: [a]\n---\n`);
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const codes = auditCodes(results, 'ReqBlank.md');
+    expect(
+      codes.some((c) => c.code === 'empty-string-required' && c.field === 'reqlist')
+    ).toBe(true);
+  });
+
+  it('parity: audit flags empty-string-required on a required multiple field with an empty array', async () => {
+    const path = join(vaultDir, 'Widgets', 'ReqEmptyArr.md');
+    await writeFile(path, `---\ntype: widget\nreqlist: [x]\nreqmulti: []\n---\n`);
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const codes = auditCodes(results, 'ReqEmptyArr.md');
+    expect(
+      codes.some((c) => c.code === 'empty-string-required' && c.field === 'reqmulti')
+    ).toBe(true);
+  });
+
+  it('parity: audit does NOT flag an optional list field that is absent or an empty array', async () => {
+    const path = join(vaultDir, 'Widgets', 'OptUnset.md');
+    await writeFile(path, `---\ntype: widget\nreqlist: [x]\nreqmulti: [a]\noptlist: []\n---\n`);
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const codes = auditCodes(results, 'OptUnset.md');
+    expect(codes.some((c) => c.field === 'optlist')).toBe(false);
+  });
+
+  it('control: a non-blank scalar on a non-alias list field is still accepted on write (soft-coerce, out of scope)', async () => {
+    const schema = await loadSchema(vaultDir);
+    const result = validateFrontmatter(schema, 'widget', {
+      type: 'widget',
+      reqlist: 'urgent',
+      reqmulti: ['a'],
+    });
+    expect(result.errors.some((e) => e.field === 'reqlist')).toBe(false);
+  });
+});

--- a/tests/ts/lib/validation.test.ts
+++ b/tests/ts/lib/validation.test.ts
@@ -290,6 +290,98 @@ describe('validation', () => {
         )
       ).toBe(true);
     });
+
+    // #707: blank optional scalar values (empty OR whitespace-only) are treated
+    // as "unset" UNIFORMLY across all scalar types on the write path, matching
+    // the audit path. validateFrontmatter must accept them (no type error).
+    describe('unified whitespace emptiness (#707)', () => {
+      const blanks: Array<[string, string]> = [
+        ['empty string', ''],
+        ['whitespace-only', '   '],
+      ];
+
+      for (const [label, blank] of blanks) {
+        it(`accepts a ${label} optional number as unset`, () => {
+          const result = validateFrontmatter(schema, 'idea', {
+            type: 'idea',
+            status: 'raw',
+            effort: blank,
+          });
+          expect(result.valid).toBe(true);
+          expect(result.errors).toHaveLength(0);
+        });
+
+        it(`accepts a ${label} optional boolean as unset`, () => {
+          const result = validateFrontmatter(schema, 'idea', {
+            type: 'idea',
+            status: 'raw',
+            archived: blank,
+          });
+          expect(result.valid).toBe(true);
+          expect(result.errors).toHaveLength(0);
+        });
+
+        it(`accepts a ${label} optional date as unset`, () => {
+          const result = validateFrontmatter(schema, 'task', {
+            type: 'objective',
+            'objective-type': 'task',
+            status: 'raw',
+            deadline: blank,
+          });
+          expect(result.valid).toBe(true);
+          expect(result.errors).toHaveLength(0);
+        });
+      }
+
+      // Non-blank values are unaffected — a genuine bad scalar still fails.
+      it('still rejects a non-numeric optional number', () => {
+        const result = validateFrontmatter(schema, 'idea', {
+          type: 'idea',
+          status: 'raw',
+          effort: 'abc',
+        });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.field === 'effort')).toBe(true);
+      });
+
+      it('still rejects a malformed optional date', () => {
+        const result = validateFrontmatter(schema, 'task', {
+          type: 'objective',
+          'objective-type': 'task',
+          status: 'raw',
+          deadline: 'not-a-date',
+        });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.type === 'invalid_date')).toBe(true);
+      });
+
+      // A required field that is whitespace-only is "unset", so it is reported
+      // as missing (not as a bad scalar) — consistent with the empty-string case.
+      it('reports a whitespace-only required field as missing', () => {
+        const raw: Schema = {
+          version: 2,
+          types: {
+            widget: {
+              output_dir: 'Widgets',
+              fields: {
+                count: { prompt: 'number', required: true },
+              },
+            },
+          },
+        } as unknown as Schema;
+        const loaded = resolveSchema(raw);
+        const result = validateFrontmatter(loaded, 'widget', {
+          type: 'widget',
+          count: '   ',
+        });
+        expect(result.valid).toBe(false);
+        expect(
+          result.errors.some(
+            (e) => e.type === 'required_field_missing' && e.field === 'count'
+          )
+        ).toBe(true);
+      });
+    });
   });
 
   describe('partial date granularity', () => {


### PR DESCRIPTION
## Summary

Collapses the three divergent optional-scalar emptiness rules into a **single trim-everywhere policy**, applied identically on the write and audit paths.

Previously a whitespace-only optional value (e.g. `count: "   "`) was handled three different ways:
- audit **dates** (#614) trimmed it → treated as unset
- audit **numbers/booleans** (#664) used exact `=== ''` → flagged as `wrong-scalar-type`
- the **write** path (`validateFrontmatter`) used exact `!== ''` → rejected

Each type was internally write↔audit consistent, but the *cross-type* rule differed (dates trimmed, numbers didn't).

## Policy decision: trim-everywhere

A blank optional value — `null` / `undefined` / absent / empty string / **whitespace-only** — is now "unset" **uniformly** for date, number, boolean, and string, on **both** write and audit.

This matches the existing convention throughout the codebase, where emptiness is already trimmed (`isEmptyRequiredValue`, `isEffectivelyEmpty`, the select-option and date-element guards). The `=== ''` exact checks added by #664/#706 were the outliers; trim-everywhere makes the whole codebase internally consistent rather than carving scalars out as the lone "whitespace is a real value" exception. The deterministic-safety-net / write↔audit-agreement philosophy is preserved (and strengthened): a blank optional is genuinely unset content, so nothing is swept under the rug.

## Where the rules now converge

New shared helper `src/lib/emptiness.ts` → `isBlankScalar(value)` (trims strings; never treats `0`/`false` as empty). Routed through it:
- write: `validateFrontmatter` (`hasValue`), `normalizeDateFields`, `applyDefaults`, `validateContextFields`, the date list-element guard
- audit: the number/boolean scalar guard and the date guard in `src/lib/audit/detection.ts`

Non-empty values are unaffected: a genuinely bad scalar (`count: "abc"`, `when: "not-a-date"`) is still rejected on write and flagged on audit. The #614/#664 write↔audit parity is preserved per type and now also holds across types.

## Tests
- `tests/ts/lib/validation.test.ts`: write path accepts blank optional number/boolean/date (empty + whitespace), still rejects genuine bad values, reports whitespace-only required as missing.
- `tests/ts/commands/audit.test.ts`: flipped the old "flag blank number" test to the unified rule; added a blank-boolean audit test; existing blank-date tests retained.

## Docs
Updated `docs/product/audit-fix-policy.md` Optional Field Emptiness section to describe the unified trim-everywhere rule.

## Gate
`pnpm qa` (typecheck, lint, schema:check, docs:lint, docs:doctor, build, test — 2792 passed) and `pnpm knip` both pass locally. No `src/types/schema.ts` change, so `schema.schema.json` is untouched.

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)