### PR TITLE
feat: add positional [mode] to recent/list/search/edit (parity with open)

### DIFF
--- a/docs-site/src/content/docs/reference/commands/edit.md
+++ b/docs-site/src/content/docs/reference/commands/edit.md
@@ -8,8 +8,16 @@ Edit the frontmatter of an existing note. This is an alias for `search --edit`.
 ## Synopsis
 
 ```bash
-bwrb edit [options] [query]
+bwrb edit [options] [query] [mode]
 ```
+
+The optional second positional `[mode]` is the app mode used with `--open`
+(`system`, `editor`, `visual`, `obsidian`, `print`) — parity with
+[`bwrb open`](/reference/commands/open/). For example,
+`bwrb edit "My Note" --open print` edits the note and then prints its path. An
+explicit `--app` flag always takes precedence over the positional `[mode]`, an
+invalid mode value is rejected with a clear error (even without `--open`), and a
+third excess positional is rejected.
 
 ## Options
 
@@ -61,6 +69,9 @@ bwrb edit "My Note" --open
 
 # Edit then open in $EDITOR
 bwrb edit "My Note" --open --app editor
+
+# Edit then open with a positional app mode (parity with `open`)
+bwrb edit "My Note" --open print
 ```
 
 ## Targeting

--- a/docs-site/src/content/docs/reference/commands/list.md
+++ b/docs-site/src/content/docs/reference/commands/list.md
@@ -8,10 +8,21 @@ List notes matching filter criteria with flexible output formats.
 ## Synopsis
 
 ```bash
-bwrb list [options] [positional]
+bwrb list [options] [positional] [mode]
 ```
 
-The positional argument is auto-detected as type, path (contains `/`), or where expression (contains operators).
+The first positional argument is auto-detected as type, path (contains `/`), or where expression (contains operators).
+
+The optional second positional `[mode]` is the app mode used with `--open`
+(`system`, `editor`, `visual`, `obsidian`, `print`) — parity with
+[`bwrb open`](/reference/commands/open/). Because `[mode]` is the **second**
+positional, a lone positional is always treated as the smart filter, never the
+mode: use `bwrb list task print --open`, not `bwrb list print --open` (which
+would treat `print` as a type filter). To set the mode without a filter
+positional, use the `--app` flag. An explicit `--app` flag always takes
+precedence over the positional `[mode]`, an invalid mode value is rejected with
+a clear error, and excess positional arguments beyond `[positional] [mode]` are
+rejected.
 
 ## Options
 
@@ -197,6 +208,7 @@ Missing sort values are always placed at the end, including with `--desc`.
 ```bash
 bwrb list --type task --open                    # Pick from tasks and open
 bwrb list --type task --where "status=inbox" --open
+bwrb list task print --open                      # Positional filter + app mode
 ```
 
 ### Save as Dashboard

--- a/docs-site/src/content/docs/reference/commands/recent.md
+++ b/docs-site/src/content/docs/reference/commands/recent.md
@@ -10,11 +10,22 @@ common "what did I touch lately?" query.
 ## Synopsis
 
 ```bash
-bwrb recent [options] [positional]
+bwrb recent [options] [positional] [mode]
 ```
 
-The positional argument is auto-detected as type, path (contains `/`), or where
-expression (contains operators) — the same smart detection used by `list`.
+The first positional argument is auto-detected as type, path (contains `/`), or
+where expression (contains operators) — the same smart detection used by `list`.
+
+The optional second positional `[mode]` is the app mode used with `--open`
+(`system`, `editor`, `visual`, `obsidian`, `print`) — parity with
+[`bwrb open`](/reference/commands/open/). Because `[mode]` is the **second**
+positional, a lone positional is always treated as the smart filter, never the
+mode: use `bwrb recent task print --open`, not `bwrb recent print --open` (which
+would treat `print` as a type filter). To set the mode without a filter
+positional, use the `--app` flag. An explicit `--app` flag always takes
+precedence over the positional `[mode]`, and an invalid mode value is rejected
+with a clear error. Excess positional arguments beyond `[positional] [mode]` are
+rejected.
 
 ## Recency source
 
@@ -91,6 +102,9 @@ bwrb recent --output json
 # Open the most recent note (or the most recent task, in your editor)
 bwrb recent --open
 bwrb recent --type task --open --app editor
+
+# Positional app mode (the filter positional comes first, then the mode)
+bwrb recent task print --open
 
 # Save a recency view as a reusable dashboard
 bwrb recent --type task --save-as "recent-tasks"

--- a/docs-site/src/content/docs/reference/commands/search.md
+++ b/docs-site/src/content/docs/reference/commands/search.md
@@ -8,8 +8,16 @@ Search for notes by name or content, with interactive selection and multiple out
 ## Synopsis
 
 ```bash
