### PR TITLE
Fix edit path-qualified relation refs

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,10 +1,10 @@
 import type { LoadedSchema, Field } from '../types/schema.js';
 import { getFieldsForType, getDescendants, getType, getFieldOptions, resolveDateGranularity } from './schema.js';
 import { isBwrbBuiltinFrontmatterField } from './frontmatter/systemFields.js';
-import { queryByType } from './vault.js';
 import { extractWikilinkTarget } from './links.js';
 import { levenshteinDistance } from './levenshtein.js';
 import { isBlankScalar } from './emptiness.js';
+import { buildVaultNoteIndex, type VaultNoteIndex } from './discovery.js';
 import {
   expandStaticValue,
   parseDate,
@@ -821,6 +821,7 @@ export async function validateContextFields(
 ): Promise<ContextValidationResult> {
   const errors: ContextValidationError[] = [];
   const fields = getFieldsForType(schema, typeName);
+  const noteIndex = await buildVaultNoteIndex(schema, vaultDir);
 
   for (const [fieldName, field] of Object.entries(fields)) {
     // Skip fields without source constraint (not context fields)
@@ -840,10 +841,10 @@ export async function validateContextFields(
       
       const error = await validateSingleContextValue(
         schema,
-        vaultDir,
         fieldName,
         field,
-        v
+        v,
+        noteIndex
       );
       
       if (error) {
@@ -863,10 +864,10 @@ export async function validateContextFields(
  */
 async function validateSingleContextValue(
   schema: LoadedSchema,
-  vaultDir: string,
   fieldName: string,
   field: Field,
-  value: string
+  value: string,
+  noteIndex: VaultNoteIndex
 ): Promise<ContextValidationError | null> {
   const source = field.source!;
   
@@ -877,9 +878,6 @@ async function validateSingleContextValue(
     return null;
   }
 
-  // "any" source accepts any note - we just need to verify it exists
-  // For type-specific sources, we query by type which also verifies existence
-  
   // Build list of valid types based on source constraint
   const validTypes = new Set<string>();
   
@@ -888,15 +886,11 @@ async function validateSingleContextValue(
   
   // Check for "any" in sources
   if (sources.includes('any')) {
-    // Any type is valid, just need to check existence
-    // Query all types to find the note
-    for (const typeName of schema.types.keys()) {
-      const typeNotes = await queryByType(schema, vaultDir, typeName);
-      if (typeNotes.includes(targetName)) {
-        return null; // Found, valid
-      }
+    const candidates = noteIndex.noteTargetIndex.targetToPaths.get(targetName.toLowerCase()) ?? [];
+    if (candidates.length > 0) {
+      return null;
     }
-    
+
     // Note not found in any type
     return {
       type: 'invalid_context_source',
@@ -928,32 +922,33 @@ async function validateSingleContextValue(
     return null;
   }
 
-  // Query notes for each valid type and check if target exists
-  for (const typeName of validTypes) {
-    const typeNotes = await queryByType(schema, vaultDir, typeName);
-    if (typeNotes.includes(targetName)) {
-      return null; // Found and valid type
-    }
+  const candidates = noteIndex.noteTargetIndex.targetToPaths.get(targetName.toLowerCase()) ?? [];
+  const candidateTypes = candidates
+    .map((candidatePath) => {
+      const pathKey = candidatePath.replace(/\.md$/, '');
+      return {
+        path: candidatePath,
+        type: noteIndex.noteTargetIndex.pathNoExtToType.get(pathKey),
+      };
+    })
+    .filter((candidate): candidate is { path: string; type: string } => Boolean(candidate.type));
+
+  if (candidateTypes.some((candidate) => validTypes.has(candidate.type))) {
+    return null;
   }
 
-  // Check if the note exists but has wrong type (for better error messages)
-  for (const [typeName, _type] of schema.types) {
-    if (validTypes.has(typeName)) continue; // Already checked
-    
-    const typeNotes = await queryByType(schema, vaultDir, typeName);
-    if (typeNotes.includes(targetName)) {
-      // Note exists but wrong type
-      return {
-        type: 'invalid_context_source',
-        field: fieldName,
-        value,
-        message: `"${targetName}" is type "${typeName}", expected ${formatExpectedTypes(validTypes)}`,
-        targetName,
-        actualType: typeName,
-        expectedTypes: Array.from(validTypes),
-        expected: Array.from(validTypes),
-      };
-    }
+  const wrongTypeCandidate = candidateTypes[0];
+  if (wrongTypeCandidate) {
+    return {
+      type: 'invalid_context_source',
+      field: fieldName,
+      value,
+      message: `"${targetName}" is type "${wrongTypeCandidate.type}", expected ${formatExpectedTypes(validTypes)}`,
+      targetName,
+      actualType: wrongTypeCandidate.type,
+      expectedTypes: Array.from(validTypes),
+      expected: Array.from(validTypes),
+    };
   }
 
   // Note not found at all

--- a/tests/ts/commands/edit.test.ts
+++ b/tests/ts/commands/edit.test.ts
@@ -242,6 +242,94 @@ status: queued
       expect(result.stdout).toContain('Updated: Ideas/Sample Idea.md');
       expect(() => JSON.parse(result.stdout)).toThrow();
     });
+
+    it('accepts path-qualified relation refs that audit accepts when editing an unrelated field (#748)', async () => {
+      await writeFile(
+        join(vaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify(
+          {
+            version: 2,
+            types: {
+              context: {
+                output_dir: 'contexts',
+                fields: {
+                  type: { value: 'context' },
+                  status: { prompt: 'select', options: ['active'], default: 'active', required: true },
+                },
+              },
+              draft: {
+                output_dir: 'drafts',
+                fields: {
+                  type: { value: 'draft' },
+                  status: { prompt: 'select', options: ['active'], default: 'active', required: true },
+                },
+              },
+              task: {
+                output_dir: 'tasks',
+                fields: {
+                  type: { value: 'task' },
+                  status: { prompt: 'select', options: ['backlog', 'done'], default: 'backlog', required: true },
+                  context: { prompt: 'relation', source: 'context' },
+                },
+              },
+            },
+          },
+          null,
+          2
+        ),
+        'utf-8'
+      );
+
+      await mkdir(join(vaultDir, 'contexts'), { recursive: true });
+      await mkdir(join(vaultDir, 'drafts'), { recursive: true });
+      await mkdir(join(vaultDir, 'tasks'), { recursive: true });
+
+      await writeFile(
+        join(vaultDir, 'contexts', 'The Molting.md'),
+        `---
+type: context
+status: active
+---
+`,
+        'utf-8'
+      );
+      await writeFile(
+        join(vaultDir, 'drafts', 'The Molting.md'),
+        `---
+type: draft
+status: active
+---
+`,
+        'utf-8'
+      );
+      await writeFile(
+        join(vaultDir, 'tasks', 'Patch Me.md'),
+        `---
+type: task
+status: backlog
+context: "[[contexts/The Molting]]"
+---
+`,
+        'utf-8'
+      );
+
+      const auditBefore = await runCLI(['audit', '--path', 'tasks/Patch Me.md'], vaultDir);
+      expect(auditBefore.exitCode).toBe(0);
+
+      const result = await runCLI(
+        ['edit', 'tasks/Patch Me.md', '--json', '{"status":"done"}'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.updated).toContain('status');
+
+      const content = await readFile(join(vaultDir, 'tasks', 'Patch Me.md'), 'utf-8');
+      expect(content).toContain('status: done');
+      expect(content).toContain('context: "[[contexts/The Molting]]"');
+    });
   });
 
   describe('stable ids', () => {


### PR DESCRIPTION
## Summary

- Reuse the vault-wide note target index in write-time context validation so `edit` resolves path-qualified relation wikilinks the same way `audit` does.
- Preserve source/type checks by validating resolved candidate paths against the index's path-to-type data.
- Add a regression where same-title `context` and `draft` notes exist, `audit` accepts `[[contexts/The Molting]]`, and `edit` can update an unrelated task field without rejecting the relation.

Closes #748.

## Validation

- `pnpm test tests/ts/commands/edit.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint`
- `pnpm knip`
- `pnpm verify:pack`
- `NODE_OPTIONS=--no-deprecation pnpm exec vitest run --exclude='**/*.pty.test.ts'`

Note: `pnpm test -- --exclude='**/*.pty.test.ts'` was also attempted under local Node v26.0.0 and failed because Node emitted `[DEP0205] module.register()` deprecation warnings into stderr/PTY output across unrelated tests. CI is documented as Node 22; the deprecation-suppressed direct non-PTY Vitest run passed.
