### PR TITLE
Add non-interactive schema migrate execution

### DIFF
--- a/docs-site/src/content/docs/concepts/migrations.md
+++ b/docs-site/src/content/docs/concepts/migrations.md
@@ -122,6 +122,20 @@ This will:
 4. Save the new schema snapshot
 5. Record the migration in history
 
+For non-interactive environments such as CI or agent shells, provide the
+version explicitly:
+
+```bash
+bwrb schema migrate --execute --set-version 1.1.0 --output json
+```
+
+If the migration includes non-deterministic changes (for example, removing a
+field that may delete note data), also pass `--yes` to accept that confirmation:
+
+```bash
+bwrb schema migrate --execute --set-version 2.0.0 --yes --output json
+```
+
 Some schema edits change the schema's shape without requiring any note update —
 *adding* a select option is the canonical example. In that case `--execute`
 reports no affected files but still refreshes the snapshot, so that if the option
@@ -214,6 +228,8 @@ When you run `bwrb schema migrate --execute`, Bowerbird suggests a version bump 
 | No structural changes | Patch | 1.0.0 → 1.0.1 |
 
 You can accept the suggestion or enter your own version.
+
+In non-interactive mode, use `--set-version <x.y.z>` instead of the prompt.
 
 ## Storage and Files
 

--- a/docs-site/src/content/docs/reference/commands/schema.md
+++ b/docs-site/src/content/docs/reference/commands/schema.md
@@ -424,7 +424,10 @@ bwrb schema migrate [options]
 | Option | Description |
 |--------|-------------|
 | `-x, --execute` | Actually apply the migration (default is dry-run) |
+| `-y, --yes` | Accept execute confirmations |
+| `--set-version <version>` | Set the new schema version for execute mode (semver, e.g. `1.2.3`) |
 | `--no-backup` | Skip backup creation (not recommended) |
+| `--show-changes` | Show per-note before/after changes in the dry-run preview |
 | `--output <format>` | Output format: `text`, `json` |
 
 ### Description
@@ -441,6 +444,7 @@ Migrations update existing notes when the schema changes:
 
 - **Dry-run by default**: Shows what would change without modifying files
 - **Automatic backup**: Creates a backup before applying changes
+- **Explicit headless execution**: Non-interactive runs with note changes require `--set-version`; non-deterministic changes also require `--yes`
 - **Atomic operations**: All changes succeed or none are applied
 
 ### Examples
@@ -451,6 +455,12 @@ bwrb schema migrate
 
 # Apply migration with backup
 bwrb schema migrate --execute
+
+# Apply non-interactively with JSON output
+bwrb schema migrate --execute --set-version 1.1.0 --output json
+
+# Apply a non-deterministic migration non-interactively
+bwrb schema migrate --execute --set-version 2.0.0 --yes --output json
 
 # Apply without backup (not recommended)
 bwrb schema migrate --execute --no-backup

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -313,6 +313,14 @@ bwrb audit --output json
 bwrb audit --fix --auto --execute --all
 # Refuse interactive audit fixes without a TTY
 bwrb audit --fix --all
+
+# Non-interactive schema migrations
+# Preview first; JSON includes uncapped per-note fileChanges.
+bwrb schema migrate --output json
+# Execute deterministic note changes with an explicit schema version.
+bwrb schema migrate --execute --set-version 1.1.0 --output json
+# Execute non-deterministic changes (data removal/review) with explicit consent.
+bwrb schema migrate --execute --set-version 2.0.0 --yes --output json
 ```
 
 #### Type Inference and Check Dependencies

--- a/src/commands/schema/migrate.ts
+++ b/src/commands/schema/migrate.ts
@@ -41,6 +41,16 @@ interface MigrateOptions {
   execute?: boolean;
   backup?: boolean;
   showChanges?: boolean;
+  yes?: boolean;
+  setVersion?: string;
+}
+
+function isSemver(version: string): boolean {
+  return /^\d+\.\d+\.\d+$/.test(version);
+}
+
+function isInteractiveStdin(): boolean {
+  return Boolean(process.stdin.isTTY);
 }
 
 /**
@@ -179,17 +189,23 @@ Examples:
     // NOTE: Commander maps --no-backup to options.backup === false.
     .option('--no-backup', 'Skip backup creation (not recommended)')
     .option('--show-changes', 'Show per-note before→after changes in the dry-run preview')
+    .option('-y, --yes', 'Accept execute confirmations (required for non-deterministic changes in non-interactive mode)')
+    .option('--set-version <version>', 'Set the new schema version for execute mode (semver, e.g. 1.2.3)')
     .addHelpText('after', `
 Examples:
   bwrb schema migrate                  # Preview migration (dry-run)
   bwrb schema migrate --show-changes   # Preview + per-note before→after changes
   bwrb schema migrate --execute        # Apply migration with backup
