### PR TITLE
Fix Node DEP0205 noise in test subprocesses

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev": "sh -c 'shift $([ \"$1\" = \"--\" ] && echo 1 || echo 0); exec tsx src/index.ts \"$@\"' --",
     "build": "tsup --config tsup.config.ts",
     "prepack": "npm run build",
-    "test": "vitest run",
+    "test": "sh -c 'shift $([ \"$1\" = \"--\" ] && echo 1 || echo 0); exec vitest run \"$@\"' --",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:pty": "vitest run --reporter=verbose .pty.test.ts",

--- a/tests/ts/commands/bulk.test.ts
+++ b/tests/ts/commands/bulk.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, mkdir, writeFile, readFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { spawn } from 'child_process';
-import { createTestVault, cleanupTestVault, runCLI, TEST_SCHEMA, CLI_PATH, PROJECT_ROOT } from '../fixtures/setup.js';
+import { createTestVault, cleanupTestVault, runCLI, TEST_SCHEMA, CLI_PATH, PROJECT_ROOT, withTestCliNodeOptions } from '../fixtures/setup.js';
 import { parseNote } from '../../../src/lib/frontmatter.js';
 
 const CLI_SRC_PATH = join(PROJECT_ROOT, 'src/index.ts');
@@ -23,7 +23,7 @@ async function runCLIWithOpenStdin(
   return await new Promise((resolve, reject) => {
     const proc = spawn(cliCommand, cliArgs, {
       cwd: PROJECT_ROOT,
-      env: { ...process.env, FORCE_COLOR: '0' },
+      env: withTestCliNodeOptions({ ...process.env, FORCE_COLOR: '0' }),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 

--- a/tests/ts/fixtures/setup.test.ts
+++ b/tests/ts/fixtures/setup.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { withTestCliNodeOptions } from './setup.js';
+
+describe('test CLI spawn environment', () => {
+  it('suppresses Node DEP0205 only for source-mode tsx subprocesses', () => {
+    expect(withTestCliNodeOptions({}, { useDist: false })).toEqual({
+      NODE_OPTIONS: '--disable-warning=DEP0205',
+    });
+
+    expect(
+      withTestCliNodeOptions({ NODE_OPTIONS: '--trace-warnings' }, { useDist: false })
+    ).toEqual({
+      NODE_OPTIONS: '--trace-warnings --disable-warning=DEP0205',
+    });
+
+    expect(
+      withTestCliNodeOptions(
+        { NODE_OPTIONS: '--trace-warnings --disable-warning=DEP0205' },
+        { useDist: false }
+      )
+    ).toEqual({
+      NODE_OPTIONS: '--trace-warnings --disable-warning=DEP0205',
+    });
+
+    expect(withTestCliNodeOptions({}, { useDist: true })).toEqual({});
+  });
+});

--- a/tests/ts/fixtures/setup.ts
+++ b/tests/ts/fixtures/setup.ts
@@ -12,6 +12,30 @@ const CLI_SRC_PATH = join(PROJECT_ROOT, 'src/index.ts');
 const TSX_BIN = join(PROJECT_ROOT, 'node_modules', '.bin', 'tsx');
 
 const USE_DIST = process.env.BWRB_TEST_DIST === '1';
+const NODE_DEP0205_SUPPRESSION = '--disable-warning=DEP0205';
+
+export function withTestCliNodeOptions(
+  env: NodeJS.ProcessEnv,
+  { useDist = USE_DIST }: { useDist?: boolean } = {}
+): Record<string, string> {
+  const normalizedEnv: Record<string, string> = Object.fromEntries(
+    Object.entries(env).filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+  );
+
+  if (useDist) return normalizedEnv;
+
+  const existingNodeOptions = normalizedEnv.NODE_OPTIONS?.trim();
+  if (existingNodeOptions?.split(/\s+/).includes(NODE_DEP0205_SUPPRESSION)) {
+    return normalizedEnv;
+  }
+
+  return {
+    ...normalizedEnv,
+    NODE_OPTIONS: existingNodeOptions
+      ? `${existingNodeOptions} ${NODE_DEP0205_SUPPRESSION}`
+      : NODE_DEP0205_SUPPRESSION,
+  };
+}
 
 /**
  * Get a relative path from the project root to the vault.
@@ -416,7 +440,7 @@ export async function runCLI(
     )
   );
 
-  const mergedEnv: Record<string, string> = {
+  let mergedEnv: Record<string, string> = {
     ...childEnv,
     ...env,
   };
@@ -424,6 +448,8 @@ export async function runCLI(
   if (mergedEnv.NO_COLOR === undefined) {
     mergedEnv.NO_COLOR = '1';
   }
+
+  mergedEnv = withTestCliNodeOptions(mergedEnv);
 
   let lastError: unknown;
   for (let attempt = 0; attempt <= retries; attempt++) {


### PR DESCRIPTION
## Summary
- normalize the `pnpm test -- ...` script path so `--exclude='**/*.pty.test.ts'` reaches Vitest as an option
- add a test-harness env helper that suppresses only Node `DEP0205` for source-mode `tsx` CLI subprocesses
- reuse the helper for the bulk test's custom open-stdin subprocess path and cover the env behavior with a focused fixture test

Fixes #765.

## Validation
- `pnpm build`
- `pnpm verify:pack` (passes; npm prints existing unknown env config warnings)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm test -- --exclude='**/*.pty.test.ts'` (100 files, 2715 passed, 3 skipped; no PTY suites included)
- post-rebase smoke: `pnpm test -- --exclude='**/*.pty.test.ts' tests/ts/fixtures/setup.test.ts tests/ts/commands/list.test.ts tests/ts/commands/bulk.test.ts tests/ts/commands/json-io.test.ts` (4 files, 245 passed)

## Risk
- The warning suppression is scoped to test-spawned `tsx` subprocesses only; `BWRB_TEST_DIST=1` built-CLI runs keep normal Node behavior.
- Product stderr remains captured and asserted by tests; this does not blanket-filter CLI stderr/stdout.