### PR TITLE
fix(schema): allow inherited field structural overrides

### DIFF
--- a/src/lib/migration/diff.ts
+++ b/src/lib/migration/diff.ts
@@ -213,9 +213,9 @@ function detectTypeChanges(
  *     refreshes the snapshot.
  *   - A field merely INHERITED (or trait-contributed) UNCHANGED in both old and
  *     new is present in BOTH effective sets → NOT an addition.
- *   - A raw redeclaration of an already-inherited field whose structural override
- *     the resolver IGNORES leaves the effective field present in BOTH sets → NOT
- *     an addition (round-9 behavior preserved without a special case).
+ *   - A raw redeclaration of an already-inherited field leaves the field present
+ *     in BOTH effective sets → NOT an addition. If the redeclaration changes the
+ *     effective field shape, detectEffectiveFieldChanges handles it as a change.
  *
  * One detection is emitted per CONCRETE type that effectively gains the field,
  * matching how executeMigration groups field ops by exact `expectedType`. Only
@@ -259,25 +259,25 @@ function detectEffectiveFieldAdditions(
 /**
  * Detect field-changed migrations from the EFFECTIVE resolved schemas.
  *
- * The schema resolver applies a RESTRICTED merge for inherited fields: when a
- * child type re-declares a field it inherits, only metadata (`default`/`value`/
- * `description`/`granularity`) merges onto the parent's definition — the child's
- * raw STRUCTURAL keys (`options`/`multiple`/`required`/`source`) are IGNORED and
- * the parent's structure wins (see computeEffectiveFields in src/lib/schema.ts).
+ * The schema resolver applies an explicit-key merge for inherited fields: when a
+ * child type re-declares a field it inherits, omitted keys keep the inherited
+ * value, while declared keys (metadata or structural: `options`/`multiple`/
+ * `required`/`source`) override it (see computeEffectiveFields in
+ * src/lib/schema.ts).
  *
  * Because notes are written against the EFFECTIVE schema, field-changed ops must
  * be derived by comparing each concrete type's effective field definition old →
  * new, NOT its raw entry. Doing so is correct in both directions:
  *
- *   - A child that raw-overrides `options` on an INHERITED field changes nothing
- *     effectively (the resolver drops the override). Its effective field is
- *     unchanged old → new, so NO op is emitted — its valid note values survive
- *     (fixes the data-loss defect, #728 P1).
+ *   - A child that overrides `options` on an INHERITED field now has its own
+ *     effective value set. Editing that child override is a real effective field
+ *     change scoped to the child, so migration emits the same option-cleanup ops
+ *     it would for any other effective select field.
  *   - A parent field change flows into every concrete descendant that inherits it
- *     (including metadata-only-override children and children whose raw
- *     same-name structural override the resolver ignores). Each such descendant's
- *     effective field changes, so it receives its own op and its notes are
- *     cleaned under its exact type (fixes the missed-cleanup defect, #728 P2).
+ *     unchanged or only metadata-overrides it. A child with a structural override
+ *     is governed by its own effective field shape instead, so parent structural
+ *     changes do not force child cleanup when the child's effective field stays
+ *     unchanged.
  *
  * One detection is emitted per CONCRETE type, because `executeMigration` matches
  * ops to notes by the note's exact `expectedType`. The OLD effective definition

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -298,9 +298,11 @@ function computeAncestors(types: Map<string, ResolvedType>, typeName: string): s
  *     "own wins over traits" guarantee — own's `prompt`/`options`/`label`/etc.
  *     all win).
  *   - colliding field came from **inheritance** (parent chain, no trait
- *     involved) → keep the historical **restricted merge**: only
- *     `default`/`value`/`description`/`granularity` merge onto the inherited
- *     definition; structural keys stay inherited.
+ *     involved) → own fields **merge by explicit key** onto the inherited
+ *     definition. Omitted keys keep the inherited value, while declared keys
+ *     (metadata or structural: `options`, `multiple`, `required`, `source`,
+ *     etc.) override it. This lets a subtype narrow/fork an inherited field
+ *     without re-copying the whole parent definition.
  *   - no collision → it is simply a new field.
  *
  *   Note: when a trait already fully replaced a parent field, that field's
@@ -314,8 +316,8 @@ function computeEffectiveFields(
 ): Record<string, Field> {
   const fields: Record<string, Field> = {};
   // Track the origin of each accumulated field so own-field collisions can
-  // distinguish "came from a trait" (full override) from "came from
-  // inheritance" (restricted merge). Own fields never land here mid-loop.
+  // distinguish "came from a trait" (full replacement) from "came from
+  // inheritance" (explicit-key merge). Own fields never land here mid-loop.
   const origin = new Map<string, 'inherited' | 'trait'>();
 
   // Start from the root and work down (so child fields override)
@@ -354,27 +356,10 @@ function computeEffectiveFields(
       const existingOrigin = fields[fieldName] ? origin.get(fieldName) : undefined;
 
       if (existingOrigin === 'inherited') {
-        // Collision with an INHERITED field → historical restricted merge:
-        // only default/value/description/granularity merge; structural keys
-        // (prompt/options/label/...) stay inherited.
-        if (fieldDef.default !== undefined) {
-          fields[fieldName] = { ...fields[fieldName], default: fieldDef.default };
-        }
-        // Also allow 'value' override - this is needed for type identity fields
-        // where each type has its own fixed value (e.g., type: task vs type: objective)
-        if (fieldDef.value !== undefined) {
-          fields[fieldName] = { ...fields[fieldName], value: fieldDef.value };
-        }
-        // Allow 'description' override - a subtype can document an inherited
-        // field with meaning specific to its context.
-        if (fieldDef.description !== undefined) {
-          fields[fieldName] = { ...fields[fieldName], description: fieldDef.description };
-        }
-        // Allow 'granularity' override - a subtype can loosen or tighten the
-        // precision required for an inherited date field.
-        if (fieldDef.granularity !== undefined) {
-          fields[fieldName] = { ...fields[fieldName], granularity: fieldDef.granularity };
-        }
+        // Collision with an INHERITED field → explicit-key merge. A subtype can
+        // keep inherited keys by omitting them, and override metadata or
+        // structure by declaring those keys locally.
+        fields[fieldName] = { ...fields[fieldName], ...fieldDef };
       } else {
         // Collision with a TRAIT field (existingOrigin === 'trait') → own FULLY
         // replaces it. Also the no-collision case → new own field. Either way
@@ -1085,7 +1070,7 @@ export interface FieldsByOrigin {
  *
  * Attribution priority matches resolution precedence (own > trait > inherited):
  * a field declared on the type itself is always attributed to `own` (even when
- * it restricted-merged onto an inherited field), and the field OBJECT returned
+ * it explicit-key-merges onto an inherited field), and the field OBJECT returned
  * for every group is the resolved *winner's* definition from `type.fields`.
  *
  * @param schema The loaded schema

--- a/tests/ts/lib/migration/diff.test.ts
+++ b/tests/ts/lib/migration/diff.test.ts
@@ -130,11 +130,11 @@ describe("diffSchemas", () => {
 
   // Defect B (#728): the raw add-field loop must be derived against the OLD
   // EFFECTIVE (resolved) schema, like the changed/removed paths. A child type that
-  // STARTS raw-declaring a field name it already INHERITS — where the declaration
-  // only changes structural keys the resolver IGNORES — does NOT change the
-  // effective schema, so it must emit NO add-field op and NOT flip hasChanges. A
-  // genuinely new own field must still emit add-field.
-  describe("raw add-field of an already-inherited field (resolver-ignored redeclaration)", () => {
+  // STARTS raw-declaring a field name it already INHERITS does NOT gain a new
+  // field effectively, so it must emit NO add-field op. If that redeclaration
+  // changes the field's effective shape, it is classified as field-changed
+  // instead. A genuinely new own field must still emit add-field.
+  describe("raw add-field of an already-inherited field", () => {
     const inheritanceBase: BwrbSchemaType = {
       version: 2,
       schemaVersion: "1.0.0",
@@ -157,10 +157,9 @@ describe("diffSchemas", () => {
       },
     };
 
-    it("emits NO add-field and does not flip hasChanges when a child raw-redeclares an inherited field with only resolver-ignored keys", () => {
-      // task STARTS raw-declaring `phase` (which it already inherits), adding only
-      // structural keys (`options`) the resolver drops for an inherited field.
-      // objective.phase is unchanged → effective schema is identical → no migration.
+    it("emits NO add-field when a child structurally redeclares an inherited field", () => {
+      // task STARTS raw-declaring `phase` (which it already inherits), changing
+      // its effective option set. This is a field change, not a field addition.
       const newSchema: BwrbSchemaType = {
         ...inheritanceBase,
         schemaVersion: "1.1.0",
@@ -170,7 +169,6 @@ describe("diffSchemas", () => {
             extends: "objective",
             fields: {
               title: { prompt: "text" },
-              // Redeclaration of an inherited field; resolver ignores this override.
               phase: { prompt: "select", options: ["todo", "doing", "done"] },
             },
           },
@@ -183,7 +181,15 @@ describe("diffSchemas", () => {
       expect(allOps.some((op) => op.op === "add-field" && op.field === "phase")).toBe(
         false
       );
-      expect(plan.hasChanges).toBe(false);
+      expect(
+        plan.nonDeterministic.some(
+          (op) =>
+            op.op === "clear-invalid-options" &&
+            op.targetType === "task" &&
+            op.field === "phase"
+        )
+      ).toBe(true);
+      expect(plan.hasChanges).toBe(true);
     });
 
     it("still emits add-field for a genuinely new own field (not previously inherited or present)", () => {
@@ -1180,19 +1186,14 @@ describe("diffSchemas", () => {
   // comparing each type's RESOLVED field old → new (see detectEffectiveFieldChanges).
   //
   // IMPORTANT — resolver semantics (verified in computeEffectiveFields,
-  // src/lib/schema.ts): a child CANNOT structurally override an INHERITED field.
-  // Its raw `options`/`multiple`/`required`/`source` are DROPPED by the restricted
-  // merge; only metadata (default/value/description/granularity) merges. So a
-  // descendant's effective structure ALWAYS follows the declaring ancestor — and
-  // therefore EVERY inheriting descendant is affected by a parent field change,
-  // even one that raw-redeclares the field's options. (The migration diff matches
-  // this actual resolver behavior; whether the resolver SHOULD allow a child to
-  // fork an inherited field's structure is a separate design question — see the
-  // PR follow-up note.)
+  // src/lib/schema.ts): a child can structurally override an INHERITED field by
+  // declaring the keys it wants to fork. Descendants with no structural override
+  // follow the declaring ancestor; descendants with a structural override are
+  // governed by their own effective field shape.
   describe("field-changed inheritance (declaring type + inheriting descendants)", () => {
     // objective declares `phase` (a select); task extends objective and inherits
     // it; subtask extends task and re-declares `phase` with its own options —
-    // which the resolver IGNORES, so subtask's effective `phase` is objective's.
+    // so subtask's effective `phase` is forked from objective's.
     const inheritanceBase: BwrbSchemaType = {
       version: 2,
       schemaVersion: "1.0.0",
@@ -1214,9 +1215,6 @@ describe("diffSchemas", () => {
         subtask: {
           extends: "task",
           fields: {
-            // Raw override of the inherited `phase` — DROPPED by the resolver's
-            // restricted merge, so subtask still effectively inherits objective's
-            // options.
             phase: { prompt: "select", options: ["todo", "doing", "done"] },
           },
         },
@@ -1258,7 +1256,7 @@ describe("diffSchemas", () => {
       expect(targetedTypes).toContain("task");
     });
 
-    it("DOES target a descendant whose raw override of an inherited field the resolver ignores (#728 P2)", () => {
+    it("does not target a descendant with its own structural option fork", () => {
       const newSchema = withObjectivePhaseOptions(["planned", "active", "done"]);
 
       const plan = diffSchemas(inheritanceBase, newSchema, "1.0.0", "1.1.0");
@@ -1270,21 +1268,9 @@ describe("diffSchemas", () => {
         op.op === "clear-invalid-options" ? op.targetType : ""
       );
 
-      // subtask raw-redeclares `phase`, but the resolver DROPS that override for
-      // an inherited field — subtask's effective options ARE objective's, so its
-      // notes hold the now-orphaned "abandoned" and MUST be cleaned. The op's
-      // allowed set is the PARENT's new effective options, not subtask's ignored
-      // raw override.
-      expect(targetedTypes).toContain("subtask");
-      const subtaskOp = clearOps.find(
-        (op) => op.op === "clear-invalid-options" && op.targetType === "subtask"
-      );
-      expect(subtaskOp).toEqual({
-        op: "clear-invalid-options",
-        targetType: "subtask",
-        field: "phase",
-        allowedValues: ["planned", "active", "done"],
-      });
+      // subtask has its own effective options. Parent option removal does not
+      // change subtask's effective field, so subtask notes are not cleaned.
+      expect(targetedTypes).not.toContain("subtask");
     });
 
     it("fans out clear-invalid-options to inheriting descendants when a PARENT field gains its first options", () => {
@@ -1346,10 +1332,10 @@ describe("diffSchemas", () => {
       }
     });
 
-    it("propagates a multiple-widen to every inheriting descendant", () => {
-      // objective.phase multiple false → true. Every concrete descendant inherits
-      // objective's `multiple` effectively (raw overrides of inherited fields are
-      // dropped), so task AND subtask are both widened.
+    it("propagates a multiple-widen through descendants that do not override multiple", () => {
+      // objective.phase multiple false → true. Descendants without their own
+      // `multiple` override inherit the widening, even if they fork other keys
+      // such as `options`.
       const newSchema: BwrbSchemaType = {
         ...inheritanceBase,
         schemaVersion: "1.1.0",
@@ -1379,11 +1365,9 @@ describe("diffSchemas", () => {
       expect(widenTargets).toContain("subtask");
     });
 
-    it("widens a descendant even when it raw-overrides `multiple` (override is ignored for an inherited field)", () => {
-      // subtask raw-declares `multiple: false`, but that is an inherited field, so
-      // the resolver DROPS it — subtask still effectively inherits objective's
-      // `multiple` and IS widened. (Under the current resolver, a child cannot
-      // shield itself from a parent's structural change to an inherited field.)
+    it("does not widen a descendant that overrides multiple locally", () => {
+      // subtask declares `multiple: false`, so parent multiple false → true does
+      // not change subtask's effective field.
       const base: BwrbSchemaType = {
         ...inheritanceBase,
         types: {
@@ -1422,16 +1406,15 @@ describe("diffSchemas", () => {
 
       expect(widenTargets).toContain("objective");
       expect(widenTargets).toContain("task");
-      expect(widenTargets).toContain("subtask");
+      expect(widenTargets).not.toContain("subtask");
     });
 
-    // A child that re-declares the inherited field ONLY to override allowed
-    // METADATA (description/default/value/granularity) keeps the parent's
-    // structural options/multiple via the restricted merge, so its notes still
-    // inherit the parent's value set and MUST be cleaned on a parent option
-    // removal — identical in outcome to a child with no raw entry, because the
-    // resolver treats a metadata-only override and an ignored structural override
-    // the same effectively.
+    // A child that re-declares the inherited field ONLY to override metadata
+    // (description/default/value/granularity) keeps the parent's structural
+    // options/multiple, so its notes still inherit the parent's value set and
+    // MUST be cleaned on a parent option removal. A child that overrides
+    // structural keys gets its own effective field and is not swept along when
+    // the parent shape changes but the child shape does not.
     describe("metadata-only child override is still affected", () => {
       const metadataOverrideBase: BwrbSchemaType = {
         version: 2,
@@ -1448,8 +1431,8 @@ describe("diffSchemas", () => {
           task: {
             extends: "objective",
             fields: {
-              // Metadata-only override: keeps parent's options via restricted
-              // merge. Should STILL be affected by a parent option removal.
+              // Metadata-only override: keeps parent's options. Should STILL be
+              // affected by a parent option removal.
               phase: {
                 prompt: "select",
                 description: "task-specific phase wording",
@@ -1459,8 +1442,6 @@ describe("diffSchemas", () => {
           subtask: {
             extends: "task",
             fields: {
-              // Raw structural override — ALSO dropped by the resolver, so it is
-              // effectively governed by objective's options too.
               phase: { prompt: "select", options: ["todo", "doing", "done"] },
             },
           },
@@ -1496,11 +1477,11 @@ describe("diffSchemas", () => {
           .filter((op) => op.op === "clear-invalid-options" && op.field === "phase")
           .map((op) => (op.op === "clear-invalid-options" ? op.targetType : ""));
 
-        // Declaring type, the metadata-only-override child, AND the
-        // (resolver-ignored) structural-override grandchild are all cleaned.
+        // Declaring type and metadata-only child are cleaned; the structural
+        // override grandchild keeps its own effective option set.
         expect(targeted).toContain("objective");
         expect(targeted).toContain("task");
-        expect(targeted).toContain("subtask");
+        expect(targeted).not.toContain("subtask");
       });
 
       it("cleans a child that overrides ONLY a default", () => {
@@ -1541,7 +1522,7 @@ describe("diffSchemas", () => {
 
         expect(targeted).toContain("objective");
         expect(targeted).toContain("task");
-        expect(targeted).toContain("subtask");
+        expect(targeted).not.toContain("subtask");
       });
     });
   });
@@ -1672,16 +1653,14 @@ describe("diffSchemas", () => {
     });
   });
 
-  // P1 (#728, fourth review): field-changed ops are derived from the EFFECTIVE
-  // (resolved) schema, not raw field entries. A subtype that edits its OWN raw
-  // structural override of an INHERITED field changes NOTHING effectively — the
-  // resolver's restricted merge drops a child's structural keys for an inherited
-  // field (see computeEffectiveFields in src/lib/schema.ts). So no op may be
-  // emitted, and the child's valid note values must not be deleted.
-  describe("subtype raw-override of an inherited field is a no-op (effective unchanged)", () => {
+  // #731: field-changed ops are derived from the EFFECTIVE (resolved) schema,
+  // not raw field entries. A subtype that edits its own structural override of
+  // an INHERITED field now changes its effective schema, so migration should
+  // produce the same cleanup op it would for any other select narrowing.
+  describe("subtype structural override of an inherited field", () => {
     // objective declares `phase`; task extends objective and re-declares `phase`
-    // with its OWN options. Resolution IGNORES task's options (parent wins), so
-    // task's effective `phase` == objective's regardless of task's raw entry.
+    // with its OWN options. Resolution merges own keys over inherited keys, so
+    // task's effective `phase` uses task's options.
     const base: BwrbSchemaType = {
       version: 2,
       schemaVersion: "1.0.0",
@@ -1697,8 +1676,6 @@ describe("diffSchemas", () => {
         task: {
           extends: "objective",
           fields: {
-            // Raw structural override that the resolver DROPS for an inherited
-            // field. Editing these options must not produce a migration op.
             phase: {
               prompt: "select",
               options: ["todo", "doing", "done", "wontfix"],
@@ -1708,9 +1685,8 @@ describe("diffSchemas", () => {
       },
     };
 
-    it("emits NO op when a subtype edits its own raw options on an inherited field", () => {
-      // Parent's `phase` is UNCHANGED; only task's (ignored) raw override is
-      // narrowed. The effective schema is identical old → new.
+    it("emits clear-invalid-options when a subtype narrows its own inherited-field option fork", () => {
+      // Parent's `phase` is unchanged; task narrows its own effective option set.
       const newSchema: BwrbSchemaType = {
         ...base,
         schemaVersion: "1.1.0",
@@ -1719,7 +1695,7 @@ describe("diffSchemas", () => {
           task: {
             extends: "objective",
             fields: {
-              // "wontfix" removed from the IGNORED override — effectively a no-op.
+              // "wontfix" removed from task's effective override.
               phase: {
                 prompt: "select",
                 options: ["todo", "doing", "done"],
@@ -1732,29 +1708,21 @@ describe("diffSchemas", () => {
       const plan = diffSchemas(base, newSchema, "1.0.0", "1.1.0");
 
       const allOps = [...plan.deterministic, ...plan.nonDeterministic];
-      // No clear-invalid-options (or any op) for the ignored raw override.
-      expect(allOps.some((op) => op.op === "clear-invalid-options")).toBe(false);
-      expect(
-        allOps.filter(
-          (op) =>
-            (op.op === "clear-invalid-options" ||
-              op.op === "review-field" ||
-              op.op === "widen-field-to-multiple") &&
-            op.field === "phase"
-        )
-      ).toHaveLength(0);
-      // Effective schema is unchanged → nothing migration-relevant happened.
-      expect(plan.hasChanges).toBe(false);
-      expect(plan.schemaChanged).toBe(false);
+      expect(allOps).toContainEqual({
+        op: "clear-invalid-options",
+        targetType: "task",
+        field: "phase",
+        allowedValues: ["todo", "doing", "done"],
+      });
+      expect(plan.hasChanges).toBe(true);
+      expect(plan.schemaChanged).toBe(true);
     });
   });
 
-  // P2 (#728, fourth review): when a PARENT removes an option, a descendant that
-  // has a raw same-name entry the resolver IGNORES is STILL governed by the
-  // parent field (its effective options come from the parent), so its notes must
-  // be cleaned. This is the inverse of P1: same ignored raw override, but here
-  // the parent changed, so the descendant's EFFECTIVE field changed too.
-  describe("parent option removal cleans a descendant whose raw same-name override is ignored", () => {
+  // #731 inverse: when a PARENT removes an option, a descendant with its own
+  // structural fork is governed by that child effective field. The parent and
+  // pure inheritors are cleaned; the forked child is not.
+  describe("parent option removal does not clean a descendant with its own structural fork", () => {
     const base: BwrbSchemaType = {
       version: 2,
       schemaVersion: "1.0.0",
@@ -1770,16 +1738,14 @@ describe("diffSchemas", () => {
         task: {
           extends: "objective",
           fields: {
-            // Raw structural override DROPPED by the resolver for an inherited
-            // field → task's effective `phase` is objective's value set.
             phase: { prompt: "select", options: ["x", "y", "z"] },
           },
         },
       },
     };
 
-    it("targets the descendant even though it raw-redeclares the field's options", () => {
-      // Remove "abandoned" from objective.phase (the real, effective value set).
+    it("targets the parent but not the structurally forked descendant", () => {
+      // Remove "abandoned" from objective.phase.
       const newSchema: BwrbSchemaType = {
         ...base,
         schemaVersion: "1.1.0",
@@ -1802,20 +1768,9 @@ describe("diffSchemas", () => {
         .filter((op) => op.op === "clear-invalid-options" && op.field === "phase")
         .map((op) => (op.op === "clear-invalid-options" ? op.targetType : ""));
 
-      // objective changed; task inherits the effective value set → both cleaned.
+      // objective changed; task's effective option fork did not.
       expect(targeted).toContain("objective");
-      expect(targeted).toContain("task");
-      // The allowed set used for task is the PARENT's new effective options, not
-      // task's ignored raw override.
-      const taskOp = plan.nonDeterministic.find(
-        (op) => op.op === "clear-invalid-options" && op.targetType === "task"
-      );
-      expect(taskOp).toEqual({
-        op: "clear-invalid-options",
-        targetType: "task",
-        field: "phase",
-        allowedValues: ["planned", "active", "done"],
-      });
+      expect(targeted).not.toContain("task");
     });
   });
 

--- a/tests/ts/lib/migration/execute.test.ts
+++ b/tests/ts/lib/migration/execute.test.ts
@@ -837,16 +837,13 @@ parent: "[[Task Two]]"
     });
   });
 
-  // P1 (#728, fourth review) — data-loss guard. A subtype that edits its OWN raw
-  // structural override of an INHERITED field changes nothing EFFECTIVELY (the
-  // resolver drops the child's structural keys for an inherited field). The diff
-  // must emit NO op, so a valid child-note value survives migration. End-to-end:
-  // a stale heuristic here would emit clear-invalid-options from the IGNORED raw
-  // override and silently delete the note's value.
-  describe("subtype raw-override of inherited field does not delete child-note data (P1)", () => {
-    it("keeps a valid child-note value when only the subtype's ignored raw options change", async () => {
+  // #731 — subtype structural overrides are effective. A subtype that narrows
+  // its own inherited-field option fork must clean child notes against the
+  // child's effective option set, while keeping child values that remain valid.
+  describe("subtype structural override of inherited field cleans child-note data", () => {
+    it("clears invalid child-note values when the subtype narrows its own options", async () => {
       // objective declares `phase`; task re-declares it with its OWN options,
-      // which resolution IGNORES — task's effective `phase` == objective's.
+      // so task's effective `phase` uses task's forked option set.
       const oldSchema = {
         version: 2 as const,
         schemaVersion: "1.0.0",
@@ -866,8 +863,6 @@ parent: "[[Task Two]]"
             output_dir: "Tasks",
             fields: {
               name: { prompt: "text", required: true },
-              // Raw structural override DROPPED by the resolver. Editing these
-              // must not touch notes.
               phase: {
                 prompt: "select",
                 options: ["todo", "doing", "done", "wontfix"],
@@ -876,7 +871,8 @@ parent: "[[Task Two]]"
           },
         },
       };
-      // Parent UNCHANGED; only task's ignored raw override narrows (drop "wontfix").
+      // Parent unchanged; task's own effective option fork narrows (drop
+      // "wontfix").
       const newSchema = {
         ...oldSchema,
         schemaVersion: "1.1.0",
@@ -900,19 +896,25 @@ parent: "[[Task Two]]"
         JSON.stringify(newSchema)
       );
       await mkdir(join(testDir, "Tasks"), { recursive: true });
-      // A task note carrying a value valid under the EFFECTIVE (parent) options.
+      // One task note carrying the now-invalid child option, and one still valid.
       await writeFile(
         join(testDir, "Tasks/Task-1.md"),
-        `---\ntype: task\nname: Task One\nphase: abandoned\n---\n# Task One\n`
+        `---\ntype: task\nname: Task One\nphase: wontfix\n---\n# Task One\n`
+      );
+      await writeFile(
+        join(testDir, "Tasks/Task-2.md"),
+        `---\ntype: task\nname: Task Two\nphase: done\n---\n# Task Two\n`
       );
 
       const schema = await loadSchema(testDir);
       const plan = diffSchemas(oldSchema, newSchema, "1.0.0", "1.1.0");
 
-      // No op may be emitted: the effective schema did not change.
-      const allOps = [...plan.deterministic, ...plan.nonDeterministic];
-      expect(allOps.some((op) => op.op === "clear-invalid-options")).toBe(false);
-      expect(plan.hasChanges).toBe(false);
+      expect(plan.nonDeterministic).toContainEqual({
+        op: "clear-invalid-options",
+        targetType: "task",
+        field: "phase",
+        allowedValues: ["todo", "doing", "done"],
+      });
 
       const result = await executeMigration({
         vaultDir: testDir,
@@ -923,10 +925,12 @@ parent: "[[Task Two]]"
       });
 
       expect(result.errors).toHaveLength(0);
-      expect(result.affectedFiles).toBe(0);
-      const content = await readFile(join(testDir, "Tasks/Task-1.md"), "utf-8");
-      // The child note's value SURVIVES — no silent data loss.
-      expect(content).toContain("phase: abandoned");
+      expect(result.affectedFiles).toBe(1);
+      const task1 = await readFile(join(testDir, "Tasks/Task-1.md"), "utf-8");
+      expect(task1).not.toContain("wontfix");
+      expect(task1).not.toContain("phase:");
+      const task2 = await readFile(join(testDir, "Tasks/Task-2.md"), "utf-8");
+      expect(task2).toContain("phase: done");
     });
   });
 

--- a/tests/ts/lib/schema-traits.test.ts
+++ b/tests/ts/lib/schema-traits.test.ts
@@ -281,7 +281,7 @@ describe('schema traits', () => {
       expect(byOrigin.inheritedFields.get('base')).toBeUndefined();
     });
 
-    it('own-vs-parent (no trait) keeps the restricted merge', async () => {
+    it('own-vs-parent (no trait) lets own keys override inherited keys', async () => {
       const loaded = await loadFromSchema({
         version: 2,
         types: {
@@ -291,11 +291,17 @@ describe('schema traits', () => {
                 prompt: 'select',
                 label: 'from-parent',
                 options: ['parent-a', 'parent-b'],
+                required: true,
+                multiple: false,
+              },
+              owner: {
+                prompt: 'relation',
+                source: ['project', 'area'],
               },
             },
           },
-          // Own carries a structural key (options) AND restricted keys; only the
-          // restricted keys should merge — structural stays inherited.
+          // Own carries structural keys (options/label) plus metadata; explicit
+          // own keys merge onto the inherited field.
           task: {
             extends: 'base',
             fields: {
@@ -304,6 +310,11 @@ describe('schema traits', () => {
                 description: 'own-doc',
                 options: ['own-only'],
                 label: 'from-own',
+                required: false,
+                multiple: true,
+              },
+              owner: {
+                source: 'project',
               },
             },
           },
@@ -311,18 +322,24 @@ describe('schema traits', () => {
       });
 
       const status = getFieldsForType(loaded, 'task').status;
-      // Restricted keys merge from own...
+      // Explicit own keys merge from own...
       expect(status?.default).toBe('parent-a');
       expect(status?.description).toBe('own-doc');
-      // ...but structural keys (options/label/prompt) stay inherited.
-      expect(status?.options).toEqual(['parent-a', 'parent-b']);
-      expect(status?.label).toBe('from-parent');
+      expect(status?.options).toEqual(['own-only']);
+      expect(status?.label).toBe('from-own');
+      expect(status?.required).toBe(false);
+      expect(status?.multiple).toBe(true);
+      // ...while omitted keys stay inherited.
       expect(status?.prompt).toBe('select');
 
-      // Validation still uses the inherited options, not own's.
+      const owner = getFieldsForType(loaded, 'task').owner;
+      expect(owner?.prompt).toBe('relation');
+      expect(owner?.source).toBe('project');
+
+      // Validation uses the child's effective option fork.
       const allowed = getOptionsForField(loaded, 'task', 'status');
-      expect(allowed).toEqual(['parent-a', 'parent-b']);
-      expect(validateSelectOptionValue('own-only', allowed)).not.toBeNull();
+      expect(allowed).toEqual(['own-only']);
+      expect(validateSelectOptionValue('own-only', allowed)).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- Let subtype redeclarations override inherited field keys explicitly, including structural keys like options, multiple, required, and source
- Keep omitted keys inherited and preserve trait collision replacement behavior
- Update migration diff/execute coverage so inherited-field forks are cleaned according to each concrete type's effective schema

Closes #731.

## Validation
- pnpm test -- --exclude='**/*.pty.test.ts' (100 files, 2732 passed, 3 skipped)
- pnpm verify:pack
- pnpm typecheck (worker run)
- pnpm lint (worker run)
- pnpm knip (worker run)
- git diff --check
