### PR TITLE
[codex] Detect field prompt and date granularity migration diffs

### DIFF
--- a/src/lib/migration/diff.ts
+++ b/src/lib/migration/diff.ts
@@ -396,6 +396,12 @@ function detectFieldPropertyChanges(oldField: Field, newField: Field): string[] 
   // Other properties that matter for migration. Note: `description` and `label`
   // are intentionally excluded — they are documentation, never data shape.
   //
+  // `prompt` controls how values are validated/interpreted, so a change can make
+  // existing values invalid even when no other structural property changes.
+  //
+  // `granularity` controls date validation strictness. It matters only for date
+  // fields, and the classifier decides whether the direction is narrowing.
+  //
   // `default` is tracked because it participates in the required-exposure rule:
   // bwrb validation exempts a missing required value only while `default !==
   // undefined`, so REMOVING a default from an already-required field newly
@@ -404,7 +410,14 @@ function detectFieldPropertyChanges(oldField: Field, newField: Field): string[] 
   // `default` here a default-only change would never surface as a `field-changed`
   // detection at all (#728). A default change that does NOT cross the
   // exposure boundary is harmless and produces no op.
-  const props: (keyof Field)[] = ['source', 'required', 'multiple', 'default'];
+  const props: (keyof Field)[] = [
+    'prompt',
+    'source',
+    'required',
+    'multiple',
+    'default',
+    'granularity',
+  ];
 
   for (const prop of props) {
     if (JSON.stringify(oldField[prop]) !== JSON.stringify(newField[prop])) {
@@ -541,6 +554,11 @@ function classifyChanges(
  *   there is no safe deterministic fix → `review-field` (non-deterministic, no note
  *   mutation, surfaced for the user). A pure `source` widening (new allowed set ⊇
  *   old) or reorder keeps existing links valid → no op.
+ * - date `granularity` narrowed (e.g. `year` → `month`/`day`, or `month` →
+ *   `day`): existing partial dates may now be invalid → `review-field`.
+ *   Widening keeps existing values valid and emits no op.
+ * - `prompt` changed without a more specific op already covering the field:
+ *   existing values may now be interpreted by a different validator → `review-field`.
  */
 function classifyFieldChange(
   change: Extract<DetectedChange, { kind: 'field-changed' }>,
@@ -550,6 +568,13 @@ function classifyFieldChange(
   nonDeterministic: MigrationOp[]
 ): void {
   const { type: targetType, field, changes: changedProps } = change;
+  const opCountForField = (): number =>
+    deterministic.filter(
+      (op) => 'targetType' in op && op.targetType === targetType && 'field' in op && op.field === field
+    ).length +
+    nonDeterministic.filter(
+      (op) => 'targetType' in op && op.targetType === targetType && 'field' in op && op.field === field
+    ).length;
 
   if (changedProps.includes('options')) {
     const oldValues = getOptionValues(oldField?.options);
@@ -719,6 +744,51 @@ function classifyFieldChange(
       }
     }
   }
+
+  if (changedProps.includes('granularity')) {
+    const oldPrompt = oldField?.prompt;
+    const newPrompt = newField?.prompt;
+    if (oldPrompt === 'date' && newPrompt === 'date') {
+      const oldGranularity = normalizeDateGranularity(oldField?.granularity);
+      const newGranularity = normalizeDateGranularity(newField?.granularity);
+      if (isDateGranularityNarrowing(oldGranularity, newGranularity)) {
+        nonDeterministic.push({
+          op: 'review-field',
+          targetType,
+          field,
+          reason:
+            'date granularity is stricter; existing partial dates may need manual review',
+        });
+      }
+    }
+  }
+
+  if (changedProps.includes('prompt') && opCountForField() === 0) {
+    nonDeterministic.push({
+      op: 'review-field',
+      targetType,
+      field,
+      reason: 'field prompt type changed; existing values may need manual review',
+    });
+  }
+}
+
+type DateGranularity = NonNullable<Field['granularity']>;
+
+function normalizeDateGranularity(granularity: Field['granularity']): DateGranularity {
+  return granularity ?? 'day';
+}
+
+function isDateGranularityNarrowing(
+  oldGranularity: DateGranularity,
+  newGranularity: DateGranularity
+): boolean {
+  const rank: Record<DateGranularity, number> = {
+    year: 1,
+    month: 2,
+    day: 3,
+  };
+  return rank[newGranularity] > rank[oldGranularity];
 }
 
 /**

--- a/tests/ts/lib/migration/diff.test.ts
+++ b/tests/ts/lib/migration/diff.test.ts
@@ -412,6 +412,124 @@ describe("diffSchemas", () => {
       ).toBe(false);
     });
 
+    it("emits review-field when date granularity narrows", () => {
+      const yearSchema: BwrbSchemaType = {
+        ...baseSchema,
+        types: {
+          ...baseSchema.types,
+          task: {
+            ...baseSchema.types.task,
+            fields: {
+              ...baseSchema.types.task.fields,
+              due: { prompt: "date", granularity: "year" },
+            },
+          },
+        },
+      };
+      const monthSchema: BwrbSchemaType = {
+        ...yearSchema,
+        schemaVersion: "2.0.0",
+        types: {
+          ...yearSchema.types,
+          task: {
+            ...yearSchema.types.task,
+            fields: {
+              ...yearSchema.types.task.fields,
+              due: { prompt: "date", granularity: "month" },
+            },
+          },
+        },
+      };
+
+      const plan = diffSchemas(yearSchema, monthSchema, "1.0.0", "2.0.0");
+
+      expect(plan.nonDeterministic).toContainEqual({
+        op: "review-field",
+        targetType: "task",
+        field: "due",
+        reason:
+          "date granularity is stricter; existing partial dates may need manual review",
+      });
+      expect(plan.deterministic).toHaveLength(0);
+    });
+
+    it("does NOT emit an op when date granularity widens", () => {
+      const daySchema: BwrbSchemaType = {
+        ...baseSchema,
+        types: {
+          ...baseSchema.types,
+          task: {
+            ...baseSchema.types.task,
+            fields: {
+              ...baseSchema.types.task.fields,
+              due: { prompt: "date", granularity: "day" },
+            },
+          },
+        },
+      };
+      const yearSchema: BwrbSchemaType = {
+        ...daySchema,
+        schemaVersion: "1.1.0",
+        types: {
+          ...daySchema.types,
+          task: {
+            ...daySchema.types.task,
+            fields: {
+              ...daySchema.types.task.fields,
+              due: { prompt: "date", granularity: "year" },
+            },
+          },
+        },
+      };
+
+      const plan = diffSchemas(daySchema, yearSchema, "1.0.0", "1.1.0");
+
+      expect(plan.hasChanges).toBe(false);
+      expect(plan.schemaChanged).toBe(true);
+      expect(plan.deterministic).toHaveLength(0);
+      expect(plan.nonDeterministic).toHaveLength(0);
+    });
+
+    it("emits review-field when an existing field prompt type changes", () => {
+      const oldSchema: BwrbSchemaType = {
+        ...baseSchema,
+        types: {
+          ...baseSchema.types,
+          task: {
+            ...baseSchema.types.task,
+            fields: {
+              ...baseSchema.types.task.fields,
+              estimate: { prompt: "number" },
+            },
+          },
+        },
+      };
+      const newSchema: BwrbSchemaType = {
+        ...oldSchema,
+        schemaVersion: "2.0.0",
+        types: {
+          ...oldSchema.types,
+          task: {
+            ...oldSchema.types.task,
+            fields: {
+              ...oldSchema.types.task.fields,
+              estimate: { prompt: "date" },
+            },
+          },
+        },
+      };
+
+      const plan = diffSchemas(oldSchema, newSchema, "1.0.0", "2.0.0");
+
+      expect(plan.nonDeterministic).toContainEqual({
+        op: "review-field",
+        targetType: "task",
+        field: "estimate",
+        reason: "field prompt type changed; existing values may need manual review",
+      });
+      expect(plan.deterministic).toHaveLength(0);
+    });
+
     it("emits review-field when a field becomes required", () => {
       // priority starts not-required → make it required.
       const newSchema: BwrbSchemaType = {


### PR DESCRIPTION
## Summary

Closes #732.

- Tracks `prompt` and `granularity` as migration-relevant existing-field property changes.
- Emits non-deterministic `review-field` ops when date granularity narrows, because existing partial dates may need human validation.
- Emits a prompt-change `review-field` when no more specific existing migration op already covers the same field, preserving current option cleanup behavior.
- Adds focused migration diff tests for date granularity narrowing, date granularity widening, and prompt-type changes.

## Validation

- `pnpm test tests/ts/lib/migration/diff.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm build`
- `pnpm verify:pack`
- `pnpm test -- --exclude='**/*.pty.test.ts'`
- `git diff --check`

## Risk

Low. The change is scoped to classification for existing field property diffs. Widening date granularity remains schema-only, and prompt changes that already generate a more specific field op do not receive a duplicate generic review op.