### PR TITLE
[codex] Reject scalar writes for plain list fields

### DIFF
--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -181,10 +181,15 @@ export async function editNoteFromJson(
   //
   // Keys the user blanked but whose field has NO default stay blank: optional →
   // unset (trim-everywhere preserved), required → still rejected at validation.
+  const fields = getFieldsForType(schema, typePath);
   const blankPatchKeys = new Set(
-    Object.keys(patchData).filter(
-      (key) => typeof patchData[key] === 'string' && isBlankScalar(patchData[key])
-    )
+    Object.keys(patchData).filter((key) => {
+      if (typeof patchData[key] !== 'string' || !isBlankScalar(patchData[key])) return false;
+      // Plain prompt:list fields must validate as arrays on write (#742). Do
+      // not let a default such as [] hide a user-supplied scalar patch before
+      // validation gets to enforce the same shape audit expects.
+      return fields[key]?.prompt !== 'list';
+    })
   );
   const defaultedFrontmatter = applyDefaults(
     schema,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -267,15 +267,14 @@ export function validateFrontmatter(
     //         is accepted). Only a NON-blank scalar is type-checked.
     //       - list-shaped field: a blank scalar string is NOT unset — it is the
     //         wrong SHAPE (a scalar where a list is expected) and must reach
-    //         `validateFieldType`, which rejects it for a `multiple` date field
-    //         (bad date) and for an alias field (`invalid_alias`), matching
-    //         audit's `wrong-scalar-type` flag. Only `null`/`undefined`/`[]` are
-    //         genuinely unset for a list field and skip the type check.
+    //         `validateFieldType`, which rejects it for list-shaped fields,
+    //         matching audit's `wrong-scalar-type` flag. Only
+    //         `null`/`undefined`/`[]` are genuinely unset for a list field and
+    //         skip the type check.
     //
-    // A non-blank scalar on a non-alias list field (e.g. `labels: 'urgent'`) is
-    // unaffected: it was never blank, so it flows to type validation and keeps its
-    // long-standing soft-coercion (audit autofixes it as `wrong-scalar-type`) —
-    // intentionally out of scope here.
+    // A non-blank scalar on a list field (e.g. `tags: 'urgent'`) also reaches
+    // type validation and is rejected, matching audit's existing
+    // `wrong-scalar-type` detection instead of persisting drift.
     const isListShapedField = field.multiple === true || field.prompt === 'list';
     const isNullish = value === undefined || value === null;
     const isEmptyArray = Array.isArray(value) && value.length === 0;
@@ -484,16 +483,16 @@ function validateFieldType(
     return validateAliasValue(fieldName, value);
   }
 
-  // Handle list fields (multi-value arrays or comma-separated strings)
+  // Handle list fields. Write paths store list-shaped fields as arrays; existing
+  // scalar drift is owned by audit's wrong-scalar-type detection/autofix.
   if (field.prompt === 'list' || field.list_format) {
-    // Accept both arrays and strings for list fields
-    if (!Array.isArray(value) && typeof value !== 'string') {
+    if (!Array.isArray(value)) {
       return {
         type: 'invalid_type',
         field: fieldName,
         value,
-        message: `Invalid type for ${fieldName}: expected array or string, got ${typeof value}`,
-        expected: 'array or string',
+        message: `Invalid type for ${fieldName}: expected array, got ${typeof value}`,
+        expected: 'array',
       };
     }
     return null;

--- a/tests/ts/commands/edit.test.ts
+++ b/tests/ts/commands/edit.test.ts
@@ -60,6 +60,26 @@ describe('edit command', () => {
       expect(json.errors[0].field).toBe('totally-extra');
     });
 
+    for (const [label, json] of [
+      ['blank scalar', '{"tags":"   "}'],
+      ['non-blank scalar', '{"tags":"urgent"}'],
+    ] as const) {
+      it(`rejects a ${label} for an optional prompt:'list' field`, async () => {
+        const taskPath = join(vaultDir, 'Objectives/Tasks/Sample Task.md');
+        const before = await readFile(taskPath, 'utf-8');
+
+        const result = await runCLI(['edit', 'Objectives/Tasks/Sample Task.md', '--json', json], vaultDir);
+
+        expect(result.exitCode).toBe(1);
+        const output = JSON.parse(result.stdout);
+        expect(output.success).toBe(false);
+        expect(output.error).toBe('Validation failed');
+        expect(output.errors[0].field).toBe('tags');
+        expect(output.errors[0].expected).toBe('array');
+        await expect(readFile(taskPath, 'utf-8')).resolves.toBe(before);
+      });
+    }
+
     it('should detect type from frontmatter type field', async () => {
       const result = await runCLI(
         ['edit', 'Ideas/Sample Idea.md', '--json', '{"status": "backlog"}'],

--- a/tests/ts/commands/new.test.ts
+++ b/tests/ts/commands/new.test.ts
@@ -198,6 +198,22 @@ defaults:
       expect(output.errors[0].field).toBe('totally-extra');
     });
 
+    for (const [label, json] of [
+      ['blank scalar', '{"name":"Bad List Blank","tags":"   "}'],
+      ['non-blank scalar', '{"name":"Bad List Scalar","tags":"urgent"}'],
+    ] as const) {
+      it(`rejects a ${label} for an optional prompt:'list' field`, async () => {
+        const result = await runCLI(['new', 'task', '--json', json, '--no-template'], vaultDir);
+
+        expect(result.exitCode).toBe(ExitCodes.VALIDATION_ERROR);
+        const output = JSON.parse(result.stdout);
+        expect(output.success).toBe(false);
+        expect(output.error).toBe('Validation failed');
+        expect(output.errors[0].field).toBe('tags');
+        expect(output.errors[0].expected).toBe('array');
+      });
+    }
+
     it('should reject templates whose defaults are invalid for the target type', async () => {
       await writeFile(
         join(vaultDir, '.bwrb', 'templates', 'task', 'invalid-default.md'),

--- a/tests/ts/lib/edit-blank-list-prompt-parity.test.ts
+++ b/tests/ts/lib/edit-blank-list-prompt-parity.test.ts
@@ -12,15 +12,14 @@ import type { Schema } from '../../../src/types/schema.js';
 
 /**
  * Regression coverage for the #707 write↔audit parity break on `prompt: 'list'`
- * fields that are NOT `multiple: true` (the alias-role shape).
+ * fields that are NOT `multiple: true`.
  *
  * A prior round restricted the blank-as-unset scalar shortcut (`isBlankScalar`)
  * to exclude only `multiple: true` fields. But a field declared as
- * `prompt: 'list'` WITHOUT `multiple` is ALSO list-shaped — this is exactly the
- * ALIAS-role schema pattern (`aliases: { prompt: 'list', alias: true }`). For
- * such a field a whitespace-only scalar like `aliases: '   '` made `hasValue`
- * false, so `validateFieldType` never ran and the non-array scalar string was
- * accepted and PERSISTED on write — while `audit` treats `prompt: 'list'` as
+ * `prompt: 'list'` WITHOUT `multiple` is ALSO list-shaped. For such a field a
+ * whitespace-only scalar like `tags: '   '` made `hasValue` false, so
+ * `validateFieldType` never ran and the non-array scalar string was accepted and
+ * PERSISTED on write — while `audit` treats `prompt: 'list'` as
  * list-shaped (`expectsList = field.prompt === 'list' || field.multiple === true`
  * in `src/lib/audit/detection.ts`) and flagged the SAME value as
  * `wrong-scalar-type`. Write accepted, audit flagged: parity violated.
@@ -28,8 +27,8 @@ import type { Schema } from '../../../src/types/schema.js';
  * Ground truth: the blank-as-unset shortcut must apply ONLY to genuinely SCALAR
  * fields. A field is list-shaped when `field.multiple === true` OR
  * `field.prompt === 'list'`. The fix uses that same predicate, so a blank scalar
- * on a `prompt: 'list'` alias field is rejected at write (alias-array
- * validation), matching audit's `wrong-scalar-type` flag. Both reject/flag.
+ * on a `prompt: 'list'` field is rejected at write, matching audit's
+ * `wrong-scalar-type` flag. Both reject/flag.
  */
 
 const SCHEMA: Schema = {
@@ -39,6 +38,7 @@ const SCHEMA: Schema = {
       output_dir: 'people',
       fields: {
         name: { prompt: 'text', required: true },
+        tags: { prompt: 'list', list_format: 'yaml-array' },
         // The alias role: `prompt: 'list'` WITHOUT `multiple` (list-shaped).
         aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
       },
@@ -85,6 +85,68 @@ describe("whitespace scalar on prompt:'list' (alias) field: write↔audit parity
     });
     expect(result.valid).toBe(false);
     expect(result.errors.some((e) => e.field === 'aliases')).toBe(true);
+  });
+
+  it("validateFrontmatter REJECTS blank and non-blank scalars on a plain prompt:'list' field", async () => {
+    const schema = await loadSchema(vaultDir);
+    for (const value of ['   ', 'urgent']) {
+      const result = validateFrontmatter(schema, 'person', {
+        type: 'person',
+        name: 'x',
+        tags: value,
+      });
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((e) => e.field === 'tags' && e.type === 'invalid_type')
+      ).toBe(true);
+    }
+  });
+
+  it("edit --json: blank and non-blank scalars for an optional plain prompt:'list' field are rejected", async () => {
+    const personPath = join(vaultDir, 'people', 'Tagged.md');
+    await writeFile(
+      personPath,
+      `---
+type: person
+name: Tagged
+tags:
+  - old
+---
+
+# Tagged
+`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    for (const value of ['   ', 'urgent']) {
+      await expect(
+        editNoteFromJson(schema, vaultDir, personPath, JSON.stringify({ tags: value }), {
+          jsonMode: false,
+        })
+      ).rejects.toThrow(/tags/);
+    }
+
+    const fm = await readFrontmatter(personPath);
+    expect(fm['tags']).toEqual(['old']);
+  });
+
+  it("parity: persisted blank and non-blank scalars on a plain prompt:'list' field are flagged wrong-scalar-type by audit", async () => {
+    await writeFile(
+      join(vaultDir, 'people', 'BlankTags.md'),
+      `---\ntype: person\nname: BlankTags\ntags: "   "\n---\n`
+    );
+    await writeFile(
+      join(vaultDir, 'people', 'ScalarTags.md'),
+      `---\ntype: person\nname: ScalarTags\ntags: urgent\n---\n`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, { strict: false, vaultDir, schema });
+    const blankIssues = auditIssues(results, 'BlankTags.md');
+    const scalarIssues = auditIssues(results, 'ScalarTags.md');
+
+    expect(blankIssues.some((i) => i.code === 'wrong-scalar-type' && i.field === 'tags')).toBe(true);
+    expect(scalarIssues.some((i) => i.code === 'wrong-scalar-type' && i.field === 'tags')).toBe(true);
   });
 
   it('edit --json: a whitespace scalar for an optional alias list field is rejected; nothing persisted', async () => {

--- a/tests/ts/lib/required-blank-list-parity.test.ts
+++ b/tests/ts/lib/required-blank-list-parity.test.ts
@@ -22,11 +22,10 @@ import type { Schema } from '../../../src/types/schema.js';
  * flagged: parity violated.
  *
  * Ground truth: a blank value on a list-shaped field is EMPTY for the required
- * check (required -> required_field_missing; optional -> unset, no error),
- * exactly as audit's `isEmptyRequiredValue` classifies it. A NON-blank scalar on
- * a non-alias list field still flows to type validation (soft-coerce, out of
- * scope). Alias fields keep their stricter array contract (covered separately in
- * edit-blank-list-prompt-parity.test.ts).
+ * check (required -> required_field_missing), exactly as audit's
+ * `isEmptyRequiredValue` classifies it. Optional list-shaped fields still allow
+ * absent/null/empty-array unset values, but scalar strings are type errors so
+ * write no longer persists values audit immediately flags as `wrong-scalar-type`.
  */
 
 const SCHEMA: Schema = {
@@ -121,8 +120,6 @@ describe('required blank list-field emptiness: write↔audit parity (#707)', () 
   });
 
   for (const [label, value] of [
-    ['empty string', ''],
-    ['whitespace-only', '   '],
     ['empty array', [] as unknown],
   ] as const) {
     it(`treats a ${label} value on an OPTIONAL list field as unset (no error)`, async () => {
@@ -134,6 +131,26 @@ describe('required blank list-field emptiness: write↔audit parity (#707)', () 
         optlist: value,
       });
       expect(result.errors.some((e) => e.field === 'optlist')).toBe(false);
+    });
+  }
+
+  for (const [label, value] of [
+    ['empty string', ''],
+    ['whitespace-only', '   '],
+    ['non-blank scalar', 'urgent'],
+  ] as const) {
+    it(`REJECTS a ${label} value on an OPTIONAL prompt:'list' field (wrong shape)`, async () => {
+      const schema = await loadSchema(vaultDir);
+      const result = validateFrontmatter(schema, 'widget', {
+        type: 'widget',
+        reqlist: ['x'],
+        reqmulti: ['a'],
+        optlist: value,
+      });
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((e) => e.field === 'optlist' && e.type === 'invalid_type')
+      ).toBe(true);
     });
   }
 
@@ -180,13 +197,14 @@ describe('required blank list-field emptiness: write↔audit parity (#707)', () 
     expect(codes.some((c) => c.field === 'optlist')).toBe(false);
   });
 
-  it('control: a non-blank scalar on a non-alias list field is still accepted on write (soft-coerce, out of scope)', async () => {
+  it('control: a non-blank scalar on a non-alias list field is rejected on write', async () => {
     const schema = await loadSchema(vaultDir);
     const result = validateFrontmatter(schema, 'widget', {
       type: 'widget',
       reqlist: 'urgent',
       reqmulti: ['a'],
     });
-    expect(result.errors.some((e) => e.field === 'reqlist')).toBe(false);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.field === 'reqlist' && e.type === 'invalid_type')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Closes #742.

This tightens the write contract for plain `prompt: 'list'` fields so JSON create/edit paths no longer persist scalar strings that `audit` immediately reports as `wrong-scalar-type`.

## What changed

- `validateFieldType` now requires list fields to be arrays on write instead of accepting string scalars.
- `edit --json` no longer lets a blank scalar patch for a plain list field get hidden by a default like `[]` before validation.
- Added regressions for blank and non-blank scalar list values through `new --json`, `edit --json`, direct validation/edit helpers, and audit parity for existing scalar drift.

## Chosen contract

Plain `prompt: 'list'` fields store arrays only. Scalar drift already on disk remains audit-owned: `audit` still reports `wrong-scalar-type` and its existing autofix can wrap scalar values where appropriate.

## Validation

- `pnpm build`
- `pnpm verify:pack`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm test -- tests/ts/lib/edit-blank-list-prompt-parity.test.ts tests/ts/lib/required-blank-list-parity.test.ts tests/ts/commands/new.test.ts tests/ts/commands/edit.test.ts`
- `pnpm test -- --exclude='**/*.pty.test.ts'`