### PR TITLE
fix: support schema diff output alias

### DIFF
--- a/src/commands/schema/migrate.ts
+++ b/src/commands/schema/migrate.ts
@@ -69,7 +69,7 @@ export function registerMigrationCommands(schemaCommand: Command): void {
   schemaCommand
     .command('diff')
     .description('Show pending schema changes since last migration')
-    .option('--output <format>', 'Output format: text (default) or json')
+    .option('-o, --output <format>', 'Output format: text (default) or json')
     .addHelpText('after', `
 Examples:
   bwrb schema diff              # Show what changed

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -558,6 +558,19 @@ describe('schema command', () => {
       }
     });
 
+    it('supports -o json as an alias for --output json', async () => {
+      const tempVaultDir = await setupAddedOptionVault();
+      try {
+        const longResult = await runCLI(['schema', 'diff', '--output', 'json'], tempVaultDir);
+        const shortResult = await runCLI(['schema', 'diff', '-o', 'json'], tempVaultDir);
+
+        expect(shortResult.exitCode).toBe(0);
+        expect(JSON.parse(shortResult.stdout)).toEqual(JSON.parse(longResult.stdout));
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
     it('reports a schema-only change (added option) in human output, not "No schema changes"', async () => {
       const tempVaultDir = await setupAddedOptionVault();
       try {


### PR DESCRIPTION
## Summary
- Add `-o` as the short alias for `bwrb schema diff --output` so the help example works as documented.
- Add a regression test comparing `schema diff -o json` with `schema diff --output json`.

Closes #733

## Verification
- `pnpm exec vitest run tests/ts/commands/schema.test.ts -t "schema diff"`
- `pnpm build`
- `pnpm verify:pack`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `eval "$(fnm env --shell zsh)" && fnm use v22.21.1 >/dev/null && pnpm exec vitest run --exclude="**/*.pty.test.ts"`
- Built CLI smoke test in a temp vault comparing `schema diff -o json` and `schema diff --output json`

## Notes
- The documented `pnpm test -- --exclude="**/*.pty.test.ts"` form did not exclude PTY tests in this shell, so I reran with Vitest direct `--exclude` under Node 22.
- A Node 26 broad test run failed on unrelated `[DEP0205] module.register()` stderr deprecation warnings; Node 22 passed.