### PR TITLE
feat: mention-index exclusion config (mention_exclude_types / mention_exclude_paths)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Mention target exclusions** — `config.mention_exclude_types` and `config.mention_exclude_paths` keep imported/reference notes out of the unlinked-mention target, fuzzy suggestion, and frequent-term nudge pools while still scanning those notes as source documents.
+
 ### Fixed
 
 - **Unlinked mention noise** — single-word note names now require exact casing, common English single-word note names are skipped, explicit aliases remain case-insensitive, and fuzzy suggestions use a length-scaled edit-distance cap.

--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -106,6 +106,20 @@
           "minimum": 0,
           "maximum": 5,
           "description": "Max Levenshtein distance cap for the `unlinked-mention` audit fuzzy (\"did you mean?\") tier (#622). Integer 0-5; default 2. The effective distance is also length-scaled. 0 disables the fuzzy tier. Overridden per run by `--mention-fuzzy-threshold` / `--no-mention-fuzzy`."
+        },
+        "mention_exclude_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Type names to exclude as targets from the mention safety-net index. Notes whose resolved type is listed, or extends a listed type, are still scanned as source documents, but their names and aliases are not link targets, fuzzy suggestions, or frequent-unlinked-term nudges."
+        },
+        "mention_exclude_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Vault-relative glob patterns to exclude as targets from the mention safety-net index. Matching notes are still scanned as source documents, but their names and aliases are not link targets, fuzzy suggestions, or frequent-unlinked-term nudges."
         }
       },
       "additionalProperties": false

--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -287,6 +287,34 @@ bwrb audit --only unlinked-mention --no-mention-fuzzy
 
 The threshold affects **only** the fuzzy tier. Exact/alias auto-fix and ambiguous flagging are unchanged.
 
+#### Excluding mention targets
+
+Use config exclusions when whole classes of notes should not become
+`unlinked-mention` targets, such as imported books or contacts. Excluded notes
+are still audited as source documents — their bodies can still flag mentions of
+non-excluded entities. Exclusion only controls whether a note contributes its
+own name and aliases to the target index.
+
+- `mention_exclude_types`: type names to exclude. Descendant types are excluded
+  too, so excluding `reference` also excludes a `book` type that extends it.
+- `mention_exclude_paths`: vault-relative path globs to exclude with the same
+  path matching used by `--path`, such as `Imports/**` or `Books/`.
+
+Excluded names and aliases are also left out of fuzzy "did you mean?"
+suggestions. Their known surfaces suppress `frequent-unlinked-term` nudges, so
+bwrb will not suggest creating a new note for an excluded note that already
+exists.
+
+```json
+// .bwrb/schema.json — keep imported references out of mention targets
+{
+  "config": {
+    "mention_exclude_types": ["book", "contact"],
+    "mention_exclude_paths": ["Imports/**"]
+  }
+}
+```
+
 #### Resolving ambiguous mentions interactively (#622)
 
 When a surface matches more than one entity (for example `Mercury` resolving to both a `[[Mercury]]` note and a person aliased `Mercury`), bwrb never guesses. In an interactive `--fix` session (a real TTY), an ambiguous mention now prompts you to **pick a candidate** (or skip / quit):

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -106,6 +106,20 @@
           "minimum": 0,
           "maximum": 5,
           "description": "Max Levenshtein distance cap for the `unlinked-mention` audit fuzzy (\"did you mean?\") tier (#622). Integer 0-5; default 2. The effective distance is also length-scaled. 0 disables the fuzzy tier. Overridden per run by `--mention-fuzzy-threshold` / `--no-mention-fuzzy`."
+        },
+        "mention_exclude_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Type names to exclude as targets from the mention safety-net index. Notes whose resolved type is listed, or extends a listed type, are still scanned as source documents, but their names and aliases are not link targets, fuzzy suggestions, or frequent-unlinked-term nudges."
+        },
+        "mention_exclude_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Vault-relative glob patterns to exclude as targets from the mention safety-net index. Matching notes are still scanned as source documents, but their names and aliases are not link targets, fuzzy suggestions, or frequent-unlinked-term nudges."
         }
       },
       "additionalProperties": false

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -14,13 +14,13 @@ import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import chalk from 'chalk';
 
-import { loadCurrentSchema, detectObsidianVault } from '../lib/schema.js';
+import { loadCurrentSchema, detectObsidianVault, resolveSchema } from '../lib/schema.js';
 import { SCHEMA_RELATIVE_PATH } from '../lib/bwrb-paths.js';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { configurePromptMode, promptInput, promptSelection } from '../lib/prompt.js';
 import { getGlobalOpts } from '../lib/command.js';
 import { ExitCodes } from '../lib/output.js';
-import type { Config } from '../types/schema.js';
+import { BwrbSchema, type Config } from '../types/schema.js';
 import { UserCancelledError } from '../lib/errors.js';
 
 // Config option metadata
@@ -233,7 +233,7 @@ configCommand
         const storedValue = normalizeConfigValue(meta.key, value);
 
         config[option] = storedValue;
-        await writeFile(schemaPath, JSON.stringify(schema, null, 2) + '\n');
+        await writeValidatedSchema(schemaPath, schema);
 
         if (jsonMode) {
           console.log(JSON.stringify({ success: true, data: { key: option, value: storedValue } }));
@@ -256,7 +256,7 @@ configCommand
             } else {
               config[option] = result.value;
             }
-            await writeFile(schemaPath, JSON.stringify(schema, null, 2) + '\n');
+            await writeValidatedSchema(schemaPath, schema);
 
             const outputValue = result.action === 'clear' ? null : result.value;
 
@@ -284,7 +284,7 @@ configCommand
               } else {
                 config[selected] = result.value;
               }
