### PR TITLE
chore(release): bwrb 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-01
+
+Patch release for the post-0.2.0 bugfix sweep.
+
+### Added
+
+- **Headless schema migrations** — `schema migrate --execute` now supports non-interactive execution with `--yes` and `--set-version`, including JSON output and per-note change reporting (#749).
+- **Relation validation coverage** — added coverage for alias targets, `source: any`, path-qualified references, and ambiguous relation refs (#761).
+
+### Fixed
+
+- **Vault path resolution** — global `-v` / `--vault` now honors `init`, completion requests, and relative paths resolved from the command cwd (#730, #735, #752, #754).
+- **Schema migration diffs** — migration planning now detects prompt and date-granularity changes, inherited field structural overrides, and relation-source widenings that are safe because descendants remain covered (#729, #731, #732).
+- **Hierarchy queries** — parent chains are keyed by path when available, preventing duplicate intermediate ancestor basenames from mis-resolving hierarchy walks (#738).
+- **Write/audit parity** — relation writes store clean wikilinks, required fields with defaults align with audit, and plain `prompt: 'list'` fields reject scalar writes (#742, #743, #746).
+- **Relation refs in edit** — `edit` accepts path-qualified wikilink relation references that `audit` already considered valid (#748).
+- **Unlinked mention noise** — fuzzy unlinked-mention audit skips common and structural headings, including composite and setext headings (#750, #759).
+- **Documented output aliases** — documented `-o` output aliases for schema commands now work as shown (#733, #756).
+- **Test output hygiene** — subprocess tests no longer leak Node DEP0205 deprecation warnings into assertions (#765).
+
 ## [0.2.0] - 2026-06-26
 
 Changes since `v0.1.9` — a large release (78 PRs). Headlines: schema **traits**, **hierarchical scope** (contexts as notes + `under()`), **fuzzy search**, the new **`recent`** command, **partial dates**, and a deep audit / migration / ownership hardening wave.

--- a/docs-site/src/content/docs/changelog.md
+++ b/docs-site/src/content/docs/changelog.md
@@ -9,6 +9,14 @@ For the complete changelog with all details, see [CHANGELOG.md](https://github.c
 
 ## Recent Highlights
 
+### 0.2.1
+
+- **Headless migration execution** — `schema migrate --execute` supports non-interactive `--yes` / `--set-version` workflows
+- **Migration diff fixes** — prompt and date-granularity edits, inherited field structural overrides, and safe relation-source widenings are classified correctly
+- **Vault path fixes** — global and relative vault paths now behave consistently across `init`, completion, and command cwd resolution
+- **Write/audit parity** — relation writes, required defaults, and plain list prompts now agree with audit validation
+- **Hierarchy and mention-noise fixes** — duplicate ancestor basenames no longer confuse hierarchy walks, and unlinked-mention audit skips structural headings
+
 ### 0.2.0
 
 - **Traits** — Reusable field bundles you compose into types, instead of repeating fields per type

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bwrb",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Schema-driven note management for markdown vaults",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump package version to 0.2.1
- add 0.2.1 release notes to CHANGELOG.md
- add 0.2.1 docs-site changelog highlights

## Local verification
- pnpm build
- pnpm verify:pack
- pnpm typecheck
- pnpm lint
- pnpm knip
- pnpm docs:lint
- pnpm docs:install
- pnpm docs:doctor
- node dist/index.js --version -> 0.2.1

After this PR merges, I will create GitHub release v0.2.1 for npm publishing.