### PR TITLE
fix: resolve relative vault paths

### DIFF
--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -143,12 +143,13 @@ export interface ResolveVaultOptions {
  */
 export async function resolveVaultDir(options: ResolveVaultOptions = {}): Promise<string> {
   if (options.vault) {
-    if (!hasVaultSchema(options.vault)) {
+    const resolvedVault = resolve(options.vault);
+    if (!hasVaultSchema(resolvedVault)) {
       throw new Error(
         `Invalid --vault path: "${options.vault}" (expected ${SCHEMA_RELATIVE_PATH})`
       );
     }
-    return options.vault;
+    return resolvedVault;
   }
 
   const cwd = options.cwd ?? process.cwd();
@@ -159,12 +160,13 @@ export async function resolveVaultDir(options: ResolveVaultOptions = {}): Promis
 
   const envVault = process.env['BWRB_VAULT'];
   if (envVault) {
-    if (!hasVaultSchema(envVault)) {
+    const resolvedEnvVault = resolve(envVault);
+    if (!hasVaultSchema(resolvedEnvVault)) {
       throw new Error(
         `Invalid BWRB_VAULT: "${envVault}" (expected ${SCHEMA_RELATIVE_PATH})`
       );
     }
-    return envVault;
+    return resolvedEnvVault;
   }
 
   if (options.allowFindDown === false) {

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -4293,6 +4293,57 @@ Content here
       expect(content).toContain('Content here');
     });
 
+    it('should move to the non-doubled target when --vault is relative', async () => {
+      const parentDir = await mkdtemp(join(tmpdir(), 'bwrb-audit-rel-vault-'));
+      const vaultName = 'collision';
+      const relativeVaultDir = join(parentDir, vaultName);
+
+      try {
+        await mkdir(join(relativeVaultDir, '.bwrb'), { recursive: true });
+        await writeFile(
+          join(relativeVaultDir, '.bwrb', 'schema.json'),
+          JSON.stringify(TEST_SCHEMA, null, 2)
+        );
+        await mkdir(join(relativeVaultDir, 'Ideas'), { recursive: true });
+        await mkdir(join(relativeVaultDir, 'Objectives'), { recursive: true });
+        await writeFile(
+          join(relativeVaultDir, 'Objectives', 'Relative Move.md'),
+          `---
+type: idea
+status: raw
+priority: medium
+---
+relative vault body
+`
+        );
+
+        const result = await runCLI(
+          ['-v', vaultName, 'audit', '--fix', '--auto', '--execute', '--all'],
+          undefined,
+          undefined,
+          { cwd: parentDir }
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Moved to Ideas/');
+
+        const moved = await readFile(
+          join(relativeVaultDir, 'Ideas', 'Relative Move.md'),
+          'utf-8'
+        );
+        expect(moved).toContain('relative vault body');
+
+        await expect(
+          readFile(join(relativeVaultDir, vaultName, 'Ideas', 'Relative Move.md'), 'utf-8')
+        ).rejects.toThrow();
+        await expect(
+          readFile(join(relativeVaultDir, 'Objectives', 'Relative Move.md'), 'utf-8')
+        ).rejects.toThrow();
+      } finally {
+        await rm(parentDir, { recursive: true, force: true });
+      }
+    });
+
     // Defect 1 (DATA LOSS) on the GENERIC wrong-directory path: the same move
     // primitive guard must protect a plain misplaced note whose destination is
     // already occupied. --fix must SKIP it, report a conflict, and overwrite

--- a/tests/ts/lib/vault.test.ts
+++ b/tests/ts/lib/vault.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
-import { join, relative } from 'path';
+import { join, relative, resolve, isAbsolute } from 'path';
 import { writeFile, mkdir, rm, mkdtemp, realpath } from 'fs/promises';
 import { tmpdir } from 'os';
 import {
@@ -57,7 +57,8 @@ describe('vault', () => {
 
         const relativeOptionVault = relative(process.cwd(), optionVaultDir);
         const result = await resolveVaultDir({ vault: relativeOptionVault });
-        expect(result).toBe(relativeOptionVault);
+        expect(result).toBe(resolve(process.cwd(), relativeOptionVault));
+        expect(isAbsolute(result)).toBe(true);
       } finally {
         await cleanupTestVault(optionVaultDir);
       }
@@ -181,7 +182,7 @@ describe('vault', () => {
       }
     });
 
-    it('should preserve relative path from --vault option', async () => {
+    it('should resolve relative path from --vault option to absolute', async () => {
       const baseDir = await mkdtemp(join(tmpdir(), 'bwrb-rel-vault-'));
       try {
         const relativeVault = './my-vault';
@@ -193,13 +194,14 @@ describe('vault', () => {
         delete process.env['BWRB_VAULT'];
 
         const result = await resolveVaultDir({ vault: relativeVault });
-        expect(result).toBe(relativeVault);
+        expect(result).toBe(resolve(process.cwd(), relativeVault));
+        expect(isAbsolute(result)).toBe(true);
       } finally {
         await rm(baseDir, { recursive: true, force: true });
       }
     });
 
-    it('should preserve relative path from env var', async () => {
+    it('should resolve relative path from env var to absolute', async () => {
       const baseDir = await mkdtemp(join(tmpdir(), 'bwrb-rel-env-'));
       try {
         await mkdir(join(baseDir, 'other-vault', '.bwrb'), { recursive: true });
@@ -210,7 +212,8 @@ describe('vault', () => {
         process.env['BWRB_VAULT'] = '../other-vault';
 
         const result = await resolveVaultDir({});
-        expect(result).toBe('../other-vault');
+        expect(result).toBe(resolve(process.cwd(), '../other-vault'));
+        expect(isAbsolute(result)).toBe(true);
       } finally {
         await rm(baseDir, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary
- Resolve `--vault` and `BWRB_VAULT` values to absolute paths in `resolveVaultDir` before validation/return.
- Add a command-level regression for `audit --fix --auto --execute` invoked from a parent directory with relative `-v collision`, proving the move lands at `collision/Ideas/...` instead of `collision/collision/Ideas/...`.
- Update resolver unit tests to assert relative vault inputs return absolute vault roots.

Closes #735

## Verification
- `pnpm build`
- real CLI smoke in throwaway temp vault with `node dist/index.js -v collision audit --fix --auto --execute --all`
- `pnpm verify:pack`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm test -- --exclude='**/*.pty.test.ts'`

Note: the documented test command still ran PTY test files in this local invocation, but the full run completed green.


## Release note
- Relative `BWRB_VAULT` values are now resolved to an absolute path at vault-resolution time, using the process working directory at that moment. This matches relative `--vault` handling and prevents downstream path-doubling bugs.
