### PR TITLE
docs: clarify template instance scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,18 @@ prompt-fields:
 | `defaults` | No | Default field values (skip prompting) |
 | `prompt-fields` | No | Fields to always prompt for, even with defaults |
 | `filename-pattern` | No | Override default filename |
+| `instances` | No | Related notes/tasks to scaffold with the parent |
+
+### Template Defaults and Dates
+
+Template defaults can use date expressions such as `@today+3d` or
+`today() + '7d'` for fields whose schema prompt is `date`. Those expressions are
+evaluated when the note is created and normalized to the schema's date format.
+Defaults on scaffolded `instances` use the same behavior, so child task fields
+like `scheduled` or `deadline` can be relative to the creation date.
+
+Non-date fields pass date-looking strings through literally. For example, a text
+field default of `@today+3d` is written as `@today+3d`, not evaluated.
 
 ### Template Body
 
@@ -292,6 +304,47 @@ The template body becomes the note body, with variable substitution:
 - `{fieldName}` - Replaced with frontmatter value
 - `{date}` - Today's date (YYYY-MM-DD)
 - `{date:FORMAT}` - Formatted date (e.g., `{date:YYYY-MM}`)
+
+### Instance Scaffolding
+
+Templates can define `instances` to create related notes when the parent is
+created. Instances may use any configured type, including the same type as the
+parent, so a `task` template can scaffold additional `task` notes.
+
+Each instance is filed into the child type's configured `output_dir`, not beside
+the parent unless both types use the same output directory. Existing instance
+files are skipped rather than overwritten.
+
+```yaml
+---
+type: template
+template-for: task
+description: Builder article production checklist
+defaults:
+  status: planned
+  scheduled: "@today+1d"
+  deadline: "@today+7d"
+instances:
+  - type: task
+    defaults:
+      name: "Outline article"
+      scheduled: "@today+1d"
+  - type: task
+    defaults:
+      name: "Draft article"
+      scheduled: "@today+3d"
+  - type: task
+    defaults:
+      name: "Review and publish article"
+      scheduled: "@today+5d"
+---
+```
+
+Instance `defaults` and explicit child `filename` values do not interpolate
+parent placeholders like `{name}`. Use literal child names/filenames, rely on
+the child type's own filename pattern, or generate article-specific child names
+with a wrapper script. Avoid braces in explicit child filenames unless you want
+the braces to be part of the actual filename.
 
 ### CLI Usage
 

--- a/docs-site/src/content/docs/reference/commands/new.md
+++ b/docs-site/src/content/docs/reference/commands/new.md
@@ -86,11 +86,18 @@ When a template defines instances, the CLI displays what files were created:
 ✓ Created: Projects/My Project.md
 
 Instances created:
-  ✓ Projects/Background Research.md
-  ✓ Projects/Competitor Analysis.md
+  ✓ Research/Background Research.md
+  ✓ Research/Competitor Analysis.md
 
 ✓ Created 3 files (1 parent + 2 instances)
 ```
+
+Instances are written to each child type's configured `output_dir`, not beside
+the parent unless the schema points both types at the same directory. Templates
+may scaffold same-type children, such as a `task` template that creates more
+`task` notes. Date expressions in instance defaults evaluate for date fields;
+non-date fields remain literal. Instance defaults and explicit instance
+filenames do not interpolate parent placeholders like `{name}`.
 
 ### Non-interactive (JSON) Mode
 
@@ -140,7 +147,7 @@ JSON output for templates with instances includes an `instances` object:
   "success": true,
   "path": "Projects/My Project.md",
   "instances": {
-    "created": ["Projects/Background Research.md", "Projects/Competitor Analysis.md"],
+    "created": ["Research/Background Research.md", "Research/Competitor Analysis.md"],
     "skipped": [],
     "errors": []
   }

--- a/docs-site/src/content/docs/templates/creating-templates.md
+++ b/docs-site/src/content/docs/templates/creating-templates.md
@@ -76,9 +76,11 @@ values at once. In `template edit`, a multi-value default offers `(keep)`,
 ### Dynamic Defaults (Date Expressions)
 
 Use date expressions for dynamic values that evaluate at note creation time. A
-default value is evaluated as a date expression **only when the entire value
-matches the date-expression grammar** — any other string (links, prose, option
-values, literal dates like `2026-01-07`) is written through unchanged. The
+default value is evaluated as a date expression **only for date fields**, and
+only when the entire value matches the date-expression grammar. Any other string
+(links, prose, option values, literal dates like `2026-01-07`) is written
+through unchanged. Non-date fields also pass date-looking prose through
+literally, so a text field default like `@today+3d` remains `@today+3d`. The
 evaluated date is then normalized to canonical `YYYY-MM-DD` on write (and a
 field's `granularity` is respected), so templated dates pass `bwrb audit`.
 
@@ -126,7 +128,8 @@ defaults:
 
 Date offsets shine with [instance scaffolding](#instance-scaffolding): a parent
 template can spawn several tasks at once, each with a deadline staggered from the
-day the parent is created.
+day the parent is created. Instance defaults use the same date-field evaluation
+as parent template defaults.
 
 ```yaml
 ---