-              await writeFile(schemaPath, JSON.stringify(schema, null, 2) + '\n');
+              await writeValidatedSchema(schemaPath, schema);
 
               const outputValue = result.action === 'clear' ? null : result.value;
 
@@ -421,6 +421,15 @@ function validateConfigValue(meta: ConfigOptionMeta, value: unknown): void {
       throw new Error(`${String(meta.key)} must be a JSON array of strings`);
     }
   }
+}
+
+async function writeValidatedSchema(
+  schemaPath: string,
+  schema: Record<string, unknown>
+): Promise<void> {
+  const parsed = BwrbSchema.parse(schema);
+  resolveSchema(parsed);
+  await writeFile(schemaPath, JSON.stringify(schema, null, 2) + '\n');
 }
 
 /**

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -77,6 +77,18 @@ const CONFIG_OPTIONS: ConfigOptionMeta[] = [
     description: 'Directory prefixes to exclude from discovery/targeting (applies to all commands)',
     default: [],
   },
+  {
+    key: 'mention_exclude_types',
+    label: 'Mention Exclude Types',
+    description: 'Type names to exclude as targets from unlinked-mention and frequent-term audit suggestions',
+    default: [],
+  },
+  {
+    key: 'mention_exclude_paths',
+    label: 'Mention Exclude Paths',
+    description: 'Vault-relative path globs to exclude as targets from unlinked-mention and frequent-term audit suggestions',
+    default: [],
+  },
 ];
 
 export const configCommand = new Command('config')
@@ -218,9 +230,7 @@ configCommand
         
         validateConfigValue(meta, value);
         
-        const storedValue = option === 'excluded_directories'
-          ? normalizeExcludedDirectoriesValue(value)
-          : value;
+        const storedValue = normalizeConfigValue(meta.key, value);
 
         config[option] = storedValue;
         await writeFile(schemaPath, JSON.stringify(schema, null, 2) + '\n');
@@ -338,6 +348,8 @@ function getConfigValue(config: Partial<Config>, key: keyof Config, vaultDir: st
     case 'default_dashboard':
       return undefined; // No auto-detection for default_dashboard
     case 'excluded_directories':
+    case 'mention_exclude_types':
+    case 'mention_exclude_paths':
       return [];
     default:
       return undefined;
@@ -369,6 +381,29 @@ function normalizeExcludedDirectoriesValue(value: unknown): string[] {
   return Array.from(new Set(normalized));
 }
 
+function normalizeStringArrayValue(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+
+  const normalized = value
+    .filter((v): v is string => typeof v === 'string')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  return Array.from(new Set(normalized));
+}
+
+function normalizeConfigValue(key: keyof Config, value: unknown): unknown {
+  if (key === 'excluded_directories') {
+    return normalizeExcludedDirectoriesValue(value);
+  }
+
+  if (key === 'mention_exclude_types' || key === 'mention_exclude_paths') {
+    return normalizeStringArrayValue(value);
+  }
+
+  return value;
+}
+
 function validateConfigValue(meta: ConfigOptionMeta, value: unknown): void {
   if (meta.options) {
     if (!meta.options.includes(String(value))) {
@@ -377,9 +412,13 @@ function validateConfigValue(meta: ConfigOptionMeta, value: unknown): void {
     return;
   }
 
-  if (meta.key === 'excluded_directories') {
+  if (
+    meta.key === 'excluded_directories' ||
+    meta.key === 'mention_exclude_types' ||
+    meta.key === 'mention_exclude_paths'
+  ) {
     if (!Array.isArray(value) || !value.every(v => typeof v === 'string')) {
-      throw new Error('excluded_directories must be a JSON array of strings');
+      throw new Error(`${String(meta.key)} must be a JSON array of strings`);
     }
   }
 }
@@ -390,6 +429,10 @@ function validateConfigValue(meta: ConfigOptionMeta, value: unknown): void {
 async function promptConfigOption(meta: ConfigOptionMeta, currentValue: unknown): Promise<ConfigEditResult> {
   if (meta.key === 'excluded_directories') {
     return promptExcludedDirectories(currentValue);
+  }
+
+  if (meta.key === 'mention_exclude_types' || meta.key === 'mention_exclude_paths') {
+    return promptStringArray(meta, currentValue);
   }
 
   if (meta.options) {
@@ -419,6 +462,58 @@ async function promptConfigOption(meta: ConfigOptionMeta, currentValue: unknown)
   if (entered === null) return { action: 'keep' };
 
   return { action: 'set', value: entered };
+}
+
+async function promptStringArray(
+  meta: ConfigOptionMeta,
+  currentValue: unknown
+): Promise<ConfigEditResult> {
+  const current = normalizeStringArrayValue(currentValue);
+  let entries = [...current];
+
+  while (true) {
+    const display = entries.length > 0 ? entries.join(', ') : '(none)';
+
+    const choice = await promptSelection(
+      `${meta.label} (current: ${display}):`,
+      ['(keep current)', '(clear)', '(add)', '(remove)', '(done)']
+    );
+
+    if (choice === null || choice === '(keep current)') {
+      return { action: 'keep' };
+    }
+
+    if (choice === '(clear)') {
+      return { action: 'clear' };
+    }
+
+    if (choice === '(done)') {
+      return { action: 'set', value: entries };
+    }
+
+    if (choice === '(add)') {
+      const entered = await promptInput(`Add ${meta.key} entries (comma-separated):`);
+      if (entered === null) continue;
+
+      const toAdd = entered
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+
+      entries = Array.from(new Set([...entries, ...toAdd]));
+      continue;
+    }
+
+    if (choice === '(remove)') {
+      if (entries.length === 0) continue;
+
+      const toRemove = await promptSelection(`Remove which ${meta.key} entry?`, [...entries, '(back)']);
+      if (toRemove === null || toRemove === '(back)') continue;
+
+      entries = entries.filter(e => e !== toRemove);
+      continue;
+    }
+  }
 }
 
 async function promptExcludedDirectories(currentValue: unknown): Promise<ConfigEditResult> {

--- a/src/lib/audit/frequent-unlinked-term.ts
+++ b/src/lib/audit/frequent-unlinked-term.ts
@@ -42,7 +42,9 @@
  *  - A candidate whose lowercased text equals an existing note name OR a
  *    registered alias is dropped — that is `unlinked-mention`'s job, not ours.
  *    We reuse #600's {@link EntityMentionIndex.bySurface} as the known-surface
- *    set so the two detections never overlap.
+ *    set so the two detections never overlap. Config-excluded mention targets
+ *    are also suppressed via {@link EntityMentionIndex.excludedSurfaces}: they
+ *    are not linkable targets, but bwrb still knows those notes exist.
  *  - Terms that are already wikilinked everywhere never reach us: masking blanks
  *    `[[...]]`, so only *prose* occurrences are ever counted. A term that is
  *    always linked has zero prose mentions and cannot meet the threshold.
@@ -309,8 +311,9 @@ export class FrequentTermAccumulator {
   private isEligible(normalized: string, atSentenceStart: boolean): boolean {
     const lower = normalized.toLowerCase();
 
-    // Exclude anything that already has a note or registered alias (#600 owns it).
-    if (this.index.bySurface.has(lower)) return false;
+    // Exclude anything that already has a note or registered alias (#600 owns
+    // it), plus known surfaces that config excluded as mention targets.
+    if (this.index.bySurface.has(lower) || this.index.excludedSurfaces.has(lower)) return false;
 
     const words = normalized.split(' ');
     if (words.length === 1) {

--- a/src/lib/audit/unlinked-mention.ts
+++ b/src/lib/audit/unlinked-mention.ts
@@ -246,11 +246,12 @@ export function buildEntityMentionIndex(
 
   for (const note of snapshot.notes) {
     const name = basename(note.relativePath, '.md');
+    const mentionTargetType = getMentionTargetType(note);
 
     if (isExcludedMentionTarget(note, schema)) {
       if (name) registerExcludedSurface(name);
-      if (note.resolvedType && note.frontmatter) {
-        const aliases = getEntityAliases(schema, note.resolvedType, note.frontmatter);
+      if (mentionTargetType && note.frontmatter) {
+        const aliases = getEntityAliases(schema, mentionTargetType, note.frontmatter);
         for (const alias of aliases) {
           registerExcludedSurface(alias);
         }
@@ -303,15 +304,20 @@ function isExcludedMentionTarget(
     return true;
   }
 
-  if (!note.resolvedType || schema.config.mentionExcludeTypes.length === 0) {
+  const mentionTargetType = getMentionTargetType(note);
+  if (!mentionTargetType || schema.config.mentionExcludeTypes.length === 0) {
     return false;
   }
 
-  const resolvedType = schema.types.get(note.resolvedType);
+  const resolvedType = schema.types.get(mentionTargetType);
   if (!resolvedType) return false;
 
   const excludedTypes = new Set(schema.config.mentionExcludeTypes);
   return excludedTypes.has(resolvedType.name) || resolvedType.ancestors.some((ancestor) => excludedTypes.has(ancestor));
+}
+
+function getMentionTargetType(note: VaultNoteSnapshot['notes'][number]): string | undefined {
+  return note.resolvedType ?? note.directoryType;
 }
 
 // ============================================================================

--- a/src/lib/audit/unlinked-mention.ts
+++ b/src/lib/audit/unlinked-mention.ts
@@ -38,6 +38,7 @@
 import { basename } from 'path';
 import type { LoadedSchema } from '../../types/schema.js';
 import type { VaultNoteSnapshot } from '../discovery.js';
+import { matchesPathPattern } from '../discovery.js';
 import { getEntityAliases } from '../schema.js';
 import { levenshteinDistance } from '../levenshtein.js';
 import type { AuditIssue } from './types.js';
@@ -175,6 +176,12 @@ export interface EntityMentionIndex {
   /** All distinct entity names (for the fuzzy "did you mean?" tier). */
   allNames: string[];
   /**
+   * Known-but-excluded surfaces that must not be link targets or fuzzy
+   * suggestions, but should still suppress `frequent-unlinked-term` "create a
+   * note" nudges.
+   */
+  excludedSurfaces: Set<string>;
+  /**
    * Combined word-boundary alternation regex over all known surfaces, or null
    * when the vault exposes no surfaces. Created fresh per scan by the caller via
    * {@link matchSurfaces} (regex carries `lastIndex` state, so it is not reused).
@@ -202,6 +209,7 @@ export function buildEntityMentionIndex(
 ): EntityMentionIndex {
   const bySurface = new Map<string, EntitySurface[]>();
   const allNames: string[] = [];
+  const excludedSurfaces = new Set<string>();
   const exactMatchSurfaceSet = new Set<string>();
 
   const register = (surface: EntitySurface): void => {
@@ -230,8 +238,26 @@ export function buildEntityMentionIndex(
     }
   };
 
+  const registerExcludedSurface = (surface: string): void => {
+    const trimmed = surface.trim();
+    if (trimmed.length < MIN_SURFACE_LENGTH) return;
+    excludedSurfaces.add(trimmed.toLowerCase());
+  };
+
   for (const note of snapshot.notes) {
     const name = basename(note.relativePath, '.md');
+
+    if (isExcludedMentionTarget(note, schema)) {
+      if (name) registerExcludedSurface(name);
+      if (note.resolvedType && note.frontmatter) {
+        const aliases = getEntityAliases(schema, note.resolvedType, note.frontmatter);
+        for (const alias of aliases) {
+          registerExcludedSurface(alias);
+        }
+      }
+      continue;
+    }
+
     if (name) {
       const nameSurface: EntitySurface = {
         surface: name,
@@ -266,7 +292,26 @@ export function buildEntityMentionIndex(
       ? surfaces.map((s) => escapeRegExp(s)).join('|')
       : null;
 
-  return { bySurface, allNames, surfacePattern };
+  return { bySurface, allNames, excludedSurfaces, surfacePattern };
+}
+
+function isExcludedMentionTarget(
+  note: VaultNoteSnapshot['notes'][number],
+  schema: LoadedSchema
+): boolean {
+  if (schema.config.mentionExcludePaths.some((pattern) => matchesPathPattern(note.relativePath, pattern))) {
+    return true;
+  }
+
+  if (!note.resolvedType || schema.config.mentionExcludeTypes.length === 0) {
+    return false;
+  }
+
+  const resolvedType = schema.types.get(note.resolvedType);
+  if (!resolvedType) return false;
+
+  const excludedTypes = new Set(schema.config.mentionExcludeTypes);
+  return excludedTypes.has(resolvedType.name) || resolvedType.ancestors.some((ancestor) => excludedTypes.has(ancestor));
 }
 
 // ============================================================================

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -57,6 +57,12 @@ export interface VaultNoteSnapshotEntry {
   path: string;
   relativePath: string;
   frontmatter?: Record<string, unknown>;
+  /**
+   * Type inferred from schema directory ownership. This is intentionally
+   * separate from resolvedType, which remains frontmatter-only for validation
+   * indexes that must not bless typeless notes as typed relation targets.
+   */
+  directoryType?: string;
   resolvedType?: string;
 }
 
