### PR TITLE
Suppress fuzzy unlinked mentions in structural headings

### DIFF
--- a/src/lib/audit/unlinked-mention.ts
+++ b/src/lib/audit/unlinked-mention.ts
@@ -499,17 +499,30 @@ function detectFuzzyCandidates(
     consumed.some(([s, e]) => start < e && end > s);
 
   const isCommonStructuralHeading = (phrase: string, start: number): boolean => {
+    if (!COMMON_STRUCTURAL_HEADING_LABELS.has(phrase.toLowerCase())) return false;
+
     const lineStart = body.lastIndexOf('\n', start - 1) + 1;
     const nextNewline = body.indexOf('\n', start);
     const lineEnd = nextNewline === -1 ? body.length : nextNewline;
     const line = body.slice(lineStart, lineEnd);
-    const heading = line.match(/^[ \t]{0,3}#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$/);
-    if (!heading) return false;
+    const lineRelativeStart = start - lineStart;
+    const candidateStartsLine =
+      start === lineStart || /^[ \t]*$/.test(body.slice(lineStart, start));
 
-    const headingText = heading[1]!.trim();
-    if (headingText !== phrase) return false;
+    const atxHeading = line.match(/^[ \t]{0,3}#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$/);
+    if (atxHeading) {
+      const headingText = atxHeading[1]!.trim();
+      const headingTextStart = line.indexOf(atxHeading[1]!);
+      const candidateStartsHeadingText = lineRelativeStart === headingTextStart;
+      return headingText === phrase || candidateStartsHeadingText;
+    }
 
-    return COMMON_STRUCTURAL_HEADING_LABELS.has(headingText.toLowerCase());
+    const afterLineStart = nextNewline === -1 ? body.length : nextNewline + 1;
+    const followingNewline = body.indexOf('\n', afterLineStart);
+    const afterLineEnd = followingNewline === -1 ? body.length : followingNewline;
+    const afterLine = body.slice(afterLineStart, afterLineEnd);
+
+    return candidateStartsLine && /^[ \t]{0,3}(?:=+|-+)[ \t]*$/.test(afterLine);
   };
 
   // Candidate phrases: runs of capitalized words (proper-noun-ish), e.g.

--- a/tests/ts/lib/audit-unlinked-mention.test.ts
+++ b/tests/ts/lib/audit-unlinked-mention.test.ts
@@ -151,6 +151,47 @@ describe('unlinked-mention: detectUnlinkedMentions', () => {
     expect(issues).toHaveLength(0);
   });
 
+  it('does not fuzzy-flag common structural labels in composite ATX headings', () => {
+    const index = indexFor([
+      { relativePath: 'Notes/quotes.md', resolvedType: 'note', frontmatter: { type: 'note' } },
+    ]);
+    const issues = detectUnlinkedMentions(
+      '## Notes from yesterday\n\nSome ordinary task detail.',
+      'Tasks/Tidy.md',
+      index
+    );
+    expect(issues.some((i) => i.meta?.['tier'] === 'fuzzy')).toBe(false);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('does not fuzzy-flag common structural labels in setext headings', () => {
+    const index = indexFor([
+      { relativePath: 'Notes/quotes.md', resolvedType: 'note', frontmatter: { type: 'note' } },
+    ]);
+    const issues = detectUnlinkedMentions(
+      'Notes from yesterday\n====================\n\nSome ordinary task detail.',
+      'Tasks/Tidy.md',
+      index
+    );
+    expect(issues.some((i) => i.meta?.['tier'] === 'fuzzy')).toBe(false);
+    expect(issues).toHaveLength(0);
+  });
+
+  it('still fuzzy-flags common labels in non-heading prose', () => {
+    const index = indexFor([
+      { relativePath: 'Notes/quotes.md', resolvedType: 'note', frontmatter: { type: 'note' } },
+    ]);
+    const issues = detectUnlinkedMentions(
+      'I took Notes from yesterday into today.',
+      'Tasks/Tidy.md',
+      index
+    );
+    const fuzzy = issues.find((i) => i.meta?.['tier'] === 'fuzzy');
+    expect(fuzzy).toBeDefined();
+    expect(fuzzy!.value).toBe('Notes');
+    expect(fuzzy!.similarFiles).toContain('quotes');
+  });
+
   it('keeps exact mention detection for common heading labels', () => {
     const index = indexFor([
       { relativePath: 'Notes/Notes.md', resolvedType: 'note', frontmatter: { type: 'note' } },


### PR DESCRIPTION
## Summary\n- Suppress fuzzy-only unlinked-mention candidates when common structural labels start composite ATX headings\n- Treat setext headings consistently with ATX headings for the same fuzzy-only suppression\n- Keep exact/alias detection intact and add focused regression coverage for heading/prose boundaries\n\nCloses #759.\n\n## Validation\n- pnpm build\n- pnpm verify:pack\n- pnpm typecheck\n- pnpm lint\n- pnpm knip\n- pnpm test tests/ts/lib/audit-unlinked-mention.test.ts\n- NODE_OPTIONS=--no-deprecation pnpm exec vitest run --exclude='**/*.pty.test.ts'\n\n## Notes\n- The direct project command `pnpm test -- --exclude='**/*.pty.test.ts'` was attempted and failed due Node DEP0205 deprecation warnings leaking into subprocess stderr/stdout assertions; filed follow-up #765.\n