### PR TITLE
Suppress fuzzy unlinked mentions for common headings

### DIFF
--- a/src/lib/audit/unlinked-mention.ts
+++ b/src/lib/audit/unlinked-mention.ts
@@ -73,6 +73,21 @@ const FUZZY_MIN_CANDIDATE_LENGTH = 4;
 /** Cap on how many distinct fuzzy "did you mean?" suggestions to list. */
 const FUZZY_MAX_SUGGESTIONS = 3;
 
+const COMMON_STRUCTURAL_HEADING_LABELS = new Set([
+  'backlinks',
+  'context',
+  'ideas',
+  'links',
+  'notes',
+  'references',
+  'related',
+  'resources',
+  'summary',
+  'tasks',
+  'todo',
+  'todos',
+]);
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -483,6 +498,20 @@ function detectFuzzyCandidates(
   const isConsumed = (start: number, end: number): boolean =>
     consumed.some(([s, e]) => start < e && end > s);
 
+  const isCommonStructuralHeading = (phrase: string, start: number): boolean => {
+    const lineStart = body.lastIndexOf('\n', start - 1) + 1;
+    const nextNewline = body.indexOf('\n', start);
+    const lineEnd = nextNewline === -1 ? body.length : nextNewline;
+    const line = body.slice(lineStart, lineEnd);
+    const heading = line.match(/^[ \t]{0,3}#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$/);
+    if (!heading) return false;
+
+    const headingText = heading[1]!.trim();
+    if (headingText !== phrase) return false;
+
+    return COMMON_STRUCTURAL_HEADING_LABELS.has(headingText.toLowerCase());
+  };
+
   // Candidate phrases: runs of capitalized words (proper-noun-ish), e.g.
   // "Steve Yeg", "Mercry". Conservative to keep the fuzzy tier low-noise.
   const phraseRe = /\b[A-Z][\w'-]*(?:\s+[A-Z][\w'-]*)*/g;
@@ -525,6 +554,7 @@ function detectFuzzyCandidates(
       const start = cand.start;
       const end = start + phrase.length;
       if (isConsumed(start, end)) continue;
+      if (isCommonStructuralHeading(phrase, start)) continue;
 
       const lower = phrase.toLowerCase();
       // Skip exact known surfaces (handled by the exact tier).

--- a/tests/ts/lib/audit-unlinked-mention.test.ts
+++ b/tests/ts/lib/audit-unlinked-mention.test.ts
@@ -142,6 +142,26 @@ describe('unlinked-mention: detectUnlinkedMentions', () => {
     expect(fuzzy!.similarFiles).toContain('Steve Yegge');
   });
 
+  it('does not fuzzy-flag common structural headings like Notes', () => {
+    const index = indexFor([
+      { relativePath: 'Notes/quotes.md', resolvedType: 'note', frontmatter: { type: 'note' } },
+    ]);
+    const issues = detectUnlinkedMentions('## Notes\n\nSome ordinary task detail.', 'Tasks/Tidy.md', index);
+    expect(issues.some((i) => i.meta?.['tier'] === 'fuzzy')).toBe(false);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('keeps exact mention detection for common heading labels', () => {
+    const index = indexFor([
+      { relativePath: 'Notes/Notes.md', resolvedType: 'note', frontmatter: { type: 'note' } },
+    ]);
+    const issues = detectUnlinkedMentions('## Notes\n\nSome ordinary task detail.', 'Tasks/Tidy.md', index);
+    const exact = issues.find((i) => i.meta?.['tier'] === 'exact');
+    expect(exact).toBeDefined();
+    expect(exact!.autoFixable).toBe(true);
+    expect(exact!.targetName).toBe('Notes');
+  });
+
   it('flags an ambiguous mention as flag-only with multiple candidates', () => {
     // Two distinct entities both expose the surface "Mercury": one by name,
     // one by alias.


### PR DESCRIPTION
## Summary
- suppress fuzzy-only `unlinked-mention` suggestions for common structural Markdown headings such as `## Notes`
- keep exact/alias detection intact for those same heading labels
- add focused regression coverage for `Notes` vs `quotes`

Closes #750

## Tests
- `pnpm test tests/ts/lib/audit-unlinked-mention.test.ts`
- `pnpm build`
- `pnpm verify:pack`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `NODE_NO_WARNINGS=1 pnpm test tests/ts/lib/audit-unlinked-mention.test.ts tests/ts/commands/audit.test.ts`

Note: `pnpm test -- --exclude='**/*.pty.test.ts'` was attempted locally on Node v26.0.0; it did not exclude PTY tests under this invocation and failed only because Node emitted `[DEP0205] module.register()` deprecation warnings into stderr, tripping unrelated stderr-purity/layout assertions. The repo CI target is Node 22.