+  bwrb schema migrate --execute --set-version 1.1.0
+  bwrb schema migrate --execute --set-version 2.0.0 --yes
   bwrb schema migrate --execute --no-backup  # Apply without backup`)
     .action(async (options: MigrateOptions, cmd: Command) => {
       const jsonMode = options.output === 'json';
       const execute = options.execute ?? false;
       const backup = options.backup !== false;
       const showChanges = options.showChanges ?? false;
+      const yes = options.yes ?? false;
+      const setVersion = options.setVersion?.trim();
 
       try {
         const globalOpts = getGlobalOpts(cmd);
@@ -375,36 +391,75 @@ Examples:
           return;
         }
         
-        // Execute mode - prompt for version if schema changed
+        // Execute mode - prompt for version if schema changed, unless a
+        // non-interactive version was supplied.
         let newVersion = currentVersion;
-        if (diff.hasChanges && !jsonMode) {
+        if (diff.hasChanges) {
           // Suggest version bump
           const suggestedVersion = suggestVersionBump(currentVersion, diff);
-          
-          console.log(chalk.bold('\nSchema Migration\n'));
-          console.log(formatDiffForDisplay(diff));
-          
-          const versionResult = await promptInput(
-            `Schema version (current: ${currentVersion})`,
-            suggestedVersion
-          );
-          if (versionResult === null) {
-            process.exit(0); // User cancelled
+
+          if (setVersion !== undefined) {
+            newVersion = setVersion;
+          } else if (jsonMode || !isInteractiveStdin()) {
+            throw new Error(
+              `Non-interactive schema migrations with note changes require --set-version <x.y.z> (suggested: ${suggestedVersion}).`
+            );
+          } else {
+            console.log(chalk.bold('\nSchema Migration\n'));
+            console.log(formatDiffForDisplay(diff));
+
+            const versionResult = await promptInput(
+              `Schema version (current: ${currentVersion})`,
+              suggestedVersion
+            );
+            if (versionResult === null) {
+              process.exit(0); // User cancelled
+            }
+            newVersion = versionResult.trim() || suggestedVersion;
           }
-          newVersion = versionResult.trim() || suggestedVersion;
           
           // Validate version format
-          if (!/^\d+\.\d+\.\d+$/.test(newVersion)) {
+          if (!isSemver(newVersion)) {
             throw new Error('Version must be in semver format (e.g., 1.2.3)');
+          }
+
+          if (!jsonMode && setVersion !== undefined) {
+            console.log(chalk.bold('\nSchema Migration\n'));
+            console.log(formatDiffForDisplay(diff));
           }
           
           // Warn if version didn't change
-          if (newVersion === currentVersion && diff.hasChanges) {
-            const confirmResult = await promptConfirm(
-              `Version unchanged (${currentVersion}). Continue anyway?`
-            );
-            if (confirmResult === null || !confirmResult) {
-              process.exit(0);
+          if (newVersion === currentVersion) {
+            if (yes) {
+              // --yes accepts the unchanged-version confirmation.
+            } else if (jsonMode || !isInteractiveStdin()) {
+              throw new Error(
+                `Schema version is unchanged (${currentVersion}); pass --yes to continue anyway.`
+              );
+            } else {
+              const confirmResult = await promptConfirm(
+                `Version unchanged (${currentVersion}). Continue anyway?`
+              );
+              if (confirmResult === null || !confirmResult) {
+                process.exit(0);
+              }
+            }
+          }
+
+          if (diff.nonDeterministic.length > 0) {
+            if (yes) {
+              // --yes accepts the non-deterministic migration confirmation.
+            } else if (jsonMode || !isInteractiveStdin()) {
+              throw new Error(
+                'Non-deterministic schema changes require --yes in non-interactive mode.'
+              );
+            } else {
+              const confirmResult = await promptConfirm(
+                'Apply non-deterministic schema changes?'
+              );
+              if (confirmResult === null || !confirmResult) {
+                process.exit(0);
+              }
             }
           }
         }

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -305,7 +305,20 @@ const COMMAND_OPTIONS: Record<string, string[]> = {
     '--dry-run',
     '--help',
   ],
-  schema: ['--vault', '-v', '--non-interactive', '--help'],
+  schema: [
+    '--vault',
+    '-v',
+    '--non-interactive',
+    '--output',
+    '--execute',
+    '-x',
+    '--yes',
+    '-y',
+    '--set-version',
+    '--no-backup',
+    '--show-changes',
+    '--help',
+  ],
   template: ['--vault', '-v', '--non-interactive', '--help'],
   dashboard: ['--output', '-o', '--vault', '-v', '--non-interactive', '--json', '--help'],
   delete: [
@@ -376,6 +389,7 @@ function isValueOption(option: string): boolean {
     '--default-output',
     '--fields',
     '--body',
+    '--set-version',
   ];
   return valueOptions.includes(option);
 }

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -587,6 +587,14 @@ describe('schema command', () => {
   });
 
   describe('schema migrate', () => {
+    it('lists non-interactive execute flags in help output', async () => {
+      const result = await runCLI(['schema', 'migrate', '--help'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('-y, --yes');
+      expect(result.stdout).toContain('--set-version <version>');
+    });
+
     it('should honor --no-backup in execute mode', async () => {
       const tempVaultDir = await createTestVault();
 
@@ -619,7 +627,16 @@ milestone: "[[Active Milestone]]"
         );
 
         const result = await runCLI(
-          ['schema', 'migrate', '--output', 'json', '--execute', '--no-backup'],
+          [
+            'schema',
+            'migrate',
+            '--output',
+            'json',
+            '--execute',
+            '--set-version',
+            '1.1.0',
+            '--no-backup',
+          ],
           tempVaultDir
         );
 
@@ -660,6 +677,37 @@ status: in-flight
         ...(currentSchema.types.task.fields ?? {}),
         priority: { prompt: 'text', default: 'medium' },
       };
+
+      await writeFile(schemaPath, JSON.stringify(currentSchema, null, 2));
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.applied.json'),
+        JSON.stringify(
+          {
+            schemaVersion: '1.0.0',
+            snapshotAt: new Date().toISOString(),
+            schema: snapshotSchema,
+          },
+          null,
+          2
+        )
+      );
+
+      return tempVaultDir;
+    }
+
+    /**
+     * Set up a vault where the current schema removes `priority` from `idea`.
+     * Existing idea notes have that field, so execution would delete data and
+     * must require an explicit non-deterministic confirmation.
+     */
+    async function setupRemoveFieldVault(): Promise<string> {
+      const tempVaultDir = await createTestVault();
+
+      const schemaPath = join(tempVaultDir, '.bwrb', 'schema.json');
+      const currentSchema = JSON.parse(await readFile(schemaPath, 'utf8'));
+      const snapshotSchema = JSON.parse(JSON.stringify(currentSchema));
+
+      delete currentSchema.types.idea.fields.priority;
 
       await writeFile(schemaPath, JSON.stringify(currentSchema, null, 2));
       await writeFile(
@@ -744,6 +792,29 @@ status: in-flight
       }
     });
 
+    it('refuses non-interactive execute with note changes unless --set-version is provided', async () => {
+      const tempVaultDir = await setupAddFieldVault();
+      try {
+        const result = await runCLI(
+          ['schema', 'migrate', '--output', 'json', '--execute', '--no-backup'],
+          tempVaultDir
+        );
+
+        expect(result.exitCode).not.toBe(0);
+        const response = JSON.parse(result.stdout);
+        expect(response.success).toBe(false);
+        expect(response.error).toContain('require --set-version');
+
+        const noteContent = await readFile(
+          join(tempVaultDir, 'Objectives', 'Tasks', 'Preview Task.md'),
+          'utf8'
+        );
+        expect(noteContent).not.toContain('priority: medium');
+      } finally {
+        await cleanupTestVault(tempVaultDir);
+      }
+    });
+
     it('execute --output json includes fileChanges and applies the change', async () => {
       const tempVaultDir = await setupAddFieldVault();
       try {
@@ -754,6 +825,8 @@ status: in-flight
             '--output',
             'json',
             '--execute',
+            '--set-version',
+            '1.1.0',
             '--no-backup',
           ],
           tempVaultDir
@@ -771,6 +844,78 @@ status: in-flight
           'utf8'
         );
         expect(noteContent).toContain('priority: medium');
+      } finally {
+        await cleanupTestVault(tempVaultDir);
+      }
+    });
+
+    it('refuses non-interactive non-deterministic execute unless --yes is provided', async () => {
+      const tempVaultDir = await setupRemoveFieldVault();
+      try {
+        const result = await runCLI(
+          [
+            'schema',
+            'migrate',
+            '--output',
+            'json',
+            '--execute',
+            '--set-version',
+            '2.0.0',
+            '--no-backup',
+          ],
+          tempVaultDir
+        );
+
+        expect(result.exitCode).not.toBe(0);
+        const response = JSON.parse(result.stdout);
+        expect(response.success).toBe(false);
+        expect(response.error).toContain('require --yes');
+
+        const noteContent = await readFile(
+          join(tempVaultDir, 'Ideas', 'Sample Idea.md'),
+          'utf8'
+        );
+        expect(noteContent).toContain('priority: medium');
+      } finally {
+        await cleanupTestVault(tempVaultDir);
+      }
+    });
+
+    it('executes non-interactive non-deterministic migrations with --set-version and --yes', async () => {
+      const tempVaultDir = await setupRemoveFieldVault();
+      try {
+        const result = await runCLI(
+          [
+            'schema',
+            'migrate',
+            '--output',
+            'json',
+            '--execute',
+            '--set-version',
+            '2.0.0',
+            '--yes',
+            '--no-backup',
+          ],
+          tempVaultDir
+        );
+
+        expect(result.exitCode).toBe(0);
+        const response = JSON.parse(result.stdout);
+        expect(response.success).toBe(true);
+        expect(response.data.fromVersion).toBe('1.0.0');
+        expect(response.data.toVersion).toBe('2.0.0');
+        expect(response.data.affectedFiles).toBeGreaterThan(0);
+
+        const noteContent = await readFile(
+          join(tempVaultDir, 'Ideas', 'Sample Idea.md'),
+          'utf8'
+        );
+        expect(noteContent).not.toContain('priority: medium');
+
+        const schema = JSON.parse(
+          await readFile(join(tempVaultDir, '.bwrb', 'schema.json'), 'utf8')
+        );
+        expect(schema.schemaVersion).toBe('2.0.0');
       } finally {
         await cleanupTestVault(tempVaultDir);
       }
@@ -850,7 +995,17 @@ status: paused
         // Because the snapshot was refreshed, the removal of `paused` is now
         // correctly detected and the orphaned value is cleared.
         const removeResult = await runCLI(
-          ['schema', 'migrate', '--output', 'json', '--execute', '--no-backup'],
+          [
+            'schema',
+            'migrate',
+            '--output',
+            'json',
+            '--execute',
+            '--set-version',
+            '2.0.0',
+            '--yes',
+            '--no-backup',
+          ],
           tempVaultDir
         );
         expect(removeResult.exitCode).toBe(0);


### PR DESCRIPTION
## Summary

Closes #749.

Adds explicit non-interactive execution support for `bwrb schema migrate`:

- Adds `-y` / `--yes` to accept execute confirmations.
- Adds `--set-version <x.y.z>` so headless runs can provide the new schema version without a prompt.
- Refuses note-changing non-interactive execute runs that omit `--set-version`.
- Refuses non-deterministic non-interactive execute runs unless `--yes` is provided.
- Keeps backups enabled by default; `--no-backup` still maps through Commander as `options.backup === false`.

## Docs / Automation

- Updates canonical docs-site command reference and migration concept docs.
- Updates `docs/skill/SKILL.md` with the new automation pattern.
- Adds schema command completion entries for the new flags.

## Validation

- `pnpm build`
- `pnpm verify:pack`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm test tests/ts/commands/schema.test.ts`
- `pnpm exec vitest run --exclude='**/*.pty.test.ts'` failed locally because Node emitted `[DEP0205] module.register()` warnings on stderr in unrelated command tests.
- `NODE_OPTIONS=--no-deprecation pnpm exec vitest run --exclude='**/*.pty.test.ts'` passed: 99 files, 2721 tests passed, 3 skipped.