-bwrb search [options] [query]
+bwrb search [options] [query] [mode]
 ```
+
+The optional second positional `[mode]` is the app mode used with `--open`
+(`system`, `editor`, `visual`, `obsidian`, `print`) — parity with
+[`bwrb open`](/reference/commands/open/). For example,
+`bwrb search "My Note" --open print` prints the resolved path. An explicit
+`--app` flag always takes precedence over the positional `[mode]`, an invalid
+mode value is rejected with a clear error, and a third excess positional is
+rejected.
 
 ## Modes
 
@@ -118,6 +126,9 @@ bwrb search "My Note" --open
 
 # Find and open in $EDITOR
 bwrb search "My Note" --open --app editor
+
+# Find and open with a positional app mode (parity with `open`)
+bwrb search "My Note" --open print
 
 # Find and edit frontmatter
 bwrb search "My Note" --edit

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -16,7 +16,7 @@ import { printJson, jsonSuccess, jsonError, ExitCodes, exitWithResolutionError }
 import { buildNoteIndex, type ManagedFile } from '../lib/navigation.js';
 import { parsePickerMode, resolveAndPick, type PickerMode } from '../lib/picker.js';
 import { editNoteFromJson, editNoteInteractive } from '../lib/edit.js';
-import { openNote, resolveAppMode } from './open.js';
+import { openNote, resolveAppMode, parseAppMode } from './open.js';
 import { resolveTargets, hasAnyTargeting, type TargetingOptions } from '../lib/targeting.js';
 import { UserCancelledError } from '../lib/errors.js';
 
@@ -64,6 +64,7 @@ function printEditSuccess(path: string, updatedFields: string[], jsonMode: boole
 export const editCommand = new Command('edit')
   .description('Edit an existing note')
   .argument('[query]', 'Note name or path to edit')
+  .argument('[mode]', 'App mode for --open: system, editor, visual, obsidian, print')
   .option('--picker <mode>', 'Picker mode: fzf, numbered, none', 'fzf')
   .option('-t, --type <type>', 'Filter by note type')
   .option('-p, --path <glob>', 'Filter by path pattern')
@@ -97,9 +98,33 @@ Examples:
 
   # Edit and open
   bwrb edit "My Note" --open                # Open the note after editing
-  bwrb edit "My Note" --open --app editor   # Edit then open in $EDITOR`)
-  .action(async (query: string | undefined, options: EditOptions, cmd: Command) => {
+  bwrb edit "My Note" --open --app editor   # Edit then open in $EDITOR
+  bwrb edit "My Note" --open print          # Positional mode (for --open)
+
+App Modes (for --open):
+  system      Open with OS default handler (default)
+  editor      Open in terminal editor ($EDITOR or config.editor)
+  visual      Open in GUI editor ($VISUAL or config.visual)
+  obsidian    Open in Obsidian via URI scheme
+  print       Print the resolved path (for scripting)
+
+Precedence (for --open app mode):
+  1. --app flag (explicit)
+  2. [mode] positional argument (e.g. bwrb edit "My Note" --open print)
+  3. BWRB_DEFAULT_APP environment variable
+  4. config.open_with in .bwrb/schema.json
+  5. Fallback: system`)
+  // Reject excess positional args (e.g. `edit "Note" print bogus`). Only
+  // [query] and [mode] are accepted; a third+ token is almost certainly a
+  // typo, and silently swallowing it (commander's default) hides the mistake.
+  .allowExcessArguments(false)
+  .action(async (query: string | undefined, mode: string | undefined, options: EditOptions, cmd: Command) => {
     const patchMode = options.json !== undefined;
+    // App-mode precedence: an explicit --app flag wins over the positional
+    // [mode]; the positional is the convenience form. An invalid positional
+    // mode surfaces via parseAppMode (inside resolveAppMode) as a clear error
+    // rather than silently falling back to the default app.
+    const appModeInput = options.app ?? mode;
     let jsonMode = patchMode;
     try {
       const globalOpts = getGlobalOpts(cmd);
@@ -122,6 +147,24 @@ Examples:
       if (globalOpts.nonInteractive && !patchMode) {
         printError('bwrb edit requires --json <patch> when --non-interactive is set.');
         process.exit(1);
+      }
+
+      // Validate the app mode eagerly (mirrors `open`): an invalid value from
+      // either --app or the positional [mode] errors loudly here rather than
+      // being silently ignored when --open isn't requested. Surface it as a
+      // VALIDATION_ERROR (exit 1) with a clear message, consistent with `open`.
+      if (appModeInput !== undefined) {
+        try {
+          parseAppMode(appModeInput);
+        } catch (modeErr) {
+          const message = modeErr instanceof Error ? modeErr.message : String(modeErr);
+          if (jsonMode) {
+            printJson(jsonError(message));
+            process.exit(ExitCodes.VALIDATION_ERROR);
+          }
+          printError(message);
+          process.exit(1);
+        }
       }
 
       // Validate type if provided
@@ -159,14 +202,14 @@ Examples:
             const editResult = await editNoteFromJson(schema, vaultDir, query, options.json!, { jsonMode });
             printEditSuccess(relative(vaultDir, query), editResult.updatedFields, jsonMode);
             if (options.open) {
-              const appMode = resolveAppMode(options.app, schema.config);
+              const appMode = resolveAppMode(appModeInput, schema.config);
               await openNote(vaultDir, query, appMode, schema.config, true);
             }
           } else {
             await editNoteInteractive(schema, vaultDir, query, {});
             printSuccess(`Updated ${basename(query, '.md')}`);
             if (options.open) {
-              const appMode = resolveAppMode(options.app, schema.config);
+              const appMode = resolveAppMode(appModeInput, schema.config);
               await openNote(vaultDir, query, appMode, schema.config, false);
             }
           }
@@ -265,7 +308,7 @@ Examples:
 
         // Open after edit if requested
         if (options.open) {
-          const appMode = resolveAppMode(options.app, schema.config);
+          const appMode = resolveAppMode(appModeInput, schema.config);
           await openNote(vaultDir, targetFile.path, appMode, schema.config, true);
         }
       } else {
@@ -275,7 +318,7 @@ Examples:
 
         // Open after edit if requested
         if (options.open) {
-          const appMode = resolveAppMode(options.app, schema.config);
+          const appMode = resolveAppMode(appModeInput, schema.config);
           await openNote(vaultDir, targetFile.path, appMode, schema.config, false);
         }
       }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -39,7 +39,7 @@ import {
   type ListOutputFormat,
 } from '../lib/output.js';
 import { UserCancelledError } from '../lib/errors.js';
-import { openNote, resolveAppMode } from './open.js';
+import { openNote, resolveAppMode, parseAppMode } from './open.js';
 import { pickFile, parsePickerMode } from '../lib/picker.js';
 import { formatDisplayValue } from '../lib/value-format.js';
 import type { LoadedSchema, DashboardDefinition } from '../types/schema.js';
@@ -200,6 +200,7 @@ Examples:
   bwrb list --type task --output json
   bwrb list --type task --open                    # Pick from tasks and open
   bwrb list --type task --where "status=inbox" --open
+  bwrb list task print --open                      # Positional filter + app mode
 
 Open Options:
   --open               Open a note from the results (picker if multiple)
@@ -212,8 +213,14 @@ App Modes:
   obsidian    Open in Obsidian via URI scheme
   print       Print the resolved path (for scripting)
 
-Precedence:
-  --app flag > BWRB_DEFAULT_APP env > config.open_with > system
+App-Mode Precedence (for --open):
+  --app flag > [mode] positional > BWRB_DEFAULT_APP env > config.open_with > system
+
+  Note: [mode] is the second positional, after the smart [positional] filter.
+  A single positional is always the filter (type/path/where), never the mode —
+  so use 'bwrb list task print --open', not 'bwrb list print --open' (which
+  would treat 'print' as a type filter). To set the app mode without a filter
+  positional, use the --app flag.
 
 Dashboard Save:
   --save-as <name>   Save the query as a reusable dashboard
@@ -225,6 +232,7 @@ Dashboard Save:
 Note: In zsh, use single quotes for expressions with '!' to avoid history expansion:
   bwrb list --type task --where '!isEmpty(deadline)'`)
   .argument('[positional]', 'Smart positional: type, path (contains /), or where expression (contains =<>~)')
+  .argument('[mode]', 'App mode for --open: system, editor, visual, obsidian, print')
   .option('-t, --type <type>', 'Filter by type path (e.g., idea, objective/task)')
   .option('-p, --path <glob>', 'Filter by file path glob (e.g., Projects/**, Ideas/)')
   .option('-b, --body <query>', 'Filter by body content search')
@@ -251,10 +259,19 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
   // Dashboard save options
   .option('--save-as <name>', 'Save this query as a dashboard')
   .option('--force', 'Overwrite existing dashboard when using --save-as')
-  .action(async (positional: string | undefined, options: ListCommandOptions, cmd: Command) => {
+  // Reject excess positional args. Only [positional] and [mode] are accepted;
+  // a third+ token is almost certainly a typo, and silently swallowing it
+  // (commander's default) hides the mistake.
+  .allowExcessArguments(false)
+  .action(async (positional: string | undefined, mode: string | undefined, options: ListCommandOptions, cmd: Command) => {
     // Resolve output format from --output flag and deprecated flags
     const outputFormat = resolveListOutputFormat(options);
     const jsonMode = outputFormat === 'json';
+
+    // App-mode precedence: an explicit --app flag wins over the positional
+    // [mode] (the convenience form). The positional is the SECOND positional;
+    // a single positional is always the smart filter, never the mode.
+    const appModeInput = options.app ?? mode;
 
     try {
       const globalOpts = getGlobalOpts(cmd);
@@ -262,6 +279,13 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
       const schema = await loadSchema(vaultDir);
+
+      // Validate the app mode eagerly (mirrors `open`): an invalid value from
+      // either --app or the positional [mode] errors loudly here rather than
+      // being silently ignored when --open isn't requested.
+      if (appModeInput !== undefined) {
+        parseAppMode(appModeInput);
+      }
 
       // Pre-flight check: if --save-as is provided without --force, check if dashboard exists
       if (options.saveAs && !options.force) {
@@ -393,7 +417,7 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
         ...(fields !== undefined && { fields }),
         // Open options
         open: options.open,
-        app: options.app,
+        app: appModeInput,
         pickerMode: resolveGlobalPickerMode(undefined, globalOpts, 'auto'),
         // Hierarchy options
         roots: options.roots,

--- a/src/commands/recent.ts
+++ b/src/commands/recent.ts
@@ -24,7 +24,7 @@ import {
 import { getTtyContext } from '../lib/tty/context.js';
 import { renderTable } from '../lib/tty/table.js';
 import { formatFileTimestamp } from '../lib/list-helpers.js';
-import { openNote, resolveAppMode } from './open.js';
+import { openNote, resolveAppMode, parseAppMode } from './open.js';
 import { pickFile, parsePickerMode } from '../lib/picker.js';
 import { createDashboard, updateDashboard, getDashboard } from '../lib/dashboard.js';
 import type { DashboardDefinition } from '../types/schema.js';
@@ -117,6 +117,19 @@ App Modes:
   obsidian    Open in Obsidian via URI scheme
   print       Print the resolved path (for scripting)
 
+App-Mode Precedence (for --open):
+  1. --app flag (explicit)
+  2. [mode] positional argument (the SECOND positional; see note below)
+  3. BWRB_DEFAULT_APP environment variable
+  4. config.open_with in .bwrb/schema.json
+  5. Fallback: system
+
+  Note: [mode] is the second positional, after the smart [positional] filter.
+  A single positional is always the filter (type/path/where), never the mode —
+  so use 'bwrb recent task print --open', not 'bwrb recent print --open'
+  (which would treat 'print' as a type filter). To set the app mode without a
+  filter positional, use the --app flag.
+
 Dashboard Save:
   --save-as <name>   Save this recency query as a reusable dashboard
                      (stored as 'list --sort file.mtime --desc')
@@ -132,8 +145,10 @@ Examples:
   bwrb recent --path "Projects/**"
   bwrb recent --open                              # Open the most recent note
   bwrb recent --type task --open --app editor
+  bwrb recent task print --open                   # Positional filter + app mode
   bwrb recent --type task --save-as "recent-tasks"`)
   .argument('[positional]', 'Smart positional: type, path (contains /), or where expression (contains =<>~)')
+  .argument('[mode]', 'App mode for --open: system, editor, visual, obsidian, print')
   .option('-t, --type <type>', 'Filter by type path (e.g., idea, objective/task)')
   .option('-p, --path <glob>', 'Filter by file path glob (e.g., Projects/**, Ideas/)')
   .option('-b, --body <query>', 'Filter by body content search')
@@ -146,9 +161,17 @@ Examples:
   // Dashboard save options (parity with `list`)
   .option('--save-as <name>', 'Save this recency query as a dashboard')
   .option('--force', 'Overwrite existing dashboard when using --save-as')
-  .action(async (positional: string | undefined, options: RecentCommandOptions, cmd: Command) => {
+  // Reject excess positional args. Only [positional] and [mode] are accepted;
+  // a third+ token is almost certainly a typo, and silently swallowing it
+  // (commander's default) hides the mistake.
+  .allowExcessArguments(false)
+  .action(async (positional: string | undefined, mode: string | undefined, options: RecentCommandOptions, cmd: Command) => {
     const outputFormat = resolveRecentOutputFormat(options.output);
     const jsonMode = outputFormat === 'json';
+
+    // App-mode precedence: an explicit --app flag wins over the positional
+    // [mode] (the convenience form, e.g. `bwrb recent --open print`).
+    const appModeInput = options.app ?? mode;
 
     try {
       const globalOpts = getGlobalOpts(cmd);
@@ -156,6 +179,13 @@ Examples:
       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
       const schema = await loadSchema(vaultDir);
+
+      // Validate the app mode eagerly (mirrors `open`): an invalid value from
+      // either --app or the positional [mode] errors loudly here rather than
+      // being silently ignored when --open isn't requested.
+      if (appModeInput !== undefined) {
+        parseAppMode(appModeInput);
+      }
 
       // Pre-flight check: if --save-as is provided without --force, error early
       // if the dashboard already exists (mirrors `list`).
@@ -329,7 +359,7 @@ Examples:
         await openNote(
           vaultDir,
           targetPath,
-          resolveAppMode(options.app, schema.config),
+          resolveAppMode(appModeInput, schema.config),
           schema.config,
           jsonMode
         );

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -14,7 +14,7 @@ import { getGlobalOpts, resolveGlobalPickerMode } from '../lib/command.js';
 import { loadSchema, getTypeDefByPath, formatUnknownTypeError } from '../lib/schema.js';
 import { configurePromptMode, printError, printSuccess, printWarning } from '../lib/prompt.js';
 import { printJson, jsonSuccess, jsonError, ExitCodes, exitWithResolutionError, warnDeprecated, type SearchOutputFormat } from '../lib/output.js';
-import { openNote, resolveAppMode } from './open.js';
+import { openNote, resolveAppMode, parseAppMode } from './open.js';
 import { editNoteFromJson, editNoteInteractive } from '../lib/edit.js';
 import {
   buildNoteIndex,
@@ -135,6 +135,7 @@ function resolveSearchOutputFormat(options: SearchOptions): SearchOutputFormat {
 export const searchCommand = new Command('search')
   .description('Search for notes by name or content')
   .argument('[query]', 'Search pattern (name/path for default mode, content pattern for --body)')
+  .argument('[mode]', 'App mode for --open: system, editor, visual, obsidian, print')
   // Output format (new unified flag)
   .option('--output <format>', 'Output format: text (default), paths, link, content, json')
   // Deprecated output flags (still work but emit warnings)
@@ -229,9 +230,10 @@ App Modes:
 
 Precedence (for default app):
   1. --app flag (explicit)
-  2. BWRB_DEFAULT_APP environment variable
-  3. config.open_with in .bwrb/schema.json
-  4. Fallback: system
+  2. [mode] positional argument (e.g. bwrb search "My Note" --open print)
+  3. BWRB_DEFAULT_APP environment variable
+  4. config.open_with in .bwrb/schema.json
+  5. Fallback: system
 
 Examples:
   # Name search
@@ -239,6 +241,7 @@ Examples:
   bwrb search "My Note" --output link      # Output: [[My Note]]
   bwrb search "My Note" --open             # Find and open in Obsidian
   bwrb search "My Note" --open --app editor  # Find and open in $EDITOR
+  bwrb search "My Note" --open print        # Positional mode (for --open)
   bwrb search "My Note" --edit             # Find and edit frontmatter
   bwrb search "My Note" --edit --json '{"status":"done"}'  # Non-interactive edit
   
@@ -258,10 +261,33 @@ Examples:
   # Piping
   bwrb search "bug" -t --output paths | xargs -I {} code {}`)
   .allowExcessArguments(false)
-  .action(async (query: string | undefined, options: SearchOptions, cmd: Command) => {
+  .action(async (query: string | undefined, mode: string | undefined, options: SearchOptions, cmd: Command) => {
     // Resolve output format from deprecated flags and new --output option
     const outputFormat = resolveSearchOutputFormat(options);
     const jsonMode = outputFormat === 'json';
+
+    // App-mode precedence: an explicit --app flag wins over the positional
+    // [mode] (the convenience form). Fold the resolved value back into
+    // options.app so every downstream resolveAppMode(options.app, ...) call
+    // (name/content/fuzzy paths) honors the positional without further plumbing.
+    if (options.app === undefined && mode !== undefined) {
+      options.app = mode;
+    }
+    // Validate the app mode eagerly (mirrors `open`): an invalid value errors
+    // loudly here rather than being silently ignored when --open isn't used.
+    if (options.app !== undefined) {
+      try {
+        parseAppMode(options.app);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (jsonMode) {
+          printJson(jsonError(message));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(message);
+        process.exit(1);
+      }
+    }
 
     // Handle deprecated --text flag
     if (options.text) {

--- a/tests/ts/commands/edit.test.ts
+++ b/tests/ts/commands/edit.test.ts
@@ -1088,3 +1088,73 @@ describe('edit command: recurrence completion atomicity (#107)', () => {
     }
   });
 });
+
+// Positional [mode] parity with `open` (#711). `edit` already takes a [query]
+// positional; [mode] is the trailing second positional and is honored only with
+// --open (after the edit). --app wins over the positional; an invalid mode
+// errors loudly even without --open; a third positional is rejected.
+describe('edit positional app mode (#711)', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  it('honors a positional mode with --open (edit <query> print --open --json {})', async () => {
+    const result = await runCLI(
+      ['edit', 'Sample Idea', 'print', '--open', '--json', '{}'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    // Print mode emits the path after the edit completes.
+    expect(result.stdout + result.stderr).toContain('Sample Idea.md');
+  });
+
+  it('lets --app flag take precedence over positional mode', async () => {
+    const result = await runCLI(
+      ['edit', 'Sample Idea', 'system', '--open', '--app', 'print', '--json', '{}'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).toContain('Sample Idea.md');
+  });
+
+  it('errors on an invalid positional mode even without --open', async () => {
+    const result = await runCLI(
+      ['edit', 'Sample Idea', 'bogus-mode', '--json', '{}'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(1);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toContain('Invalid app mode');
+  });
+
+  it('rejects excess positional args (edit <query> <mode> <extra>)', async () => {
+    const result = await runCLI(
+      ['edit', 'Sample Idea', 'print', 'bogus', '--json', '{}'],
+      vaultDir
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('too many arguments');
+  });
+
+  it('does not regress single-positional edit', async () => {
+    const result = await runCLI(
+      ['edit', 'Sample Idea', '--json', '{"status":"backlog"}', '--output', 'json'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(true);
+    expect(json.updated).toContain('status');
+  });
+});

--- a/tests/ts/commands/list.test.ts
+++ b/tests/ts/commands/list.test.ts
@@ -1471,3 +1471,74 @@ status: done
     });
   });
 });
+
+// Positional [mode] parity with `open` (#711). [mode] is the SECOND positional,
+// after the smart filter positional. A single positional is always the filter,
+// never the mode. --app wins over the positional; an invalid mode errors loudly;
+// a third positional is rejected.
+describe('list positional app mode (#711)', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  it('honors a positional mode after a filter positional (list idea print --open ...)', async () => {
+    // Scope to a single idea so --open resolves deterministically (no picker).
+    const result = await runCLI(
+      ['list', 'idea', 'print', '--where', "status == 'raw'", '--open'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Sample Idea.md');
+  });
+
+  it('lets --app flag take precedence over positional mode', async () => {
+    const result = await runCLI(
+      ['list', 'idea', 'system', '--where', "status == 'raw'", '--open', '--app', 'print'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Sample Idea.md');
+  });
+
+  it('errors on an invalid positional mode even without --open', async () => {
+    const result = await runCLI(['list', 'idea', 'bogus-mode'], vaultDir);
+
+    expect(result.exitCode).toBe(1);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toContain('Invalid app mode');
+  });
+
+  it('rejects excess positional args (list <filter> <mode> <extra>)', async () => {
+    const result = await runCLI(
+      ['list', 'idea', 'print', 'bogus', '--open'],
+      vaultDir
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('too many arguments');
+  });
+
+  it('treats a single positional as the smart filter, not the mode', async () => {
+    // `list print` -> "print" is parsed as a type filter (unknown type).
+    const result = await runCLI(['list', 'print'], vaultDir);
+
+    expect(result.exitCode).toBe(1);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toMatch(/Unknown type|Ambiguous argument/i);
+  });
+
+  it('does not regress plain listing with a single positional filter', async () => {
+    const result = await runCLI(['list', 'idea', '--output', 'paths'], vaultDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Ideas/Sample Idea.md');
+  });
+});

--- a/tests/ts/commands/recent.test.ts
+++ b/tests/ts/commands/recent.test.ts
@@ -198,6 +198,67 @@ describe('recent command', () => {
     });
   });
 
+  // Positional [mode] parity with `open` (#711). [mode] is the SECOND
+  // positional, after the smart filter positional. A single positional is
+  // always the filter, never the mode. --app wins over the positional; an
+  // invalid mode errors loudly; a third positional is rejected.
+  describe('positional app mode (#711)', () => {
+    it('honors a positional mode after a filter positional (recent idea print --open)', async () => {
+      const base = 1_700_000_000;
+      await setMtime(join(vaultDir, 'Ideas', 'Sample Idea.md'), base + 100);
+      await setMtime(join(vaultDir, 'Ideas', 'Another Idea.md'), base + 999);
+
+      const result = await runCLI(
+        ['recent', 'idea', 'print', '--open'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toContain('Ideas/Another Idea.md');
+    });
+
+    it('lets --app flag take precedence over positional mode', async () => {
+      const result = await runCLI(
+        ['recent', 'idea', 'system', '--open', '--app', 'print', '--limit', '1'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toMatch(/Ideas\/.*\.md/);
+    });
+
+    it('errors on an invalid positional mode even without --open', async () => {
+      const result = await runCLI(
+        ['recent', 'idea', 'bogus-mode'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toContain('Invalid app mode');
+    });
+
+    it('rejects excess positional args (recent <filter> <mode> <extra>)', async () => {
+      const result = await runCLI(
+        ['recent', 'idea', 'print', 'bogus', '--open'],
+        vaultDir
+      );
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('too many arguments');
+    });
+
+    it('treats a single positional as the smart filter, not the mode', async () => {
+      // `recent print` -> "print" is parsed as a type filter (unknown), so it
+      // errors as an unknown type rather than being treated as the app mode.
+      const result = await runCLI(['recent', 'print'], vaultDir);
+
+      expect(result.exitCode).toBe(1);
+      const combined = result.stdout + result.stderr;
+      expect(combined).toMatch(/Unknown type|Ambiguous argument/i);
+    });
+  });
+
   describe('--save-as', () => {
     it('saves a recency query as a dashboard (sort file.mtime --desc)', async () => {
       const result = await runCLI(

--- a/tests/ts/commands/search.test.ts
+++ b/tests/ts/commands/search.test.ts
@@ -470,10 +470,22 @@ Some content
   });
 
   describe('argument validation', () => {
-    it('should reject extra positional arguments', async () => {
+    it('should reject a second positional that is not a valid app mode', async () => {
+      // After #711, the second positional is [mode] (parity with `open`). A
+      // non-mode value like "status!=done" is rejected via app-mode validation
+      // (in JSON mode the error is returned as structured JSON on stdout).
       const result = await runCLI(['search', 'TODO', '--body', 'status!=done', '--output', 'json'], vaultDir);
 
       expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toMatch(/Invalid app mode/i);
+    });
+
+    it('should reject a third excess positional argument', async () => {
+      const result = await runCLI(['search', 'TODO', 'print', 'extra'], vaultDir);
+
+      expect(result.exitCode).not.toBe(0);
       expect(result.stderr).toMatch(/too many arguments/i);
     });
   });
@@ -967,6 +979,70 @@ Some content
         expect(json.error).toContain('Unknown function: missingFn');
       });
     });
+  });
+});
+
+// Positional [mode] parity with `open` (#711). `search` already takes a
+// [query] positional; [mode] is the trailing second positional and is honored
+// only with --open. An explicit --app flag wins over the positional; an invalid
+// mode errors loudly; a third positional is rejected.
+describe('search positional app mode (#711)', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  it('honors a positional mode with --open (search <query> print --open)', async () => {
+    const result = await runCLI(
+      ['search', 'Sample Idea', 'print', '--open', '--picker', 'none'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Sample Idea.md');
+  });
+
+  it('lets --app flag take precedence over positional mode', async () => {
+    // Positional says system, flag says print -> print wins (prints path).
+    const result = await runCLI(
+      ['search', 'Sample Idea', 'system', '--open', '--app', 'print', '--picker', 'none'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Sample Idea.md');
+  });
+
+  it('errors on an invalid positional mode', async () => {
+    const result = await runCLI(
+      ['search', 'Sample Idea', 'bogus-mode', '--open', '--picker', 'none'],
+      vaultDir
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Invalid app mode');
+  });
+
+  it('rejects excess positional args (search <query> <mode> <extra>)', async () => {
+    const result = await runCLI(
+      ['search', 'Sample Idea', 'print', 'bogus', '--open', '--picker', 'none'],
+      vaultDir
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('too many arguments');
+  });
+
+  it('does not regress single-positional name search', async () => {
+    const result = await runCLI(['search', 'Sample Idea'], vaultDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('Sample Idea');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds the optional `[mode]` positional that #662 introduced on `bwrb open` to the four sibling commands that already expose `--app <mode>` but lacked the positional convenience: `recent`, `list`, `search`, and `edit`.

## The `open` pattern, mirrored

- **Positional shape**: `[mode]` is the trailing positional after each command's existing positional.
  - `search` / `edit`: `[query] [mode]` (identical to `open`'s `[query] [mode]`).
  - `recent` / `list`: `[positional] [mode]` — `[mode]` is the **second** positional, after the smart filter positional. A lone positional is always the smart filter (type/path/where), never the mode, so the usable form is `<filter> <mode>` (e.g. `bwrb recent task print --open`). To set the mode without a filter positional, use `--app`. This caveat is documented in `--help` and the docs.
- **Precedence**: an explicit `--app` flag always wins over the positional `[mode]` (`options.app ?? mode`), exactly as `open` does.
- **Mode validation**: an invalid value is rejected with a clear `Invalid app mode` error via `parseAppMode`, validated **eagerly** so it errors even when `--open` is not requested (rather than being silently ignored).
- **Excess args**: `allowExcessArguments(false)` so a stray third positional errors loudly. `search` already had it; added to `recent`/`list`/`edit`.

## Tests

For each of the four commands: positional mode honored, `--app` precedence over positional, invalid mode rejected, excess args rejected, and existing single-positional behavior unregressed. Updated one pre-existing `search` arg-validation test whose second positional is now interpreted as `[mode]` (still rejected, now via app-mode validation).

## Docs

Documented the new `[mode]` positional, precedence, and the recent/list "second positional" caveat in the `recent`/`list`/`search`/`edit` command reference pages.

## Gate

`pnpm qa` (typecheck, lint, schema:check, docs:lint, docs:doctor, build, 2861 tests) and `pnpm knip` both green locally. `src/types/schema.ts` was not touched, so no `schema.schema.json` regen needed.

Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)