### PR TITLE
[codex] Align audit with required defaults

### DIFF
--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -500,12 +500,18 @@ export async function auditFile(
       const hasDefault = field.default !== undefined;
 
       if (!hasKey) {
+        // A missing required field with a schema default is satisfied by the
+        // default contract, matching validateFrontmatter and edit's explicit
+        // null-removal semantics. A present-but-blank value is still broken and
+        // remains fixable below.
+        if (hasDefault) continue;
+
         issues.push({
           severity: 'error',
           code: 'missing-required',
           message: `Missing required field: ${fieldName}`,
           field: fieldName,
-          autoFixable: hasDefault,
+          autoFixable: false,
         });
       } else if (isEmptyValue) {
         issues.push({

--- a/tests/ts/commands/audit-fix.pty.test.ts
+++ b/tests/ts/commands/audit-fix.pty.test.ts
@@ -531,7 +531,7 @@ effort: "not-a-number"
   });
 
   describe('missing required field fix', () => {
-    it('should add required field with default value', async () => {
+    it('does not prompt for a missing required field when the field has a default (#743)', async () => {
       const missingField: TempVaultFile = {
         path: 'Ideas/Missing Status.md',
         content: `---
@@ -544,24 +544,15 @@ type: idea
         ['audit', 'idea', '--fix'],
         async (proc, vaultPath) => {
           await proc.waitFor('Auditing vault', 10000);
-          await proc.waitFor('Missing Status.md', 10000);
-
-          // Should offer to add with default value
-          await proc.waitFor('Add with default', 10000);
-
-          // Confirm
-          proc.write('y');
-          proc.write(Keys.ENTER);
-
-          // Should show success
-          await proc.waitFor('Added status', 5000);
+          await proc.waitFor('No issues found', 10000);
 
           // Wait for completion
           await proc.waitForStable(500);
 
-          // Verify field was added
+          // Verify field absence stayed absent: it is satisfied by the default
+          // contract, but audit --fix should not materialize it.
           const content = await readVaultFile(vaultPath, 'Ideas/Missing Status.md');
-          expect(content).toContain('status: raw');
+          expect(content).not.toContain('status: raw');
         },
         { files: [missingField], schema: BASELINE_SCHEMA }
       );

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -813,7 +813,7 @@ priority: medium
       await rm(tempVaultDir, { recursive: true, force: true });
     });
 
-    it('should auto-fix missing required field with default', async () => {
+    it('should not flag a missing required field when the field has a default (#743)', async () => {
       // Create a file missing the 'status' field (which has default: 'raw')
       await writeFile(
         join(tempVaultDir, 'Ideas', 'Missing Status.md'),
@@ -827,14 +827,15 @@ Some content
 
       const result = await runCLI(['audit', 'idea', '--fix', '--auto', '--execute'], tempVaultDir);
 
-      expect(result.stdout).toContain('Auto-fixing');
-      expect(result.stdout).toContain('Added status');
-      expect(result.stdout).toContain('Fixed: 1 issues');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Fixed: 0 issues');
+      expect(result.stdout).toContain('Remaining: 0 issues');
+      expect(result.stdout).not.toContain('Added status');
+      expect(result.stdout).not.toContain('Fixed: 1 issues');
 
-      // Verify the file was actually fixed
-      const { readFile } = await import('fs/promises');
+      // Verify audit --fix left the satisfied-by-default absence untouched.
       const content = await readFile(join(tempVaultDir, 'Ideas', 'Missing Status.md'), 'utf-8');
-      expect(content).toContain('status: raw');
+      expect(content).not.toContain('status: raw');
     });
 
     it('should report non-fixable issues for manual review', async () => {
@@ -859,11 +860,12 @@ priority: medium
     });
 
     it('should handle mix of fixable and non-fixable issues', async () => {
-      // File with missing status (fixable) and invalid enum (not fixable)
+      // File with blank status (fixable) and invalid enum (not fixable)
       await writeFile(
         join(tempVaultDir, 'Ideas', 'Fixable.md'),
         `---
 type: idea
+status: " "
 priority: medium
 ---
 `
@@ -891,6 +893,7 @@ priority: medium
         join(tempVaultDir, 'Ideas', 'Missing Status.md'),
         `---
 type: idea
+status: " "
 priority: medium
 ---
 `
@@ -975,6 +978,7 @@ status: raw
         join(tempVaultDir, 'Ideas', 'Needs Status.md'),
         `---
 type: idea
+status: " "
 priority: medium
 ---
 `
@@ -1003,7 +1007,8 @@ priority: medium
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Dry run - no changes written');
-      expect(result.stdout).toContain('Would fix: 1 issues');
+      expect(result.stdout).toContain('Would fill status with default "raw"');
+      expect(result.stdout).toContain('Would skip: 1 issues');
       expect(result.stderr).not.toContain('requires a TTY');
     });
 
@@ -1094,6 +1099,7 @@ priority: medium
         join(tempVaultDir, 'Ideas', 'Bad.md'),
         `---
 type: idea
+status: " "
 priority: medium
 ---
 `
@@ -6721,6 +6727,7 @@ tags: later
         join(tempVaultDir, 'Ideas', 'Dry Run.md'),
         `---
 type: idea
+status: " "
 priority: medium
 ---
 `
@@ -6735,7 +6742,7 @@ priority: medium
       expect(result.stdout).toContain("Re-run with '--execute' to apply fixes.");
 
       const content = await readFile(join(tempVaultDir, 'Ideas', 'Dry Run.md'), 'utf-8');
-      expect(content).not.toContain('status:');
+      expect(content).not.toContain('status: raw');
     });
 
     it('should confirm applied fixes when --execute is provided', async () => {
@@ -6743,6 +6750,7 @@ priority: medium
         join(tempVaultDir, 'Ideas', 'Applied Fix.md'),
         `---
 type: idea
+status: " "
 priority: medium
 ---
 `

--- a/tests/ts/lib/edit-blank-required-defaults.test.ts
+++ b/tests/ts/lib/edit-blank-required-defaults.test.ts
@@ -136,7 +136,7 @@ owner: Alice
     expect(fm['owner']).toBe('Alice');
   });
 
-  it('explicit null removal of a defaulted field stays removed (default NOT re-applied)', async () => {
+  it('explicit null removal of a required defaulted field stays removed and audit stays clean (#743)', async () => {
     // Regression: a blanket applyDefaults over the merged frontmatter would write
     // `status`'s default back in immediately after `mergeFrontmatter` deleted it,
     // silently undoing the documented `{"field": null}` removal. The surgical fix
@@ -165,6 +165,11 @@ priority: high
     expect('status' in fm).toBe(false);
     // Untouched field is preserved.
     expect(fm['priority']).toBe('high');
+
+    // Parity: validateFrontmatter accepts missing required-with-default values,
+    // so audit must not report the post-edit file as missing-required.
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    expect(auditIssues(results, 'Drop.md')).not.toContain('missing-required');
   });
 
   it('editing one field does NOT materialize an unrelated untouched defaulted field', async () => {


### PR DESCRIPTION
## Summary
- Treat missing required fields with schema defaults as satisfied during audit, matching validateFrontmatter and edit null-removal semantics
- Keep present-but-blank required values audit-visible and default-fixable
- Update command, parity, and PTY regression coverage for issue #743

Fixes #743

## Validation
- pnpm build
- pnpm verify:pack
- pnpm typecheck
- pnpm lint
- pnpm knip
- pnpm test tests/ts/lib/edit-blank-required-defaults.test.ts
- pnpm test tests/ts/commands/audit.test.ts
- pnpm test -- --exclude="**/*.pty.test.ts"
- pnpm test tests/ts/commands/audit-fix.pty.test.ts