### PR TITLE
fix(new): store clean relation links

### DIFF
--- a/src/commands/new/write-plan.ts
+++ b/src/commands/new/write-plan.ts
@@ -8,7 +8,7 @@ import {
   generateUniqueNoteId,
   registerIssuedNoteId,
 } from '../../lib/note-id.js';
-import { ensureOwnedOutputDir, formatValue } from '../../lib/vault.js';
+import { cleanRelationLink, ensureOwnedOutputDir } from '../../lib/vault.js';
 import { getTypeDefByPath } from '../../lib/schema.js';
 import { normalizeDateFields } from '../../lib/validation.js';
 import { ExitCodes, jsonError } from '../../lib/output.js';
@@ -101,7 +101,7 @@ export async function writeNotePlan(
   const noteId = await generateUniqueNoteId(args.vaultDir);
   args.content.frontmatter.id = noteId;
   if (args.ownership.kind === 'owned') {
-    args.content.frontmatter.owner = formatValue(args.ownership.owner.ownerName, args.schema.config.linkFormat);
+    args.content.frontmatter.owner = cleanRelationLink(args.ownership.owner.ownerName, args.schema.config.linkFormat);
   }
   const orderedFields = ensureIdInFieldOrder(args.content.orderedFields);
 

--- a/src/lib/field-prompt.ts
+++ b/src/lib/field-prompt.ts
@@ -7,7 +7,7 @@ import {
   promptConfirm,
   printWarning,
 } from './prompt.js';
-import { queryByType, formatValue } from './vault.js';
+import { queryByType, cleanRelationLink } from './vault.js';
 import { expandStaticValue } from './local-date.js';
 import { UserCancelledError } from './errors.js';
 import {
@@ -282,7 +282,7 @@ async function promptRelationField(
     const selected = await promptSelection(`Select ${fieldName}:`, options);
     if (selected === null) throw new UserCancelledError();
     if (skipLabel && selected === skipLabel) return field.default ?? '';
-    return formatValue(selected, schema.config.linkFormat);
+    return cleanRelationLink(selected, schema.config.linkFormat);
   }
 
   if (opts.mode === 'template-default') {
@@ -488,28 +488,6 @@ async function promptNumberTemplate(
     }
     return parsed;
   }
-}
-
-/**
- * Build a CLEAN relation link for storing in a frontmatter OBJECT (e.g. a
- * template's `defaults` map) that will subsequently be YAML-serialized.
- *
- * `formatValue` (vault.ts) returns a PRE-QUOTED string such as `"[[Alice]]"`,
- * which is correct for direct TEXT interpolation into raw YAML (where the
- * surrounding quotes keep `[[` from being read as a flow sequence). But when
- * that pre-quoted string is placed into an object and handed to the YAML
- * serializer, the serializer quotes it AGAIN, producing `'"[[Alice]]"'` on disk
- * — a malformed value that instantiates into notes with literal quote
- * characters around the wikilink. For object values we need the RAW link
- * (`[[Alice]]` / `[Alice](Alice.md)`); the serializer then quotes it exactly
- * once, yielding the canonical `"[[Alice]]"` that parses back to `[[Alice]]`.
- *
- * Mirrors `cleanChainLink` in recurrence.ts, which solves the same double-quote
- * hazard for chain (`next`/`prev`) links.
- */
-function cleanRelationLink(name: string, linkFormat: 'wikilink' | 'markdown'): string {
-  if (!name) return '';
-  return linkFormat === 'markdown' ? `[${name}](${name}.md)` : `[[${name}]]`;
 }
 
 function formatUniqueRelationValues(

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -270,6 +270,24 @@ export function formatValue(value: string, linkFormat: 'wikilink' | 'markdown' =
 }
 
 /**
+ * Build a relation link for storing in a frontmatter object before YAML
+ * serialization. Unlike {@link formatValue}, this returns the raw link so the
+ * serializer can add exactly one layer of YAML-safe quoting.
+ */
+export function cleanRelationLink(value: string, linkFormat: 'wikilink' | 'markdown' = 'wikilink'): string {
+  if (!value) return '';
+
+  switch (linkFormat) {
+    case 'wikilink':
+      return `[[${value}]]`;
+    case 'markdown':
+      return `[${value}](${value}.md)`;
+    default:
+      return value;
+  }
+}
+
+/**
  * Check if a filter condition matches a value.
  */
 function matchesCondition(value: unknown, condition: FilterCondition): boolean {

--- a/tests/ts/commands/new-ownership.test.ts
+++ b/tests/ts/commands/new-ownership.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdir, writeFile } from 'fs/promises';
+import { mkdir, readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { createTestVault, cleanupTestVault, runCLI, waitForFile } from '../fixtures/setup.js';
 import { ExitCodes } from '../../../src/lib/output.js';
@@ -52,7 +52,13 @@ A test project for ownership testing.
     expect(output.success).toBe(true);
     expect(output.path).toContain('Projects/My Project/research/Project Research.md');
 
-    const { frontmatter } = await parseNote(join(vaultDir, output.path));
+    const notePath = join(vaultDir, output.path);
+    const content = await readFile(notePath, 'utf-8');
+    expect(content).toMatch(/^owner: "\[\[My Project\]\]"$/m);
+    expect(content).not.toContain(`'"[[`);
+
+    const { frontmatter } = await parseNote(notePath);
+    expect(frontmatter.owner).toBe('[[My Project]]');
     expect(extractWikilinkTarget(String(frontmatter.owner))).toBe('My Project');
   });
 
@@ -111,6 +117,14 @@ Owned folder placement test.
     const output = JSON.parse(result.stdout);
     expect(output.success).toBe(true);
     expect(output.path).toContain('Albums/Best Album/songs/Opening Track.md');
+
+    const notePath = join(vaultDir, output.path);
+    const content = await readFile(notePath, 'utf-8');
+    expect(content).toMatch(/^owner: "\[\[Best Album\]\]"$/m);
+    expect(content).not.toContain(`'"[[`);
+
+    const { frontmatter } = await parseNote(notePath);
+    expect(frontmatter.owner).toBe('[[Best Album]]');
   });
 
   it('should create pooled note with --standalone flag', async () => {

--- a/tests/ts/commands/new.pty.test.ts
+++ b/tests/ts/commands/new.pty.test.ts
@@ -179,8 +179,9 @@ status: in-flight
           const content = await readVaultFile(vaultPath, 'Tasks/Full Task Flow.md');
           // In the new inheritance model, we use a single 'type: task' field
           expect(content).toContain('type: task');
-          // YAML quotes the wikilink value
-          expect(content).toContain('[[Active Milestone]]');
+          // YAML quotes the wikilink value once; the parsed value is the raw link.
+          expect(content).toMatch(/^milestone: "\[\[Active Milestone\]\]"$/m);
+          expect(content).not.toContain(`'"[[`);
           expect(content).toContain('## Steps');
           expect(content).toContain('- [ ] Step one');
           expect(content).toContain('- [ ] Step two');


### PR DESCRIPTION
## Summary
- add a shared cleanRelationLink helper for frontmatter-object relation storage
- use clean relation links for interactive new relation prompts and owned-note owner fields
- add regression coverage for normal create relation storage and owner-path storage so literal quote characters do not sneak back in

Closes #746.

## Validation
- pnpm build
- pnpm verify:pack
- pnpm typecheck
- pnpm lint
- pnpm knip
- pnpm exec vitest run tests/ts/commands/new.pty.test.ts
- BWRB_TEST_DIST=1 pnpm exec vitest run tests/ts/commands/new-ownership.test.ts
- NODE_OPTIONS=--no-deprecation pnpm test -- --exclude='**/*.pty.test.ts' (attempted; invocation unexpectedly included PTY tests and was killed with exit 137 after many passing suites)

## Risk
- Low: swaps only relation values that are placed into frontmatter objects before YAML serialization. Raw YAML text interpolation still uses formatValue.
