### PR TITLE
feat: mention_link_once — first-occurrence-only auto-linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Bowerbird are documented in this file.
 ### Added
 
 - **Mention target exclusions** — `config.mention_exclude_types` and `config.mention_exclude_paths` keep imported/reference notes out of the unlinked-mention target, fuzzy suggestion, and frequent-term nudge pools while still scanning those notes as source documents.
+- **First-occurrence mention linking** — `config.mention_link_once` plus `audit --fix --auto --mention-link-once` limit unlinked-mention auto-fixes to one new wikilink per note/target pair, with existing wikilinks counting as covered (#785).
 
 ### Fixed
 

--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -122,6 +122,10 @@
           "maximum": 1,
           "description": "Strict non-canonical-case occurrence share threshold for corpus-calibrated commonness damping (#783). Defaults to 0.5, so exactly half non-canonical keeps the surface."
         },
+        "mention_link_once": {
+          "type": "boolean",
+          "description": "When true, `audit --fix --auto` writes at most one new `unlinked-mention` wikilink per note/target pair, and writes none when the note already contains a wikilink to that target. Defaults to false; overridden per run by `--mention-link-once` / `--no-mention-link-once`."
+        },
         "mention_exclude_types": {
           "type": "array",
           "items": {

--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -35,6 +35,8 @@ The target argument is auto-detected as type, path (contains `/`), or where expr
 | `--allow-field <fields>` | Allow additional fields beyond schema (repeatable) |
 | `--mention-fuzzy-threshold <n>` | Max edit-distance cap (0–5) for the `unlinked-mention` fuzzy "did you mean?" tier (default: `config.mention_fuzzy_threshold` or `2`; candidate length also caps the effective distance) |
 | `--no-mention-fuzzy` | Disable the `unlinked-mention` fuzzy "did you mean?" tier entirely |
+| `--mention-link-once` | With `--fix --auto`: link at most one `unlinked-mention` occurrence per note/target pair, overriding `config.mention_link_once` |
+| `--no-mention-link-once` | With `--fix --auto`: link every eligible `unlinked-mention` occurrence, overriding `config.mention_link_once` |
 | `--check-schema-docs` | Also report schema types/fields that have no `description` |
 
 ### Repair
@@ -48,6 +50,13 @@ The target argument is auto-detected as type, path (contains `/`), or where expr
 
 Repair mode writes by default and requires explicit targeting (selectors or `--all`).
 Use `--dry-run` to preview fixes without writing.
+
+`unlinked-mention` auto-fixes normally link every eligible exact/alias occurrence. Set
+`config.mention_link_once: true` or pass `--mention-link-once` to make
+`--fix --auto` write at most one new wikilink per note/target pair. Existing
+wikilinks to that target in the note, including display forms like
+`[[Target|display]]`, count as covered, so no new link is written for that target.
+Detection and reporting remain exhaustive; only fix application is limited.
 
 Delete semantics in repair mode:
 
@@ -174,6 +183,9 @@ bwrb audit --path "Ideas/**" --fix --auto --execute
 
 # Preview auto-fixes
 bwrb audit --path "Ideas/**" --fix --auto
+
+# Auto-link only the first eligible unlinked mention per note/target pair
+bwrb audit --path "Ideas/**" --fix --auto --execute --mention-link-once
 ```
 
 ### Trailing whitespace hygiene semantics

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -308,6 +308,11 @@ bwrb audit --path "Ideas/**" --fix --auto
 #       and capitalized single-word names are ignored at sentence/list/heading
 #       starts where capitalization carries no signal. Declared aliases remain
 #       explicit link intent.
+# Note: to link each mention target at most once per note (dense repeats read
+#       poorly), enable link-once: pass --mention-link-once (or set config
+#       mention_link_once: true; --no-mention-link-once overrides it off).
+#       Notes already containing a prose/frontmatter wikilink to the target get
+#       no new links; detection/reporting still lists every occurrence.
 
 # Fix a specific issue code (auto-fix; safe to script)
 bwrb audit --path "Ideas/**" --only trailing-whitespace --fix --auto --execute

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -122,6 +122,10 @@
           "maximum": 1,
           "description": "Strict non-canonical-case occurrence share threshold for corpus-calibrated commonness damping (#783). Defaults to 0.5, so exactly half non-canonical keeps the surface."
         },
+        "mention_link_once": {
+          "type": "boolean",
+          "description": "When true, `audit --fix --auto` writes at most one new `unlinked-mention` wikilink per note/target pair, and writes none when the note already contains a wikilink to that target. Defaults to false; overridden per run by `--mention-link-once` / `--no-mention-link-once`."
+        },
         "mention_exclude_types": {
           "type": "array",
           "items": {

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -198,6 +198,14 @@ Examples:
     'unlinked-mention fuzzy "did you mean?" max edit-distance cap (0-5; default from config or 2)'
   )
   .option('--no-mention-fuzzy', 'Disable the unlinked-mention fuzzy "did you mean?" tier')
+  .option(
+    '--mention-link-once',
+    'With --fix --auto: link at most one unlinked mention per note/target pair'
+  )
+  .option(
+    '--no-mention-link-once',
+    'With --fix --auto: link every eligible unlinked mention (overrides config.mention_link_once)'
+  )
   .option('--check-schema-docs', 'Also report schema types/fields that have no description')
   .action(async (target: string | undefined, options: AuditOptions & {
     type?: string;
@@ -280,6 +288,7 @@ Examples:
           mentionFuzzyThreshold = parsed.value;
         }
       }
+      const mentionLinkOnce = options.mentionLinkOnce ?? schema.config.mentionLinkOnce;
 
       if (globalOpts.nonInteractive && fixMode && !autoMode) {
         exitWithValidationError('bwrb audit --fix requires --auto when --non-interactive is set.');
@@ -390,9 +399,17 @@ Examples:
           : undefined;
 
         const fixSummary = autoMode
-          ? await runAutoFix(results, schema, vaultDir, { dryRun: autoFixDryRun, dryRunReason: autoFixDryRunReason })
+          ? await runAutoFix(results, schema, vaultDir, {
+              dryRun: autoFixDryRun,
+              ...(autoFixDryRunReason ? { dryRunReason: autoFixDryRunReason } : {}),
+              mentionLinkOnce,
+            })
           : headlessDryRunPreview
-            ? await runAutoFix(results, schema, vaultDir, { dryRun: true, dryRunReason: 'explicit' })
+            ? await runAutoFix(results, schema, vaultDir, {
+                dryRun: true,
+                dryRunReason: 'explicit',
+                mentionLinkOnce,
+              })
           : await runInteractiveFix(results, schema, vaultDir, { dryRun: dryRunMode });
 
         outputFixResults(fixSummary, autoMode);

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -89,6 +89,12 @@ const CONFIG_OPTIONS: ConfigOptionMeta[] = [
     description: 'Vault-relative path globs to exclude as targets from unlinked-mention and frequent-term audit suggestions',
     default: [],
   },
+  {
+    key: 'mention_link_once',
+    label: 'Mention Link Once',
+    description: 'Limit audit --fix --auto unlinked-mention writes to one wikilink per note/target pair',
+    default: false,
+  },
 ];
 
 export const configCommand = new Command('config')
@@ -351,6 +357,8 @@ function getConfigValue(config: Partial<Config>, key: keyof Config, vaultDir: st
     case 'mention_exclude_types':
     case 'mention_exclude_paths':
       return [];
+    case 'mention_link_once':
+      return false;
     default:
       return undefined;
   }
@@ -421,6 +429,10 @@ function validateConfigValue(meta: ConfigOptionMeta, value: unknown): void {
       throw new Error(`${String(meta.key)} must be a JSON array of strings`);
     }
   }
+
+  if (meta.key === 'mention_link_once' && typeof value !== 'boolean') {
+    throw new Error(`${String(meta.key)} must be a boolean`);
+  }
 }
 
 async function writeValidatedSchema(
@@ -442,6 +454,10 @@ async function promptConfigOption(meta: ConfigOptionMeta, currentValue: unknown)
 
   if (meta.key === 'mention_exclude_types' || meta.key === 'mention_exclude_paths') {
     return promptStringArray(meta, currentValue);
+  }
+
+  if (meta.key === 'mention_link_once') {
+    return promptBoolean(meta, currentValue);
   }
 
   if (meta.options) {
@@ -471,6 +487,25 @@ async function promptConfigOption(meta: ConfigOptionMeta, currentValue: unknown)
   if (entered === null) return { action: 'keep' };
 
   return { action: 'set', value: entered };
+}
+
+async function promptBoolean(
+  meta: ConfigOptionMeta,
+  currentValue: unknown
+): Promise<ConfigEditResult> {
+  const current = typeof currentValue === 'boolean' ? currentValue : meta.default;
+  const choice = await promptSelection(
+    `${meta.label} (current: ${String(current)}):`,
+    ['(keep current)', 'true', 'false', '(clear)']
+  );
+
+  if (choice === null || choice === '(keep current)') {
+    return { action: 'keep' };
+  }
+  if (choice === '(clear)') {
+    return { action: 'clear' };
+  }
+  return { action: 'set', value: choice === 'true' };
 }
 
 async function promptStringArray(

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -56,7 +56,7 @@ import {
   type FixSummary,
   type FixContext,
 } from './types.js';
-import { toMarkdownLink, toWikilink } from '../links.js';
+import { toMarkdownLink, toWikilink, wikilinkTargetBasename } from '../links.js';
 import { spawnSuccessor, needsSuccessor, CHAIN_NEXT_FIELD } from '../recurrence.js';
 import {
   maskNonProse,
@@ -220,6 +220,42 @@ function isWordBounded(body: string, start: number, length: number): boolean {
 
 function isMentionWordBoundaryChar(char: string | undefined): boolean {
   return char !== undefined && /[\w']/.test(char);
+}
+
+function normalizeMentionTargetKey(target: string): string {
+  return target.trim().toLowerCase();
+}
+
+function getUnlinkedMentionTargetKey(issue: AuditIssue): string | undefined {
+  if (typeof issue.targetName === 'string' && issue.targetName.trim().length > 0) {
+    return normalizeMentionTargetKey(issue.targetName);
+  }
+
+  const replacement = issue.meta?.['replacement'];
+  if (typeof replacement === 'string') {
+    const basenameTarget = wikilinkTargetBasename(replacement);
+    if (basenameTarget.length > 0) return normalizeMentionTargetKey(basenameTarget);
+  }
+
+  return undefined;
+}
+
+async function readExistingWikilinkTargetKeys(filePath: string): Promise<Set<string>> {
+  const raw = await readFile(filePath, 'utf-8');
+  const keys = new Set<string>();
+  const wikilinkRe = /\[\[([^\]]+)\]\]/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = wikilinkRe.exec(raw)) !== null) {
+    const inner = match[1];
+    if (!inner) continue;
+    const basenameTarget = wikilinkTargetBasename(inner);
+    if (basenameTarget.length > 0) {
+      keys.add(normalizeMentionTargetKey(basenameTarget));
+    }
+  }
+
+  return keys;
 }
 
 /**
@@ -1062,10 +1098,15 @@ export async function runAutoFix(
   results: FileAuditResult[],
   schema: LoadedSchema,
   vaultDir: string,
-  options?: { dryRun?: boolean; dryRunReason?: FixSummary['dryRunReason'] }
+  options?: {
+    dryRun?: boolean;
+    dryRunReason?: FixSummary['dryRunReason'];
+    mentionLinkOnce?: boolean;
+  }
 ): Promise<FixSummary> {
   const dryRun = options?.dryRun ?? false;
   const dryRunReason = dryRun ? options?.dryRunReason : undefined;
+  const mentionLinkOnce = options?.mentionLinkOnce ?? false;
   dryRunStorage.enterWith(dryRun);
   
   console.log(chalk.bold('Auditing vault...\n'));
@@ -1073,6 +1114,7 @@ export async function runAutoFix(
 
   let fixed = 0;
   let skipped = 0;
+  let linkOnceSkipped = 0;
   let failed = 0;
   const manualReviewNeeded: { file: string; issue: AuditIssue }[] = [];
   const resolvedNonFixable = new Set<AuditIssue>();
@@ -1084,6 +1126,9 @@ export async function runAutoFix(
   for (const result of results) {
     const fixableIssues = result.issues.filter(i => i.autoFixable);
     const nonFixableIssues = result.issues.filter(i => !i.autoFixable);
+    const linkOnceCoveredTargets = mentionLinkOnce
+      ? await readExistingWikilinkTargetKeys(result.path)
+      : undefined;
 
 
     // Handle wrong-directory issues
@@ -1720,12 +1765,24 @@ export async function runAutoFix(
       } else if (issue.code === 'unlinked-mention') {
         // Only exact/alias mentions are auto-fixable (fuzzy/ambiguous are
         // flag-only and never reach here, since autoFixable is false on them).
+        const linkOnceTargetKey = linkOnceCoveredTargets
+          ? getUnlinkedMentionTargetKey(issue)
+          : undefined;
+        if (linkOnceCoveredTargets && linkOnceTargetKey && linkOnceCoveredTargets.has(linkOnceTargetKey)) {
+          skipped++;
+          linkOnceSkipped++;
+          continue;
+        }
+
         const fixResult = await applyFix(schema, result.path, issue);
         if (fixResult.action === 'fixed') {
           const replacement = (issue.meta?.['replacement'] as string | undefined) ?? '';
           console.log(chalk.cyan(`  ${result.relativePath}`));
           console.log(chalk.green(`    ✓ Linked '${String(issue.value)}' → ${replacement}`));
           fixed++;
+          if (linkOnceCoveredTargets && linkOnceTargetKey) {
+            linkOnceCoveredTargets.add(linkOnceTargetKey);
+          }
         } else if (fixResult.action === 'skipped') {
           console.log(chalk.cyan(`  ${result.relativePath}`));
           console.log(chalk.yellow(`    ⚠ ${fixResult.message}`));
@@ -1818,6 +1875,7 @@ export async function runAutoFix(
     ...(dryRunReason ? { dryRunReason } : {}),
     fixed,
     skipped,
+    ...(linkOnceSkipped > 0 ? { linkOnceSkipped } : {}),
     failed,
     remaining: manualReviewNeeded.length,
   };

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -59,6 +59,7 @@ import {
 import { toMarkdownLink, toWikilink, wikilinkTargetBasename } from '../links.js';
 import { spawnSuccessor, needsSuccessor, CHAIN_NEXT_FIELD } from '../recurrence.js';
 import {
+  maskCodeSpans,
   maskNonProse,
   shouldSkipNoCasingSignalNameOccurrence,
 } from './unlinked-mention.js';
@@ -242,11 +243,16 @@ function getUnlinkedMentionTargetKey(issue: AuditIssue): string | undefined {
 
 async function readExistingWikilinkTargetKeys(filePath: string): Promise<Set<string>> {
   const raw = await readFile(filePath, 'utf-8');
+  // Link-once coverage follows the detector's prose philosophy for code:
+  // wikilinks inside fenced or inline code are examples, not real graph edges.
+  // Frontmatter is intentionally left visible; relation fields are genuine
+  // note-to-target links, so they count as existing coverage for the target.
+  const linkCoverageSource = maskCodeSpans(raw);
   const keys = new Set<string>();
   const wikilinkRe = /\[\[([^\]]+)\]\]/g;
   let match: RegExpExecArray | null;
 
-  while ((match = wikilinkRe.exec(raw)) !== null) {
+  while ((match = wikilinkRe.exec(linkCoverageSource)) !== null) {
     const inner = match[1];
     if (!inner) continue;
     const basenameTarget = wikilinkTargetBasename(inner);

--- a/src/lib/audit/output.ts
+++ b/src/lib/audit/output.ts
@@ -191,6 +191,9 @@ export function outputFixResults(summary: FixSummary, autoMode: boolean): void {
   const skippedLabel = summary.dryRun ? 'Would skip' : 'Skipped';
   console.log(`  ${fixedLabel}: ${summary.fixed} issues`);
   console.log(`  ${skippedLabel}: ${summary.skipped} issues`);
+  if (summary.linkOnceSkipped && summary.linkOnceSkipped > 0) {
+    console.log(`  ${skippedLabel} by mention link-once: ${summary.linkOnceSkipped} issues`);
+  }
   if (summary.failed > 0) {
     console.log(`  Failed: ${summary.failed} issues`);
   }

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -197,6 +197,8 @@ export interface FixSummary {
   dryRunReason?: 'explicit' | 'execute-required';
   fixed: number;
   skipped: number;
+  /** Subset of skipped issues intentionally covered by mention link-once mode. */
+  linkOnceSkipped?: number;
   failed: number;
   remaining: number;
 }
@@ -235,6 +237,11 @@ export interface AuditOptions {
    * mean?" tier. Commander stores the negatable boolean here.
    */
   mentionFuzzy?: boolean;
+  /**
+   * Commander stores both `--mention-link-once` and `--no-mention-link-once`
+   * on this positive key. Undefined means use schema config.
+   */
+  mentionLinkOnce?: boolean;
 }
 
 /**

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -568,6 +568,7 @@ function resolveConfig(
     mentionCorpusMinNotes: config?.mention_corpus_min_notes ?? 3,
     mentionCorpusNonCanonicalRatio:
       config?.mention_corpus_noncanonical_ratio ?? 0.5,
+    mentionLinkOnce: config?.mention_link_once ?? false,
     mentionExcludeTypes: Array.from(
       new Set(
         (config?.mention_exclude_types ?? [])

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -458,6 +458,14 @@ export const ConfigSchema = z.object({
     .describe(
       'Strict non-canonical-case occurrence share threshold for corpus-calibrated commonness damping (#783). Defaults to 0.5, so exactly half non-canonical keeps the surface.'
     ),
+  // First-occurrence-only auto-link mode for `unlinked-mention` fixes (#785).
+  // Detection remains exhaustive; this only limits `audit --fix --auto` writes.
+  mention_link_once: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, `audit --fix --auto` writes at most one new `unlinked-mention` wikilink per note/target pair, and writes none when the note already contains a wikilink to that target. Defaults to false; overridden per run by `--mention-link-once` / `--no-mention-link-once`.'
+    ),
   // Type names to exclude as targets from the mention safety-net index. Notes
   // whose resolved type is listed, or extends a listed type, are still scanned
   // as source documents, but their names and aliases are not link targets,
@@ -660,6 +668,13 @@ export interface ResolvedConfig {
    * 0.5, so exactly half non-canonical keeps the surface.
    */
   mentionCorpusNonCanonicalRatio: number;
+  /**
+   * When true, `audit --fix --auto` writes at most one new unlinked-mention
+   * wikilink per note/target pair and treats pre-existing wikilinks as covered.
+   * Defaults to false to preserve historical "link every eligible occurrence"
+   * behavior.
+   */
+  mentionLinkOnce: boolean;
   /**
    * Canonical type names excluded as mention targets. Descendants of these
    * types are excluded by the mention index builder.

--- a/tests/ts/lib/audit-unlinked-mention.test.ts
+++ b/tests/ts/lib/audit-unlinked-mention.test.ts
@@ -1012,6 +1012,90 @@ describe('unlinked-mention: end-to-end audit + fix', () => {
     expect(after).toContain('Then Builder appears twice.');
   });
 
+  it('link-once treats a pre-existing prose wikilink to the target as covered', async () => {
+    await writeNote('Notes/Builder.md', '');
+    await writeNote(
+      'Notes/Daily.md',
+      'Context: [[Builder]].\nLater Builder appears again.\nThen Builder appears twice.'
+    );
+    const schema = await loadSchema(vaultDir);
+
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'unlinked-mention',
+    });
+    const daily = results.find((r) => r.relativePath === 'Notes/Daily.md');
+    expect(daily?.issues.filter((i) => i.targetName === 'Builder')).toHaveLength(2);
+
+    const summary = await runAutoFix(results, schema, vaultDir, {
+      dryRun: false,
+      mentionLinkOnce: true,
+    });
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(summary.fixed).toBe(0);
+    expect(summary.skipped).toBe(2);
+    expect(summary.linkOnceSkipped).toBe(2);
+    expect(countInText(after, '[[Builder]]')).toBe(1);
+    expect(after).toContain('Later Builder appears again.');
+    expect(after).toContain('Then Builder appears twice.');
+  });
+
+  it('link-once ignores wikilinks inside fenced code when deciding existing coverage', async () => {
+    await writeNote('Notes/Builder.md', '');
+    await writeNote(
+      'Notes/Daily.md',
+      '```md\n[[Builder]]\n```\nLater Builder appears again.\nThen Builder appears twice.'
+    );
+    const schema = await loadSchema(vaultDir);
+
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'unlinked-mention',
+    });
+    const daily = results.find((r) => r.relativePath === 'Notes/Daily.md');
+    expect(daily?.issues.filter((i) => i.targetName === 'Builder')).toHaveLength(2);
+
+    const summary = await runAutoFix(results, schema, vaultDir, {
+      dryRun: false,
+      mentionLinkOnce: true,
+    });
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(summary.fixed).toBe(1);
+    expect(summary.skipped).toBe(1);
+    expect(summary.linkOnceSkipped).toBe(1);
+    expect(after).toContain('```md\n[[Builder]]\n```');
+    expect(after).toContain('Later [[Builder]] appears again.');
+    expect(after).toContain('Then Builder appears twice.');
+  });
+
+  it('link-once ignores wikilinks inside inline code when deciding existing coverage', async () => {
+    await writeNote('Notes/Builder.md', '');
+    await writeNote(
+      'Notes/Daily.md',
+      'Example: `[[Builder]]`.\nLater Builder appears again.\nThen Builder appears twice.'
+    );
+    const schema = await loadSchema(vaultDir);
+
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'unlinked-mention',
+    });
+    const daily = results.find((r) => r.relativePath === 'Notes/Daily.md');
+    expect(daily?.issues.filter((i) => i.targetName === 'Builder')).toHaveLength(2);
+
+    const summary = await runAutoFix(results, schema, vaultDir, {
+      dryRun: false,
+      mentionLinkOnce: true,
+    });
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(summary.fixed).toBe(1);
+    expect(summary.skipped).toBe(1);
+    expect(summary.linkOnceSkipped).toBe(1);
+    expect(after).toContain('Example: `[[Builder]]`.');
+    expect(after).toContain('Later [[Builder]] appears again.');
+    expect(after).toContain('Then Builder appears twice.');
+  });
+
   it('link-once gives each distinct target one link in the same note', async () => {
     await writeNote('Notes/Builder.md', '');
     await writeFile(

--- a/tests/ts/lib/audit-unlinked-mention.test.ts
+++ b/tests/ts/lib/audit-unlinked-mention.test.ts
@@ -759,6 +759,10 @@ describe('unlinked-mention: end-to-end audit + fix', () => {
     await writeNote('Notes/Source C.md', 'this vault says lumen this way.');
   }
 
+  function countInText(text: string, needle: string): number {
+    return text.split(needle).length - 1;
+  }
+
   it('drops a vault-common lowercase single-word name surface via corpus damping', async () => {
     await writeNote('Notes/Lumen.md', '');
     await seedLowercaseLumenCorpus();
@@ -949,6 +953,196 @@ describe('unlinked-mention: end-to-end audit + fix', () => {
     expect(after).toContain('- [ ] Pass site around.');
     expect(after).toContain('- [x] Pass it on');
     expect(after).toContain('- [ ] ask [[Pass]] for help.');
+  });
+
+  it('link-once auto-fix links only the first eligible occurrence per note and target', async () => {
+    await writeNote('Notes/Builder.md', '');
+    await writeNote(
+      'Notes/Daily.md',
+      'I tested Builder today.\nWe saw Builder still needs polish.\nI think Builder shipped anyway.'
+    );
+    const schema = await loadSchema(vaultDir);
+
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'unlinked-mention',
+    });
+    const daily = results.find((r) => r.relativePath === 'Notes/Daily.md');
+    expect(daily?.issues.filter((i) => i.targetName === 'Builder')).toHaveLength(3);
+
+    const summary = await runAutoFix(results, schema, vaultDir, {
+      dryRun: false,
+      mentionLinkOnce: true,
+    });
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(summary.fixed).toBe(1);
+    expect(summary.skipped).toBe(2);
+    expect(summary.linkOnceSkipped).toBe(2);
+    expect(after).toContain('I tested [[Builder]] today.');
+    expect(countInText(after, '[[Builder]]')).toBe(1);
+    expect(after).toContain('We saw Builder still needs polish.');
+    expect(after).toContain('I think Builder shipped anyway.');
+  });
+
+  it('link-once treats a pre-existing wikilink to the target as covered', async () => {
+    await writeNote('Notes/Builder.md', '');
+    await writeNote(
+      'Notes/Daily.md',
+      'Context: [[Builder|the Builder system]].\nLater Builder appears again.\nThen Builder appears twice.'
+    );
+    const schema = await loadSchema(vaultDir);
+
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'unlinked-mention',
+    });
+    const daily = results.find((r) => r.relativePath === 'Notes/Daily.md');
+    expect(daily?.issues.filter((i) => i.targetName === 'Builder')).toHaveLength(2);
+
+    const summary = await runAutoFix(results, schema, vaultDir, {
+      dryRun: false,
+      mentionLinkOnce: true,
+    });
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(summary.fixed).toBe(0);
+    expect(summary.skipped).toBe(2);
+    expect(summary.linkOnceSkipped).toBe(2);
+    expect(after).toContain('Context: [[Builder|the Builder system]].');
+    expect(after).toContain('Later Builder appears again.');
+    expect(after).toContain('Then Builder appears twice.');
+  });
+
+  it('link-once gives each distinct target one link in the same note', async () => {
+    await writeNote('Notes/Builder.md', '');
+    await writeFile(
+      join(vaultDir, 'People', 'Grace Hopper.md'),
+      `---\ntype: person\n---\n`
+    );
+    await writeNote(
+      'Notes/Daily.md',
+      'Today Builder met Grace Hopper.\nThen Builder followed up.\nLater Grace Hopper replied.'
+    );
+    const schema = await loadSchema(vaultDir);
+
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'unlinked-mention',
+    });
+    const summary = await runAutoFix(results, schema, vaultDir, {
+      dryRun: false,
+      mentionLinkOnce: true,
+    });
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(summary.fixed).toBe(2);
+    expect(summary.skipped).toBe(2);
+    expect(summary.linkOnceSkipped).toBe(2);
+    expect(after).toContain('Today [[Builder]] met [[Grace Hopper]].');
+    expect(countInText(after, '[[Builder]]')).toBe(1);
+    expect(countInText(after, '[[Grace Hopper]]')).toBe(1);
+  });
+
+  it('link-once does not choose guarded sentence/list-start occurrences before the first eligible occurrence', async () => {
+    await writeNote('Notes/Pass.md', '');
+    await writeNote(
+      'Notes/Daily.md',
+      'Pass site around.\n- Pass it on\n...\nI used Pass today.\nThen Pass was useful again.'
+    );
+    const schema = await loadSchema(vaultDir);
+
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'unlinked-mention',
+    });
+    const daily = results.find((r) => r.relativePath === 'Notes/Daily.md');
+    expect(daily?.issues.map((i) => i.lineNumber)).toEqual([4, 5]);
+
+    const summary = await runAutoFix(results, schema, vaultDir, {
+      dryRun: false,
+      mentionLinkOnce: true,
+    });
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(summary.fixed).toBe(1);
+    expect(summary.linkOnceSkipped).toBe(1);
+    expect(after).toContain('Pass site around.');
+    expect(after).toContain('- Pass it on');
+    expect(after).toContain('I used [[Pass]] today.');
+    expect(after).toContain('Then Pass was useful again.');
+  });
+
+  it('link-once is idempotent on re-run', async () => {
+    await writeNote('Notes/Builder.md', '');
+    await writeNote('Notes/Daily.md', 'First Builder one.\nSecond Builder two.');
+    const schema = await loadSchema(vaultDir);
+
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'unlinked-mention',
+    });
+    await runAutoFix(results, schema, vaultDir, {
+      dryRun: false,
+      mentionLinkOnce: true,
+    });
+    const afterFirst = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+
+    const secondResults = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'unlinked-mention',
+    });
+    const secondSummary = await runAutoFix(secondResults, schema, vaultDir, {
+      dryRun: false,
+      mentionLinkOnce: true,
+    });
+    const afterSecond = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(secondSummary.fixed).toBe(0);
+    expect(secondSummary.linkOnceSkipped).toBe(1);
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  it('default auto-fix behavior still links every eligible occurrence', async () => {
+    await writeNote('Notes/Builder.md', '');
+    await writeNote('Notes/Daily.md', 'First Builder one.\nSecond Builder two.\nThird Builder three.');
+    const schema = await loadSchema(vaultDir);
+
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'unlinked-mention',
+    });
+    const summary = await runAutoFix(results, schema, vaultDir, { dryRun: false });
+    const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(summary.fixed).toBe(3);
+    expect(summary.linkOnceSkipped).toBeUndefined();
+    expect(countInText(after, '[[Builder]]')).toBe(3);
+  });
+
+  it('link-once dry-run reports the same fix/skip counts as execute without writing', async () => {
+    await writeNote('Notes/Builder.md', '');
+    await writeNote('Notes/Daily.md', 'First Builder one.\nSecond Builder two.\nThird Builder three.');
+    const schema = await loadSchema(vaultDir);
+
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      onlyIssue: 'unlinked-mention',
+    });
+    const dryRunSummary = await runAutoFix(results, schema, vaultDir, {
+      dryRun: true,
+      mentionLinkOnce: true,
+    });
+    const afterDryRun = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(dryRunSummary.fixed).toBe(1);
+    expect(dryRunSummary.skipped).toBe(2);
+    expect(dryRunSummary.linkOnceSkipped).toBe(2);
+    expect(afterDryRun).toContain('First Builder one.');
+    expect(afterDryRun).not.toContain('[[Builder]]');
+
+    const executeSummary = await runAutoFix(results, schema, vaultDir, {
+      dryRun: false,
+      mentionLinkOnce: true,
+    });
+    const afterExecute = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
+    expect(executeSummary.fixed).toBe(dryRunSummary.fixed);
+    expect(executeSummary.skipped).toBe(dryRunSummary.skipped);
+    expect(executeSummary.linkOnceSkipped).toBe(dryRunSummary.linkOnceSkipped);
+    expect(countInText(afterExecute, '[[Builder]]')).toBe(1);
   });
 
   it('detects and auto-fixes an exact unlinked mention to a wikilink', async () => {

--- a/tests/ts/lib/schema-schema-drift.test.ts
+++ b/tests/ts/lib/schema-schema-drift.test.ts
@@ -174,6 +174,9 @@ describe('published JSON Schema is generated from Zod (no drift, #666)', () => {
     expect(configProps.mention_fuzzy_threshold).toBeDefined();
     expect(configProps.mention_fuzzy_threshold.type).toBe('integer');
 
+    expect(configProps.mention_link_once).toBeDefined();
+    expect(configProps.mention_link_once.type).toBe('boolean');
+
     expect(configProps.mention_exclude_types).toBeDefined();
     expect(configProps.mention_exclude_types.type).toBe('array');
     expect(configProps.mention_exclude_types.items.type).toBe('string');


### PR DESCRIPTION
Adds `mention_link_once` config (default false) plus `--mention-link-once` / `--no-mention-link-once` audit flags. When enabled, `--fix --auto` writes at most one new wikilink per (note, target): the first position-guard-eligible occurrence, and none at all if the note already links that target. Detection stays exhaustive; the fix summary reports link-once skips distinctly. Dry-run parity and idempotent re-runs covered by tests.

Motivation: without it, one real brief picked up `[[Builder]]` 73 times.

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)