@@ -418,6 +424,7 @@ export async function buildVaultNoteSnapshot(
     const entry: VaultNoteSnapshotEntry = {
       path: file.path,
       relativePath: file.relativePath,
+      ...(file.expectedType ? { directoryType: file.expectedType } : {}),
     };
 
     try {
@@ -427,10 +434,8 @@ export async function buildVaultNoteSnapshot(
       const { frontmatter } = await parseNote(file.path);
       entry.frontmatter = frontmatter;
       const resolvedType = resolveTypeFromFrontmatter(schema, frontmatter);
-      const fallbackType = file.expectedType;
-      const snapshotType = resolvedType ?? fallbackType;
-      if (snapshotType) {
-        entry.resolvedType = snapshotType;
+      if (resolvedType) {
+        entry.resolvedType = resolvedType;
       }
     } catch {
       // Skip parse metadata for files that can't be parsed.

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -721,6 +721,17 @@ export function filterByPath(
   files: ManagedFile[],
   pathPattern: string
 ): ManagedFile[] {
+  const pattern = normalizePathPattern(pathPattern);
+
+  return files.filter(file => matchesPathPattern(file.relativePath, pattern));
+}
+
+/**
+ * Normalize directory-like path patterns to the glob form used by vault path
+ * filters. Exported so config-driven path filters can share the exact same
+ * matching semantics as `--path`.
+ */
+export function normalizePathPattern(pathPattern: string): string {
   let pattern = pathPattern;
 
   // Normalize directory-like patterns to match .md files
@@ -737,12 +748,17 @@ export function filterByPath(
     pattern = pattern + '/**/*.md';
   }
 
-  return files.filter(file => {
-    // Match against relative path
-    return minimatch(file.relativePath, pattern, {
-      matchBase: true,
-      nocase: true,
-    });
+  return pattern;
+}
+
+/**
+ * Match a vault-relative path against a path pattern normalized by
+ * {@link normalizePathPattern}, or a raw pattern accepted by `--path`.
+ */
+export function matchesPathPattern(relativePath: string, pathPattern: string): boolean {
+  return minimatch(relativePath, normalizePathPattern(pathPattern), {
+    matchBase: true,
+    nocase: true,
   });
 }
 
@@ -1251,4 +1267,3 @@ export function findSimilarFiles(target: string, allFiles: Set<string>, maxResul
   results.sort((a, b) => b.score - a.score || a.file.localeCompare(b.file));
   return results.slice(0, maxResults).map(r => r.file);
 }
-

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -7,6 +7,7 @@
 
 import ignore, { type Ignore } from 'ignore';
 import { minimatch } from 'minimatch';
+import { parseDocument } from 'yaml';
 import { readdir, readFile, realpath } from 'fs/promises';
 import { join, basename, relative } from 'path';
 import { existsSync } from 'fs';
@@ -409,9 +410,7 @@ export async function buildVaultNoteSnapshot(
   schema: LoadedSchema,
   vaultDir: string
 ): Promise<VaultNoteSnapshot> {
-  const excluded = getExcludedDirectories(schema);
-  const ignoreMatcher = await loadIgnoreMatcher(vaultDir, excluded);
-  const allFiles = await collectAllMarkdownFiles(vaultDir, vaultDir, excluded, ignoreMatcher);
+  const allFiles = await discoverFilesForQueryResolution(schema, vaultDir);
 
   const notes: VaultNoteSnapshotEntry[] = [];
 
@@ -422,11 +421,16 @@ export async function buildVaultNoteSnapshot(
     };
 
     try {
+      if (await hasMalformedTopFrontmatter(file.path)) {
+        throw new Error('Malformed frontmatter');
+      }
       const { frontmatter } = await parseNote(file.path);
       entry.frontmatter = frontmatter;
       const resolvedType = resolveTypeFromFrontmatter(schema, frontmatter);
-      if (resolvedType) {
-        entry.resolvedType = resolvedType;
+      const fallbackType = file.expectedType;
+      const snapshotType = resolvedType ?? fallbackType;
+      if (snapshotType) {
+        entry.resolvedType = snapshotType;
       }
     } catch {
       // Skip parse metadata for files that can't be parsed.
@@ -436,6 +440,15 @@ export async function buildVaultNoteSnapshot(
   }
 
   return { notes };
+}
+
+async function hasMalformedTopFrontmatter(filePath: string): Promise<boolean> {
+  const raw = await readFile(filePath, 'utf-8');
+  const match = raw.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/);
+  if (!match) return false;
+
+  const doc = parseDocument(match[1]!);
+  return doc.errors.length > 0;
 }
 
 /**

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -143,6 +143,8 @@ export function resolveSchema(schema: Schema): LoadedSchema {
     type.fields = computeEffectiveFields(types, type, traits);
     type.fieldOrder = computeFieldOrder(types, type, traits);
   }
+
+  validateMentionExcludeTypes(types, schema.config?.mention_exclude_types);
   
   // Fourth pass: add implied parent field for recursive types
   for (const type of types.values()) {
@@ -175,7 +177,7 @@ export function resolveSchema(schema: Schema): LoadedSchema {
   const ownership = buildOwnershipMap(types);
   
   // Sixth pass: resolve configuration with defaults
-  const config = resolveConfig(schema.config);
+  const config = resolveConfig(schema.config, types);
   
   return { raw: schema, types, ownership, config };
 }
@@ -260,6 +262,49 @@ function validateTraits(
         );
       }
     }
+  }
+}
+
+function resolveConfiguredTypeName(
+  types: Map<string, ResolvedType>,
+  typeName: string
+): string | undefined {
+  const direct = types.get(typeName);
+  if (direct) return direct.name;
+
+  // Match the public type lookup behavior for legacy slash notation, e.g.
+  // "objective/task" resolving to the "task" type when its ancestors include
+  // "objective".
+  if (typeName.includes('/')) {
+    const segments = typeName.split('/');
+    const leafName = segments[segments.length - 1]!;
+    const resolved = types.get(leafName);
+    if (resolved) {
+      const ancestors = new Set(resolved.ancestors);
+      const parentSegments = segments.slice(0, -1);
+      if (parentSegments.every(seg => ancestors.has(seg))) return resolved.name;
+    }
+  }
+
+  return undefined;
+}
+
+function validateMentionExcludeTypes(
+  types: Map<string, ResolvedType>,
+  excludeTypes: string[] | undefined
+): void {
+  if (!excludeTypes) return;
+
+  for (const typeName of excludeTypes) {
+    if (resolveConfiguredTypeName(types, typeName)) continue;
+
+    const available = Array.from(types.keys()).join(', ');
+    const suggestion = closeMatchValues(typeName, Array.from(types.keys()), { maxDistance: 3 })[0];
+    throw new Error(
+      `config.mention_exclude_types includes unknown type "${typeName}". ` +
+      `Available types: ${available}` +
+      (suggestion ? `. Did you mean "${suggestion}"?` : '')
+    );
   }
 }
 
@@ -501,7 +546,10 @@ function buildOwnershipMap(types: Map<string, ResolvedType>): OwnershipMap {
  * Resolve configuration with defaults.
  * Falls back to environment variables and sensible defaults.
  */
-function resolveConfig(config: Schema['config']): ResolvedConfig {
+function resolveConfig(
+  config: Schema['config'],
+  types: Map<string, ResolvedType>
+): ResolvedConfig {
   return {
     linkFormat: config?.link_format ?? 'wikilink',
     editor: config?.editor ?? process.env.EDITOR,
@@ -514,6 +562,14 @@ function resolveConfig(config: Schema['config']): ResolvedConfig {
     // Default mirrors DEFAULT_FUZZY_MAX_DISTANCE in audit/unlinked-mention.ts.
     // Inlined to avoid importing the audit module into the schema loader (#622).
     mentionFuzzyThreshold: config?.mention_fuzzy_threshold ?? 2,
+    mentionExcludeTypes: Array.from(
+      new Set(
+        (config?.mention_exclude_types ?? [])
+          .map((typeName) => resolveConfiguredTypeName(types, typeName))
+          .filter((typeName): typeName is string => Boolean(typeName))
+      )
+    ),
+    mentionExcludePaths: config?.mention_exclude_paths ?? [],
   };
 }
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -432,6 +432,26 @@ export const ConfigSchema = z.object({
     .describe(
       'Max Levenshtein distance cap for the `unlinked-mention` audit fuzzy ("did you mean?") tier (#622). Integer 0-5; default 2. The effective distance is also length-scaled. 0 disables the fuzzy tier. Overridden per run by `--mention-fuzzy-threshold` / `--no-mention-fuzzy`.'
     ),
+  // Type names to exclude as targets from the mention safety-net index. Notes
+  // whose resolved type is listed, or extends a listed type, are still scanned
+  // as source documents, but their names and aliases are not link targets,
+  // fuzzy suggestions, or frequent-unlinked-term nudges.
+  mention_exclude_types: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Type names to exclude as targets from the mention safety-net index. Notes whose resolved type is listed, or extends a listed type, are still scanned as source documents, but their names and aliases are not link targets, fuzzy suggestions, or frequent-unlinked-term nudges.'
+    ),
+  // Vault-relative glob patterns to exclude as targets from the mention
+  // safety-net index. Matching notes are still scanned as source documents, but
+  // their names and aliases are not link targets, fuzzy suggestions, or
+  // frequent-unlinked-term nudges.
+  mention_exclude_paths: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Vault-relative glob patterns to exclude as targets from the mention safety-net index. Matching notes are still scanned as source documents, but their names and aliases are not link targets, fuzzy suggestions, or frequent-unlinked-term nudges.'
+    ),
 });
 
 // ============================================================================
@@ -599,6 +619,15 @@ export interface ResolvedConfig {
    * this; candidate length also caps the effective distance.
    */
   mentionFuzzyThreshold: number;
+  /**
+   * Canonical type names excluded as mention targets. Descendants of these
+   * types are excluded by the mention index builder.
+   */
+  mentionExcludeTypes: string[];
+  /**
+   * Vault-relative path globs excluded as mention targets.
+   */
+  mentionExcludePaths: string[];
 }
 
 /**

--- a/tests/ts/commands/config.test.ts
+++ b/tests/ts/commands/config.test.ts
@@ -203,6 +203,30 @@ describe('config command', () => {
       expect(json.data.value).toEqual(['Archive', 'Templates']);
     });
 
+    it('should reject unknown mention_exclude_types without writing', async () => {
+      const before = await readFile(join(tempVaultDir, '.bwrb', 'schema.json'), 'utf-8');
+      const result = await runCLI(
+        [
+          'config',
+          'edit',
+          'mention_exclude_types',
+          '--json',
+          '["zzz-not-a-type"]',
+          '--output',
+          'json',
+        ],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('config.mention_exclude_types includes unknown type "zzz-not-a-type"');
+
+      const after = await readFile(join(tempVaultDir, '.bwrb', 'schema.json'), 'utf-8');
+      expect(after).toBe(before);
+    });
+
     it('should reject invalid enum value', async () => {
       const result = await runCLI(
         ['config', 'edit', 'link_format', '--json', '"invalid"'],

--- a/tests/ts/lib/audit-frequent-unlinked-term.test.ts
+++ b/tests/ts/lib/audit-frequent-unlinked-term.test.ts
@@ -52,6 +52,23 @@ function indexFor(
   );
 }
 
+function indexForSchema(
+  loadedSchema: ReturnType<typeof resolveSchema>,
+  notes: Array<{ relativePath: string; frontmatter?: Record<string, unknown>; resolvedType?: string }>
+) {
+  return buildEntityMentionIndex(
+    {
+      notes: notes.map((n) => ({
+        path: n.relativePath,
+        relativePath: n.relativePath,
+        ...(n.frontmatter ? { frontmatter: n.frontmatter } : {}),
+        ...(n.resolvedType ? { resolvedType: n.resolvedType } : {}),
+      })),
+    },
+    loadedSchema
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Candidate extraction (unit)
 // ---------------------------------------------------------------------------
@@ -164,6 +181,37 @@ describe('frequent-unlinked-term: FrequentTermAccumulator', () => {
     const acc = new FrequentTermAccumulator(index, { minMentions: 2, minNotes: 1 });
     acc.addBody('Stevey said this. Stevey said that.', 'a.md');
     expect(acc.finish().find((i) => i.value?.toString().toLowerCase() === 'stevey')).toBeUndefined();
+  });
+
+  it('suppresses terms that match config-excluded mention targets', () => {
+    const loadedSchema = resolveSchema({
+      ...SCHEMA,
+      config: { mention_exclude_types: ['book'] },
+      types: {
+        ...SCHEMA.types,
+        book: {
+          extends: 'meta',
+          output_dir: 'Books',
+          fields: {
+            type: { value: 'book' },
+            aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
+          },
+        },
+      },
+    });
+    const index = indexForSchema(loadedSchema, [
+      {
+        relativePath: 'Books/Rust Foundation.md',
+        resolvedType: 'book',
+        frontmatter: { type: 'book', aliases: ['Rust Org'] },
+      },
+    ]);
+
+    const acc = new FrequentTermAccumulator(index, { minMentions: 2, minNotes: 1 });
+    acc.addBody('Rust Foundation appears here. Rust Foundation appears again. Rust Org too. Rust Org twice.', 'a.md');
+    const issues = acc.finish();
+    expect(issues.find((i) => i.value === 'Rust Foundation')).toBeUndefined();
+    expect(issues.find((i) => i.value === 'Rust Org')).toBeUndefined();
   });
 
   it('does not count text inside code/links/wikilinks (reuses #600 masking)', () => {

--- a/tests/ts/lib/audit-unlinked-mention.test.ts
+++ b/tests/ts/lib/audit-unlinked-mention.test.ts
@@ -605,7 +605,10 @@ describe('unlinked-mention: mention target exclusions', () => {
       const loadedSchema = await loadSchema(vaultDir);
       const snapshot = await buildVaultNoteSnapshot(loadedSchema, vaultDir);
       const index = buildEntityMentionIndex(snapshot, loadedSchema);
+      const typelessNote = snapshot.notes.find((note) => note.relativePath === 'Books/Typeless Tome.md');
 
+      expect(typelessNote?.resolvedType).toBeUndefined();
+      expect(typelessNote?.directoryType).toBe('book');
       expect(index.bySurface.has('typeless tome')).toBe(false);
       expect(index.allNames).not.toContain('Typeless Tome');
       expect(index.excludedSurfaces.has('typeless tome')).toBe(true);

--- a/tests/ts/lib/audit-unlinked-mention.test.ts
+++ b/tests/ts/lib/audit-unlinked-mention.test.ts
@@ -463,6 +463,157 @@ describe('unlinked-mention: parseFuzzyThreshold validation', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Mention target exclusion config
+// ---------------------------------------------------------------------------
+
+describe('unlinked-mention: mention target exclusions', () => {
+  const EXCLUSION_SCHEMA: Schema = {
+    version: 2,
+    config: {
+      mention_exclude_types: ['book'],
+      mention_exclude_paths: ['Imports/**'],
+    },
+    types: {
+      meta: { fields: {} },
+      reference: {
+        extends: 'meta',
+        output_dir: 'References',
+        fields: { type: { value: 'reference' } },
+      },
+      book: {
+        extends: 'reference',
+        output_dir: 'Books',
+        fields: {
+          type: { value: 'book' },
+          aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
+        },
+      },
+      person: {
+        extends: 'meta',
+        output_dir: 'People',
+        fields: {
+          type: { value: 'person' },
+          aliases: { prompt: 'list', alias: true, list_format: 'yaml-array' },
+        },
+      },
+      note: {
+        extends: 'meta',
+        output_dir: 'Notes',
+        fields: { type: { value: 'note' } },
+      },
+    },
+  };
+
+  const exclusionSchema = resolveSchema(EXCLUSION_SCHEMA);
+
+  function exclusionIndexFor(
+    notes: Array<{ relativePath: string; frontmatter?: Record<string, unknown>; resolvedType?: string }>
+  ) {
+    return buildEntityMentionIndex(
+      {
+        notes: notes.map((n) => ({
+          path: n.relativePath,
+          relativePath: n.relativePath,
+          ...(n.frontmatter ? { frontmatter: n.frontmatter } : {}),
+          ...(n.resolvedType ? { resolvedType: n.resolvedType } : {}),
+        })),
+      },
+      exclusionSchema
+    );
+  }
+
+  it('excludes a configured type from name and alias mention surfaces', () => {
+    const index = exclusionIndexFor([
+      {
+        relativePath: 'Books/The Great Gatsby.md',
+        resolvedType: 'book',
+        frontmatter: { type: 'book', aliases: ['Jay Gatsby'] },
+      },
+    ]);
+
+    expect(index.bySurface.has('the great gatsby')).toBe(false);
+    expect(index.bySurface.has('jay gatsby')).toBe(false);
+    expect(index.allNames).not.toContain('The Great Gatsby');
+    expect(index.excludedSurfaces.has('the great gatsby')).toBe(true);
+    expect(index.excludedSurfaces.has('jay gatsby')).toBe(true);
+
+    const issues = detectUnlinkedMentions(
+      'The Great Gatsby introduces Jay Gatsby.',
+      'Notes/Daily.md',
+      index
+    );
+    expect(issues).toHaveLength(0);
+  });
+
+  it('excludes descendants of a configured type', () => {
+    const schema = resolveSchema({
+      ...EXCLUSION_SCHEMA,
+      config: { mention_exclude_types: ['reference'] },
+    });
+    const index = buildEntityMentionIndex(
+      {
+        notes: [
+          {
+            path: 'Books/The Left Hand of Darkness.md',
+            relativePath: 'Books/The Left Hand of Darkness.md',
+            resolvedType: 'book',
+            frontmatter: { type: 'book', aliases: ['Left Hand'] },
+          },
+        ],
+      },
+      schema
+    );
+
+    expect(index.bySurface.has('the left hand of darkness')).toBe(false);
+    expect(index.bySurface.has('left hand')).toBe(false);
+    expect(index.excludedSurfaces.has('the left hand of darkness')).toBe(true);
+  });
+
+  it('excludes notes matching configured vault-relative path globs', () => {
+    const index = exclusionIndexFor([
+      {
+        relativePath: 'Imports/Imported Person.md',
+        resolvedType: 'person',
+        frontmatter: { type: 'person', aliases: ['Imported Alias'] },
+      },
+      {
+        relativePath: 'People/Handmade Person.md',
+        resolvedType: 'person',
+        frontmatter: { type: 'person' },
+      },
+    ]);
+
+    expect(index.bySurface.has('imported person')).toBe(false);
+    expect(index.bySurface.has('imported alias')).toBe(false);
+    expect(index.bySurface.has('handmade person')).toBe(true);
+  });
+
+  it('does not use excluded names for fuzzy did-you-mean suggestions', () => {
+    const index = exclusionIndexFor([
+      {
+        relativePath: 'Books/Neuromancer.md',
+        resolvedType: 'book',
+        frontmatter: { type: 'book' },
+      },
+    ]);
+
+    const issues = detectUnlinkedMentions('Reading Neuromansir today.', 'Notes/Daily.md', index, {
+      fuzzyThreshold: 5,
+    });
+    expect(issues.some((i) => i.meta?.['tier'] === 'fuzzy')).toBe(false);
+  });
+
+  it('throws a clear config error for unknown mention_exclude_types entries', () => {
+    expect(() =>
+      resolveSchema({
+        ...SCHEMA,
+        config: { mention_exclude_types: ['persno'] },
+      })
+    ).toThrow(/config\.mention_exclude_types includes unknown type "persno".*person/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Integration tests through runAudit / runAutoFix on a real vault
 // ---------------------------------------------------------------------------
 
@@ -561,5 +712,38 @@ describe('unlinked-mention: end-to-end audit + fix', () => {
     const results = await runAudit(schema, vaultDir, { strict: false, ignoreIssue: 'unlinked-mention' });
     const daily = results.find((r) => r.relativePath === 'Notes/Daily.md');
     expect(daily?.issues.some((i) => i.code === 'unlinked-mention')).toBeFalsy();
+  });
+
+  it('still scans excluded target notes as source documents', async () => {
+    const schemaWithExcludedBooks: Schema = {
+      version: 2,
+      config: { mention_exclude_types: ['book'] },
+      types: {
+        ...SCHEMA.types,
+        book: {
+          extends: 'meta',
+          output_dir: 'Books',
+          fields: { type: { value: 'book' } },
+        },
+      },
+    };
+    await writeFile(
+      join(vaultDir, '.bwrb', 'schema.json'),
+      JSON.stringify(schemaWithExcludedBooks, null, 2)
+    );
+    await mkdir(join(vaultDir, 'Books'), { recursive: true });
+    await writeFile(
+      join(vaultDir, 'Books', 'Imported Book.md'),
+      `---\ntype: book\n---\nThis imported note mentions Steve Yegge in prose.\n`
+    );
+
+    const schema = await loadSchema(vaultDir);
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'unlinked-mention',
+    });
+    const imported = results.find((r) => r.relativePath === 'Books/Imported Book.md');
+    expect(imported?.issues.some((i) => i.code === 'unlinked-mention')).toBe(true);
+    expect(imported?.issues[0]?.targetName).toBe('Steve Yegge');
   });
 });

--- a/tests/ts/lib/audit-unlinked-mention.test.ts
+++ b/tests/ts/lib/audit-unlinked-mention.test.ts
@@ -588,6 +588,35 @@ describe('unlinked-mention: mention target exclusions', () => {
     expect(index.bySurface.has('handmade person')).toBe(true);
   });
 
+  it('excludes typeless notes discovered in an excluded type output_dir', async () => {
+    const vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-mention-exclude-typeless-'));
+    try {
+      await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+      await mkdir(join(vaultDir, 'Books'), { recursive: true });
+      await writeFile(
+        join(vaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify(EXCLUSION_SCHEMA, null, 2)
+      );
+      await writeFile(
+        join(vaultDir, 'Books', 'Typeless Tome.md'),
+        `---\ntitle: Imported without type\n---\n`
+      );
+
+      const loadedSchema = await loadSchema(vaultDir);
+      const snapshot = await buildVaultNoteSnapshot(loadedSchema, vaultDir);
+      const index = buildEntityMentionIndex(snapshot, loadedSchema);
+
+      expect(index.bySurface.has('typeless tome')).toBe(false);
+      expect(index.allNames).not.toContain('Typeless Tome');
+      expect(index.excludedSurfaces.has('typeless tome')).toBe(true);
+
+      const issues = detectUnlinkedMentions('Typeless Tome is imported.', 'Notes/Daily.md', index);
+      expect(issues).toHaveLength(0);
+    } finally {
+      await rm(vaultDir, { recursive: true, force: true });
+    }
+  });
+
   it('does not use excluded names for fuzzy did-you-mean suggestions', () => {
     const index = exclusionIndexFor([
       {

--- a/tests/ts/lib/schema-schema-drift.test.ts
+++ b/tests/ts/lib/schema-schema-drift.test.ts
@@ -173,6 +173,14 @@ describe('published JSON Schema is generated from Zod (no drift, #666)', () => {
     // schema. Generating from Zod fixes that drift.
     expect(configProps.mention_fuzzy_threshold).toBeDefined();
     expect(configProps.mention_fuzzy_threshold.type).toBe('integer');
+
+    expect(configProps.mention_exclude_types).toBeDefined();
+    expect(configProps.mention_exclude_types.type).toBe('array');
+    expect(configProps.mention_exclude_types.items.type).toBe('string');
+
+    expect(configProps.mention_exclude_paths).toBeDefined();
+    expect(configProps.mention_exclude_paths.type).toBe('array');
+    expect(configProps.mention_exclude_paths.items.type).toBe('string');
   });
 
   // --- #626: config.date_granularity must exist (Zod ConfigSchema.date_granularity) ---

--- a/tests/ts/lib/validation.test.ts
+++ b/tests/ts/lib/validation.test.ts
@@ -795,6 +795,7 @@ describe('validation', () => {
             output_dir: 'Tasks',
             fields: {
               milestone: { prompt: 'relation', source: 'milestone' },
+              idea_ref: { prompt: 'relation', source: 'idea' },
               any_ref: { prompt: 'relation', source: 'any' },
             },
           },
@@ -843,6 +844,13 @@ type: idea
         join(tempVaultDir, 'Ideas', 'Only Wrong.md'),
         `---
 type: idea
+---
+`
+      );
+      await writeFile(
+        join(tempVaultDir, 'Ideas', 'Untyped.md'),
+        `---
+title: Directory-owned but typeless
 ---
 `
       );
@@ -942,6 +950,32 @@ type: idea
             expected: ['milestone'],
           }),
         ]);
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
+    it('does not accept a typeless note as a typed relation target based on directory', async () => {
+      const { relationSchema, tempVaultDir } = await buildRelationContractVault();
+      try {
+        const result = await validateContextFields(relationSchema, tempVaultDir, 'task', {
+          type: 'task',
+          idea_ref: '[[Untyped]]',
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual([
+          expect.objectContaining({
+            type: 'invalid_context_source',
+            field: 'idea_ref',
+            value: '[[Untyped]]',
+            targetName: 'Untyped',
+            expectedTypes: ['idea'],
+            expected: ['idea'],
+          }),
+        ]);
+        expect(result.errors[0]).not.toHaveProperty('actualType');
+        expect(result.errors[0].message).toContain('Referenced note not found');
       } finally {
         await rm(tempVaultDir, { recursive: true, force: true });
       }


### PR DESCRIPTION
Adds two schema config keys that scope which notes feed the unlinked-mention entity index:

- `mention_exclude_types`: notes of these types (or subtypes) contribute neither names nor aliases to the mention index, the fuzzy name pool, or frequent-unlinked-term nudges.
- `mention_exclude_paths`: same exclusion by vault-relative glob.

Excluded notes are still scanned as source documents — exclusion is about being a link *target*, not a document. Unknown type names in the config error at load.

Motivation: vaults with thousands of imported reference entities (books, contacts) need the ingest safety net for hand-made notes without prose being matched against 1,500 imported book titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)