### PR TITLE
Fix documented output aliases

### DIFF
--- a/docs-site/src/content/docs/reference/commands/dashboard.md
+++ b/docs-site/src/content/docs/reference/commands/dashboard.md
@@ -34,6 +34,7 @@ bwrb dashboard inbox --output json   # Override output format
 | `list` | List all saved dashboards |
 | `new <name>` | Create a new dashboard |
 | `edit [name]` | Edit an existing dashboard |
+| `delete [name]` | Delete a dashboard |
 
 ## Creating Dashboards
 
@@ -76,6 +77,10 @@ bwrb dashboard new my-query --type task --where "status=active"
 
 # Edit a dashboard
 bwrb dashboard edit my-tasks
+
+# Delete a dashboard
+bwrb dashboard delete my-tasks --force
+bwrb dashboard delete my-tasks -o json --force
 ```
 
 ## See Also

--- a/docs-site/src/content/docs/reference/commands/schema.md
+++ b/docs-site/src/content/docs/reference/commands/schema.md
@@ -378,7 +378,7 @@ bwrb schema diff [options]
 
 | Option | Description |
 |--------|-------------|
-| `--output <format>` | Output format: `text`, `json` |
+| `-o, --output <format>` | Output format: `text`, `json` |
 
 ### Description
 
@@ -398,7 +398,7 @@ Compares the current schema.json against the last migration snapshot to show:
 bwrb schema diff
 
 # JSON output for scripting
-bwrb schema diff --output json
+bwrb schema diff -o json
 ```
 
 ### Workflow
@@ -480,7 +480,7 @@ bwrb schema history [options]
 | Option | Description |
 |--------|-------------|
 | `--limit <n>` | Number of entries to show (default: 10) |
-| `--output <format>` | Output format: `text`, `json` |
+| `-o, --output <format>` | Output format: `text`, `json` |
 
 ### Description
 
@@ -500,7 +500,7 @@ bwrb schema history
 bwrb schema history --limit 5
 
 # JSON output
-bwrb schema history --output json
+bwrb schema history -o json
 ```
 
 ---

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1025,7 +1025,7 @@ dashboardCommand
   .command('delete [name]')
   .description('Delete a dashboard')
   .option('-f, --force', 'Skip confirmation prompt')
-  .option('--output <format>', 'Output format: text (default) or json')
+  .option('-o, --output <format>', 'Output format: text (default) or json')
   .addHelpText('after', `
 Delete a saved dashboard. Shows a picker if no name is provided.
 

--- a/src/commands/schema/migrate.ts
+++ b/src/commands/schema/migrate.ts
@@ -523,7 +523,7 @@ Examples:
   schemaCommand
     .command('history')
     .description('Show migration history')
-    .option('--output <format>', 'Output format: text (default) or json')
+    .option('-o, --output <format>', 'Output format: text (default) or json')
     .option('--limit <n>', 'Number of entries to show (default: 10)')
     .addHelpText('after', `
 Examples:

--- a/tests/ts/commands/dashboard.test.ts
+++ b/tests/ts/commands/dashboard.test.ts
@@ -1566,6 +1566,19 @@ describe('dashboard command', () => {
         expect(json.data.wasDefault).toBe(false);
       });
 
+      it('supports -o json as an alias for --output json', async () => {
+        const result = await runCLI(
+          ['dashboard', 'delete', 'to-delete', '-o', 'json', '--force'],
+          vaultDir
+        );
+
+        expect(result.exitCode).toBe(0);
+        const json = JSON.parse(result.stdout);
+        expect(json.success).toBe(true);
+        expect(json.data.name).toBe('to-delete');
+        expect(json.data.wasDefault).toBe(false);
+      });
+
       it('should return error JSON when dashboard does not exist', async () => {
         const result = await runCLI(
           ['dashboard', 'delete', 'nonexistent', '--force', '--output', 'json'],

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -2214,4 +2214,25 @@ status: paused
       expect(result.stdout).toContain('status');
     });
   });
+
+  describe('schema history', () => {
+    it('supports -o json as an alias for --output json', async () => {
+      const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-schema-history-output-alias-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify({ version: 2, types: { meta: {} } }, null, 2)
+      );
+
+      try {
+        const longResult = await runCLI(['schema', 'history', '--output', 'json'], tempVaultDir);
+        const shortResult = await runCLI(['schema', 'history', '-o', 'json'], tempVaultDir);
+
+        expect(shortResult.exitCode).toBe(0);
+        expect(JSON.parse(shortResult.stdout)).toEqual(JSON.parse(longResult.stdout));
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add `-o, --output` aliases for `schema history` and `dashboard delete` to match advertised help examples
- update docs-site command reference for `schema diff`, `schema history`, and dashboard delete examples
- add focused regression coverage for `schema history -o json` and `dashboard delete -o json`

Closes #756

## Tests
- `pnpm test tests/ts/commands/schema.test.ts tests/ts/commands/dashboard.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm docs:install`
- `pnpm docs:lint`
- `pnpm docs:doctor`
- `pnpm docs:check`
- `pnpm schema:check`
- `pnpm verify:pack`
- `node dist/index.js schema history --help`
- `node dist/index.js dashboard delete --help`
- `node dist/index.js --vault tests/fixtures/vault schema history -o json`
- built CLI smoke: `dashboard delete my-tasks -o json --force` against a temporary fixture dashboard
