### PR TITLE
fix(init): honor global vault target

### DIFF
--- a/docs-site/src/content/docs/getting-started/quick-start.md
+++ b/docs-site/src/content/docs/getting-started/quick-start.md
@@ -207,9 +207,14 @@ bwrb list objective/task     # Lists only tasks
 
 Bowerbird finds your vault in this order:
 
-1. `--vault=<path>` flag
-2. `BWRB_VAULT` environment variable
-3. Current working directory
+1. `--vault=<path>` / `-v <path>` flag
+2. The nearest parent directory with `.bwrb/schema.json`
+3. `BWRB_VAULT` environment variable
+4. A single vault discovered under the current directory
+
+`bwrb init` creates a vault instead of finding one, so its target precedence is
+different: positional `[path]`, then global `--vault` / `-v`, then the current
+directory.
 
 Set a default vault in your shell profile:
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -82,8 +82,10 @@ Examples:
         throw new Error('bwrb init requires --yes when --non-interactive is set.');
       }
 
-      // Resolve vault path
-      const vaultDir = pathArg ? resolve(pathArg) : process.cwd();
+      // Resolve vault path. For init, a positional path is the most specific
+      // target, then the global --vault/-v option, then the current directory.
+      const vaultTarget = pathArg ?? globalOpts.vault;
+      const vaultDir = vaultTarget ? resolve(vaultTarget) : process.cwd();
       const bwrbDir = join(vaultDir, BWRB_DIR);
 
       // Check if vault directory exists

--- a/tests/ts/commands/init.test.ts
+++ b/tests/ts/commands/init.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { writeFile, rm, mkdir, readFile, readdir } from 'fs/promises';
+import { writeFile, rm, mkdir, readFile, readdir, realpath } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { mkdtemp } from 'fs/promises';
@@ -104,6 +104,62 @@ describe('init command', () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('not a directory');
+    });
+  });
+
+  // ============================================================================
+  // Global --vault/-v option
+  // ============================================================================
+
+  describe('global --vault/-v option', () => {
+    it('should initialize the global -v target instead of the current directory', async () => {
+      const targetDir = join(tempDir, 'target-vault');
+      const cwdDir = join(tempDir, 'cwd');
+      await mkdir(targetDir);
+      await mkdir(cwdDir);
+
+      const result = await runCLI(['-v', targetDir, 'init', '--yes'], undefined, undefined, {
+        cwd: cwdDir,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(join(targetDir, '.bwrb', 'schema.json'))).toBe(true);
+      expect(existsSync(join(cwdDir, '.bwrb'))).toBe(false);
+    });
+
+    it('should resolve a relative global -v init target from the command cwd', async () => {
+      const targetDir = join(tempDir, 'relative-target');
+      const cwdDir = join(tempDir, 'runner');
+      await mkdir(targetDir);
+      await mkdir(cwdDir);
+
+      const result = await runCLI(
+        ['-v', '../relative-target', 'init', '--yes', '--output', 'json'],
+        undefined,
+        undefined,
+        { cwd: cwdDir }
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(join(targetDir, '.bwrb', 'schema.json'))).toBe(true);
+      expect(existsSync(join(cwdDir, '.bwrb'))).toBe(false);
+
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      await expect(realpath(json.data.vault)).resolves.toBe(await realpath(targetDir));
+    });
+
+    it('should let a positional init path take precedence over global -v', async () => {
+      const positionalDir = join(tempDir, 'positional-vault');
+      const vaultOptionDir = join(tempDir, 'vault-option-vault');
+      await mkdir(positionalDir);
+      await mkdir(vaultOptionDir);
+
+      const result = await runCLI(['-v', vaultOptionDir, 'init', positionalDir, '--yes']);
+
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(join(positionalDir, '.bwrb', 'schema.json'))).toBe(true);
+      expect(existsSync(join(vaultOptionDir, '.bwrb'))).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- make `bwrb -v <path> init --yes` initialize the global vault target when no positional init path is provided
- preserve positional `[path]` precedence over global `--vault` / `-v` for `init`
- add regression coverage for absolute and relative `-v` init targets, plus docs for init target precedence

Closes #730

## Verification
- `pnpm test tests/ts/commands/init.test.ts`
- real CLI smoke: `node dist/index.js -v ../target init --yes --output json` from a separate throwaway cwd, verified target schema exists and cwd `.bwrb` does not
- Node 22 via `fnm exec --using=22`: `pnpm build`; `pnpm verify:pack`; `pnpm typecheck`; `pnpm lint`; `pnpm knip`; `pnpm test -- --exclude='**/*.pty.test.ts'`\n\n## Notes\n- A local Node 26 run of the final test command failed from `DEP0205 module.register()` deprecation warnings on stderr; rerunning under the repo/CI Node 22 version passed.\n- I inspected the existing local worktree `fix/735-730-vault-path-resolution` and kept this PR narrowly scoped to #730 rather than carrying over the broader #735 vault-resolution changes.