### PR TITLE
test: cover relation validation edge cases

### DIFF
--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -1889,6 +1889,9 @@ unknownField: should warn
         },
         milestone: {
           extends: 'objective',
+          fields: {
+            aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
+          },
         },
         task: {
           extends: 'objective',
@@ -1901,11 +1904,16 @@ unknownField: should warn
               prompt: 'relation',
               source: 'objective',  // Accepts objective or any descendant
             },
+            any_ref: {
+              prompt: 'relation',
+              source: 'any',
+            },
           },
         },
         idea: {
           fields: {
             status: { prompt: 'select', options: ['raw', 'backlog', 'in-flight', 'settled'], default: 'raw' },
+            aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
           },
         },
       },
@@ -1925,6 +1933,170 @@ unknownField: should warn
 
     afterEach(async () => {
       await rm(tempVaultDir, { recursive: true, force: true });
+    });
+
+    it('accepts an alias target when the aliased note satisfies the source type', async () => {
+      await writeFile(
+        join(tempVaultDir, 'objectives/milestones', 'Launch.md'),
+        `---
+type: milestone
+status: raw
+aliases:
+  - Release Alias
+---
+`
+      );
+
+      await writeFile(
+        join(tempVaultDir, 'objectives/tasks', 'Alias Ref.md'),
+        `---
+type: task
+status: backlog
+milestone: "[[Release Alias]]"
+---
+`
+      );
+
+      const result = await runCLI(['audit', 'task', '--output', 'json'], tempVaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const output = JSON.parse(result.stdout);
+      expect(output.files).toEqual([]);
+    });
+
+    it('accepts path-qualified references for source any', async () => {
+      await writeFile(
+        join(tempVaultDir, 'ideas', 'Only Wrong.md'),
+        `---
+type: idea
+status: raw
+---
+`
+      );
+
+      await writeFile(
+        join(tempVaultDir, 'objectives/tasks', 'Any Ref.md'),
+        `---
+type: task
+status: backlog
+any_ref: "[[ideas/Only Wrong]]"
+---
+`
+      );
+
+      const result = await runCLI(['audit', 'task', '--output', 'json'], tempVaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const output = JSON.parse(result.stdout);
+      expect(output.files).toEqual([]);
+    });
+
+    it('reports a clear wrong-type error for a path-qualified reference', async () => {
+      await writeFile(
+        join(tempVaultDir, 'ideas', 'Only Wrong.md'),
+        `---
+type: idea
+status: raw
+---
+`
+      );
+
+      await writeFile(
+        join(tempVaultDir, 'objectives/tasks', 'Path Wrong Type.md'),
+        `---
+type: task
+status: backlog
+milestone: "[[ideas/Only Wrong]]"
+---
+`
+      );
+
+      const result = await runCLI(['audit', 'task', '--output', 'json'], tempVaultDir);
+
+      expect(result.exitCode).toBe(1);
+      const output = JSON.parse(result.stdout);
+      const taskFile = output.files.find((f: { path: string }) => f.path.includes('Path Wrong Type.md'));
+      const sourceIssue = taskFile.issues.find((i: { code: string }) => i.code === 'invalid-source-type');
+      expect(sourceIssue).toMatchObject({
+        field: 'milestone',
+        value: '[[ideas/Only Wrong]]',
+        expectedType: 'milestone',
+        actualType: 'idea',
+        expected: 'milestone',
+        autoFixable: false,
+      });
+      expect(sourceIssue.message).toContain("'milestone' expects milestone");
+      expect(sourceIssue.message).toContain("'ideas/Only Wrong' is idea");
+    });
+
+    it('accepts a bare ambiguous basename when one candidate has an allowed type', async () => {
+      await writeFile(
+        join(tempVaultDir, 'objectives/milestones', 'Shared.md'),
+        `---
+type: milestone
+status: raw
+---
+`
+      );
+      await writeFile(
+        join(tempVaultDir, 'ideas', 'Shared.md'),
+        `---
+type: idea
+status: raw
+---
+`
+      );
+
+      await writeFile(
+        join(tempVaultDir, 'objectives/tasks', 'Ambiguous Allowed.md'),
+        `---
+type: task
+status: backlog
+milestone: "[[Shared]]"
+---
+`
+      );
+
+      const result = await runCLI(['audit', 'task', '--output', 'json'], tempVaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const output = JSON.parse(result.stdout);
+      expect(output.files).toEqual([]);
+    });
+
+    it('reports wrong-type when a bare basename has no allowed-type candidates', async () => {
+      await writeFile(
+        join(tempVaultDir, 'ideas', 'Only Wrong.md'),
+        `---
+type: idea
+status: raw
+---
+`
+      );
+
+      await writeFile(
+        join(tempVaultDir, 'objectives/tasks', 'Ambiguous None Allowed.md'),
+        `---
+type: task
+status: backlog
+milestone: "[[Only Wrong]]"
+---
+`
+      );
+
+      const result = await runCLI(['audit', 'task', '--output', 'json'], tempVaultDir);
+
+      expect(result.exitCode).toBe(1);
+      const output = JSON.parse(result.stdout);
+      const taskFile = output.files.find((f: { path: string }) => f.path.includes('Ambiguous None Allowed.md'));
+      const sourceIssue = taskFile.issues.find((i: { code: string }) => i.code === 'invalid-source-type');
+      expect(sourceIssue).toMatchObject({
+        field: 'milestone',
+        value: '[[Only Wrong]]',
+        expectedType: 'milestone',
+        actualType: 'idea',
+        expected: 'milestone',
+      });
     });
 
     it('should detect type mismatch when context field references wrong type', async () => {

--- a/tests/ts/lib/validation.test.ts
+++ b/tests/ts/lib/validation.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import {
   validateFrontmatter,
   validateContextFields,
@@ -781,6 +784,167 @@ describe('validation', () => {
 
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
+    });
+
+    const buildRelationContractVault = async () => {
+      const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-validation-context-'));
+      const relationSchema = resolveSchema({
+        version: 2,
+        types: {
+          task: {
+            output_dir: 'Tasks',
+            fields: {
+              milestone: { prompt: 'relation', source: 'milestone' },
+              any_ref: { prompt: 'relation', source: 'any' },
+            },
+          },
+          milestone: {
+            output_dir: 'Milestones',
+            fields: {
+              aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
+            },
+          },
+          idea: {
+            output_dir: 'Ideas',
+            fields: {
+              aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
+            },
+          },
+        },
+      } as unknown as Schema);
+
+      await mkdir(join(tempVaultDir, 'Tasks'), { recursive: true });
+      await mkdir(join(tempVaultDir, 'Milestones'), { recursive: true });
+      await mkdir(join(tempVaultDir, 'Ideas'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, 'Milestones', 'Launch.md'),
+        `---
+type: milestone
+aliases:
+  - Release Alias
+---
+`
+      );
+      await writeFile(
+        join(tempVaultDir, 'Milestones', 'Shared.md'),
+        `---
+type: milestone
+---
+`
+      );
+      await writeFile(
+        join(tempVaultDir, 'Ideas', 'Shared.md'),
+        `---
+type: idea
+---
+`
+      );
+      await writeFile(
+        join(tempVaultDir, 'Ideas', 'Only Wrong.md'),
+        `---
+type: idea
+---
+`
+      );
+
+      return { relationSchema, tempVaultDir };
+    };
+
+    it('accepts an alias target when the aliased note satisfies the source type', async () => {
+      const { relationSchema, tempVaultDir } = await buildRelationContractVault();
+      try {
+        const result = await validateContextFields(relationSchema, tempVaultDir, 'task', {
+          type: 'task',
+          milestone: '[[Release Alias]]',
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.errors).toHaveLength(0);
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
+    it('accepts path-qualified references for source any', async () => {
+      const { relationSchema, tempVaultDir } = await buildRelationContractVault();
+      try {
+        const result = await validateContextFields(relationSchema, tempVaultDir, 'task', {
+          type: 'task',
+          any_ref: '[[Ideas/Only Wrong]]',
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.errors).toHaveLength(0);
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
+    it('reports a clear wrong-type error for a path-qualified reference', async () => {
+      const { relationSchema, tempVaultDir } = await buildRelationContractVault();
+      try {
+        const result = await validateContextFields(relationSchema, tempVaultDir, 'task', {
+          type: 'task',
+          milestone: '[[Ideas/Only Wrong]]',
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual([
+          expect.objectContaining({
+            type: 'invalid_context_source',
+            field: 'milestone',
+            value: '[[Ideas/Only Wrong]]',
+            targetName: 'Ideas/Only Wrong',
+            actualType: 'idea',
+            expectedTypes: ['milestone'],
+            expected: ['milestone'],
+          }),
+        ]);
+        expect(result.errors[0].message).toContain('"Ideas/Only Wrong" is type "idea"');
+        expect(result.errors[0].message).toContain('expected "milestone"');
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
+    it('allows a bare ambiguous basename when one candidate has an allowed type', async () => {
+      const { relationSchema, tempVaultDir } = await buildRelationContractVault();
+      try {
+        const result = await validateContextFields(relationSchema, tempVaultDir, 'task', {
+          type: 'task',
+          milestone: '[[Shared]]',
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.errors).toHaveLength(0);
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
+    it('reports wrong-type when a bare basename has no allowed-type candidates', async () => {
+      const { relationSchema, tempVaultDir } = await buildRelationContractVault();
+      try {
+        const result = await validateContextFields(relationSchema, tempVaultDir, 'task', {
+          type: 'task',
+          milestone: '[[Only Wrong]]',
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual([
+          expect.objectContaining({
+            type: 'invalid_context_source',
+            field: 'milestone',
+            value: '[[Only Wrong]]',
+            targetName: 'Only Wrong',
+            actualType: 'idea',
+            expectedTypes: ['milestone'],
+            expected: ['milestone'],
+          }),
+        ]);
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- add validateContextFields coverage for alias targets, source:any path-qualified refs, path-qualified wrong-type errors, and ambiguous basename source filtering
- add matching audit coverage so the write-path and audit contracts stay pinned together
- document the current contract in tests: a bare ambiguous basename passes when at least one candidate has an allowed type; if none do, it reports wrong type

Closes #761.

## Validation
- pnpm exec vitest run tests/ts/lib/validation.test.ts --testNamePattern "validateContextFields"
- pnpm exec vitest run tests/ts/commands/audit.test.ts --testNamePattern "context field source type validation"
- pnpm build
- pnpm verify:pack
- pnpm typecheck
- pnpm lint
- pnpm knip
- fnm exec --using=v22.21.1 pnpm exec vitest run --exclude="**/*.pty.test.ts"