@@ -320,7 +323,7 @@ instances:
 | Property | Required | Description |
 |----------|----------|-------------|
 | `type` | Yes | Type of note to create |
-| `filename` | No | Override filename (default: `{type}.md`) |
+| `filename` | No | Literal filename override (default comes from filename pattern, `title`, `name`, or `{type}.md`) |
 | `template` | No | Template to use for the instance |
 | `defaults` | No | Instance-specific default values |
 
@@ -329,18 +332,70 @@ instances:
 When you run `bwrb new project --template with-research`:
 
 1. The parent project note is created
-2. Each instance file is created in the same directory
-3. Existing instance files are **skipped** (not overwritten)
-4. A summary shows what was created
+2. Each instance file is created in that instance type's configured `output_dir`
+3. Instances may use the same type as the parent, so a `task` template can scaffold more `task` notes
+4. Existing instance files are **skipped** (not overwritten)
+5. A summary shows what was created
+
+Instance `defaults` are applied to the child note's own fields. Date expressions
+such as `@today+3d` or `today() + '7d'` evaluate for child date fields, including
+fields like `scheduled` and `deadline`; non-date fields keep date-looking strings
+literally.
+
+Instance `defaults` and explicit `filename` values do **not** interpolate parent
+placeholders such as `{name}`. For article-specific child task names, write the
+literal child names you want in the template, rely on the child type's own
+`filename` pattern, or wrap `bwrb new` in a script that generates the desired
+instance definitions. Avoid braces in explicit child filenames unless you want
+the braces to be part of the actual filename.
 
 ```
 ✓ Created: Projects/My Project.md
 
 Instances created:
-  ✓ Projects/Background Research.md
-  ✓ Projects/Competitor Analysis.md
+  ✓ Research/Background Research.md
+  ✓ Research/Competitor Analysis.md
 
 ✓ Created 3 files (1 parent + 2 instances)
+```
+
+### Same-Type Task Example
+
+A writing workflow can create a parent task plus predictable same-type task
+follow-ups. The child task notes are placed in the `task` type's `output_dir`,
+which may be the same directory as the parent or a separate task directory
+depending on your schema.
+
+```yaml
+---
+type: template
+template-for: task
+description: Builder article production checklist
+defaults:
+  status: planned
+  scheduled: "@today+1d"
+  deadline: "@today+7d"
+instances:
+  - type: task
+    defaults:
+      name: "Outline article"
+      status: planned
+      scheduled: "@today+1d"
+  - type: task
+    defaults:
+      name: "Draft article"
+      status: planned
+      scheduled: "@today+3d"
+  - type: task
+    defaults:
+      name: "Review and publish article"
+      status: planned
+      scheduled: "@today+5d"
+---
+
+## Brief
+
+## Notes
 ```
 
 ### Skipping Instance Creation

--- a/docs-site/src/content/docs/templates/overview.md
+++ b/docs-site/src/content/docs/templates/overview.md
@@ -106,6 +106,13 @@ bwrb template validate
 | **prompt-fields** | Always prompt for these fields, even with defaults |
 | **Date expressions** | Dynamic values like `@today+7d` (or `today() + '7d'`) |
 | **Body variables** | `{fieldName}`, `{date}` replaced at creation |
+| **instances** | Scaffold related notes, including same-type child tasks, into each child type's `output_dir` |
+
+Date expressions evaluate only for date fields in template defaults, including
+defaults on scaffolded instances. Non-date fields keep date-looking strings
+literally. Instance `defaults` and explicit instance `filename` values do not
+interpolate parent placeholders like `{name}`; use literal child values or a
+wrapper script for dynamically named child tasks.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- document template `instances` in the README and docs site
- clarify that instances are created in each child type output directory
- document date-expression behavior for parent and instance defaults
- call out that instance defaults and explicit filenames do not interpolate parent placeholders

## Local verification
- node scripts/docs-link-consistency.mjs
- node scripts/docs-doctor.mjs
- docs-site/node_modules/.bin/astro build --root docs-site
- npm pack --dry-run --json
- node dist/index.js --version -> 0.2.1

This should land before npm publish so the 0.2.1 package README matches main.