### PR TITLE
Fix hierarchy parent path keying

### DIFF
--- a/src/lib/expression.ts
+++ b/src/lib/expression.ts
@@ -31,6 +31,32 @@ export interface HierarchyData {
    * notion of "attached".
    */
   parentMap: Map<string, string>;
+  /**
+   * Optional path-keyed structural parent map. Keys and values are vault-relative
+   * note paths without `.md` (for example `Objectives/Tasks/Child`). This lets a
+   * chain climb through the exact note named by a path-qualified parent link,
+   * instead of collapsing duplicate intermediate basenames into one global edge.
+   * The basename `parentMap` above remains the compatibility fallback for bare
+   * links and direct unit-test contexts.
+   */
+  parentPathMap?: Map<string, string>;
+  /**
+   * Vault-relative note path (without `.md`) to basename. Used with
+   * `parentPathMap` so path-keyed walks can still satisfy supported bare-node
+   * queries such as `isDescendantOf('[[Parent]]')`.
+   */
+  pathNameMap?: Map<string, string>;
+  /**
+   * Unambiguous basename -> vault-relative note path (without `.md`). Duplicate
+   * basenames are omitted so a bare link never silently chooses one duplicate.
+   */
+  uniquePathByName?: Map<string, string>;
+  /**
+   * Internal raw structural parent targets by path, populated while query builds
+   * hierarchy data and resolved into `parentPathMap` after the vault snapshot is
+   * available.
+   */
+  parentTargetByPath?: Map<string, string>;
   /** Map from note name to set of child note names (structural `parent` only). */
   childrenMap: Map<string, Set<string>>;
   /**
@@ -421,10 +447,11 @@ const FUNCTIONS: Record<string, FunctionImpl> = {
       aliasMap
     );
     const noteName = context.file?.name;
+    const notePath = normalizeNotePath(context.file?.path);
     if (!noteName || !targetParent || !context.hierarchyData) return false;
-    const rawParent = context.hierarchyData.parentMap.get(noteName);
-    if (rawParent === undefined) return false;
-    return canonicalizeAlias(rawParent, aliasMap) === targetParent;
+    const parent = getHierarchyParent(noteName, notePath, context.hierarchyData, aliasMap);
+    if (!parent) return false;
+    return hierarchyNodeMatches(parent, targetParent, context.hierarchyData);
   },
 
   /**
@@ -445,16 +472,24 @@ const FUNCTIONS: Record<string, FunctionImpl> = {
       aliasMap
     );
     const noteName = context.file?.name;
+    const notePath = normalizeNotePath(context.file?.path);
     if (!noteName || !targetAncestor || !context.hierarchyData) return false;
 
     // Walk up the CURRENT note's own parent chain checking for the target.
-    const startParent = context.hierarchyData.parentMap.get(noteName);
+    const startParent = getHierarchyParent(
+      noteName,
+      notePath,
+      context.hierarchyData,
+      aliasMap
+    );
     if (!startParent) return false;
     return ancestorChainContains(
-      startParent,
+      startParent.name,
       targetAncestor,
       context.hierarchyData.parentMap,
-      aliasMap
+      aliasMap,
+      context.hierarchyData,
+      startParent.path
     );
   },
 
@@ -500,13 +535,31 @@ const FUNCTIONS: Record<string, FunctionImpl> = {
 
     const parentMap = context.hierarchyData.parentMap;
     for (const rawTarget of relationTargets) {
-      const relationTarget = canonicalizeAlias(rawTarget, aliasMap);
+      const relationTarget = canonicalizeAlias(noteNameFromTarget(rawTarget), aliasMap);
       if (!relationTarget) continue;
+      const relationTargetPath = resolveHierarchyPath(rawTarget, context.hierarchyData);
       // Inclusive of the direct target (depth 0).
-      if (relationTarget === targetNode) return true;
+      if (
+        hierarchyNodeMatches(
+          hierarchyNode(relationTarget, relationTargetPath),
+          targetNode,
+          context.hierarchyData
+        )
+      ) {
+        return true;
+      }
       // Otherwise walk the target's own ancestor chain. Pass the alias map so a
       // mid-chain `parent` written as an alias still resolves while walking.
-      if (ancestorChainContains(relationTarget, targetNode, parentMap, aliasMap)) {
+      if (
+        ancestorChainContains(
+          relationTarget,
+          targetNode,
+          parentMap,
+          aliasMap,
+          context.hierarchyData,
+          relationTargetPath
+        )
+      ) {
         return true;
       }
     }
@@ -549,17 +602,93 @@ function ancestorChainContains(
   start: string,
   target: string,
   parentMap: Map<string, string>,
-  aliasMap?: Map<string, string>
+  aliasMap?: Map<string, string>,
+  hierarchyData?: HierarchyData,
+  startPath?: string
 ): boolean {
   const visited = new Set<string>();
-  let current: string | undefined = canonicalizeAlias(start, aliasMap) ?? undefined;
-  while (current && !visited.has(current)) {
-    if (current === target) return true;
-    visited.add(current);
-    const next = parentMap.get(current);
-    current = next === undefined ? undefined : (canonicalizeAlias(next, aliasMap) ?? undefined);
+  const data = hierarchyData ?? { parentMap, childrenMap: new Map<string, Set<string>>() };
+  let current: HierarchyNode | undefined = hierarchyNode(
+    canonicalizeAlias(noteNameFromTarget(start), aliasMap) ?? noteNameFromTarget(start),
+    startPath ?? resolveHierarchyPath(start, hierarchyData)
+  );
+  while (current && !visited.has(hierarchyVisitKey(current))) {
+    if (hierarchyNodeMatches(current, target, hierarchyData)) return true;
+    visited.add(hierarchyVisitKey(current));
+    current = getHierarchyParent(current.name, current.path, data, aliasMap);
   }
   return false;
+}
+
+interface HierarchyNode {
+  name: string;
+  path?: string;
+}
+
+function getHierarchyParent(
+  noteName: string,
+  notePath: string | undefined,
+  hierarchyData: HierarchyData,
+  aliasMap?: Map<string, string>
+): HierarchyNode | undefined {
+  const pathParent = notePath ? hierarchyData.parentPathMap?.get(notePath) : undefined;
+  if (pathParent) {
+    return {
+      name: canonicalizeAlias(
+        hierarchyData.pathNameMap?.get(pathParent) ?? noteNameFromTarget(pathParent),
+        aliasMap
+      ) ?? noteNameFromTarget(pathParent),
+      path: pathParent,
+    };
+  }
+
+  const rawParent = hierarchyData.parentMap.get(noteName);
+  if (rawParent === undefined) return undefined;
+  const parentName = canonicalizeAlias(noteNameFromTarget(rawParent), aliasMap) ?? noteNameFromTarget(rawParent);
+  return hierarchyNode(parentName, resolveHierarchyPath(rawParent, hierarchyData));
+}
+
+function hierarchyNode(name: string, path: string | undefined): HierarchyNode {
+  return path ? { name, path } : { name };
+}
+
+function hierarchyNodeMatches(
+  node: HierarchyNode,
+  target: string,
+  hierarchyData?: HierarchyData
+): boolean {
+  const targetPath = resolveHierarchyPath(target, hierarchyData);
+  if (targetPath && node.path === targetPath) return true;
+  return node.name === noteNameFromTarget(target);
+}
+
+function resolveHierarchyPath(
+  target: string | undefined,
+  hierarchyData: HierarchyData | undefined
+): string | undefined {
+  if (!target || !hierarchyData) return undefined;
+  const normalized = normalizeNotePath(target);
+  if (!normalized) return undefined;
+  if (normalized.includes('/')) {
+    return hierarchyData.pathNameMap?.has(normalized) ? normalized : undefined;
+  }
+  return hierarchyData.uniquePathByName?.get(normalized);
+}
+
+function normalizeNotePath(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const target = value.replace(/\\/g, '/').replace(/\.md$/i, '').trim();
+  return target || undefined;
+}
+
+function noteNameFromTarget(target: string): string {
+  const normalized = normalizeNotePath(target) ?? target;
+  const parts = normalized.split('/');
+  return parts[parts.length - 1] ?? normalized;
+}
+
+function hierarchyVisitKey(node: HierarchyNode): string {
+  return node.path ? `path:${node.path}` : `name:${node.name}`;
 }
 
 /**

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1,4 +1,4 @@
-import { basename } from 'path';
+import { basename, relative } from 'path';
 import type { LoadedSchema } from '../types/schema.js';
 import {
   getAllFieldsForType,
@@ -99,19 +99,31 @@ function expressionsNeedVaultAugmentation(expressions: string[]): boolean {
  */
 function buildHierarchyDataFromFiles(
   files: FileWithFrontmatter[],
-  options: Pick<FrontmatterFilterOptions, 'schema' | 'typePath'>
+  options: Pick<FrontmatterFilterOptions, 'schema' | 'typePath' | 'vaultDir'>
 ): HierarchyData {
   const parentMap = new Map<string, string>();
   const childrenMap = new Map<string, Set<string>>();
   const nonRootNames = new Set<string>();
   const reservedNames = new Set<string>();
+  const parentTargetByPath = new Map<string, string>();
+  const pathNameMap = new Map<string, string>();
   const hierarchyFieldCache = new Map<string, string[]>();
 
   for (const file of files) {
+    const notePath = notePathKey(file.path, options.vaultDir);
+    if (notePath) pathNameMap.set(notePath, basename(file.path, '.md'));
     // Candidate pass: reserve every candidate's basename as an authoritative
     // hierarchy identity (with or without a literal `parent`), so the full-vault
     // augmentation cannot fill/overwrite it from a same-basename note elsewhere.
-    addParentRelationship(file, parentMap, childrenMap, reservedNames, true);
+    addParentRelationship(
+      file,
+      parentMap,
+      childrenMap,
+      reservedNames,
+      true,
+      notePath,
+      parentTargetByPath
+    );
     // Separately record whether the candidate carries ANY parent-like link, for
     // `isRoot`. This is broader than the structural `parent` chain (it includes
     // single-valued same-ancestry relations like `task.milestone`), which is why
@@ -121,7 +133,14 @@ function buildHierarchyDataFromFiles(
     }
   }
 
-  return { parentMap, childrenMap, nonRootNames, reservedNames };
+  return {
+    parentMap,
+    childrenMap,
+    nonRootNames,
+    reservedNames,
+    parentTargetByPath,
+    pathNameMap,
+  };
 }
 
 /**
@@ -160,7 +179,9 @@ function addParentRelationship(
   parentMap: Map<string, string>,
   childrenMap: Map<string, Set<string>>,
   reservedNames: Set<string>,
-  reserve: boolean
+  reserve: boolean,
+  notePath?: string,
+  parentTargetByPath?: Map<string, string>
 ): void {
   const noteName = basename(file.path, '.md');
 
@@ -175,10 +196,6 @@ function addParentRelationship(
     return;
   }
 
-  // Don't let a later (less specific, full-vault) pass clobber an entry the
-  // type-aware pass already resolved for the candidate set.
-  if (parentMap.has(noteName)) return;
-
   // The STRUCTURAL parent chain is the literal `parent` field ONLY. Parent-like
   // relations (e.g. `task.milestone`) are NOT folded in here: doing so used to
   // make `isDescendantOf` silently collapse with `under(<relation>, …)` and made
@@ -189,6 +206,16 @@ function addParentRelationship(
 
   const parentTarget = extractLinkTarget(parentValue) ?? parentValue.trim();
   if (!parentTarget) return;
+
+  if (notePath && parentTargetByPath && !parentTargetByPath.has(notePath)) {
+    parentTargetByPath.set(notePath, parentTarget);
+  }
+
+  // Don't let a later (less specific, full-vault) pass clobber an entry the
+  // type-aware pass already resolved for the candidate set. Path-keyed parent
+  // targets were recorded above, so duplicate non-candidate basenames can still
+  // be walked exactly when a chain has a path identity (#738).
+  if (parentMap.has(noteName)) return;
 
   parentMap.set(noteName, parentTarget);
 
@@ -237,6 +264,9 @@ async function augmentHierarchyDataFromVault(
 
   const snapshot =
     options.snapshot ?? (await buildVaultNoteSnapshot(options.schema, options.vaultDir));
+  const uniquePathByName = buildUniquePathByName(snapshot);
+  const parentTargetByPath = hierarchyData.parentTargetByPath ?? new Map<string, string>();
+  const pathNameMap = hierarchyData.pathNameMap ?? new Map<string, string>();
 
   // Candidate basenames are authoritative identities; the vault pass must not
   // fill or overwrite them from a same-basename note elsewhere (see
@@ -245,20 +275,85 @@ async function augmentHierarchyDataFromVault(
   // through filtered-out notes (#709).
   const reservedNames = hierarchyData.reservedNames ?? new Set<string>();
   for (const note of snapshot.notes) {
+    const notePath = notePathKey(note.relativePath);
+    if (notePath) pathNameMap.set(notePath, basename(note.relativePath, '.md'));
     if (!note.frontmatter) continue;
     addParentRelationship(
       { path: note.path, frontmatter: note.frontmatter },
       hierarchyData.parentMap,
       hierarchyData.childrenMap,
       reservedNames,
-      false
+      false,
+      notePath,
+      parentTargetByPath
     );
   }
+  hierarchyData.parentTargetByPath = parentTargetByPath;
+  hierarchyData.pathNameMap = pathNameMap;
+  hierarchyData.uniquePathByName = uniquePathByName;
+  hierarchyData.parentPathMap = buildParentPathMap(parentTargetByPath, pathNameMap, uniquePathByName);
 
   // Build the alias -> canonical-note map from the SAME snapshot so the
   // operators can canonicalize aliased values and query nodes (see
   // HierarchyData.aliasMap) without re-reading the vault.
   hierarchyData.aliasMap = buildVaultAliasMap(options.schema, snapshot);
+}
+
+function buildUniquePathByName(snapshot: VaultNoteSnapshot): Map<string, string> {
+  const pathByName = new Map<string, string | null>();
+
+  for (const note of snapshot.notes) {
+    const notePath = notePathKey(note.relativePath);
+    if (!notePath) continue;
+    const noteName = basename(note.relativePath, '.md');
+    if (pathByName.has(noteName)) {
+      pathByName.set(noteName, null);
+    } else {
+      pathByName.set(noteName, notePath);
+    }
+  }
+
+  const unique = new Map<string, string>();
+  for (const [name, path] of pathByName) {
+    if (path) unique.set(name, path);
+  }
+  return unique;
+}
+
+function buildParentPathMap(
+  parentTargetByPath: Map<string, string>,
+  pathNameMap: Map<string, string>,
+  uniquePathByName: Map<string, string>
+): Map<string, string> {
+  const parentPathMap = new Map<string, string>();
+
+  for (const [notePath, parentTarget] of parentTargetByPath) {
+    const parentPath = resolveParentTargetPath(parentTarget, pathNameMap, uniquePathByName);
+    if (parentPath) {
+      parentPathMap.set(notePath, parentPath);
+    }
+  }
+
+  return parentPathMap;
+}
+
+function resolveParentTargetPath(
+  parentTarget: string,
+  pathNameMap: Map<string, string>,
+  uniquePathByName: Map<string, string>
+): string | undefined {
+  const targetPath = notePathKey(parentTarget);
+  if (!targetPath) return undefined;
+  if (targetPath.includes('/')) {
+    return pathNameMap.has(targetPath) ? targetPath : undefined;
+  }
+  return uniquePathByName.get(targetPath);
+}
+
+function notePathKey(path: string, vaultDir?: string): string | undefined {
+  const relativePath = vaultDir ? relative(vaultDir, path) : path;
+  const normalized = relativePath.replace(/\\/g, '/').replace(/\.md$/i, '').trim();
+  return normalized || undefined;
 }
 
 /**
@@ -444,6 +539,7 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
     expressionsUseHierarchyFunctions(normalizedExpressions)
   ) {
     hierarchyData = buildHierarchyDataFromFiles(files, {
+      vaultDir,
       ...(schema ? { schema } : {}),
       ...(typePath ? { typePath } : {}),
     });

--- a/tests/ts/lib/query.test.ts
+++ b/tests/ts/lib/query.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { join } from 'path';
-import { writeFile, rm } from 'fs/promises';
+import { mkdir, writeFile, rm } from 'fs/promises';
 import {
   validateFieldForType,
   applyFrontmatterFilters,
@@ -611,6 +611,98 @@ describe('query', () => {
           typePath: 'task',
         });
         expect(childResult).toHaveLength(1);
+      });
+    });
+
+    describe('duplicate intermediate ancestor basenames keep path identity (#738)', () => {
+      const builtNotes: string[] = [];
+
+      beforeAll(async () => {
+        const writeNote = async (
+          dir: string,
+          name: string,
+          fm: string
+        ): Promise<void> => {
+          const path = join(vaultDir, dir, `${name}.md`);
+          await mkdir(join(vaultDir, dir), { recursive: true });
+          await writeFile(path, `---\n${fm}\n---\n`);
+          builtNotes.push(path);
+        };
+
+        await writeNote('Objectives/Tasks', 'correct-root', 'type: task\nstatus: backlog');
+        await writeNote('Objectives/Tasks', 'wrong-root', 'type: task\nstatus: backlog');
+        await writeNote(
+          'Archive/Milestones',
+          'Shared Phase',
+          'type: milestone\nstatus: backlog\nparent: "[[wrong-root]]"'
+        );
+        await writeNote(
+          'Objectives/Milestones',
+          'Shared Phase',
+          'type: milestone\nstatus: backlog\nparent: "[[correct-root]]"'
+        );
+      });
+
+      afterAll(async () => {
+        await Promise.all(builtNotes.map(p => rm(p, { force: true })));
+      });
+
+      it('climbs through the path-qualified same-basename parent, not the first basename edge', async () => {
+        const files = makeFiles([
+          {
+            path: 'Objectives/Tasks/Path Keyed Leaf.md',
+            fm: {
+              type: 'task',
+              status: 'backlog',
+              parent: '"[[Objectives/Milestones/Shared Phase]]"',
+            },
+          },
+        ]);
+
+        const correctResult = await applyFrontmatterFilters(files, {
+          whereExpressions: ["isDescendantOf('[[correct-root]]')"],
+          vaultDir,
+          schema,
+          typePath: 'task',
+        });
+        expect(correctResult).toHaveLength(1);
+
+        const wrongResult = await applyFrontmatterFilters(files, {
+          whereExpressions: ["isDescendantOf('[[wrong-root]]')"],
+          vaultDir,
+          schema,
+          typePath: 'task',
+        });
+        expect(wrongResult).toHaveLength(0);
+      });
+
+      it('under() also walks the path-qualified relation target through the correct duplicate basename', async () => {
+        const files = makeFiles([
+          {
+            path: 'Objectives/Tasks/Path Keyed Relation.md',
+            fm: {
+              type: 'task',
+              status: 'backlog',
+              milestone: '"[[Objectives/Milestones/Shared Phase]]"',
+            },
+          },
+        ]);
+
+        const correctResult = await applyFrontmatterFilters(files, {
+          whereExpressions: ["under(milestone, '[[correct-root]]')"],
+          vaultDir,
+          schema,
+          typePath: 'task',
+        });
+        expect(correctResult).toHaveLength(1);
+
+        const wrongResult = await applyFrontmatterFilters(files, {
+          whereExpressions: ["under(milestone, '[[wrong-root]]')"],
+          vaultDir,
+          schema,
+          typePath: 'task',
+        });
+        expect(wrongResult).toHaveLength(0);
       });
     });
 


### PR DESCRIPTION
## Summary
- add path-keyed hierarchy parent data alongside the existing basename parent map
- use path identity when walking `isChildOf`, `isDescendantOf`, and `under` chains, while preserving bare-link fallback behavior
- add regression coverage for duplicate intermediate ancestor basenames resolving through the path-qualified parent

Fixes #738.

## Validation
- pnpm build
- pnpm verify:pack
- pnpm typecheck
- pnpm lint
- pnpm knip
- pnpm test tests/ts/lib/query.test.ts
- pnpm test -- --exclude='**/*.pty.test.ts'
