### PR TITLE
Fix relative vault resolution against cwd

### DIFF
--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -134,6 +134,9 @@ export interface ResolveVaultOptions {
 
 /**
  * Resolve vault directory.
+ * Relative explicit vault paths are resolved against options.cwd when supplied,
+ * otherwise against the current process cwd. This applies to both --vault and
+ * BWRB_VAULT for consistency with find-up/find-down discovery.
  *
  * Precedence (authoritative):
  * 1) --vault option
@@ -142,8 +145,10 @@ export interface ResolveVaultOptions {
  * 4) find-down under cwd (Phase 2)
  */
 export async function resolveVaultDir(options: ResolveVaultOptions = {}): Promise<string> {
+  const cwd = options.cwd ?? process.cwd();
+
   if (options.vault) {
-    const resolvedVault = resolve(options.vault);
+    const resolvedVault = resolve(cwd, options.vault);
     if (!hasVaultSchema(resolvedVault)) {
       throw new Error(
         `Invalid --vault path: "${options.vault}" (expected ${SCHEMA_RELATIVE_PATH})`
@@ -152,7 +157,6 @@ export async function resolveVaultDir(options: ResolveVaultOptions = {}): Promis
     return resolvedVault;
   }
 
-  const cwd = options.cwd ?? process.cwd();
   const found = findUpVaultDir(cwd);
   if (found) {
     return found;
@@ -160,7 +164,7 @@ export async function resolveVaultDir(options: ResolveVaultOptions = {}): Promis
 
   const envVault = process.env['BWRB_VAULT'];
   if (envVault) {
-    const resolvedEnvVault = resolve(envVault);
+    const resolvedEnvVault = resolve(cwd, envVault);
     if (!hasVaultSchema(resolvedEnvVault)) {
       throw new Error(
         `Invalid BWRB_VAULT: "${envVault}" (expected ${SCHEMA_RELATIVE_PATH})`

--- a/tests/ts/lib/vault.test.ts
+++ b/tests/ts/lib/vault.test.ts
@@ -201,6 +201,26 @@ describe('vault', () => {
       }
     });
 
+    it('should resolve relative --vault path against options.cwd when provided', async () => {
+      const baseDir = await mkdtemp(join(tmpdir(), 'bwrb-rel-vault-cwd-'));
+      try {
+        const processCwd = join(baseDir, 'process-cwd');
+        const optionCwd = join(baseDir, 'option-cwd');
+        await mkdir(join(optionCwd, 'my-vault', '.bwrb'), { recursive: true });
+        await mkdir(processCwd, { recursive: true });
+        await writeFile(join(optionCwd, 'my-vault', '.bwrb', 'schema.json'), '{}');
+
+        process.chdir(processCwd);
+        delete process.env['BWRB_VAULT'];
+
+        const result = await resolveVaultDir({ cwd: optionCwd, vault: './my-vault' });
+        expect(result).toBe(resolve(optionCwd, './my-vault'));
+        expect(isAbsolute(result)).toBe(true);
+      } finally {
+        await rm(baseDir, { recursive: true, force: true });
+      }
+    });
+
     it('should resolve relative path from env var to absolute', async () => {
       const baseDir = await mkdtemp(join(tmpdir(), 'bwrb-rel-env-'));
       try {
@@ -213,6 +233,26 @@ describe('vault', () => {
 
         const result = await resolveVaultDir({});
         expect(result).toBe(resolve(process.cwd(), '../other-vault'));
+        expect(isAbsolute(result)).toBe(true);
+      } finally {
+        await rm(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should resolve relative BWRB_VAULT against options.cwd when provided', async () => {
+      const baseDir = await mkdtemp(join(tmpdir(), 'bwrb-rel-env-cwd-'));
+      try {
+        const processCwd = join(baseDir, 'process-cwd');
+        const optionCwd = join(baseDir, 'option-cwd');
+        await mkdir(join(optionCwd, 'env-vault', '.bwrb'), { recursive: true });
+        await mkdir(processCwd, { recursive: true });
+        await writeFile(join(optionCwd, 'env-vault', '.bwrb', 'schema.json'), '{}');
+
+        process.chdir(processCwd);
+        process.env['BWRB_VAULT'] = './env-vault';
+
+        const result = await resolveVaultDir({ cwd: optionCwd });
+        expect(result).toBe(resolve(optionCwd, './env-vault'));
         expect(isAbsolute(result)).toBe(true);
       } finally {
         await rm(baseDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Resolve relative explicit `--vault` paths against `options.cwd` when supplied.
- Apply the same `options.cwd` behavior to relative `BWRB_VAULT` for consistency with find-up/find-down discovery.
- Add focused `resolveVaultDir` regression tests for both relative explicit sources.

Closes #754.

## Tests
- `pnpm build`
- `pnpm verify:pack`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm exec vitest run tests/ts/lib/vault.test.ts`

## Notes
- An accidental broad `pnpm test -- tests/ts/lib/vault.test.ts` invocation expanded into the wider suite. `tests/ts/lib/vault.test.ts` passed there too, but unrelated command/PTY assertions failed because Node emitted `[DEP0205] module.register()` deprecation warnings to stderr/output.