### PR TITLE
feat: relative-date fields — position notes in time relative to other notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage/
 *.swp
 *.swo
 .vscode/
+.claude/
 
 # OS
 .DS_Store

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -48,6 +48,7 @@ export default defineConfig({
 					items: [
 						{ slug: 'concepts/schema' },
 						{ slug: 'concepts/types-and-inheritance' },
+						{ slug: 'concepts/relative-dates' },
 						{ slug: 'concepts/validation-and-audit' },
 						{ slug: 'concepts/migrations' },
 						{ slug: 'concepts/hierarchical-scope' },

--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -259,11 +259,12 @@
             "select",
             "list",
             "date",
+            "relative-date",
             "relation",
             "boolean",
             "number"
           ],
-          "description": "Type of prompt: text (free text), select (from options), relation (from vault query), list (comma-separated list), date (date picker), boolean (yes/no), number (numeric input)"
+          "description": "Type of prompt: text (free text), select (from options), relation (from vault query), list (comma-separated list), date (date picker), relative-date (constraints relative to another note date), boolean (yes/no), number (numeric input)"
         },
         "granularity": {
           "type": "string",
@@ -322,7 +323,7 @@
               }
             }
           ],
-          "description": "Type name(s) for relation prompts. When a relation's value is ambiguous because two notes share a name, path-qualify the link (e.g. `[[contexts/Betson]]`); see the search command docs for the shortest-unambiguous-form rule."
+          "description": "Type name(s) for relation and relative-date prompts. When a relation's value is ambiguous because two notes share a name, path-qualify the link (e.g. `[[contexts/Betson]]`); see the search command docs for the shortest-unambiguous-form rule."
         },
         "filter": {
           "type": "object",

--- a/docs-site/src/content/docs/concepts/relative-dates.md
+++ b/docs-site/src/content/docs/concepts/relative-dates.md
@@ -1,0 +1,88 @@
+---
+title: Relative Dates
+description: Model story-time and sequence positions without writing computed dates back to notes
+---
+
+Relative-date fields describe where a note sits in time relative to another note. They are useful for fictional timelines, historical sequences, research events, or any vault where the order matters before every absolute date is known.
+
+The stored frontmatter is only the source constraint. Bowerbird resolves the computed position at query time and never writes the resolved value back to the note.
+
+## Schema
+
+Declare a `relative-date` field alongside a normal `date` field that can anchor the chain:
+
+```json
+{
+  "types": {
+    "event": {
+      "fields": {
+        "name": { "prompt": "text", "required": true },
+        "start": { "prompt": "date" },
+        "position": { "prompt": "relative-date", "source": "event" }
+      }
+    }
+  }
+}
+```
+
+`source` works like relation fields: it constrains which note types can be used as anchors.
+
+## Frontmatter
+
+A relative-date value is an object or a list of objects:
+
+```yaml
+position:
+  - kind: equal
+    ref: "[[The Rending]]"
+    field: start
+    offset: 34h
+```
+
+| Key | Description |
+| --- | --- |
+| `kind` | `equal`, `after`, or `before` |
+| `ref` | Anchor note reference, usually a wikilink |
+| `field` | Optional anchor field. If omitted, Bowerbird uses the anchor's date field, then its relative-date field |
+| `offset` | Optional signed duration using `min`, `h`, `d`, or `w` |
+
+Offsets are parsed internally as `{ amount, unit, mode }` so future calendar-aware resolvers can preserve the unit instead of inheriting a millisecond-only value.
+
+## Resolution
+
+A relative-date field resolves to:
+
+- the note's own `date` field, when the note has one and no relative constraint is set
+- the transitive result of its first `equal` constraint plus the offset
+- `null` when it only has `after`/`before` bounds or the chain has no absolute anchor
+
+Multiple `equal` constraints are allowed, but only the first one provides the resolved value. If later equal constraints resolve to a different position, Bowerbird reports a contradiction.
+
+Cycles do not crash commands. The involved notes resolve to `null` and are marked with `resolution: "cycle"` in JSON output.
+
+## Querying
+
+`bwrb list --output json` expands the field:
+
+```json
+{
+  "position": {
+    "source": [{ "kind": "equal", "ref": "[[A]]", "offset": "34h" }],
+    "resolved": "2026-01-02T15:00:00.000Z",
+    "resolution": "ok"
+  }
+}
+```
+
+`--sort position` sorts by the resolved value, with unresolved values last.
+
+`--where` comparisons use the resolved value:
+
+```bash
+bwrb list event --where "position < date('2026-01-03T00:00:00Z')"
+```
+
+## Audit
+
+`bwrb audit` reports relative-date cycles, contradictions, invalid anchor references, and bound violations as warnings. Unanchored chains are normal and appear as `resolution: "unanchored"` in JSON list output instead of audit noise.
+

--- a/docs-site/src/content/docs/concepts/relative-dates.md
+++ b/docs-site/src/content/docs/concepts/relative-dates.md
@@ -15,6 +15,7 @@ Declare a `relative-date` field alongside a normal `date` field that can anchor 
 {
   "types": {
     "event": {
+      "output_dir": "Events",
       "fields": {
         "name": { "prompt": "text", "required": true },
         "start": { "prompt": "date" },
@@ -56,6 +57,8 @@ A relative-date field resolves to:
 - the transitive result of its first `equal` constraint plus the offset
 - `null` when it only has `after`/`before` bounds or the chain has no absolute anchor
 
+Plain `YYYY-MM-DD` dates are interpreted at local midnight in the machine's timezone before being converted to UTC.
+
 Multiple `equal` constraints are allowed, but only the first one provides the resolved value. If later equal constraints resolve to a different position, Bowerbird reports a contradiction.
 
 Cycles do not crash commands. The involved notes resolve to `null` and are marked with `resolution: "cycle"` in JSON output.
@@ -85,4 +88,3 @@ bwrb list event --where "position < date('2026-01-03T00:00:00Z')"
 ## Audit
 
 `bwrb audit` reports relative-date cycles, contradictions, invalid anchor references, and bound violations as warnings. Unanchored chains are normal and appear as `resolution: "unanchored"` in JSON list output instead of audit noise.
-

--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -95,6 +95,10 @@ Delete semantics in repair mode:
 | `broken-body-wikilink` | A well-formed `[[wikilink]]` in the note **body** whose target resolves to **no note** via the alias-aware, case-insensitive note index (warning; **flag-only** — offers a "did you mean?" hint but never auto-links — see below) |
 | `malformed-body-wikilink` | Wikilink bracket syntax in the body that is broken — an empty target (`[[]]`/`[[ ]]`) or an unclosed `[[` (warning; **flag-only**) |
 | `broken-body-file-link` | A relative markdown file/image link in the body — `[text](path.md)` / `![alt](img.png)` — whose target does not exist on disk (warning; **flag-only**) |
+| `relative-date-cycle` | A [`relative-date`](/concepts/relative-dates/) equal chain loops back on itself (warning; flag-only) |
+| `relative-date-contradiction` | Multiple `equal` constraints on a relative-date field resolve to different positions (warning; flag-only) |
+| `relative-date-bound-violation` | A resolved relative date violates an `after` or `before` bound (warning; flag-only) |
+| `relative-date-invalid-ref` | A relative-date anchor reference is missing or ambiguous (warning; flag-only) |
 | `missing-successor` | A [recurring](/automation/task-system/) note satisfies its trigger (e.g. `status = done`) but its chain field (`next`) is empty — a successor was never spawned (e.g. completed outside bwrb). Warning; **auto-fixable** (`--fix` spawns it, identical to the fast path) |
 | `invalid-recurrence` | A [recurrence](/automation/task-system/) rule is broken at the config level — a malformed trigger, a non-date offset base, or a template that doesn't exist (error; **never auto-fixable** — a config error gets the same safety net as data) |
 

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -284,6 +284,7 @@ Fields define the frontmatter properties of a note. Each field has a name (the o
 | `number` | Numeric input | `number` | Priority, counts |
 | `boolean` | Y/n confirm | `true`/`false` | Flags, toggles |
 | `date` | Date input | `string` (YYYY-MM-DD) | Deadlines, dates |
+| `relative-date` | JSON/object input | object or object list | Query-time positions relative to another note |
 | `select` | Picker from options | `string` or `string[]` | Status, category |
 | `relation` | Picker from vault | `string` (wikilink) | Links to other notes |
 | `list` | Comma-separated input | `string[]` | Tags, aliases |
@@ -383,6 +384,42 @@ is the *coarsest* precision allowed; finer values are always accepted:
 Partial dates are stored verbatim (ISO partials still sort lexically). To relax
 the default for *all* date fields at once, set [`date_granularity`](#config) in
 config; a field's own `granularity` overrides that default.
+
+### relative-date
+
+Structured constraints that position a note relative to another note's date or
+relative-date field. The raw constraint is stored in frontmatter; resolved
+positions are computed at query time and are never written back to the note.
+
+```json
+{
+  "position": {
+    "prompt": "relative-date",
+    "source": "event"
+  }
+}
+```
+
+Stored value:
+
+```yaml
+position:
+  - kind: equal
+    ref: "[[The Rending]]"
+    field: start
+    offset: 34h
+```
+
+`kind` is `equal`, `after`, or `before`. `ref` is the anchor note reference.
+`field` is optional; when omitted, Bowerbird uses the anchor's date field, then
+its relative-date field. `offset` is an optional signed duration using `min`,
+`h`, `d`, or `w`.
+
+`bwrb list --output json` expands the field to include `source`, `resolved`, and
+`resolution`. `--sort <field>` and `--where` comparisons use the resolved value,
+with unresolved values sorted last. Audit reports cycles, contradictions,
+invalid anchor references, and after/before bound violations as warnings. See
+[Relative Dates](/concepts/relative-dates/) for the full query-time behavior.
 
 ### select
 
@@ -630,7 +667,7 @@ Complete list of field properties:
 | Property | Type | Applies To | Description |
 |----------|------|------------|-------------|
 | `value` | string | static | Fixed value (mutually exclusive with `prompt`) |
-| `prompt` | string | prompted | Prompt type: `text`, `number`, `boolean`, `date`, `select`, `relation`, `list` |
+| `prompt` | string | prompted | Prompt type: `text`, `number`, `boolean`, `date`, `relative-date`, `select`, `relation`, `list` |
 | `label` | string | prompted | Custom label shown during prompting (the imperative prompt text) |
 | `description` | string | any | What this field is for and when to use it. Surfaced by `bwrb schema list`; distinct from `label` |
 | `required` | boolean | prompted | Whether field must have a value (default: `false`) |
@@ -638,7 +675,7 @@ Complete list of field properties:
 | `granularity` | string | `date` | Coarsest precision allowed: `day` (default), `month`, or `year`. Overrides `date_granularity` |
 | `options` | array | `select` | Allowed values: bare strings or `{ value, description }` objects |
 | `multiple` | boolean | `select`, `relation` | Allow multiple values (default: `false`) |
-| `source` | string | `relation` | Type name to filter picker, or `"any"` |
+| `source` | string | `relation`, `relative-date` | Type name to filter anchor/picker candidates, or `"any"` |
 | `filter` | object | `relation` | Filter conditions for source query |
 | `owned` | boolean | `relation` | Whether referenced notes are owned/colocated (default: `false`) |
 | `alias` | boolean | `list` | Field role: marks this field as the entity's aliases. Value must be an array of non-empty, unique strings. Consulted by name resolution and linking (default: `false`) |

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -148,6 +148,10 @@ bwrb list task --fields status,priority --output json
 bwrb list task --sort deadline --output json
 bwrb list task --sort priority --desc --output json
 
+# Relative-date fields sort/filter by their resolved query-time value
+bwrb list event --sort position --output json
+bwrb list event --where "position < date('2026-01-03T00:00:00Z')" --output json
+
 # Limit or count matches
 bwrb list task --limit 5 --output json
 bwrb list task --count --output json
@@ -158,6 +162,20 @@ bwrb list --id "<uuid>" --output json
 # Full-text search in note content
 bwrb list --body "search term" --output json
 ```
+
+### Relative-Date Fields
+
+Schema fields with `prompt: "relative-date"` store structured constraints, not
+computed dates. Use JSON/object input in automation:
+
+```bash
+bwrb new event --json '{"name":"Scene B","position":{"kind":"equal","ref":"[[Scene A]]","field":"start","offset":"34h"}}'
+bwrb edit "Scene B" --json '{"position":[{"kind":"after","ref":"[[Scene A]]","field":"start","offset":"1w"}]}'
+```
+
+`kind` is `equal`, `after`, or `before`; `offset` uses `min`, `h`, `d`, or `w`.
+`bwrb list --output json` renders the field as `{ source, resolved, resolution }`.
+Do not write resolved values back into frontmatter.
 
 ### Creating Notes
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,6 @@ export default tseslint.config(
   },
   {
     // Ignore build output, test fixtures, config files, and generated docs-site files
-    ignores: ["dist/**", "tests/**", "*.config.js", "*.config.ts", "docs-site/.astro/**", "docs-site/.cache/**", "docs-site/dist/**"],
+    ignores: ["dist/**", "tests/**", "*.config.js", "*.config.ts", ".claude/**", "docs-site/.astro/**", "docs-site/.cache/**", "docs-site/dist/**"],
   }
 );

--- a/plans/features/relative-dates.md
+++ b/plans/features/relative-dates.md
@@ -1,0 +1,62 @@
+# Relative Dates (PR 1 of the story-time pair)
+
+Owner: Alice (design agreed 2026-07-05). Vault brief: teenylilthoughts `briefs/bwrb relative dates and custom calendars.md`. PR 2 (custom calendars) is out of scope here — but see "Forward compatibility."
+
+## What
+
+A new field prompt type `relative-date`: a structured constraint (or list of constraints) positioning this note in time relative to another note's date-bearing field. Resolution is computed at query time — never written back to frontmatter.
+
+## Frontmatter shape
+
+```yaml
+position:
+  - kind: equal        # equal | after | before
+    ref: "[[The Rending]]"
+    field: start       # optional; names which date-ish field on the anchor (default: the anchor's own relative-date/date field per resolution rules below)
+    offset: 34h        # optional; default 0. parseDuration units: min/h/d/w (d=24h, w=7d). No mon/y in v1.
+```
+
+- `kind: equal` — this note sits exactly `offset` after the anchor (negative positioning is expressed by putting the constraint on the other note or with `before`+`equal` semantics? No: allow `offset: -12h` too; signed offsets are cheaper than a fourth kind).
+- `kind: after` / `before` — inequality bound: at least `offset` after/before the anchor. Bounds do not produce a position by themselves; they validate and can clamp an unknown.
+- Single-constraint scalar convenience: a bare object (not in a list) must also parse.
+- `ref` is a real relation value: wiki-link, participates in link extraction, rename handling, and relation validation like any other relation field.
+
+## Resolution semantics (query time)
+
+- A note's **resolved position** is: its own absolute `date`-type anchor field if the schema declares one alongside, else the transitive resolution of its `equal` constraint chain until a note with an absolute date (or a dead end) is reached.
+- Chains: memoize per index build. Cycle → both notes get `resolved: null` with a reported diagnostic (audit warning + a `resolution: "cycle"` marker in JSON), never a crash.
+- Multiple `equal` constraints that disagree → contradiction diagnostic; resolve to the first, flag the rest.
+- `after`/`before` bounds: checked when both sides resolve; violations are audit warnings. When a note has only bounds (no equal, no absolute), `resolved` is null but `bounds` are exposed in JSON.
+- Anchors without any date anywhere in the chain: `resolved: null`, `resolution: "unanchored"` — this is normal, not an error.
+
+## Query surface
+
+- `bwrb list --output json`: relative-date fields emit `{ source: <raw constraints>, resolved: <ISO or null>, resolution: "ok"|"cycle"|"unanchored"|"contradiction" }`.
+- `--sort` must accept the relative-date field name and order by resolved value (nulls last).
+- `--where` comparisons against the field compare the resolved value.
+- `bwrb audit` reports cycles, contradictions, and bound violations on affected notes.
+
+## Offset representation (forward compatibility with PR 2)
+
+Parse offsets into `{ amount, unit, mode }` structures and resolve to a linear timestamp **at the last moment**. Do not collapse to milliseconds inside the AST. PR 2 (custom calendars) will introduce calendar-scoped units and a non-Gregorian linear timestamp; keeping the AST unit-symbolic means that lands as a resolver swap, not a parser rewrite.
+
+## Schema surface
+
+- `prompt: "relative-date"` in field definitions (zod schema in src/types/schema.ts, docs strings included), `source:` like relation fields to constrain anchor types, `multiple` semantics come free from the list shape.
+- `bwrb schema list <type>` renders the new prompt kind sensibly.
+- `bwrb new`/`edit` interactive + `--json` paths accept the object/list shape with validation errors that state exactly which key is wrong.
+
+## Non-goals (v1)
+
+- No custom calendars, no calendar units (mon/y excluded on purpose).
+- No writing resolved values into notes, ever.
+- No cross-vault refs.
+
+## Acceptance (will be tested by a fresh agent driving only the CLI)
+
+1. Define a `relative-date` field on a type via `bwrb schema` commands (or direct schema.json edit + migrate).
+2. Create three notes: A with absolute date, B `equal` A `+34h`, C `equal` B `-2h`; `bwrb list --sort <field>` orders A, C, B with correct resolved values in JSON.
+3. Add D `after` A `+1w` with no equal — JSON shows null resolved + bounds; no crash anywhere.
+4. Point B at C to create a cycle — `bwrb audit` and `list` both surface it comprehensibly; exit codes stay sane.
+5. Full CI parity passes: `pnpm build && pnpm verify:pack && pnpm typecheck && pnpm lint && pnpm knip && pnpm test -- --exclude='**/*.pty.test.ts'`.
+6. Docs: canonical behavior page in `docs-site/src/content/docs/` + `docs/skill/SKILL.md` updated per repo policy.

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -259,11 +259,12 @@
             "select",
             "list",
             "date",
+            "relative-date",
             "relation",
             "boolean",
             "number"
           ],
-          "description": "Type of prompt: text (free text), select (from options), relation (from vault query), list (comma-separated list), date (date picker), boolean (yes/no), number (numeric input)"
+          "description": "Type of prompt: text (free text), select (from options), relation (from vault query), list (comma-separated list), date (date picker), relative-date (constraints relative to another note date), boolean (yes/no), number (numeric input)"
         },
         "granularity": {
           "type": "string",
@@ -322,7 +323,7 @@
               }
             }
           ],
-          "description": "Type name(s) for relation prompts. When a relation's value is ambiguous because two notes share a name, path-qualify the link (e.g. `[[contexts/Betson]]`); see the search command docs for the shortest-unambiguous-form rule."
+          "description": "Type name(s) for relation and relative-date prompts. When a relation's value is ambiguous because two notes share a name, path-qualify the link (e.g. `[[contexts/Betson]]`); see the search command docs for the shortest-unambiguous-form rule."
         },
         "filter": {
           "type": "object",

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -136,6 +136,10 @@ Issue Types:
                         unclosed [[) (flag-only)
   broken-body-file-link A relative [text](path)/![alt](img) link in the body
                         whose target doesn't exist on disk (flag-only)
+  relative-date-cycle Relative-date equal constraints form a cycle
+  relative-date-contradiction Multiple equal constraints resolve differently
+  relative-date-bound-violation Resolved date violates an after/before bound
+  relative-date-invalid-ref Relative-date anchor is missing or ambiguous
 
 Type Resolution:
   Audit resolves each file's type from its frontmatter 'type' field.

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -54,6 +54,11 @@ import { createDashboard, updateDashboard, getDashboard } from '../lib/dashboard
 import { suggestFieldName } from '../lib/validation.js';
 import { getTtyContext } from '../lib/tty/context.js';
 import { renderTable } from '../lib/tty/table.js';
+import { buildVaultNoteIndex } from '../lib/discovery.js';
+import {
+  buildRelativeDateFieldMap,
+  type RelativeDateFieldMap,
+} from '../lib/relative-date.js';
 
 /**
  * Resolve the output format from --output flag and deprecated flags.
@@ -583,13 +588,26 @@ export async function listObjects(
     ? await collectFileStats(filteredFiles.map(f => f.path))
     : undefined;
 
+  const relativeDateFields = await resolveRelativeDateFieldsForList(schema, vaultDir);
   const fileComparator = createFileComparator(
     vaultDir,
     options.sortField,
     options.sortDesc,
     fileStats
   );
-  filteredFiles.sort(fileComparator);
+  const sortFrontmatterFiles = options.sortField
+    ? new Map(filteredFiles.map(file => [
+        file.path,
+        {
+          ...file,
+          frontmatter: frontmatterForRelativeDateSort(file, options.sortField!, relativeDateFields),
+        },
+      ]))
+    : undefined;
+  filteredFiles.sort((a, b) => fileComparator(
+    sortFrontmatterFiles?.get(a.path) ?? a,
+    sortFrontmatterFiles?.get(b.path) ?? b
+  ));
 
   const matchCount = filteredFiles.length;
 
@@ -664,7 +682,7 @@ export async function listObjects(
         if (!options.fields || options.fields.length === 0) {
           return {
             ...base,
-            ...frontmatter,
+            ...frontmatterWithRelativeDates(path, frontmatter, relativeDateFields),
           };
         }
 
@@ -681,6 +699,11 @@ export async function listObjects(
             // JSON consumers see the same data the table shows (#689).
             const value = fileStatJsonValue(field, fileStats?.get(path));
             if (value !== undefined) selected[field] = value;
+            continue;
+          }
+          const relativeValue = relativeDateFields.get(path)?.get(field);
+          if (relativeValue !== undefined) {
+            selected[field] = relativeValue;
             continue;
           }
           if (Object.prototype.hasOwnProperty.call(frontmatter, field)) {
@@ -730,12 +753,26 @@ export async function listObjects(
 
   // Default output (table with fields or simple names)
   if (options.fields && options.fields.length > 0) {
-    printTable(filteredFiles, vaultDir, showPaths, options.fields, fileStats);
+    printTable(filteredFiles, vaultDir, showPaths, options.fields, fileStats, relativeDateFields);
   } else {
     for (const { path } of filteredFiles) {
       console.log(basename(path, '.md'));
     }
   }
+}
+
+function frontmatterWithRelativeDates(
+  path: string,
+  frontmatter: Record<string, unknown>,
+  relativeDateFields: RelativeDateFieldMap | undefined
+): Record<string, unknown> {
+  const relativeFields = relativeDateFields?.get(path);
+  if (!relativeFields || relativeFields.size === 0) return frontmatter;
+  const result = { ...frontmatter };
+  for (const [field, value] of relativeFields) {
+    result[field] = value;
+  }
+  return result;
 }
 
 /**
@@ -746,7 +783,8 @@ function printTable(
   vaultDir: string,
   showPaths: boolean,
   fields: string[],
-  fileStats?: FileStatMap
+  fileStats?: FileStatMap,
+  relativeDateFields?: RelativeDateFieldMap
 ): void {
   const context = getTtyContext();
   const headerStyle = context.colorEnabled ? (text: string) => chalk.gray(text) : null;
@@ -791,7 +829,7 @@ function printTable(
         ? basename(path, '.md')
         : field === '_path'
           ? relative(vaultDir, path)
-          : frontmatter[field];
+          : getListJsonFieldValue(path, field, frontmatter, relativeDateFields);
       row[field] = formatDisplayValue(value, { empty: '—' });
     }
 
@@ -802,6 +840,52 @@ function printTable(
   for (const line of lines) {
     console.log(line);
   }
+}
+
+async function resolveRelativeDateFieldsForList(
+  schema: LoadedSchema,
+  vaultDir: string
+): Promise<RelativeDateFieldMap> {
+  if (!schemaHasRelativeDateFields(schema)) return new Map();
+
+  const index = await buildVaultNoteIndex(schema, vaultDir);
+  return buildRelativeDateFieldMap(
+    schema,
+    vaultDir,
+    index.snapshot,
+    index.noteTargetIndex
+  ).fields;
+}
+
+function schemaHasRelativeDateFields(schema: LoadedSchema): boolean {
+  for (const type of schema.types.values()) {
+    for (const field of Object.values(type.fields)) {
+      if (field.prompt === 'relative-date') return true;
+    }
+  }
+  return false;
+}
+
+function getListJsonFieldValue(
+  path: string,
+  field: string,
+  frontmatter: Record<string, unknown>,
+  relativeDateFields: RelativeDateFieldMap | undefined
+): unknown {
+  return relativeDateFields?.get(path)?.get(field) ?? frontmatter[field];
+}
+
+function frontmatterForRelativeDateSort(
+  file: { path: string; frontmatter: Record<string, unknown> },
+  sortField: string,
+  relativeDateFields: RelativeDateFieldMap
+): Record<string, unknown> {
+  const resolved = relativeDateFields.get(file.path)?.get(sortField);
+  if (!resolved) return file.frontmatter;
+  return {
+    ...file.frontmatter,
+    [sortField]: resolved.resolved,
+  };
 }
 
 // ============================================================================

--- a/src/commands/schema/field.ts
+++ b/src/commands/schema/field.ts
@@ -250,7 +250,7 @@ export function registerEditFieldCommand(editCommand: Command): void {
               }
             }
           } else if (choice === 'Change prompt type') {
-            const promptOptions = ['text', 'select', 'list', 'date', 'relation', 'boolean', 'number'];
+            const promptOptions = ['text', 'select', 'list', 'date', 'relative-date', 'relation', 'boolean', 'number'];
             const newPrompt = await promptSelection('Prompt type', promptOptions);
             const fieldEntry = rawTypeEntry.fields?.[fieldName];
             if (newPrompt !== null && fieldEntry) {

--- a/src/commands/schema/helpers/output.ts
+++ b/src/commands/schema/helpers/output.ts
@@ -530,6 +530,8 @@ export function getFieldType(field: Field): string {
       return chalk.blue('text');
     case 'date':
       return chalk.blue('date');
+    case 'relative-date':
+      return chalk.blue('relative-date');
     case 'relation':
       return field.source ? chalk.blue(`relation:${field.source}`) : chalk.blue('relation');
     case 'boolean':

--- a/src/commands/schema/helpers/prompts.ts
+++ b/src/commands/schema/helpers/prompts.ts
@@ -64,6 +64,7 @@ export async function promptFieldDefinition(
     'text',
     'select (options)',
     'date',
+    'relative date',
     'list (multi-value)',
     'relation (from other notes)',
     'boolean (yes/no)',
@@ -78,11 +79,12 @@ export async function promptFieldDefinition(
     0: 'text',
     1: 'select',
     2: 'date',
-    3: 'list',
-    4: 'relation',
-    5: 'boolean',
-    6: 'number',
-    7: 'value',
+    3: 'relative-date',
+    4: 'list',
+    5: 'relation',
+    6: 'boolean',
+    7: 'number',
+    8: 'value',
   };
   const promptType = promptTypeMap[promptTypeIndex];
   
@@ -111,7 +113,7 @@ export async function promptFieldDefinition(
     }
     
     // For dynamic, get source type
-    if (promptType === 'relation') {
+    if (promptType === 'relation' || promptType === 'relative-date') {
       const typeNames = getTypeNames(schema).filter(t => t !== 'meta');
       if (typeNames.length === 0) {
         printError('No types defined in schema yet.');
@@ -178,6 +180,7 @@ export async function promptSingleFieldDefinition(
     'text',
     'select (options)',
     'date',
+    'relative date',
     'list (multi-value)',
     'relation (from other notes)',
     'boolean (yes/no)',
@@ -192,11 +195,12 @@ export async function promptSingleFieldDefinition(
     0: 'text',
     1: 'select',
     2: 'date',
-    3: 'list',
-    4: 'relation',
-    5: 'boolean',
-    6: 'number',
-    7: 'value',
+    3: 'relative-date',
+    4: 'list',
+    5: 'relation',
+    6: 'boolean',
+    7: 'number',
+    8: 'value',
   };
   const promptType = promptTypeMap[promptTypeIndex];
   
@@ -223,8 +227,8 @@ export async function promptSingleFieldDefinition(
       field.options = annotated;
     }
     
-    // For relation, get source type
-    if (promptType === 'relation') {
+    // For relation-like fields, get source type
+    if (promptType === 'relation' || promptType === 'relative-date') {
       const typeNames = getTypeNames(schema).filter(t => t !== 'meta');
       if (typeNames.length === 0) {
         throw new Error('No types defined in schema yet.');

--- a/src/commands/schema/type.ts
+++ b/src/commands/schema/type.ts
@@ -145,7 +145,7 @@ export function registerNewTypeCommand(newCommand: Command): void {
               throw new Error(`Invalid field definition: "${fieldDef}". Use "name:type" format.`);
             }
             // Map simple type strings to field definitions
-            const promptType = fieldType as 'text' | 'select' | 'date' | 'list' | 'relation' | 'boolean' | 'number';
+            const promptType = fieldType as Field['prompt'];
             fields[fieldName] = { prompt: promptType };
           }
         } else if (!jsonMode) {

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -78,6 +78,7 @@ import {
   resolveRelationTarget,
   type NoteTargetIndex,
 } from '../discovery.js';
+import { buildRelativeDateFieldMap, validateRelativeDateValue } from '../relative-date.js';
 
 // Import ownership tracking
 import {
@@ -246,6 +247,38 @@ export async function runAudit(
         path: file.path,
         relativePath: file.relativePath,
         issues: filteredIssues,
+      });
+    }
+  }
+
+  const relativeDateDiagnostics = buildRelativeDateFieldMap(
+    schema,
+    vaultDir,
+    noteIndex.snapshot,
+    noteIndex.noteTargetIndex
+  ).diagnostics;
+  for (const diagnostic of relativeDateDiagnostics) {
+    const relativePath = filteredFiles.find(file => file.path === diagnostic.path)?.relativePath;
+    if (!relativePath) continue;
+    const issue: AuditIssue = {
+      severity: diagnostic.severity,
+      code: diagnostic.code,
+      message: diagnostic.message,
+      field: diagnostic.field,
+      autoFixable: false,
+      ...(diagnostic.relatedPaths ? { meta: { relatedPaths: diagnostic.relatedPaths } } : {}),
+    };
+    if (options.onlyIssue && issue.code !== options.onlyIssue) continue;
+    if (options.ignoreIssue && issue.code === options.ignoreIssue) continue;
+
+    const existing = results.find(result => result.path === diagnostic.path);
+    if (existing) {
+      existing.issues.push(issue);
+    } else {
+      results.push({
+        path: diagnostic.path,
+        relativePath,
+        issues: [issue],
       });
     }
   }
@@ -550,6 +583,22 @@ export async function auditFile(
   for (const [fieldName, value] of Object.entries(frontmatter)) {
     const field = fields[fieldName];
     if (!field) continue;
+
+    if (field.prompt === 'relative-date') {
+      const relativeDateError = validateRelativeDateValue(fieldName, value);
+      if (relativeDateError) {
+        issues.push({
+          severity: 'error',
+          code: 'format-violation',
+          message: relativeDateError,
+          field: fieldName,
+          value,
+          expected: '{ kind, ref, field?, offset? } or a list of those objects',
+          autoFixable: false,
+        });
+      }
+      continue;
+    }
 
     const expectsList = field.prompt === 'list' || field.multiple === true;
     const expectedScalarType = getExpectedScalarType(field);

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -86,7 +86,12 @@ export type IssueCode =
   // Body link validation (#652): a markdown file/image link `[t](path)` /
   // `![a](img)` whose relative target doesn't exist on disk (resolved relative to
   // the note's directory). External URLs / anchors are not checked. Flag-only.
-  | 'broken-body-file-link';
+  | 'broken-body-file-link'
+  | 'relative-date-cycle'
+  | 'relative-date-contradiction'
+  | 'relative-date-bound-violation'
+  | 'relative-date-unanchored'
+  | 'relative-date-invalid-ref';
 
 /**
  * A single audit issue.

--- a/src/lib/field-prompt.ts
+++ b/src/lib/field-prompt.ts
@@ -146,6 +146,10 @@ export async function promptField(
       if (opts.mode === 'create') return promptDateFieldCreate(label, field);
       return promptTextOrDateTemplate(label, opts);
 
+    case 'relative-date':
+      if (opts.mode === 'create') return promptRelativeDateFieldCreate(label, field);
+      return promptRelativeDateTemplate(label, opts);
+
     case 'boolean':
       if (opts.mode === 'create') return promptBooleanFieldCreate(label);
       return promptBooleanTemplate(label, opts);
@@ -379,6 +383,39 @@ async function promptDateFieldCreate(label: string, field: Field): Promise<unkno
   const value = await promptInput(label, defaultVal);
   if (value === null) throw new UserCancelledError();
   return value;
+}
+
+async function promptRelativeDateFieldCreate(label: string, field: Field): Promise<unknown> {
+  const defaultVal = typeof field.default === 'string' ? field.default : undefined;
+  const value = await promptInput(label, defaultVal);
+  if (value === null) throw new UserCancelledError();
+  if (!value.trim()) return field.default ?? '';
+  return parseRelativeDatePromptInput(value);
+}
+
+async function promptRelativeDateTemplate(
+  label: string,
+  opts: Extract<FieldPromptOptions, { mode: 'template-default' } | { mode: 'template-edit' }>
+): Promise<unknown> {
+  if (opts.mode === 'template-default') {
+    const input = await promptInput(`Default ${label} as JSON (or Enter to skip)`);
+    if (input === null) throw new UserCancelledError();
+    if (!input.trim()) return undefined;
+    return parseRelativeDatePromptInput(input);
+  }
+  const input = await promptInput(`New ${label} as JSON (Enter to keep, "clear" to remove)`);
+  if (input === null) throw new UserCancelledError();
+  if (!input.trim()) return opts.currentValue;
+  if (input.toLowerCase() === 'clear') return CLEAR;
+  return parseRelativeDatePromptInput(input);
+}
+
+function parseRelativeDatePromptInput(input: string): unknown {
+  try {
+    return JSON.parse(input);
+  } catch (error) {
+    throw new Error(`Invalid relative-date JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
 }
 
 async function promptBooleanFieldCreate(label: string): Promise<unknown> {

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -12,9 +12,14 @@ import { collectFrontmatterKeys, normalizeWhereExpressions } from './where-norma
 import { extractLinkTarget } from './links.js';
 import {
   buildVaultNoteSnapshot,
+  buildVaultNoteIndex,
   deriveNoteTargetIndex,
   type VaultNoteSnapshot,
 } from './discovery.js';
+import {
+  buildRelativeDateFieldMap,
+  type RelativeDateFieldMap,
+} from './relative-date.js';
 
 /**
  * Validate that a field name is valid for a type.
@@ -588,10 +593,15 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
   }
 
   const relationSourceCache = new Map<string, Map<string, string | string[] | undefined>>();
+  const relativeDateFields =
+    schema && expressionPairs.length > 0
+      ? await resolveRelativeDateFieldsForQuery(schema, vaultDir)
+      : undefined;
   for (const file of files) {
     // Apply expression filters (--where style)
     if (expressionPairs.length > 0) {
-      const context = await buildEvalContext(file.path, vaultDir, file.frontmatter);
+      const evalFrontmatter = frontmatterWithResolvedRelativeDates(file, relativeDateFields);
+      const context = await buildEvalContext(file.path, vaultDir, evalFrontmatter);
       const relationType = resolveHierarchyType(file.frontmatter, {
         ...(schema ? { schema } : {}),
         ...(typePath ? { typePath } : {}),
@@ -626,4 +636,31 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
   }
 
   return result;
+}
+
+async function resolveRelativeDateFieldsForQuery(
+  schema: LoadedSchema,
+  vaultDir: string
+): Promise<RelativeDateFieldMap> {
+  const index = await buildVaultNoteIndex(schema, vaultDir);
+  return buildRelativeDateFieldMap(
+    schema,
+    vaultDir,
+    index.snapshot,
+    index.noteTargetIndex
+  ).fields;
+}
+
+function frontmatterWithResolvedRelativeDates<T extends FileWithFrontmatter>(
+  file: T,
+  relativeDateFields: RelativeDateFieldMap | undefined
+): Record<string, unknown> {
+  const fields = relativeDateFields?.get(file.path);
+  if (!fields || fields.size === 0) return file.frontmatter;
+
+  const frontmatter = { ...file.frontmatter };
+  for (const [fieldName, output] of fields) {
+    frontmatter[fieldName] = output.resolved;
+  }
+  return frontmatter;
 }

--- a/src/lib/relative-date.ts
+++ b/src/lib/relative-date.ts
@@ -1,0 +1,483 @@
+import { relative } from 'path';
+import type { LoadedSchema, Field } from '../types/schema.js';
+import { getFieldsForType, resolveTypeFromFrontmatter } from './schema.js';
+import { extractLinkTarget } from './links.js';
+import {
+  resolveRelationTarget,
+  type NoteTargetIndex,
+  type VaultNoteSnapshot,
+} from './discovery.js';
+import { parseDate } from './local-date.js';
+
+export type RelativeDateKind = 'equal' | 'after' | 'before';
+export type RelativeDateUnit = 'min' | 'h' | 'd' | 'w';
+export type RelativeDateResolution = 'ok' | 'cycle' | 'unanchored' | 'contradiction';
+
+export interface RelativeDateOffset {
+  amount: number;
+  unit: RelativeDateUnit;
+  mode: 'linear';
+}
+
+export interface RelativeDateConstraint {
+  kind: RelativeDateKind;
+  ref: string;
+  field?: string;
+  offset?: RelativeDateOffset;
+}
+
+export interface RelativeDateFieldOutput {
+  source: unknown;
+  resolved: string | null;
+  resolution: RelativeDateResolution;
+  bounds?: RelativeDateBoundOutput[];
+}
+
+export interface RelativeDateBoundOutput {
+  kind: 'after' | 'before';
+  ref: string;
+  field?: string;
+  offset?: RelativeDateOffset;
+  resolved: string | null;
+}
+
+export type RelativeDateDiagnosticCode =
+  | 'relative-date-cycle'
+  | 'relative-date-contradiction'
+  | 'relative-date-bound-violation'
+  | 'relative-date-unanchored'
+  | 'relative-date-invalid-ref';
+
+export interface RelativeDateDiagnostic {
+  code: RelativeDateDiagnosticCode;
+  severity: 'warning';
+  path: string;
+  field: string;
+  message: string;
+  relatedPaths?: string[];
+}
+
+interface IndexedNote {
+  path: string;
+  relativePath: string;
+  frontmatter: Record<string, unknown>;
+  typePath: string;
+  fields: Record<string, Field>;
+}
+
+interface ResolveKey {
+  path: string;
+  field: string;
+}
+
+interface ResolveResult {
+  resolvedMs: number | null;
+  resolution: RelativeDateResolution;
+  source: unknown;
+  constraints: RelativeDateConstraint[];
+  diagnostics: RelativeDateDiagnostic[];
+  bounds: RelativeDateBoundOutput[];
+}
+
+export type RelativeDateFieldMap = Map<string, Map<string, RelativeDateFieldOutput>>;
+
+const DEFAULT_OFFSET: RelativeDateOffset = { amount: 0, unit: 'h', mode: 'linear' };
+const MS_PER_UNIT: Record<RelativeDateUnit, number> = {
+  min: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+  w: 7 * 24 * 60 * 60 * 1000,
+};
+
+function parseRelativeDateOffset(value: unknown): RelativeDateOffset | null {
+  if (value === undefined || value === null || value === '') return { ...DEFAULT_OFFSET };
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    const raw = value as Record<string, unknown>;
+    if (
+      typeof raw.amount === 'number' &&
+      Number.isFinite(raw.amount) &&
+      isRelativeDateUnit(raw.unit) &&
+      (raw.mode === undefined || raw.mode === 'linear')
+    ) {
+      return { amount: raw.amount, unit: raw.unit, mode: 'linear' };
+    }
+    return null;
+  }
+  if (typeof value !== 'string') return null;
+
+  const match = value.trim().match(/^([+-]?\d+)(min|h|d|w)$/);
+  if (!match) return null;
+  return {
+    amount: Number.parseInt(match[1]!, 10),
+    unit: match[2]! as RelativeDateUnit,
+    mode: 'linear',
+  };
+}
+
+function parseRelativeDateConstraints(value: unknown): RelativeDateConstraint[] | null {
+  const rawConstraints = Array.isArray(value) ? value : [value];
+  const parsed: RelativeDateConstraint[] = [];
+
+  for (const rawConstraint of rawConstraints) {
+    if (typeof rawConstraint !== 'object' || rawConstraint === null || Array.isArray(rawConstraint)) {
+      return null;
+    }
+    const raw = rawConstraint as Record<string, unknown>;
+    if (!isRelativeDateKind(raw.kind) || typeof raw.ref !== 'string' || raw.ref.trim() === '') {
+      return null;
+    }
+    if (raw.field !== undefined && typeof raw.field !== 'string') return null;
+    const offset = parseRelativeDateOffset(raw.offset);
+    if (!offset) return null;
+
+    parsed.push({
+      kind: raw.kind,
+      ref: raw.ref,
+      ...(raw.field !== undefined ? { field: raw.field } : {}),
+      offset,
+    });
+  }
+
+  return parsed;
+}
+
+export function validateRelativeDateValue(fieldName: string, value: unknown): string | null {
+  const rawConstraints = Array.isArray(value) ? value : [value];
+  for (let index = 0; index < rawConstraints.length; index++) {
+    const prefix = Array.isArray(value) ? `${fieldName}[${index}]` : fieldName;
+    const rawConstraint = rawConstraints[index];
+    if (typeof rawConstraint !== 'object' || rawConstraint === null || Array.isArray(rawConstraint)) {
+      return `Invalid relative-date for ${prefix}: expected object with kind, ref, field, and offset`;
+    }
+    const raw = rawConstraint as Record<string, unknown>;
+    if (!isRelativeDateKind(raw.kind)) {
+      return `Invalid relative-date for ${prefix}.kind: expected equal, after, or before`;
+    }
+    if (typeof raw.ref !== 'string' || raw.ref.trim() === '') {
+      return `Invalid relative-date for ${prefix}.ref: expected non-empty wikilink or note reference`;
+    }
+    if (raw.field !== undefined && typeof raw.field !== 'string') {
+      return `Invalid relative-date for ${prefix}.field: expected string`;
+    }
+    if (raw.offset !== undefined && parseRelativeDateOffset(raw.offset) === null) {
+      return `Invalid relative-date for ${prefix}.offset: expected signed duration using min, h, d, or w`;
+    }
+  }
+  return null;
+}
+
+export function buildRelativeDateFieldMap(
+  schema: LoadedSchema,
+  vaultDir: string,
+  snapshot: VaultNoteSnapshot,
+  noteTargetIndex: NoteTargetIndex
+): { fields: RelativeDateFieldMap; diagnostics: RelativeDateDiagnostic[] } {
+  const notes = new Map<string, IndexedNote>();
+  const cache = new Map<string, ResolveResult>();
+  const diagnostics: RelativeDateDiagnostic[] = [];
+  const emitted = new Set<string>();
+
+  for (const note of snapshot.notes) {
+    if (!note.frontmatter) continue;
+    const typePath = note.resolvedType ?? resolveTypeFromFrontmatter(schema, note.frontmatter);
+    if (!typePath) continue;
+    const fields = getFieldsForType(schema, typePath);
+    notes.set(note.relativePath, {
+      path: note.path,
+      relativePath: note.relativePath,
+      frontmatter: note.frontmatter,
+      typePath,
+      fields,
+    });
+  }
+
+  const ctx = {
+    schema,
+    notes,
+    noteTargetIndex,
+    cache,
+    diagnostics,
+    emitted,
+  };
+
+  const output: RelativeDateFieldMap = new Map();
+  for (const note of notes.values()) {
+    for (const [fieldName, field] of Object.entries(note.fields)) {
+      if (field.prompt !== 'relative-date') continue;
+      const result = resolveRelativeDateField(ctx, { path: note.relativePath, field: fieldName }, []);
+      setRelativeDateOutput(output, note.path, fieldName, {
+        source: result.source ?? null,
+        resolved: result.resolvedMs === null ? null : new Date(result.resolvedMs).toISOString(),
+        resolution: result.resolution,
+        ...(result.bounds.length > 0 ? { bounds: result.bounds } : {}),
+      });
+    }
+  }
+
+  // Keep diagnostics stable and display-oriented.
+  diagnostics.sort((a, b) => {
+    const pathCompare = relative(vaultDir, a.path).localeCompare(relative(vaultDir, b.path));
+    return pathCompare || a.field.localeCompare(b.field) || a.code.localeCompare(b.code);
+  });
+
+  return { fields: output, diagnostics };
+}
+
+function resolveRelativeDateField(
+  ctx: {
+    schema: LoadedSchema;
+    notes: Map<string, IndexedNote>;
+    noteTargetIndex: NoteTargetIndex;
+    cache: Map<string, ResolveResult>;
+    diagnostics: RelativeDateDiagnostic[];
+    emitted: Set<string>;
+  },
+  key: ResolveKey,
+  stack: ResolveKey[]
+): ResolveResult {
+  const cacheKey = makeCacheKey(key);
+  const cached = ctx.cache.get(cacheKey);
+  if (cached) return cached;
+
+  const note = ctx.notes.get(key.path);
+  if (!note) {
+    return emptyResult(undefined, 'unanchored');
+  }
+
+  const cycleStart = stack.findIndex(item => makeCacheKey(item) === cacheKey);
+  if (cycleStart >= 0) {
+    const cycle = [...stack.slice(cycleStart), key];
+    const relatedPaths = [...new Set(cycle.map(item => item.path))];
+    for (const cycleKey of cycle) {
+      const cycleNote = ctx.notes.get(cycleKey.path);
+      if (!cycleNote) continue;
+      emitDiagnostic(ctx, {
+        code: 'relative-date-cycle',
+        severity: 'warning',
+        path: cycleNote.path,
+        field: cycleKey.field,
+        relatedPaths,
+        message: `Relative date cycle detected for ${cycleKey.field}: ${relatedPaths.join(' -> ')}`,
+      });
+      ctx.cache.set(makeCacheKey(cycleKey), emptyResult(cycleNote.frontmatter[cycleKey.field], 'cycle'));
+    }
+    return emptyResult(note.frontmatter[key.field], 'cycle');
+  }
+
+  const field = note.fields[key.field];
+  if (!field || field.prompt !== 'relative-date') {
+    const absolute = parseAbsoluteDateValue(note.frontmatter[key.field]);
+    return {
+      resolvedMs: absolute,
+      resolution: absolute === null ? 'unanchored' : 'ok',
+      source: note.frontmatter[key.field],
+      constraints: [],
+      diagnostics: [],
+      bounds: [],
+    };
+  }
+
+  const source = note.frontmatter[key.field];
+  const constraints = parseRelativeDateConstraints(source);
+  if (!constraints || constraints.length === 0) {
+    const ownAnchorMs = resolveOwnAbsoluteAnchor(note);
+    const result: ResolveResult = ownAnchorMs === null
+      ? emptyResult(source, 'unanchored')
+      : {
+          resolvedMs: ownAnchorMs,
+          resolution: 'ok',
+          source,
+          constraints: [],
+          diagnostics: [],
+          bounds: [],
+        };
+    ctx.cache.set(cacheKey, result);
+    return result;
+  }
+
+  const equalResults: Array<{ constraint: RelativeDateConstraint; resolvedMs: number | null; resolution: RelativeDateResolution; path?: string }> = [];
+  const bounds: RelativeDateBoundOutput[] = [];
+
+  for (const constraint of constraints) {
+    const targetPath = resolveConstraintTarget(ctx, constraint, field);
+    if (!targetPath) {
+      emitDiagnostic(ctx, {
+        code: 'relative-date-invalid-ref',
+        severity: 'warning',
+        path: note.path,
+        field: key.field,
+        message: `Relative date ${key.field} references an unknown or ambiguous note: ${constraint.ref}`,
+      });
+      continue;
+    }
+
+    const target = ctx.notes.get(targetPath);
+    const targetField = target ? resolveTargetField(target, constraint.field) : undefined;
+    const targetResult = target && targetField
+      ? resolveRelativeDateField(ctx, { path: targetPath, field: targetField }, [...stack, key])
+      : emptyResult(undefined, 'unanchored');
+    const resolvedMs = targetResult.resolvedMs === null
+      ? null
+      : targetResult.resolvedMs + offsetToMilliseconds(constraint.offset ?? DEFAULT_OFFSET);
+
+    if (constraint.kind === 'equal') {
+      equalResults.push({ constraint, resolvedMs, resolution: targetResult.resolution, path: targetPath });
+    } else {
+      const bound: RelativeDateBoundOutput = {
+        kind: constraint.kind,
+        ref: constraint.ref,
+        ...(constraint.field ? { field: constraint.field } : {}),
+        offset: constraint.offset ?? DEFAULT_OFFSET,
+        resolved: resolvedMs === null ? null : new Date(resolvedMs).toISOString(),
+      };
+      bounds.push(bound);
+    }
+  }
+
+  const firstEqual = equalResults[0];
+  let resolution: RelativeDateResolution = 'unanchored';
+  let resolvedMs: number | null = null;
+
+  if (firstEqual) {
+    resolvedMs = firstEqual.resolvedMs;
+    resolution = firstEqual.resolution === 'ok' ? 'ok' : firstEqual.resolution;
+    const disagreeing = equalResults.slice(1).filter(result =>
+      result.resolvedMs !== null &&
+      firstEqual.resolvedMs !== null &&
+      result.resolvedMs !== firstEqual.resolvedMs
+    );
+    if (disagreeing.length > 0) {
+      resolution = 'contradiction';
+      emitDiagnostic(ctx, {
+        code: 'relative-date-contradiction',
+        severity: 'warning',
+        path: note.path,
+        field: key.field,
+        relatedPaths: equalResults.map(result => result.path).filter((path): path is string => Boolean(path)),
+        message: `Relative date ${key.field} has equal constraints that resolve to different positions`,
+      });
+    }
+  }
+
+  if (!firstEqual && bounds.length > 0) {
+    resolution = 'unanchored';
+  }
+
+  if (resolvedMs !== null) {
+    for (const bound of bounds) {
+      if (!bound.resolved) continue;
+      const boundMs = Date.parse(bound.resolved);
+      const violates = bound.kind === 'after' ? resolvedMs < boundMs : resolvedMs > boundMs;
+      if (violates) {
+        emitDiagnostic(ctx, {
+          code: 'relative-date-bound-violation',
+          severity: 'warning',
+          path: note.path,
+          field: key.field,
+          message: `Relative date ${key.field} violates ${bound.kind} bound against ${bound.ref}`,
+        });
+      }
+    }
+  }
+
+  const result: ResolveResult = {
+    resolvedMs,
+    resolution,
+    source,
+    constraints,
+    diagnostics: [],
+    bounds,
+  };
+  ctx.cache.set(cacheKey, result);
+  return result;
+}
+
+function resolveTargetField(note: IndexedNote, explicitField: string | undefined): string | undefined {
+  if (explicitField) return explicitField;
+  for (const [fieldName, field] of Object.entries(note.fields)) {
+    if (field.prompt === 'date' && note.frontmatter[fieldName] !== undefined) return fieldName;
+  }
+  for (const [fieldName, field] of Object.entries(note.fields)) {
+    if (field.prompt === 'relative-date' && note.frontmatter[fieldName] !== undefined) return fieldName;
+  }
+  return undefined;
+}
+
+function resolveOwnAbsoluteAnchor(note: IndexedNote): number | null {
+  for (const [fieldName, field] of Object.entries(note.fields)) {
+    if (field.prompt !== 'date') continue;
+    const resolved = parseAbsoluteDateValue(note.frontmatter[fieldName]);
+    if (resolved !== null) return resolved;
+  }
+  return null;
+}
+
+function resolveConstraintTarget(
+  ctx: { schema: LoadedSchema; noteTargetIndex: NoteTargetIndex },
+  constraint: RelativeDateConstraint,
+  field: Field
+): string | null {
+  const target = extractLinkTarget(constraint.ref) ?? constraint.ref.trim();
+  if (!target) return null;
+  const resolved = resolveRelationTarget(ctx.noteTargetIndex, target, {
+    schema: ctx.schema,
+    source: field.source,
+  });
+  return resolved.resolvedPath ?? null;
+}
+
+function parseAbsoluteDateValue(value: unknown): number | null {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'number') value = String(value);
+  if (typeof value !== 'string') return null;
+  const parsed = parseDate(value);
+  return parsed.valid && parsed.date ? parsed.date.getTime() : null;
+}
+
+function offsetToMilliseconds(offset: RelativeDateOffset): number {
+  return offset.amount * MS_PER_UNIT[offset.unit];
+}
+
+function setRelativeDateOutput(
+  map: RelativeDateFieldMap,
+  path: string,
+  field: string,
+  value: RelativeDateFieldOutput
+): void {
+  const fields = map.get(path) ?? new Map<string, RelativeDateFieldOutput>();
+  fields.set(field, value);
+  map.set(path, fields);
+}
+
+function emptyResult(source: unknown, resolution: RelativeDateResolution): ResolveResult {
+  return {
+    resolvedMs: null,
+    resolution,
+    source,
+    constraints: [],
+    diagnostics: [],
+    bounds: [],
+  };
+}
+
+function emitDiagnostic(
+  ctx: { diagnostics: RelativeDateDiagnostic[]; emitted: Set<string> },
+  diagnostic: RelativeDateDiagnostic
+): void {
+  const key = `${diagnostic.code}:${diagnostic.path}:${diagnostic.field}:${diagnostic.message}`;
+  if (ctx.emitted.has(key)) return;
+  ctx.emitted.add(key);
+  ctx.diagnostics.push(diagnostic);
+}
+
+function makeCacheKey(key: ResolveKey): string {
+  return `${key.path}#${key.field}`;
+}
+
+function isRelativeDateKind(value: unknown): value is RelativeDateKind {
+  return value === 'equal' || value === 'after' || value === 'before';
+}
+
+function isRelativeDateUnit(value: unknown): value is RelativeDateUnit {
+  return value === 'min' || value === 'h' || value === 'd' || value === 'w';
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -18,6 +18,7 @@ import {
   isPrecisionAllowed,
   type DatePrecision,
 } from './local-date.js';
+import { validateRelativeDateValue } from './relative-date.js';
 
 export type NormalizedDateResult =
   | { valid: true; value: string }
@@ -197,6 +198,7 @@ type ValidationErrorType =
   | 'invalid_type'
   | 'unknown_field'
   | 'invalid_date'
+  | 'invalid_relative_date'
   | 'invalid_alias'
   | 'invalid_context_source';
 
@@ -522,6 +524,20 @@ function validateFieldType(
     }
 
     return validateDateValue(fieldName, value, granularity);
+  }
+
+  if (field.prompt === 'relative-date') {
+    const relativeDateError = validateRelativeDateValue(fieldName, value);
+    if (relativeDateError) {
+      return {
+        type: 'invalid_relative_date',
+        field: fieldName,
+        value,
+        message: relativeDateError,
+        expected: '{ kind: equal|after|before, ref: "[[Note]]", field?: string, offset?: signed duration min|h|d|w }',
+      };
+    }
+    return null;
   }
 
   // Boolean fields

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -34,10 +34,10 @@ export const FieldOptionSchema = z.union([
 export const FieldSchema = z.object({
   // Prompt type (how the field is collected)
   prompt: z
-    .enum(['text', 'select', 'list', 'date', 'relation', 'boolean', 'number'])
+    .enum(['text', 'select', 'list', 'date', 'relative-date', 'relation', 'boolean', 'number'])
     .optional()
     .describe(
-      'Type of prompt: text (free text), select (from options), relation (from vault query), list (comma-separated list), date (date picker), boolean (yes/no), number (numeric input)'
+      'Type of prompt: text (free text), select (from options), relation (from vault query), list (comma-separated list), date (date picker), relative-date (constraints relative to another note date), boolean (yes/no), number (numeric input)'
     ),
   // Coarsest date precision allowed for `date` fields (finer is always allowed).
   // - day (default): full YYYY-MM-DD only
@@ -79,7 +79,7 @@ export const FieldSchema = z.object({
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe(
-      'Type name(s) for relation prompts. When a relation\'s value is ambiguous because two notes share a name, path-qualify the link (e.g. `[[contexts/Betson]]`); see the search command docs for the shortest-unambiguous-form rule.'
+      'Type name(s) for relation and relative-date prompts. When a relation\'s value is ambiguous because two notes share a name, path-qualify the link (e.g. `[[contexts/Betson]]`); see the search command docs for the shortest-unambiguous-form rule.'
     ),
   // Filter conditions for type-based source queries
   // Applies frontmatter conditions to filter results (e.g., { status: { not_in: ["settled"] } })

--- a/tests/ts/commands/relative-date.test.ts
+++ b/tests/ts/commands/relative-date.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runCLI, TEST_SCHEMA } from '../fixtures/setup.js';
+import { ExitCodes } from '../../../src/lib/output.js';
+
+describe('relative-date fields', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-relative-date-'));
+    await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+    await mkdir(join(vaultDir, 'Moments'), { recursive: true });
+    await writeFile(
+      join(vaultDir, '.bwrb', 'schema.json'),
+      JSON.stringify(relativeDateSchema(), null, 2)
+    );
+  });
+
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('resolves chains for list JSON, sort, and where comparisons', async () => {
+    await writeMoment('A', { start: '2026-01-01' });
+    await writeMoment('B', {
+      position: [{ kind: 'equal', ref: '[[A]]', field: 'start', offset: '34h' }],
+    });
+    await writeMoment('C', {
+      position: [{ kind: 'equal', ref: '[[B]]', field: 'position', offset: '-2h' }],
+    });
+    await writeMoment('D', {
+      position: [{ kind: 'after', ref: '[[A]]', field: 'start', offset: '1w' }],
+    });
+
+    const sorted = await runCLI(['list', 'moment', '--sort', 'position', '--output', 'json'], vaultDir);
+    expect(sorted.exitCode).toBe(0);
+    const rows = JSON.parse(sorted.stdout) as Array<Record<string, unknown>>;
+    expect(rows.map(row => row._name)).toEqual(['A', 'C', 'B', 'D']);
+    expect(rows[0]!.position).toMatchObject({
+      resolved: '2026-01-01T05:00:00.000Z',
+      resolution: 'ok',
+    });
+    expect(rows[1]!.position).toMatchObject({
+      resolved: '2026-01-02T13:00:00.000Z',
+      resolution: 'ok',
+    });
+    expect(rows[2]!.position).toMatchObject({
+      resolved: '2026-01-02T15:00:00.000Z',
+      resolution: 'ok',
+    });
+    expect(rows[3]!.position).toMatchObject({
+      resolved: null,
+      resolution: 'unanchored',
+    });
+
+    const filtered = await runCLI(
+      ['list', 'moment', '--where', "position < date('2026-01-02T14:00:00Z')", '--output', 'json'],
+      vaultDir
+    );
+    expect(filtered.exitCode).toBe(0);
+    const filteredRows = JSON.parse(filtered.stdout) as Array<Record<string, unknown>>;
+    expect(filteredRows.map(row => row._name)).toEqual(['A', 'C']);
+  });
+
+  it('keeps unresolved relative-date sort values last in both directions', async () => {
+    await writeMoment('Early', { start: '2026-01-01' });
+    await writeMoment('Late', { start: '2026-02-01' });
+    await writeMoment('Floating', {
+      position: [{ kind: 'after', ref: '[[Late]]', field: 'start', offset: '1w' }],
+    });
+
+    const ascending = await runCLI(['list', 'moment', '--sort', 'position', '--output', 'json'], vaultDir);
+    expect(ascending.exitCode).toBe(0);
+    const ascendingRows = JSON.parse(ascending.stdout) as Array<Record<string, unknown>>;
+    expect(ascendingRows.map(row => row._name)).toEqual(['Early', 'Late', 'Floating']);
+    expect(ascendingRows[2]!.position).toMatchObject({
+      resolved: null,
+      resolution: 'unanchored',
+    });
+
+    const descending = await runCLI(['list', 'moment', '--sort', 'position', '--desc', '--output', 'json'], vaultDir);
+    expect(descending.exitCode).toBe(0);
+    const descendingRows = JSON.parse(descending.stdout) as Array<Record<string, unknown>>;
+    expect(descendingRows.map(row => row._name)).toEqual(['Late', 'Early', 'Floating']);
+    expect(descendingRows[2]!.position).toMatchObject({
+      resolved: null,
+      resolution: 'unanchored',
+    });
+  });
+
+  it('reports cycles, contradictions, and bound violations in audit', async () => {
+    await writeMoment('Cycle A', {
+      position: [{ kind: 'equal', ref: '[[Cycle B]]', field: 'position', offset: '0h' }],
+    });
+    await writeMoment('Cycle B', {
+      position: [{ kind: 'equal', ref: '[[Cycle A]]', field: 'position', offset: '0h' }],
+    });
+    await writeMoment('Anchor 1', { start: '2026-01-01' });
+    await writeMoment('Anchor 2', { start: '2026-01-03' });
+    await writeMoment('Contradiction', {
+      position: [
+        { kind: 'equal', ref: '[[Anchor 1]]', field: 'start', offset: '0h' },
+        { kind: 'equal', ref: '[[Anchor 2]]', field: 'start', offset: '0h' },
+      ],
+    });
+    await writeMoment('Bounded', {
+      position: [
+        { kind: 'equal', ref: '[[Anchor 1]]', field: 'start', offset: '0h' },
+        { kind: 'after', ref: '[[Anchor 1]]', field: 'start', offset: '1w' },
+      ],
+    });
+
+    const audit = await runCLI(['audit', 'moment', '--output', 'json'], vaultDir);
+    expect(audit.exitCode).toBe(0);
+    const output = JSON.parse(audit.stdout) as {
+      files: Array<{ path: string; issues: Array<{ code: string; field?: string }> }>;
+    };
+    const codes = output.files.flatMap(file => file.issues.map(issue => issue.code));
+    expect(codes).toContain('relative-date-cycle');
+    expect(codes).toContain('relative-date-contradiction');
+    expect(codes).toContain('relative-date-bound-violation');
+  });
+
+  it('accepts new/edit JSON object and list shapes with key-specific validation', async () => {
+    await writeMoment('Anchor', { start: '2026-01-01' });
+
+    const created = await runCLI(
+      [
+        'new',
+        'moment',
+        '--no-template',
+        '--json',
+        JSON.stringify({
+          name: 'Created',
+          position: { kind: 'equal', ref: '[[Anchor]]', field: 'start', offset: '12h' },
+        }),
+      ],
+      vaultDir
+    );
+    expect(created.exitCode).toBe(ExitCodes.SUCCESS);
+    const createdOutput = JSON.parse(created.stdout) as { path: string };
+    const content = await readFile(join(vaultDir, createdOutput.path), 'utf-8');
+    expect(content).toContain('position:');
+    expect(content).toContain('kind: equal');
+    expect(content).toContain('offset: 12h');
+
+    const edited = await runCLI(
+      [
+        'edit',
+        'Created',
+        '--json',
+        JSON.stringify({
+          position: [{ kind: 'after', ref: '[[Anchor]]', field: 'start', offset: '1w' }],
+        }),
+      ],
+      vaultDir
+    );
+    expect(edited.exitCode).toBe(ExitCodes.SUCCESS);
+
+    const invalid = await runCLI(
+      [
+        'edit',
+        'Created',
+        '--json',
+        JSON.stringify({ position: { kind: 'near', ref: '[[Anchor]]' } }),
+      ],
+      vaultDir
+    );
+    expect(invalid.exitCode).toBe(ExitCodes.VALIDATION_ERROR);
+    const invalidOutput = JSON.parse(invalid.stdout) as { errors: Array<{ message: string }> };
+    expect(invalidOutput.errors[0]!.message).toContain('position.kind');
+  });
+
+  async function writeMoment(
+    name: string,
+    fields: { start?: string; position?: unknown }
+  ): Promise<void> {
+    const lines = ['---', 'type: moment', `name: ${JSON.stringify(name)}`];
+    if (fields.start) lines.push(`start: ${JSON.stringify(fields.start)}`);
+    if (fields.position !== undefined) {
+      lines.push(`position: ${JSON.stringify(fields.position)}`);
+    }
+    lines.push('---', '');
+    await writeFile(join(vaultDir, 'Moments', `${name}.md`), lines.join('\n'));
+  }
+});
+
+function relativeDateSchema(): Record<string, unknown> {
+  return {
+    ...TEST_SCHEMA,
+    types: {
+      ...TEST_SCHEMA.types,
+      moment: {
+        output_dir: 'Moments',
+        filename: '{name}',
+        fields: {
+          name: { prompt: 'text', required: true },
+          start: { prompt: 'date' },
+          position: { prompt: 'relative-date', source: 'moment' },
+        },
+      },
+    },
+  };
+}

--- a/tests/ts/commands/relative-date.test.ts
+++ b/tests/ts/commands/relative-date.test.ts
@@ -34,20 +34,26 @@ describe('relative-date fields', () => {
       position: [{ kind: 'after', ref: '[[A]]', field: 'start', offset: '1w' }],
     });
 
+    // Plain YYYY-MM-DD anchors resolve at local midnight, so expected instants
+    // must be derived the same way to stay timezone-independent (local vs CI).
+    const HOUR = 60 * 60 * 1000;
+    const baseMs = new Date(2026, 0, 1).getTime();
+    const iso = (ms: number) => new Date(ms).toISOString();
+
     const sorted = await runCLI(['list', 'moment', '--sort', 'position', '--output', 'json'], vaultDir);
     expect(sorted.exitCode).toBe(0);
     const rows = JSON.parse(sorted.stdout) as Array<Record<string, unknown>>;
     expect(rows.map(row => row._name)).toEqual(['A', 'C', 'B', 'D']);
     expect(rows[0]!.position).toMatchObject({
-      resolved: '2026-01-01T05:00:00.000Z',
+      resolved: iso(baseMs),
       resolution: 'ok',
     });
     expect(rows[1]!.position).toMatchObject({
-      resolved: '2026-01-02T13:00:00.000Z',
+      resolved: iso(baseMs + 32 * HOUR),
       resolution: 'ok',
     });
     expect(rows[2]!.position).toMatchObject({
-      resolved: '2026-01-02T15:00:00.000Z',
+      resolved: iso(baseMs + 34 * HOUR),
       resolution: 'ok',
     });
     expect(rows[3]!.position).toMatchObject({
@@ -56,7 +62,7 @@ describe('relative-date fields', () => {
     });
 
     const filtered = await runCLI(
-      ['list', 'moment', '--where', "position < date('2026-01-02T14:00:00Z')", '--output', 'json'],
+      ['list', 'moment', '--where', `position < date('${iso(baseMs + 33 * HOUR)}')`, '--output', 'json'],
       vaultDir
     );
     expect(filtered.exitCode).toBe(0);

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -1247,6 +1247,39 @@ status: paused
       expect(result.stdout).toContain('Own fields:');
     });
 
+    it('should render relative-date prompt kinds in type details', async () => {
+      const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-relative-date-schema-list-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          types: {
+            meta: {},
+            event: {
+              extends: 'meta',
+              output_dir: 'Events',
+              fields: {
+                name: { prompt: 'text', required: true },
+                start: { prompt: 'date' },
+                position: { prompt: 'relative-date', source: 'event' },
+              },
+            },
+          },
+        })
+      );
+
+      try {
+        const result = await runCLI(['schema', 'list', 'event'], tempVaultDir);
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toMatch(/position:\s+relative-date/);
+        expect(result.stdout).not.toMatch(/position:\s+auto/);
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
     it('should support --type alias for type details', async () => {
       const result = await runCLI(['schema', 'list', '--type', 'idea'], vaultDir);
 


### PR DESCRIPTION
## What

A new `relative-date` field prompt type: structured constraints positioning a note in time relative to another note's date field, resolved at query time and never written back to frontmatter.

```yaml
position:
  - kind: equal        # equal | after | before
    ref: "[[The Rending]]"
    field: start
    offset: 34h        # signed; min/h/d/w
```

- Resolution: memoized chain-walking with cycle, contradiction, bound-violation, and invalid-ref diagnostics (all non-fatal; surfaced in `list` JSON as `resolution` markers and in `audit` as warnings).
- `list --sort <field>` orders by resolved position, nulls last; `--where` compares resolved values; `--output json` expands `{source, resolved, resolution, bounds}`.
- Offsets kept as `{amount, unit, mode}` AST — groundwork for calendar-aware resolution (PR 2).
- Vaults with no relative-date fields skip all of this: `list` short-circuits before building the note index.

Spec: `plans/features/relative-dates.md`. Motivation: importing 166 relative date constraints from an Aeon Timeline into a story-world vault.

## Verification

- Full CI parity green locally (build, verify:pack, typecheck, lint, knip, 2,797 tests).
- Blind acceptance test: a fresh agent given only the built CLI + docs passed all five scripted scenarios (schema definition, constraint chains, sorted JSON queries, unanchored bounds, cycle handling). Its three UX findings (docs `output_dir` trap, timezone callout, `schema list` prompt-kind label) are fixed in the final commit.
- Known pre-existing issue, out of scope: `schema validate` labels missing `output_dir` a warning though `new` later hard-fails on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)