### PR TITLE
feat: custom calendars — schema-defined fictional timekeeping

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -48,6 +48,7 @@ export default defineConfig({
 					items: [
 						{ slug: 'concepts/schema' },
 						{ slug: 'concepts/types-and-inheritance' },
+						{ slug: 'concepts/custom-calendars' },
 						{ slug: 'concepts/relative-dates' },
 						{ slug: 'concepts/validation-and-audit' },
 						{ slug: 'concepts/migrations' },

--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -101,6 +101,86 @@
           ],
           "description": "Default coarsest date precision allowed for all date fields (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Per-field `granularity` overrides this default."
         },
+        "calendars": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "label": {
+                "type": "string",
+                "description": "Human-readable calendar label"
+              },
+              "hoursInDay": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Number of hours in a calendar day; defaults to 24"
+              },
+              "eras": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Era name"
+                    },
+                    "shortName": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "Short era token used in date strings"
+                    },
+                    "backwards": {
+                      "type": "boolean",
+                      "description": "Whether years count down toward the era boundary"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "shortName"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1,
+                "description": "Calendar eras"
+              },
+              "months": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Month name"
+                    },
+                    "shortName": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "Short month label"
+                    },
+                    "days": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "description": "Number of days in this month"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "days"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1,
+                "description": "Calendar months"
+              }
+            },
+            "required": [
+              "eras",
+              "months"
+            ],
+            "additionalProperties": false
+          },
+          "description": "Named custom calendars available to date fields"
+        },
         "mention_fuzzy_threshold": {
           "type": "integer",
           "minimum": 0,
@@ -216,6 +296,10 @@
           },
           "description": "Field definitions, merged with ancestors and traits at load time"
         },
+        "calendar_default": {
+          "type": "string",
+          "description": "Default calendar id for date fields on this type"
+        },
         "field_order": {
           "type": "array",
           "items": {
@@ -274,6 +358,10 @@
             "year"
           ],
           "description": "Coarsest date precision allowed for this `date` field, finer is always allowed (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Overrides the global config.date_granularity for this field."
+        },
+        "calendar": {
+          "type": "string",
+          "description": "Calendar id for date fields using config.calendars"
         },
         "value": {
           "type": "string",

--- a/docs-site/src/content/docs/concepts/custom-calendars.md
+++ b/docs-site/src/content/docs/concepts/custom-calendars.md
@@ -1,0 +1,120 @@
+---
+title: Custom Calendars
+description: Define fictional calendars for native date validation, sorting, and relative-date chains
+---
+
+Custom calendars let a vault store fictional or alternative dates without converting them to Gregorian dates. A calendar is declared once in `.bwrb/schema.json`, then date fields opt in by calendar id.
+
+Calendar dates are stored as canonical strings in frontmatter, but Bowerbird parses them to a timezone-independent linear hour value for sorting, `--where` comparisons, JSON output, audit, and calendar-anchored relative-date chains.
+
+## Schema
+
+Declare calendars under `config.calendars`:
+
+```json
+{
+  "config": {
+    "calendars": {
+      "tmi": {
+        "label": "TMI lunar calendar",
+        "hoursInDay": 336,
+        "eras": [
+          { "name": "Before Humans", "shortName": "BH", "backwards": true },
+          { "name": "After Humans", "shortName": "AR" }
+        ],
+        "months": [
+          { "name": "Month One", "shortName": "M1", "days": 2 },
+          { "name": "Month Two", "shortName": "M2", "days": 2 }
+        ]
+      }
+    }
+  }
+}
+```
+
+`hoursInDay` defaults to `24`. Each calendar needs at least one era and one month. Month indexes are one-based in date strings.
+
+Era support is intentionally limited in v1: a calendar can declare one era, or one backwards era plus one forward era. Calendars cannot declare more than two eras, more than one `backwards: true` era, or two forward-only eras.
+
+## Date Fields
+
+Opt a date field into a calendar:
+
+```json
+{
+  "types": {
+    "event": {
+      "calendar_default": "tmi",
+      "fields": {
+        "name": { "prompt": "text", "required": true },
+        "when": { "prompt": "date" },
+        "gregorian": { "prompt": "date", "calendar": "earth" }
+      }
+    }
+  }
+}
+```
+
+`calendar_default` applies to date fields on the type that do not declare their own `calendar`. A `calendar` key is valid only on `prompt: "date"` fields. Unknown calendar ids are schema errors.
+
+## Date Format
+
+The canonical format is:
+
+```text
+<eraShort> <year>-<month>-<day> [<hour>:<minute>]
+```
+
+Examples:
+
+```yaml
+when: "AR 3019-09-02 266:50"
+origin: "BH 12-01-01"
+```
+
+Month and day are canonicalized to two digits. Hours may exceed `23` when the calendar's `hoursInDay` is larger than a Gregorian day, but must be less than `hoursInDay`. Minutes must be `0-59`.
+
+## Querying
+
+Text table output displays the canonical string. JSON output expands calendar date fields:
+
+```json
+{
+  "when": {
+    "value": "AR 3019-09-02 266:50",
+    "calendar": "tmi",
+    "linear": 24324338.833333332
+  }
+}
+```
+
+`linear` is the internal hour count used for sorting and comparisons. It is stable and timezone-independent.
+
+```bash
+bwrb list event --sort when --output json
+bwrb list event --where "when > 'AR 1000-01-01'" --output json
+```
+
+Dates from different calendars are not converted. Cross-calendar sort ties fall back to name order with a warning; cross-calendar `--where` comparisons do not match.
+
+## Relative Dates
+
+Relative-date chains anchored on a calendar date resolve in that calendar's linear hours:
+
+```yaml
+position:
+  kind: equal
+  ref: "[[Anchor]]"
+  field: when
+  offset: 2d
+```
+
+For calendar chains, `d` means the calendar's `hoursInDay`. The `w` unit is rejected for calendar chains in v1; use hours or days instead. Gregorian chains keep the existing real-time meanings: `d = 24h`, `w = 168h`.
+
+## Audit
+
+`bwrb audit` validates calendar date strings against the configured calendar. It reports invalid eras, month ranges, day ranges, hours, and minutes as `invalid-date-format`.
+
+## Limits
+
+Custom calendars v1 do not support more than one backwards era and one forward era, leap cycles, weekday names, timezone concepts, or conversion between calendars.

--- a/docs-site/src/content/docs/concepts/relative-dates.md
+++ b/docs-site/src/content/docs/concepts/relative-dates.md
@@ -49,6 +49,8 @@ position:
 
 Offsets are parsed internally as `{ amount, unit, mode }` so future calendar-aware resolvers can preserve the unit instead of inheriting a millisecond-only value.
 
+For fictional or alternative timekeeping, define a [custom calendar](/concepts/custom-calendars/) and anchor relative-date chains on calendar date fields.
+
 ## Resolution
 
 A relative-date field resolves to:
@@ -58,6 +60,8 @@ A relative-date field resolves to:
 - `null` when it only has `after`/`before` bounds or the chain has no absolute anchor
 
 Plain `YYYY-MM-DD` dates are interpreted at local midnight in the machine's timezone before being converted to UTC.
+
+Calendar anchors resolve in their calendar's linear hours instead. On those chains, `d` uses the calendar's configured `hoursInDay`, and `w` is rejected in v1.
 
 Multiple `equal` constraints are allowed, but only the first one provides the resolved value. If later equal constraints resolve to a different position, Bowerbird reports a contradiction.
 

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -92,6 +92,7 @@ bwrb supports vault-wide configuration in `.bwrb/schema.json` under the `config`
 |--------|--------|---------|-------------|
 | `link_format` | `wikilink`, `markdown` | `wikilink` | Format for relation field links |
 | `date_format` | Pattern string | `YYYY-MM-DD` | Format for date fields |
+| `calendars` | Object | `{}` | Custom calendar registry for non-Gregorian date fields |
 | `open_with` | `system`, `editor`, `visual`, `obsidian` | `system` | Default --open behavior |
 | `editor` | Command string | `$EDITOR` | Terminal editor command |
 | `visual` | Command string | `$VISUAL` | GUI editor command |
@@ -108,6 +109,34 @@ The `date_format` option controls how dates are written to frontmatter:
 
 **Validation is format-agnostic**: bwrb accepts any unambiguous date format during audit/validation.
 Ambiguous dates like `01/02/2026` (where both parts are ≤12) are rejected.
+
+### Custom Calendars
+
+Vaults can define custom calendars in `config.calendars` and opt date fields in
+with `calendar` or type-level `calendar_default`:
+
+```json
+{
+  "config": {
+    "calendars": {
+      "tmi": {
+        "hoursInDay": 336,
+        "eras": [
+          { "name": "Before Humans", "shortName": "BH", "backwards": true },
+          { "name": "After Humans", "shortName": "AR" }
+        ],
+        "months": [{ "name": "Month One", "days": 2 }]
+      }
+    }
+  }
+}
+```
+
+Calendar date strings use `<eraShort> <year>-<month>-<day> [<hour>:<minute>]`,
+for example `AR 3019-09-02 266:50`. JSON list output expands these fields as
+`{ value, calendar, linear }`; sort and `--where` compare the linear value.
+For calendar-anchored relative-date chains, `d` means the calendar's
+`hoursInDay`; `w` is rejected.
 
 ```bash
 # View current config
@@ -151,6 +180,10 @@ bwrb list task --sort priority --desc --output json
 # Relative-date fields sort/filter by their resolved query-time value
 bwrb list event --sort position --output json
 bwrb list event --where "position < date('2026-01-03T00:00:00Z')" --output json
+
+# Calendar date fields sort/filter by their linear calendar value
+bwrb list event --sort when --output json
+bwrb list event --where "when > 'AR 1000-01-01'" --output json
 
 # Limit or count matches
 bwrb list task --limit 5 --output json

--- a/plans/features/custom-calendars.md
+++ b/plans/features/custom-calendars.md
@@ -1,0 +1,69 @@
+# Custom Calendars (PR 2 of the story-time pair)
+
+Prereq: relative-dates (PR 1, merged). Vault brief: teenylilthoughts `briefs/bwrb relative dates and custom calendars.md`.
+
+## What
+
+Schema-defined calendars for fictional/alternative timekeeping. A calendar is declared once in vault config; `date` fields opt in by id. Calendar dates parse, format, validate, and sort natively (via a linear timestamp), so `list --sort`, `--where` comparisons, and relative-date chains work on non-Gregorian time.
+
+## Config shape (`.bwrb/schema.json` → `config.calendars`)
+
+```json
+{
+  "config": {
+    "calendars": {
+      "tmi": {
+        "label": "TMI lunar calendar",
+        "hoursInDay": 336,
+        "eras": [
+          { "name": "Before Humans", "shortName": "BH", "backwards": true },
+          { "name": "After Humans", "shortName": "AR" }
+        ],
+        "months": [
+          { "name": "Month One", "shortName": "M1", "days": 2 },
+          { "name": "Month Two", "shortName": "M2", "days": 2 }
+        ]
+      }
+    }
+  }
+}
+```
+
+- `hoursInDay` (default 24), `eras` (≥1; `backwards: true` counts years down toward the era boundary), `months` (≥1, each with `days`).
+- No leap-cycle support in v1 (documented limitation).
+
+## Field opt-in
+
+```json
+"in-world-when": { "prompt": "date", "calendar": "tmi" }
+```
+
+- `calendar` key valid only on `prompt: "date"` fields; unknown calendar id = schema validation error.
+- Optional type-level `calendar_default` applying to all date fields of the type without their own `calendar`.
+
+## Date string format (canonical, round-trippable)
+
+`<eraShort> <year>-<month>-<day>` with optional ` <hour>:<minute>` — e.g. `AR 3019-09-02 266:50`.
+- month/day are 1-based indexes into the calendar; hour may exceed 23 when `hoursInDay` > 24.
+- Parse errors must state the failing component and the calendar's valid ranges.
+- Formatting for display (`list` table) uses the same canonical string; `--output json` adds `{ calendar: "tmi", linear: <number> }` where `linear` is the internal linear timestamp (hours since era-zero; stable, documented, sortable).
+
+## Semantics
+
+- Sorting/`--where` comparisons on calendar date fields compare linear timestamps. Comparing dates across *different* calendars is a diagnostic (warning; treated as null ordering), not a crash.
+- Relative-date (PR 1) chains: an anchor whose resolved field is a calendar date resolves in that calendar's linear hours; linear offset units (min/h/d/w) apply with `d`/`w` meaning **real 24h/168h only when the chain is Gregorian**. For calendar chains, `d` = the calendar's `hoursInDay` and `w` is rejected with a clear error (v1; a future PR may add calendar-scoped units). The `{amount, unit, mode}` AST gains `mode: "calendar"` resolution at this boundary — the parser is untouched.
+- `audit` validates calendar date strings against the calendar definition (month index in range, day within month's `days`, hour < `hoursInDay`).
+
+## Non-goals (v1)
+
+- Leap cycles, week structures, named weekdays, timezone concepts.
+- Converting dates between calendars.
+- Calendar-scoped offset unit *names* ("2 cycles") — the groundwork (`mode` on the AST) lands, the surface syntax does not.
+
+## Acceptance (fresh agent, CLI only)
+
+1. Define the TMI calendar in config + an `event` type with `when: { prompt: date, calendar: tmi }` via schema edit + migrate.
+2. Create events with `AR 960-06-01`, `AR 3019-09-02 266:50`, `BH 12-01-01`; `list --sort when` orders BH before AR, and within AR by linear time; JSON shows canonical string + linear.
+3. Feed an invalid date (`AR 3019-14-01`, month out of range) — creation fails with an error naming the month range; `audit` catches the same if hand-edited in.
+4. Mix a relative-date constraint chain anchored on a calendar date: `equal [[X]] + 340h` resolves correctly in linear hours; `+2d` means 2×336h; `+1w` errors clearly.
+5. Full CI parity passes; docs-site page for calendars + SKILL.md updated; relative-dates docs cross-link.

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -101,6 +101,86 @@
           ],
           "description": "Default coarsest date precision allowed for all date fields (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Per-field `granularity` overrides this default."
         },
+        "calendars": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "label": {
+                "type": "string",
+                "description": "Human-readable calendar label"
+              },
+              "hoursInDay": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Number of hours in a calendar day; defaults to 24"
+              },
+              "eras": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Era name"
+                    },
+                    "shortName": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "Short era token used in date strings"
+                    },
+                    "backwards": {
+                      "type": "boolean",
+                      "description": "Whether years count down toward the era boundary"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "shortName"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1,
+                "description": "Calendar eras"
+              },
+              "months": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Month name"
+                    },
+                    "shortName": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "Short month label"
+                    },
+                    "days": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "description": "Number of days in this month"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "days"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1,
+                "description": "Calendar months"
+              }
+            },
+            "required": [
+              "eras",
+              "months"
+            ],
+            "additionalProperties": false
+          },
+          "description": "Named custom calendars available to date fields"
+        },
         "mention_fuzzy_threshold": {
           "type": "integer",
           "minimum": 0,
@@ -216,6 +296,10 @@
           },
           "description": "Field definitions, merged with ancestors and traits at load time"
         },
+        "calendar_default": {
+          "type": "string",
+          "description": "Default calendar id for date fields on this type"
+        },
         "field_order": {
           "type": "array",
           "items": {
@@ -274,6 +358,10 @@
             "year"
           ],
           "description": "Coarsest date precision allowed for this `date` field, finer is always allowed (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Overrides the global config.date_granularity for this field."
+        },
+        "calendar": {
+          "type": "string",
+          "description": "Calendar id for date fields using config.calendars"
         },
         "value": {
           "type": "string",

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -7,6 +7,9 @@ import {
   getTypeDefByPath,
   getAllFieldsForType,
   formatUnknownTypeError,
+  getFieldsForType,
+  resolveDateCalendar,
+  resolveTypeFromFrontmatter,
 } from '../lib/schema.js';
 import {
   buildParentMapFromFiles,
@@ -59,6 +62,12 @@ import {
   buildRelativeDateFieldMap,
   type RelativeDateFieldMap,
 } from '../lib/relative-date.js';
+import {
+  calendarDateJsonValue,
+  calendarDateValue,
+  isCalendarDateValue,
+  parseCalendarDate,
+} from '../lib/calendar-date.js';
 
 /**
  * Resolve the output format from --output flag and deprecated flags.
@@ -600,10 +609,16 @@ export async function listObjects(
         file.path,
         {
           ...file,
-          frontmatter: frontmatterForRelativeDateSort(file, options.sortField!, relativeDateFields),
+          frontmatter: frontmatterForCalendarDateSort(
+            schema,
+            file,
+            options.sortField!,
+            frontmatterForRelativeDateSort(file, options.sortField!, relativeDateFields)
+          ),
         },
       ]))
     : undefined;
+  warnOnCrossCalendarSort(options.sortField, sortFrontmatterFiles);
   filteredFiles.sort((a, b) => fileComparator(
     sortFrontmatterFiles?.get(a.path) ?? a,
     sortFrontmatterFiles?.get(b.path) ?? b
@@ -682,7 +697,10 @@ export async function listObjects(
         if (!options.fields || options.fields.length === 0) {
           return {
             ...base,
-            ...frontmatterWithRelativeDates(path, frontmatter, relativeDateFields),
+            ...frontmatterWithCalendarDateJson(
+              schema,
+              frontmatterWithRelativeDates(path, frontmatter, relativeDateFields)
+            ),
           };
         }
 
@@ -707,7 +725,7 @@ export async function listObjects(
             continue;
           }
           if (Object.prototype.hasOwnProperty.call(frontmatter, field)) {
-            selected[field] = frontmatter[field];
+            selected[field] = calendarDateJsonFieldValue(schema, frontmatter, field) ?? frontmatter[field];
           }
         }
 
@@ -759,6 +777,53 @@ export async function listObjects(
       console.log(basename(path, '.md'));
     }
   }
+}
+
+function frontmatterWithCalendarDateJson(
+  schema: LoadedSchema,
+  frontmatter: Record<string, unknown>
+): Record<string, unknown> {
+  const typePath = resolveTypeFromFrontmatter(schema, frontmatter);
+  if (!typePath) return frontmatter;
+
+  const fields = getFieldsForType(schema, typePath);
+  let result: Record<string, unknown> | undefined;
+  for (const [fieldName, field] of Object.entries(fields)) {
+    const calendarId = resolveDateCalendar(schema, typePath, fieldName, field);
+    if (!calendarId || !(fieldName in frontmatter)) continue;
+    const parsed = parseCalendarDate(
+      frontmatter[fieldName],
+      calendarId,
+      schema.config.calendars[calendarId]!
+    );
+    if (!parsed.valid) continue;
+    result ??= { ...frontmatter };
+    result[fieldName] = calendarDateJsonValue(
+      calendarDateValue(parsed.date, schema.config.calendars[calendarId]!)
+    );
+  }
+  return result ?? frontmatter;
+}
+
+function calendarDateJsonFieldValue(
+  schema: LoadedSchema,
+  frontmatter: Record<string, unknown>,
+  fieldName: string
+): unknown {
+  const typePath = resolveTypeFromFrontmatter(schema, frontmatter);
+  if (!typePath) return undefined;
+  const field = getFieldsForType(schema, typePath)[fieldName];
+  if (!field) return undefined;
+  const calendarId = resolveDateCalendar(schema, typePath, fieldName, field);
+  if (!calendarId) return undefined;
+  const parsed = parseCalendarDate(
+    frontmatter[fieldName],
+    calendarId,
+    schema.config.calendars[calendarId]!
+  );
+  return parsed.valid
+    ? calendarDateJsonValue(calendarDateValue(parsed.date, schema.config.calendars[calendarId]!))
+    : undefined;
 }
 
 function frontmatterWithRelativeDates(
@@ -849,12 +914,19 @@ async function resolveRelativeDateFieldsForList(
   if (!schemaHasRelativeDateFields(schema)) return new Map();
 
   const index = await buildVaultNoteIndex(schema, vaultDir);
-  return buildRelativeDateFieldMap(
+  const result = buildRelativeDateFieldMap(
     schema,
     vaultDir,
     index.snapshot,
     index.noteTargetIndex
-  ).fields;
+  );
+  const invalidOffset = result.diagnostics.find(
+    (diagnostic) => diagnostic.code === 'relative-date-invalid-offset'
+  );
+  if (invalidOffset) {
+    throw new Error(invalidOffset.message);
+  }
+  return result.fields;
 }
 
 function schemaHasRelativeDateFields(schema: LoadedSchema): boolean {
@@ -884,8 +956,56 @@ function frontmatterForRelativeDateSort(
   if (!resolved) return file.frontmatter;
   return {
     ...file.frontmatter,
-    [sortField]: resolved.resolved,
+    [sortField]: resolved.calendar && resolved.linear !== undefined && resolved.resolved
+      ? {
+          __bwrbCalendarDate: true,
+          value: resolved.resolved,
+          calendar: resolved.calendar,
+          linear: resolved.linear,
+        }
+      : resolved.resolved,
   };
+}
+
+function frontmatterForCalendarDateSort(
+  schema: LoadedSchema,
+  file: { path: string; frontmatter: Record<string, unknown> },
+  sortField: string,
+  frontmatter: Record<string, unknown>
+): Record<string, unknown> {
+  const typePath = resolveTypeFromFrontmatter(schema, file.frontmatter);
+  if (!typePath) return frontmatter;
+  const field = getFieldsForType(schema, typePath)[sortField];
+  if (!field) return frontmatter;
+  const calendarId = resolveDateCalendar(schema, typePath, sortField, field);
+  if (!calendarId) return frontmatter;
+  const parsed = parseCalendarDate(
+    frontmatter[sortField],
+    calendarId,
+    schema.config.calendars[calendarId]!
+  );
+  if (!parsed.valid) return frontmatter;
+  return {
+    ...frontmatter,
+    [sortField]: calendarDateValue(parsed.date, schema.config.calendars[calendarId]!),
+  };
+}
+
+function warnOnCrossCalendarSort(
+  sortField: string | undefined,
+  files: Map<string, { frontmatter: Record<string, unknown> }> | undefined
+): void {
+  if (!sortField || !files) return;
+  const calendars = new Set<string>();
+  for (const file of files.values()) {
+    const value = file.frontmatter[sortField];
+    if (isCalendarDateValue(value)) calendars.add(value.calendar);
+  }
+  if (calendars.size > 1) {
+    console.error(
+      `Warning: cannot compare ${sortField} across different calendars (${Array.from(calendars).join(', ')}); cross-calendar ties use name order.`
+    );
+  }
 }
 
 // ============================================================================

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -920,12 +920,6 @@ async function resolveRelativeDateFieldsForList(
     index.snapshot,
     index.noteTargetIndex
   );
-  const invalidOffset = result.diagnostics.find(
-    (diagnostic) => diagnostic.code === 'relative-date-invalid-offset'
-  );
-  if (invalidOffset) {
-    throw new Error(invalidOffset.message);
-  }
   return result.fields;
 }
 

--- a/src/commands/new/json-mode.ts
+++ b/src/commands/new/json-mode.ts
@@ -15,6 +15,7 @@ import {
   validateContextFields,
   validateFrontmatter,
 } from '../../lib/validation.js';
+import { validateRelativeDateCalendarOffsetsForWrite } from '../../lib/relative-date.js';
 import {
   getFilenamePattern,
   processTemplateBody,
@@ -192,6 +193,23 @@ async function validateJsonFrontmatter(
         message: e.message,
         ...(e.value !== undefined && { value: e.value }),
         ...(e.expected !== undefined && { expected: e.expected }),
+      })),
+    }, ExitCodes.VALIDATION_ERROR);
+  }
+
+  const relativeDateDiagnostics = await validateRelativeDateCalendarOffsetsForWrite(
+    schema,
+    vaultDir,
+    typePath,
+    mergedInput
+  );
+  if (relativeDateDiagnostics.length > 0) {
+    throwJsonError({
+      success: false,
+      error: 'Validation failed',
+      errors: relativeDateDiagnostics.map(diagnostic => ({
+        field: diagnostic.field,
+        message: diagnostic.message,
       })),
     }, ExitCodes.VALIDATION_ERROR);
   }

--- a/src/commands/schema/helpers/output.ts
+++ b/src/commands/schema/helpers/output.ts
@@ -192,6 +192,7 @@ function formatFieldForJson(field: Field): Record<string, unknown> {
   if (field.source) result.source = field.source;
   if (field.list_format) result.list_format = field.list_format;
   if (field.granularity) result.granularity = field.granularity;
+  if (field.calendar) result.calendar = field.calendar;
 
   return result;
 }
@@ -456,7 +457,10 @@ function printFieldDetails(
     details.push(`granularity=${field.granularity}`);
   }
 
-  const prefix = `${indent}${chalk.yellow(name)}: ${type}`;
+  const calendarSuffix = field.prompt === 'date' && field.calendar
+    ? ` ${chalk.gray(`(calendar: ${field.calendar})`)}`
+    : '';
+  const prefix = `${indent}${chalk.yellow(name)}: ${type}${calendarSuffix}`;
   const suffix = details.length > 0 ? ` ${chalk.gray(details.join(' '))}` : '';
 
   const content = details.join(' ');

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -15,6 +15,7 @@ import {
   getTypeFamilies,
   getDescendants,
   getOwnedFields,
+  resolveDateCalendar,
   resolveDateGranularity,
   getRecurrenceForType,
 } from '../schema.js';
@@ -79,6 +80,7 @@ import {
   type NoteTargetIndex,
 } from '../discovery.js';
 import { buildRelativeDateFieldMap, validateRelativeDateValue } from '../relative-date.js';
+import { parseCalendarDate } from '../calendar-date.js';
 
 // Import ownership tracking
 import {
@@ -702,6 +704,8 @@ export async function auditFile(
 
     if (field.prompt === 'date') {
       const granularity = resolveDateGranularity(field, schema.config);
+      const calendarId = resolveDateCalendar(schema, resolvedTypePath, fieldName, field);
+      const calendar = calendarId ? schema.config.calendars[calendarId] : undefined;
 
       // Validate a single date element. `listIndex` is supplied for elements of
       // a list/multiple date field so the reported issue identifies the element.
@@ -717,6 +721,43 @@ export async function auditFile(
         // reported once as `invalid-list-element`. Skipping here keeps write and
         // audit in agreement and avoids double-reporting.
         if (typeof element === 'string' && isBlankScalar(element)) return;
+
+        if (calendarId && calendar) {
+          if (typeof element !== 'string') {
+            issues.push({
+              severity: 'error',
+              code: 'invalid-date-format',
+              message:
+                listIndex === undefined
+                  ? `Invalid calendar date for ${fieldName}: expected string for calendar "${calendarId}"`
+                  : `Invalid calendar date for ${fieldName} at index ${listIndex}: expected string for calendar "${calendarId}"`,
+              field: fieldName,
+              value: element,
+              expected: '<eraShort> <year>-<month>-<day> [<hour>:<minute>]',
+              ...(listIndex !== undefined && { listIndex }),
+              autoFixable: false,
+            });
+            return;
+          }
+
+          const parsed = parseCalendarDate(element, calendarId, calendar);
+          if (!parsed.valid) {
+            issues.push({
+              severity: 'error',
+              code: 'invalid-date-format',
+              message:
+                listIndex === undefined
+                  ? `Invalid calendar date for ${fieldName}: ${parsed.error}`
+                  : `Invalid calendar date for ${fieldName} at index ${listIndex} ('${element}'): ${parsed.error}`,
+              field: fieldName,
+              value: element,
+              expected: '<eraShort> <year>-<month>-<day> [<hour>:<minute>]',
+              ...(listIndex !== undefined && { listIndex }),
+              autoFixable: false,
+            });
+          }
+          return;
+        }
 
         // A bare year (e.g. 2026) is parsed as a number by YAML; treat it as a
         // partial date string for validation.

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -91,7 +91,8 @@ export type IssueCode =
   | 'relative-date-contradiction'
   | 'relative-date-bound-violation'
   | 'relative-date-unanchored'
-  | 'relative-date-invalid-ref';
+  | 'relative-date-invalid-ref'
+  | 'relative-date-invalid-offset';
 
 /**
  * A single audit issue.

--- a/src/lib/calendar-date.ts
+++ b/src/lib/calendar-date.ts
@@ -1,0 +1,274 @@
+import type { Calendar } from '../types/schema.js';
+
+export interface ParsedCalendarDate {
+  value: string;
+  calendar: string;
+  era: string;
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  linear: number;
+}
+
+export interface CalendarDateValue {
+  __bwrbCalendarDate: true;
+  value: string;
+  calendar: string;
+  linear: number;
+  calendarDef?: Calendar;
+}
+
+export type CalendarDateParseResult =
+  | { valid: true; date: ParsedCalendarDate }
+  | { valid: false; error: string };
+
+const CALENDAR_DATE_PATTERN =
+  /^([^\s]+)\s+(\d+)-(\d{1,2})-(\d{1,2})(?:\s+(\d+):(\d{2}))?$/;
+
+export function parseCalendarDate(
+  value: unknown,
+  calendarId: string,
+  calendar: Calendar
+): CalendarDateParseResult {
+  if (typeof value !== 'string') {
+    return {
+      valid: false,
+      error: `expected calendar date string for calendar "${calendarId}"`,
+    };
+  }
+
+  const trimmed = value.trim();
+  const match = trimmed.match(CALENDAR_DATE_PATTERN);
+  if (!match) {
+    return {
+      valid: false,
+      error: `expected <eraShort> <year>-<month>-<day> with optional <hour>:<minute> for calendar "${calendarId}"`,
+    };
+  }
+
+  const eraShort = match[1]!;
+  const eraIndex = calendar.eras.findIndex((era) => era.shortName === eraShort);
+  if (eraIndex < 0) {
+    return {
+      valid: false,
+      error: `invalid era "${eraShort}" for calendar "${calendarId}"; expected one of ${calendar.eras.map((era) => era.shortName).join(', ')}`,
+    };
+  }
+
+  const year = Number.parseInt(match[2]!, 10);
+  const month = Number.parseInt(match[3]!, 10);
+  const day = Number.parseInt(match[4]!, 10);
+  const hour = match[5] === undefined ? 0 : Number.parseInt(match[5], 10);
+  const minute = match[6] === undefined ? 0 : Number.parseInt(match[6], 10);
+  const hoursInDay = calendar.hoursInDay ?? 24;
+
+  if (year < 1) {
+    return { valid: false, error: `invalid year ${year}; expected year >= 1` };
+  }
+
+  if (month < 1 || month > calendar.months.length) {
+    return {
+      valid: false,
+      error: `invalid month ${month} for calendar "${calendarId}"; expected 1-${calendar.months.length}`,
+    };
+  }
+
+  const monthDef = calendar.months[month - 1]!;
+  if (day < 1 || day > monthDef.days) {
+    return {
+      valid: false,
+      error: `invalid day ${day} for month ${month} in calendar "${calendarId}"; expected 1-${monthDef.days}`,
+    };
+  }
+
+  if (hour < 0 || hour >= hoursInDay) {
+    return {
+      valid: false,
+      error: `invalid hour ${hour} for calendar "${calendarId}"; expected 0-${hoursInDay - 1}`,
+    };
+  }
+
+  if (minute < 0 || minute > 59) {
+    return { valid: false, error: `invalid minute ${minute}; expected 0-59` };
+  }
+
+  const canonical = formatCalendarDate({
+    era: eraShort,
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    includeTime: match[5] !== undefined,
+  });
+
+  return {
+    valid: true,
+    date: {
+      value: canonical,
+      calendar: calendarId,
+      era: eraShort,
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      linear: toLinearHours(calendar, eraIndex, year, month, day, hour, minute),
+    },
+  };
+}
+
+export function calendarDateValue(date: ParsedCalendarDate, calendar?: Calendar): CalendarDateValue {
+  return {
+    __bwrbCalendarDate: true,
+    value: date.value,
+    calendar: date.calendar,
+    linear: date.linear,
+    ...(calendar ? { calendarDef: calendar } : {}),
+  };
+}
+
+export function isCalendarDateValue(value: unknown): value is CalendarDateValue {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<string, unknown>).__bwrbCalendarDate === true
+  );
+}
+
+export function calendarDateJsonValue(value: CalendarDateValue): {
+  value: string;
+  calendar: string;
+  linear: number;
+} {
+  return {
+    value: value.value,
+    calendar: value.calendar,
+    linear: value.linear,
+  };
+}
+
+export function compareCalendarDateValues(
+  left: CalendarDateValue,
+  right: CalendarDateValue
+): number | null {
+  if (left.calendar !== right.calendar) return null;
+  return left.linear - right.linear;
+}
+
+export function formatLinearCalendarDate(
+  linear: number,
+  calendarId: string,
+  calendar: Calendar
+): CalendarDateParseResult {
+  const formattedLinear = Math.round(linear * 60) / 60;
+  const hoursInDay = calendar.hoursInDay ?? 24;
+  const hoursInYear = calendar.months.reduce(
+    (sum, current) => sum + current.days * hoursInDay,
+    0
+  );
+  const eraIndex = formattedLinear < 0
+    ? calendar.eras.findIndex((era) => era.backwards === true)
+    : calendar.eras.findIndex((era) => era.backwards !== true);
+  if (eraIndex < 0) {
+    return {
+      valid: false,
+      error: `calendar "${calendarId}" has no ${formattedLinear < 0 ? 'backwards' : 'forward'} era for linear value ${linear}`,
+    };
+  }
+
+  const era = calendar.eras[eraIndex]!;
+  const year = era.backwards === true
+    ? Math.floor((-formattedLinear - 1) / hoursInYear) + 1
+    : Math.floor(formattedLinear / hoursInYear) + 1;
+  const yearStart = era.backwards === true ? -year * hoursInYear : (year - 1) * hoursInYear;
+  const withinYear = formattedLinear - yearStart;
+  const dayIndex = Math.floor(withinYear / hoursInDay);
+  const hourFloat = withinYear - dayIndex * hoursInDay;
+  let hour = Math.floor(hourFloat);
+  let minute = Math.round((hourFloat - hour) * 60);
+  if (minute === 60) {
+    hour += 1;
+    minute = 0;
+  }
+
+  let remainingDays = dayIndex;
+  let month = 1;
+  for (const monthDef of calendar.months) {
+    if (remainingDays < monthDef.days) break;
+    remainingDays -= monthDef.days;
+    month++;
+  }
+  const day = remainingDays + 1;
+  const value = formatCalendarDate({
+    era: era.shortName,
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    includeTime: hour !== 0 || minute !== 0,
+  });
+
+  return {
+    valid: true,
+    date: {
+      value,
+      calendar: calendarId,
+      era: era.shortName,
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      linear,
+    },
+  };
+}
+
+function formatCalendarDate(parts: {
+  era: string;
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  includeTime: boolean;
+}): string {
+  const date = `${parts.era} ${parts.year}-${pad2(parts.month)}-${pad2(parts.day)}`;
+  if (!parts.includeTime) return date;
+  return `${date} ${parts.hour}:${pad2(parts.minute)}`;
+}
+
+function toLinearHours(
+  calendar: Calendar,
+  eraIndex: number,
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number
+): number {
+  const hoursInDay = calendar.hoursInDay ?? 24;
+  const hoursInYear = calendar.months.reduce(
+    (sum, current) => sum + current.days * hoursInDay,
+    0
+  );
+  const dayOffset = calendar.months
+    .slice(0, month - 1)
+    .reduce((sum, current) => sum + current.days, 0) + (day - 1);
+  const withinYear = dayOffset * hoursInDay + hour + minute / 60;
+  const era = calendar.eras[eraIndex]!;
+
+  if (era.backwards === true) {
+    return -year * hoursInYear + withinYear;
+  }
+
+  return (year - 1) * hoursInYear + withinYear;
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -6,6 +6,7 @@
  * - `search --edit` (unified interface)
  */
 
+import { relative } from 'path';
 import {
   getTypeDefByPath,
   resolveTypePathFromFrontmatter,
@@ -45,6 +46,7 @@ import { type LoadedSchema, type Field, type BodySection, getOptionValues } from
 import { UserCancelledError } from './errors.js';
 import { expandStaticValue } from './local-date.js';
 import { prepareRecurrenceFastPath, commitRecurrenceFastPath } from './recurrence-fast-path.js';
+import { validateRelativeDateCalendarOffsetsForWrite } from './relative-date.js';
 
 // ============================================================================
 // Types
@@ -249,6 +251,30 @@ export async function editNoteFromJson(
       process.exit(ExitCodes.VALIDATION_ERROR);
     }
     throw new Error(`Context validation failed: ${contextValidation.errors.map(e => e.message).join(', ')}`);
+  }
+
+  const relativeDateDiagnostics = await validateRelativeDateCalendarOffsetsForWrite(
+    schema,
+    vaultDir,
+    typePath,
+    resolvedFrontmatter,
+    relative(vaultDir, filePath)
+  );
+  if (relativeDateDiagnostics.length > 0) {
+    if (jsonMode) {
+      printJson({
+        success: false,
+        error: 'Validation failed',
+        errors: relativeDateDiagnostics.map(diagnostic => ({
+          field: diagnostic.field,
+          message: diagnostic.message,
+          currentValue: frontmatter[diagnostic.field],
+          value: resolvedFrontmatter[diagnostic.field],
+        })),
+      });
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(`Validation failed: ${relativeDateDiagnostics.map(diagnostic => diagnostic.message).join(', ')}`);
   }
 
   // Validate parent field doesn't create a cycle (for recursive types)

--- a/src/lib/expression.ts
+++ b/src/lib/expression.ts
@@ -5,6 +5,7 @@ import { FRONTMATTER_IDENTIFIER } from './where-constants.js';
 import { extractLinkTargets } from './links.js';
 import { resolveRelationTarget, type NoteTargetIndex } from './discovery.js';
 import type { LoadedSchema } from '../types/schema.js';
+import { compareCalendarDateValues, isCalendarDateValue, parseCalendarDate } from './calendar-date.js';
 
 // Configure jsep for our expression language
 jsep.addBinaryOp('&&', 2);
@@ -830,6 +831,21 @@ function compareValues(a: unknown, b: unknown): number {
   }
   if (b === null || b === undefined) {
     return 1;
+  }
+
+  if (isCalendarDateValue(a) || isCalendarDateValue(b)) {
+    if (isCalendarDateValue(a) && isCalendarDateValue(b)) {
+      return compareCalendarDateValues(a, b) ?? Number.NaN;
+    }
+    if (isCalendarDateValue(a) && typeof b === 'string' && a.calendarDef) {
+      const parsed = parseCalendarDate(b, a.calendar, a.calendarDef);
+      return parsed.valid ? a.linear - parsed.date.linear : Number.NaN;
+    }
+    if (isCalendarDateValue(b) && typeof a === 'string' && b.calendarDef) {
+      const parsed = parseCalendarDate(a, b.calendar, b.calendarDef);
+      return parsed.valid ? parsed.date.linear - b.linear : Number.NaN;
+    }
+    return Number.NaN;
   }
 
   // Handle dates

--- a/src/lib/list-helpers.ts
+++ b/src/lib/list-helpers.ts
@@ -13,6 +13,7 @@
 
 import { basename, relative } from 'path';
 import { extractWikilinkTarget } from './links.js';
+import { compareCalendarDateValues, isCalendarDateValue } from './calendar-date.js';
 
 // ============================================================================
 // Types
@@ -189,6 +190,9 @@ export function normalizeSortValue(value: unknown): string | number | boolean {
   if (Array.isArray(value)) {
     return value.map(item => String(item)).join(', ');
   }
+  if (isCalendarDateValue(value)) {
+    return value.linear;
+  }
   if (typeof value === 'number' || typeof value === 'boolean') {
     return value;
   }
@@ -201,6 +205,13 @@ export function normalizeSortValue(value: unknown): string | number | boolean {
  * comparison (so "2" sorts before "10").
  */
 export function compareSortValues(a: unknown, b: unknown): number {
+  if (isCalendarDateValue(a) || isCalendarDateValue(b)) {
+    if (isCalendarDateValue(a) && isCalendarDateValue(b)) {
+      return compareCalendarDateValues(a, b) ?? Number.NaN;
+    }
+    return Number.NaN;
+  }
+
   const normalizedA = normalizeSortValue(a);
   const normalizedB = normalizeSortValue(b);
 
@@ -247,6 +258,9 @@ export function createFileComparator(
     if (missingB) return -1;
 
     const comparison = compareSortValues(valueA, valueB);
+    if (Number.isNaN(comparison)) {
+      return compareByName(a, b);
+    }
     if (comparison !== 0) {
       return descending ? -comparison : comparison;
     }

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -5,6 +5,7 @@ import {
   getEntityAliases,
   getFieldsForType,
   getType,
+  resolveDateCalendar,
   resolveTypeFromFrontmatter,
 } from './schema.js';
 import { matchesExpression, buildEvalContext, type HierarchyData } from './expression.js';
@@ -20,6 +21,7 @@ import {
   buildRelativeDateFieldMap,
   type RelativeDateFieldMap,
 } from './relative-date.js';
+import { calendarDateValue, parseCalendarDate } from './calendar-date.js';
 
 /**
  * Validate that a field name is valid for a type.
@@ -600,7 +602,11 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
   for (const file of files) {
     // Apply expression filters (--where style)
     if (expressionPairs.length > 0) {
-      const evalFrontmatter = frontmatterWithResolvedRelativeDates(file, relativeDateFields);
+      const evalFrontmatter = frontmatterWithCalendarDates(
+        schema,
+        file,
+        frontmatterWithResolvedRelativeDates(schema, file, relativeDateFields)
+      );
       const context = await buildEvalContext(file.path, vaultDir, evalFrontmatter);
       const relationType = resolveHierarchyType(file.frontmatter, {
         ...(schema ? { schema } : {}),
@@ -643,15 +649,23 @@ async function resolveRelativeDateFieldsForQuery(
   vaultDir: string
 ): Promise<RelativeDateFieldMap> {
   const index = await buildVaultNoteIndex(schema, vaultDir);
-  return buildRelativeDateFieldMap(
+  const result = buildRelativeDateFieldMap(
     schema,
     vaultDir,
     index.snapshot,
     index.noteTargetIndex
-  ).fields;
+  );
+  const invalidOffset = result.diagnostics.find(
+    (diagnostic) => diagnostic.code === 'relative-date-invalid-offset'
+  );
+  if (invalidOffset) {
+    throw new Error(invalidOffset.message);
+  }
+  return result.fields;
 }
 
 function frontmatterWithResolvedRelativeDates<T extends FileWithFrontmatter>(
+  schema: LoadedSchema | undefined,
   file: T,
   relativeDateFields: RelativeDateFieldMap | undefined
 ): Record<string, unknown> {
@@ -660,7 +674,42 @@ function frontmatterWithResolvedRelativeDates<T extends FileWithFrontmatter>(
 
   const frontmatter = { ...file.frontmatter };
   for (const [fieldName, output] of fields) {
-    frontmatter[fieldName] = output.resolved;
+    frontmatter[fieldName] = output.calendar && output.linear !== undefined && output.resolved
+      ? {
+          __bwrbCalendarDate: true,
+          value: output.resolved,
+          calendar: output.calendar,
+          linear: output.linear,
+          calendarDef: schema?.config.calendars[output.calendar],
+        }
+      : output.resolved;
   }
   return frontmatter;
+}
+
+function frontmatterWithCalendarDates<T extends FileWithFrontmatter>(
+  schema: LoadedSchema | undefined,
+  file: T,
+  frontmatter: Record<string, unknown>
+): Record<string, unknown> {
+  if (!schema) return frontmatter;
+  const typePath = resolveTypeFromFrontmatter(schema, file.frontmatter);
+  if (!typePath) return frontmatter;
+
+  const fields = getFieldsForType(schema, typePath);
+  let result: Record<string, unknown> | undefined;
+  for (const [fieldName, field] of Object.entries(fields)) {
+    const calendarId = resolveDateCalendar(schema, typePath, fieldName, field);
+    if (!calendarId) continue;
+    const parsed = parseCalendarDate(
+      frontmatter[fieldName],
+      calendarId,
+      schema.config.calendars[calendarId]!
+    );
+    if (!parsed.valid) continue;
+    result ??= { ...frontmatter };
+    result[fieldName] = calendarDateValue(parsed.date, schema.config.calendars[calendarId]!);
+  }
+
+  return result ?? frontmatter;
 }

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -655,12 +655,6 @@ async function resolveRelativeDateFieldsForQuery(
     index.snapshot,
     index.noteTargetIndex
   );
-  const invalidOffset = result.diagnostics.find(
-    (diagnostic) => diagnostic.code === 'relative-date-invalid-offset'
-  );
-  if (invalidOffset) {
-    throw new Error(invalidOffset.message);
-  }
   return result.fields;
 }
 

--- a/src/lib/relative-date.ts
+++ b/src/lib/relative-date.ts
@@ -1,6 +1,6 @@
 import { relative } from 'path';
-import type { LoadedSchema, Field } from '../types/schema.js';
-import { getFieldsForType, resolveTypeFromFrontmatter } from './schema.js';
+import type { Calendar, LoadedSchema, Field } from '../types/schema.js';
+import { getFieldsForType, resolveDateCalendar, resolveTypeFromFrontmatter } from './schema.js';
 import { extractLinkTarget } from './links.js';
 import {
   resolveRelationTarget,
@@ -8,6 +8,7 @@ import {
   type VaultNoteSnapshot,
 } from './discovery.js';
 import { parseDate } from './local-date.js';
+import { formatLinearCalendarDate, parseCalendarDate } from './calendar-date.js';
 
 export type RelativeDateKind = 'equal' | 'after' | 'before';
 export type RelativeDateUnit = 'min' | 'h' | 'd' | 'w';
@@ -16,7 +17,7 @@ export type RelativeDateResolution = 'ok' | 'cycle' | 'unanchored' | 'contradict
 export interface RelativeDateOffset {
   amount: number;
   unit: RelativeDateUnit;
-  mode: 'linear';
+  mode: 'linear' | 'calendar';
 }
 
 export interface RelativeDateConstraint {
@@ -30,6 +31,8 @@ export interface RelativeDateFieldOutput {
   source: unknown;
   resolved: string | null;
   resolution: RelativeDateResolution;
+  calendar?: string;
+  linear?: number;
   bounds?: RelativeDateBoundOutput[];
 }
 
@@ -46,7 +49,8 @@ export type RelativeDateDiagnosticCode =
   | 'relative-date-contradiction'
   | 'relative-date-bound-violation'
   | 'relative-date-unanchored'
-  | 'relative-date-invalid-ref';
+  | 'relative-date-invalid-ref'
+  | 'relative-date-invalid-offset';
 
 export interface RelativeDateDiagnostic {
   code: RelativeDateDiagnosticCode;
@@ -71,12 +75,19 @@ interface ResolveKey {
 }
 
 interface ResolveResult {
-  resolvedMs: number | null;
+  resolved: ResolvedPosition | null;
   resolution: RelativeDateResolution;
   source: unknown;
   constraints: RelativeDateConstraint[];
   diagnostics: RelativeDateDiagnostic[];
   bounds: RelativeDateBoundOutput[];
+}
+
+interface ResolvedPosition {
+  value: number;
+  display: string;
+  calendar?: string;
+  calendarDef?: Calendar;
 }
 
 export type RelativeDateFieldMap = Map<string, Map<string, RelativeDateFieldOutput>>;
@@ -97,9 +108,9 @@ function parseRelativeDateOffset(value: unknown): RelativeDateOffset | null {
       typeof raw.amount === 'number' &&
       Number.isFinite(raw.amount) &&
       isRelativeDateUnit(raw.unit) &&
-      (raw.mode === undefined || raw.mode === 'linear')
+      (raw.mode === undefined || raw.mode === 'linear' || raw.mode === 'calendar')
     ) {
-      return { amount: raw.amount, unit: raw.unit, mode: 'linear' };
+      return { amount: raw.amount, unit: raw.unit, mode: raw.mode === 'calendar' ? 'calendar' : 'linear' };
     }
     return null;
   }
@@ -207,8 +218,9 @@ export function buildRelativeDateFieldMap(
       const result = resolveRelativeDateField(ctx, { path: note.relativePath, field: fieldName }, []);
       setRelativeDateOutput(output, note.path, fieldName, {
         source: result.source ?? null,
-        resolved: result.resolvedMs === null ? null : new Date(result.resolvedMs).toISOString(),
+        resolved: result.resolved?.display ?? null,
         resolution: result.resolution,
+        ...(result.resolved?.calendar ? { calendar: result.resolved.calendar, linear: result.resolved.value } : {}),
         ...(result.bounds.length > 0 ? { bounds: result.bounds } : {}),
       });
     }
@@ -266,9 +278,9 @@ function resolveRelativeDateField(
 
   const field = note.fields[key.field];
   if (!field || field.prompt !== 'relative-date') {
-    const absolute = parseAbsoluteDateValue(note.frontmatter[key.field]);
+    const absolute = parseAbsoluteDateValue(ctx.schema, note, key.field, field);
     return {
-      resolvedMs: absolute,
+      resolved: absolute,
       resolution: absolute === null ? 'unanchored' : 'ok',
       source: note.frontmatter[key.field],
       constraints: [],
@@ -280,11 +292,11 @@ function resolveRelativeDateField(
   const source = note.frontmatter[key.field];
   const constraints = parseRelativeDateConstraints(source);
   if (!constraints || constraints.length === 0) {
-    const ownAnchorMs = resolveOwnAbsoluteAnchor(note);
-    const result: ResolveResult = ownAnchorMs === null
+    const ownAnchor = resolveOwnAbsoluteAnchor(ctx.schema, note);
+    const result: ResolveResult = ownAnchor === null
       ? emptyResult(source, 'unanchored')
       : {
-          resolvedMs: ownAnchorMs,
+          resolved: ownAnchor,
           resolution: 'ok',
           source,
           constraints: [],
@@ -295,8 +307,9 @@ function resolveRelativeDateField(
     return result;
   }
 
-  const equalResults: Array<{ constraint: RelativeDateConstraint; resolvedMs: number | null; resolution: RelativeDateResolution; path?: string }> = [];
+  const equalResults: Array<{ constraint: RelativeDateConstraint; resolved: ResolvedPosition | null; resolution: RelativeDateResolution; path?: string }> = [];
   const bounds: RelativeDateBoundOutput[] = [];
+  const boundResults: Array<{ bound: RelativeDateBoundOutput; resolved: ResolvedPosition | null }> = [];
 
   for (const constraint of constraints) {
     const targetPath = resolveConstraintTarget(ctx, constraint, field);
@@ -316,35 +329,37 @@ function resolveRelativeDateField(
     const targetResult = target && targetField
       ? resolveRelativeDateField(ctx, { path: targetPath, field: targetField }, [...stack, key])
       : emptyResult(undefined, 'unanchored');
-    const resolvedMs = targetResult.resolvedMs === null
+    const resolved = targetResult.resolved === null
       ? null
-      : targetResult.resolvedMs + offsetToMilliseconds(constraint.offset ?? DEFAULT_OFFSET);
+      : applyOffsetToPosition(ctx, note, key.field, targetResult.resolved, constraint.offset ?? DEFAULT_OFFSET);
 
     if (constraint.kind === 'equal') {
-      equalResults.push({ constraint, resolvedMs, resolution: targetResult.resolution, path: targetPath });
+      equalResults.push({ constraint, resolved, resolution: targetResult.resolution, path: targetPath });
     } else {
+      const offset = resolvedOffsetForPosition(targetResult.resolved, constraint.offset ?? DEFAULT_OFFSET);
       const bound: RelativeDateBoundOutput = {
         kind: constraint.kind,
         ref: constraint.ref,
         ...(constraint.field ? { field: constraint.field } : {}),
-        offset: constraint.offset ?? DEFAULT_OFFSET,
-        resolved: resolvedMs === null ? null : new Date(resolvedMs).toISOString(),
+        offset,
+        resolved: resolved?.display ?? null,
       };
       bounds.push(bound);
+      boundResults.push({ bound, resolved });
     }
   }
 
   const firstEqual = equalResults[0];
   let resolution: RelativeDateResolution = 'unanchored';
-  let resolvedMs: number | null = null;
+  let resolved: ResolvedPosition | null = null;
 
   if (firstEqual) {
-    resolvedMs = firstEqual.resolvedMs;
+    resolved = firstEqual.resolved;
     resolution = firstEqual.resolution === 'ok' ? 'ok' : firstEqual.resolution;
     const disagreeing = equalResults.slice(1).filter(result =>
-      result.resolvedMs !== null &&
-      firstEqual.resolvedMs !== null &&
-      result.resolvedMs !== firstEqual.resolvedMs
+      result.resolved !== null &&
+      firstEqual.resolved !== null &&
+      !positionsEqual(result.resolved, firstEqual.resolved)
     );
     if (disagreeing.length > 0) {
       resolution = 'contradiction';
@@ -363,11 +378,11 @@ function resolveRelativeDateField(
     resolution = 'unanchored';
   }
 
-  if (resolvedMs !== null) {
-    for (const bound of bounds) {
+  if (resolved !== null) {
+    for (const { bound, resolved: boundResult } of boundResults) {
       if (!bound.resolved) continue;
-      const boundMs = Date.parse(bound.resolved);
-      const violates = bound.kind === 'after' ? resolvedMs < boundMs : resolvedMs > boundMs;
+      if (!boundResult || !positionsComparable(resolved, boundResult)) continue;
+      const violates = bound.kind === 'after' ? resolved.value < boundResult.value : resolved.value > boundResult.value;
       if (violates) {
         emitDiagnostic(ctx, {
           code: 'relative-date-bound-violation',
@@ -381,7 +396,7 @@ function resolveRelativeDateField(
   }
 
   const result: ResolveResult = {
-    resolvedMs,
+    resolved,
     resolution,
     source,
     constraints,
@@ -403,10 +418,10 @@ function resolveTargetField(note: IndexedNote, explicitField: string | undefined
   return undefined;
 }
 
-function resolveOwnAbsoluteAnchor(note: IndexedNote): number | null {
+function resolveOwnAbsoluteAnchor(schema: LoadedSchema, note: IndexedNote): ResolvedPosition | null {
   for (const [fieldName, field] of Object.entries(note.fields)) {
     if (field.prompt !== 'date') continue;
-    const resolved = parseAbsoluteDateValue(note.frontmatter[fieldName]);
+    const resolved = parseAbsoluteDateValue(schema, note, fieldName, field);
     if (resolved !== null) return resolved;
   }
   return null;
@@ -426,16 +441,105 @@ function resolveConstraintTarget(
   return resolved.resolvedPath ?? null;
 }
 
-function parseAbsoluteDateValue(value: unknown): number | null {
-  if (value instanceof Date) return value.getTime();
+function parseAbsoluteDateValue(
+  schema: LoadedSchema,
+  note: IndexedNote,
+  fieldName: string,
+  field: Field | undefined
+): ResolvedPosition | null {
+  let value = note.frontmatter[fieldName];
+  const calendarId = field
+    ? resolveDateCalendar(schema, note.typePath, fieldName, field)
+    : undefined;
+  if (calendarId) {
+    const parsed = parseCalendarDate(value, calendarId, schema.config.calendars[calendarId]!);
+    return parsed.valid
+      ? {
+          value: parsed.date.linear,
+          display: parsed.date.value,
+          calendar: calendarId,
+          calendarDef: schema.config.calendars[calendarId]!,
+        }
+      : null;
+  }
+  if (value instanceof Date) {
+    return { value: value.getTime(), display: value.toISOString() };
+  }
   if (typeof value === 'number') value = String(value);
   if (typeof value !== 'string') return null;
   const parsed = parseDate(value);
-  return parsed.valid && parsed.date ? parsed.date.getTime() : null;
+  return parsed.valid && parsed.date
+    ? { value: parsed.date.getTime(), display: parsed.date.toISOString() }
+    : null;
 }
 
-function offsetToMilliseconds(offset: RelativeDateOffset): number {
+function applyOffsetToPosition(
+  ctx: { diagnostics: RelativeDateDiagnostic[]; emitted: Set<string> },
+  note: IndexedNote,
+  fieldName: string,
+  position: ResolvedPosition,
+  offset: RelativeDateOffset
+): ResolvedPosition | null {
+  if (position.calendar && offset.unit === 'w') {
+    emitDiagnostic(ctx, {
+      code: 'relative-date-invalid-offset',
+      severity: 'warning',
+      path: note.path,
+      field: fieldName,
+      message: `Relative date ${fieldName} uses unsupported calendar offset unit "w"; use h or d for calendar chains`,
+    });
+    return null;
+  }
+
+  const amount = offsetAmount(position, offset);
+  const nextValue = position.value + amount;
+  if (position.calendar && position.calendarDef) {
+    const formatted = formatLinearCalendarDate(nextValue, position.calendar, position.calendarDef);
+    if (!formatted.valid) {
+      emitDiagnostic(ctx, {
+        code: 'relative-date-invalid-offset',
+        severity: 'warning',
+        path: note.path,
+        field: fieldName,
+        message: `Relative date ${fieldName} offset cannot be formatted in calendar "${position.calendar}": ${formatted.error}`,
+      });
+      return null;
+    }
+    return {
+      value: nextValue,
+      display: formatted.date.value,
+      calendar: position.calendar,
+      calendarDef: position.calendarDef,
+    };
+  }
+
+  return {
+    value: nextValue,
+    display: new Date(nextValue).toISOString(),
+  };
+}
+
+function resolvedOffsetForPosition(
+  position: ResolvedPosition | null,
+  offset: RelativeDateOffset
+): RelativeDateOffset {
+  return position?.calendar ? { ...offset, mode: 'calendar' } : offset;
+}
+
+function offsetAmount(position: ResolvedPosition, offset: RelativeDateOffset): number {
+  if (!position.calendar) return offset.amount * MS_PER_UNIT[offset.unit];
+  if (offset.unit === 'min') return offset.amount / 60;
+  if (offset.unit === 'h') return offset.amount;
+  if (offset.unit === 'd') return offset.amount * (position.calendarDef?.hoursInDay ?? 24);
   return offset.amount * MS_PER_UNIT[offset.unit];
+}
+
+function positionsEqual(left: ResolvedPosition, right: ResolvedPosition): boolean {
+  return positionsComparable(left, right) && left.value === right.value;
+}
+
+function positionsComparable(left: ResolvedPosition, right: ResolvedPosition): boolean {
+  return left.calendar === right.calendar;
 }
 
 function setRelativeDateOutput(
@@ -451,7 +555,7 @@ function setRelativeDateOutput(
 
 function emptyResult(source: unknown, resolution: RelativeDateResolution): ResolveResult {
   return {
-    resolvedMs: null,
+    resolved: null,
     resolution,
     source,
     constraints: [],

--- a/src/lib/relative-date.ts
+++ b/src/lib/relative-date.ts
@@ -1,8 +1,10 @@
-import { relative } from 'path';
+import { join, relative } from 'path';
 import type { Calendar, LoadedSchema, Field } from '../types/schema.js';
 import { getFieldsForType, resolveDateCalendar, resolveTypeFromFrontmatter } from './schema.js';
 import { extractLinkTarget } from './links.js';
 import {
+  buildVaultNoteIndex,
+  deriveNoteTargetIndex,
   resolveRelationTarget,
   type NoteTargetIndex,
   type VaultNoteSnapshot,
@@ -12,7 +14,7 @@ import { formatLinearCalendarDate, parseCalendarDate } from './calendar-date.js'
 
 export type RelativeDateKind = 'equal' | 'after' | 'before';
 export type RelativeDateUnit = 'min' | 'h' | 'd' | 'w';
-export type RelativeDateResolution = 'ok' | 'cycle' | 'unanchored' | 'contradiction';
+export type RelativeDateResolution = 'ok' | 'cycle' | 'unanchored' | 'contradiction' | 'invalid-offset';
 
 export interface RelativeDateOffset {
   amount: number;
@@ -91,6 +93,11 @@ interface ResolvedPosition {
 }
 
 export type RelativeDateFieldMap = Map<string, Map<string, RelativeDateFieldOutput>>;
+
+interface OffsetApplication {
+  resolved: ResolvedPosition | null;
+  resolution?: Extract<RelativeDateResolution, 'invalid-offset'>;
+}
 
 const DEFAULT_OFFSET: RelativeDateOffset = { amount: 0, unit: 'h', mode: 'linear' };
 const MS_PER_UNIT: Record<RelativeDateUnit, number> = {
@@ -235,6 +242,49 @@ export function buildRelativeDateFieldMap(
   return { fields: output, diagnostics };
 }
 
+export async function validateRelativeDateCalendarOffsetsForWrite(
+  schema: LoadedSchema,
+  vaultDir: string,
+  typePath: string,
+  frontmatter: Record<string, unknown>,
+  relativePath = `.__bwrb_pending__/${typePath.replace(/\//g, '-')}.md`
+): Promise<RelativeDateDiagnostic[]> {
+  const fields = getFieldsForType(schema, typePath);
+  const relativeDateFieldNames = Object.entries(fields)
+    .filter(([, field]) => field.prompt === 'relative-date')
+    .map(([fieldName]) => fieldName)
+    .filter((fieldName) => frontmatter[fieldName] !== undefined);
+  if (relativeDateFieldNames.length === 0) return [];
+
+  const index = await buildVaultNoteIndex(schema, vaultDir);
+  const path = join(vaultDir, relativePath);
+  const snapshot: VaultNoteSnapshot = {
+    notes: [
+      ...index.snapshot.notes.filter((note) => note.relativePath !== relativePath),
+      {
+        path,
+        relativePath,
+        frontmatter: { ...frontmatter, type: frontmatter['type'] ?? typePath },
+        resolvedType: typePath,
+      },
+    ],
+  };
+  const result = buildRelativeDateFieldMap(
+    schema,
+    vaultDir,
+    snapshot,
+    deriveNoteTargetIndex(snapshot, schema)
+  );
+
+  const relativeDateFieldSet = new Set(relativeDateFieldNames);
+  return result.diagnostics.filter(
+    (diagnostic) =>
+      diagnostic.code === 'relative-date-invalid-offset' &&
+      diagnostic.path === path &&
+      relativeDateFieldSet.has(diagnostic.field)
+  );
+}
+
 function resolveRelativeDateField(
   ctx: {
     schema: LoadedSchema;
@@ -329,12 +379,14 @@ function resolveRelativeDateField(
     const targetResult = target && targetField
       ? resolveRelativeDateField(ctx, { path: targetPath, field: targetField }, [...stack, key])
       : emptyResult(undefined, 'unanchored');
-    const resolved = targetResult.resolved === null
+    const offsetResult = targetResult.resolved === null
       ? null
       : applyOffsetToPosition(ctx, note, key.field, targetResult.resolved, constraint.offset ?? DEFAULT_OFFSET);
+    const resolved = offsetResult?.resolved ?? null;
+    const resolution = offsetResult?.resolution ?? targetResult.resolution;
 
     if (constraint.kind === 'equal') {
-      equalResults.push({ constraint, resolved, resolution: targetResult.resolution, path: targetPath });
+      equalResults.push({ constraint, resolved, resolution, path: targetPath });
     } else {
       const offset = resolvedOffsetForPosition(targetResult.resolved, constraint.offset ?? DEFAULT_OFFSET);
       const bound: RelativeDateBoundOutput = {
@@ -479,7 +531,7 @@ function applyOffsetToPosition(
   fieldName: string,
   position: ResolvedPosition,
   offset: RelativeDateOffset
-): ResolvedPosition | null {
+): OffsetApplication {
   if (position.calendar && offset.unit === 'w') {
     emitDiagnostic(ctx, {
       code: 'relative-date-invalid-offset',
@@ -488,7 +540,7 @@ function applyOffsetToPosition(
       field: fieldName,
       message: `Relative date ${fieldName} uses unsupported calendar offset unit "w"; use h or d for calendar chains`,
     });
-    return null;
+    return { resolved: null, resolution: 'invalid-offset' };
   }
 
   const amount = offsetAmount(position, offset);
@@ -503,19 +555,23 @@ function applyOffsetToPosition(
         field: fieldName,
         message: `Relative date ${fieldName} offset cannot be formatted in calendar "${position.calendar}": ${formatted.error}`,
       });
-      return null;
+      return { resolved: null, resolution: 'invalid-offset' };
     }
     return {
-      value: nextValue,
-      display: formatted.date.value,
-      calendar: position.calendar,
-      calendarDef: position.calendarDef,
+      resolved: {
+        value: nextValue,
+        display: formatted.date.value,
+        calendar: position.calendar,
+        calendarDef: position.calendarDef,
+      },
     };
   }
 
   return {
-    value: nextValue,
-    display: new Date(nextValue).toISOString(),
+    resolved: {
+      value: nextValue,
+      display: new Date(nextValue).toISOString(),
+    },
   };
 }
 

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -109,6 +109,7 @@ export function resolveSchema(schema: Schema): LoadedSchema {
       children: [],
       fields: { ...typeDef.fields },
       fieldOrder: typeDef.field_order ?? (typeDef.fields ? Object.keys(typeDef.fields) : []),
+      calendarDefault: typeDef.calendar_default,
       bodySections: typeDef.body_sections ?? [],
       recursive: typeDef.recursive ?? false,
       outputDir: typeDef.output_dir,
@@ -133,6 +134,17 @@ export function resolveSchema(schema: Schema): LoadedSchema {
       }
     }
     type.ancestors = computeAncestors(types, name);
+  }
+
+  for (const type of types.values()) {
+    if (type.calendarDefault !== undefined) continue;
+    for (const ancestorName of type.ancestors) {
+      const ancestor = types.get(ancestorName);
+      if (ancestor?.calendarDefault !== undefined) {
+        type.calendarDefault = ancestor.calendarDefault;
+        break;
+      }
+    }
   }
   
   // Third pass: compute effective fields (inherit from ancestors, then compose
@@ -178,6 +190,8 @@ export function resolveSchema(schema: Schema): LoadedSchema {
   
   // Sixth pass: resolve configuration with defaults
   const config = resolveConfig(schema.config, types);
+
+  validateCalendarReferences(types, config);
   
   return { raw: schema, types, ownership, config };
 }
@@ -194,6 +208,7 @@ function createImplicitMeta(): ResolvedType {
     children: [],
     fields: {},
     fieldOrder: [],
+    calendarDefault: undefined,
     bodySections: [],
     recursive: false,
     outputDir: undefined,
@@ -559,6 +574,7 @@ function resolveConfig(
     defaultDashboard: config?.default_dashboard,
     dateFormat: config?.date_format ?? 'YYYY-MM-DD',
     dateGranularity: config?.date_granularity ?? 'day',
+    calendars: config?.calendars ?? {},
     // Default mirrors DEFAULT_FUZZY_MAX_DISTANCE in audit/unlinked-mention.ts.
     // Inlined to avoid importing the audit module into the schema loader (#622).
     mentionFuzzyThreshold: config?.mention_fuzzy_threshold ?? 2,
@@ -578,6 +594,43 @@ function resolveConfig(
     ),
     mentionExcludePaths: config?.mention_exclude_paths ?? [],
   };
+}
+
+function validateCalendarReferences(
+  types: Map<string, ResolvedType>,
+  config: ResolvedConfig
+): void {
+  const calendarIds = new Set(Object.keys(config.calendars));
+
+  for (const type of types.values()) {
+    if (type.calendarDefault && !calendarIds.has(type.calendarDefault)) {
+      throw new Error(
+        `Type "${type.name}" references unknown calendar_default "${type.calendarDefault}". ` +
+        describeAvailableCalendars(calendarIds)
+      );
+    }
+
+    for (const [fieldName, field] of Object.entries(type.fields)) {
+      if (field.calendar && field.prompt !== 'date') {
+        throw new Error(
+          `Field "${type.name}.${fieldName}" declares calendar "${field.calendar}", but calendar is only valid on prompt: "date" fields.`
+        );
+      }
+
+      if (field.calendar && !calendarIds.has(field.calendar)) {
+        throw new Error(
+          `Field "${type.name}.${fieldName}" references unknown calendar "${field.calendar}". ` +
+          describeAvailableCalendars(calendarIds)
+        );
+      }
+    }
+  }
+}
+
+function describeAvailableCalendars(calendarIds: Set<string>): string {
+  return calendarIds.size > 0
+    ? `Available calendars: ${Array.from(calendarIds).join(', ')}`
+    : 'No calendars are declared in config.calendars.';
 }
 
 /**
@@ -693,6 +746,17 @@ export function resolveDateGranularity(
   config: ResolvedConfig
 ): DatePrecision {
   return field.granularity ?? config.dateGranularity;
+}
+
+export function resolveDateCalendar(
+  schema: LoadedSchema,
+  typeName: string,
+  _fieldName: string,
+  field: Field
+): string | undefined {
+  if (field.prompt !== 'date') return undefined;
+  if (field.calendar) return field.calendar;
+  return getType(schema, typeName)?.calendarDefault;
 }
 
 /**

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,5 +1,5 @@
-import type { LoadedSchema, Field } from '../types/schema.js';
-import { getFieldsForType, getFieldOptions, resolveDateGranularity } from './schema.js';
+import type { LoadedSchema, Field, Calendar } from '../types/schema.js';
+import { getFieldsForType, getFieldOptions, resolveDateCalendar, resolveDateGranularity } from './schema.js';
 import { isBwrbBuiltinFrontmatterField } from './frontmatter/systemFields.js';
 import { extractWikilinkTarget } from './links.js';
 import { levenshteinDistance } from './levenshtein.js';
@@ -19,6 +19,7 @@ import {
   type DatePrecision,
 } from './local-date.js';
 import { validateRelativeDateValue } from './relative-date.js';
+import { parseCalendarDate } from './calendar-date.js';
 
 export type NormalizedDateResult =
   | { valid: true; value: string }
@@ -139,6 +140,18 @@ export function normalizeDateFields(
     if (!(fieldName in normalized)) continue;
 
     const value = normalized[fieldName];
+    const calendarId = resolveDateCalendar(schema, typePath, fieldName, field);
+    if (calendarId) {
+      const calendar = schema.config.calendars[calendarId]!;
+      if (field.multiple && Array.isArray(value)) {
+        normalized[fieldName] = value.map((element) =>
+          normalizeCalendarDateValue(element, calendarId, calendar)
+        );
+      } else {
+        normalized[fieldName] = normalizeCalendarDateValue(value, calendarId, calendar);
+      }
+      continue;
+    }
     const granularity = resolveDateGranularity(field, schema.config);
 
     // A `multiple: true` date field holds an array; canonicalize each element
@@ -186,6 +199,13 @@ function normalizeDateValue(value: unknown, granularity: DatePrecision): unknown
 
   const result = normalizeToIsoDate(dateValue, granularity);
   return result.valid ? result.value : value;
+}
+
+function normalizeCalendarDateValue(value: unknown, calendarId: string, calendar: Calendar): unknown {
+  if (isBlankScalar(value)) return value;
+  if (typeof value !== 'string') return value;
+  const result = parseCalendarDate(value, calendarId, calendar);
+  return result.valid ? result.date.value : value;
 }
 
 
@@ -348,7 +368,14 @@ export function validateFrontmatter(
     // Type checking
     if (hasValue) {
       const granularity = resolveDateGranularity(field, schema.config);
-      const typeError = validateFieldType(fieldName, value, field, granularity);
+      const calendarId = resolveDateCalendar(schema, typeName, fieldName, field);
+      const typeError = validateFieldType(
+        fieldName,
+        value,
+        field,
+        granularity,
+        calendarId ? { id: calendarId, calendar: schema.config.calendars[calendarId]! } : undefined
+      );
       if (typeError) {
         errors.push(typeError);
       }
@@ -442,10 +469,11 @@ function validateDateValue(
   fieldName: string,
   value: unknown,
   granularity: DatePrecision,
+  calendarContext?: { id: string; calendar: Calendar },
   listIndex?: number
 ): ValidationError | null {
-  // Accept Date objects surfaced by YAML parsing, normalize elsewhere.
-  if (value instanceof Date) {
+  // Accept Date objects surfaced by YAML parsing for Gregorian dates, normalize elsewhere.
+  if (value instanceof Date && !calendarContext) {
     return null;
   }
 
@@ -463,6 +491,20 @@ function validateDateValue(
       message: `Invalid type for ${location}: expected date string, got ${typeof value}`,
       expected: 'date string (YYYY-MM-DD)',
     };
+  }
+
+  if (calendarContext) {
+    const parsed = parseCalendarDate(dateValue, calendarContext.id, calendarContext.calendar);
+    if (!parsed.valid) {
+      return {
+        type: 'invalid_date',
+        field: fieldName,
+        value,
+        message: `Invalid calendar date for ${location}: ${parsed.error}`,
+        expected: '<eraShort> <year>-<month>-<day> [<hour>:<minute>]',
+      };
+    }
+    return null;
   }
 
   const normalized = normalizeToIsoDate(dateValue, granularity);
@@ -483,7 +525,8 @@ function validateFieldType(
   fieldName: string,
   value: unknown,
   field: Field,
-  granularity: DatePrecision = 'day'
+  granularity: DatePrecision = 'day',
+  calendarContext?: { id: string; calendar: Calendar }
 ): ValidationError | null {
   // Alias-role fields: enforce Obsidian `aliases` format regardless of prompt
   // type — an array of non-empty, unique strings.
@@ -517,13 +560,13 @@ function validateFieldType(
         // reported separately. Shared `isBlankScalar` rule keeps this in step
         // with the scalar paths (#707).
         if (isBlankScalar(element)) continue;
-        const elementError = validateDateValue(fieldName, element, granularity, index);
+        const elementError = validateDateValue(fieldName, element, granularity, calendarContext, index);
         if (elementError) return elementError;
       }
       return null;
     }
 
-    return validateDateValue(fieldName, value, granularity);
+    return validateDateValue(fieldName, value, granularity, calendarContext);
   }
 
   if (field.prompt === 'relative-date') {

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -12,6 +12,63 @@ export const FilterConditionSchema = z.object({
   not_in: z.array(z.string()).optional().describe('Field must not be one of these values'),
 });
 
+export const CalendarEraSchema = z.object({
+  name: z.string().describe('Era name'),
+  shortName: z.string().min(1).describe('Short era token used in date strings'),
+  backwards: z
+    .boolean()
+    .optional()
+    .describe('Whether years count down toward the era boundary'),
+});
+
+export const CalendarMonthSchema = z.object({
+  name: z.string().describe('Month name'),
+  shortName: z.string().min(1).optional().describe('Short month label'),
+  days: z.number().int().min(1).describe('Number of days in this month'),
+});
+
+export const CalendarSchema = z
+  .object({
+    label: z.string().optional().describe('Human-readable calendar label'),
+    hoursInDay: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe('Number of hours in a calendar day; defaults to 24'),
+    eras: z.array(CalendarEraSchema).min(1).describe('Calendar eras'),
+    months: z.array(CalendarMonthSchema).min(1).describe('Calendar months'),
+  })
+  .superRefine((calendar, ctx) => {
+    const backwardsCount = calendar.eras.filter((era) => era.backwards === true).length;
+
+    if (calendar.eras.length > 2) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['eras'],
+        message:
+          'Custom calendar eras support at most 2 eras: one backwards era and one forward era.',
+      });
+    }
+
+    if (backwardsCount > 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['eras'],
+        message: 'Custom calendar eras support at most one backwards: true era.',
+      });
+    }
+
+    if (calendar.eras.length === 2 && backwardsCount !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['eras'],
+        message:
+          'Custom calendars with 2 eras must define exactly one backwards: true era and one forward era.',
+      });
+    }
+  });
+
 /**
  * A single select option.
  * Either a bare value ("active") or an object that pairs the value with a
@@ -50,6 +107,10 @@ export const FieldSchema = z.object({
     .describe(
       'Coarsest date precision allowed for this `date` field, finer is always allowed (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Overrides the global config.date_granularity for this field.'
     ),
+  calendar: z
+    .string()
+    .optional()
+    .describe('Calendar id for date fields using config.calendars'),
   // Static value (no prompting)
   value: z
     .string()
@@ -298,6 +359,10 @@ export const TypeSchema = z.object({
     .record(FieldSchema)
     .optional()
     .describe('Field definitions, merged with ancestors and traits at load time'),
+  calendar_default: z
+    .string()
+    .optional()
+    .describe('Default calendar id for date fields on this type'),
   // Explicit field ordering (optional - defaults to definition order)
   field_order: z
     .array(z.string())
@@ -419,6 +484,10 @@ export const ConfigSchema = z.object({
     .describe(
       'Default coarsest date precision allowed for all date fields (day = full YYYY-MM-DD, month = YYYY-MM or finer, year = YYYY or finer). Per-field `granularity` overrides this default.'
     ),
+  calendars: z
+    .record(CalendarSchema)
+    .optional()
+    .describe('Named custom calendars available to date fields'),
   // Max Levenshtein distance cap for the `unlinked-mention` audit fuzzy ("did
   // you mean?") tier (#622). Integer 0-5; default 2. The effective distance is
   // also length-scaled. 0 disables the fuzzy tier. Overridden per run by
@@ -542,6 +611,9 @@ export const BwrbSchema = z.object({
 
 export type Field = z.infer<typeof FieldSchema>;
 export type FieldOption = z.infer<typeof FieldOptionSchema>;
+export type Calendar = z.infer<typeof CalendarSchema>;
+export type CalendarEra = z.infer<typeof CalendarEraSchema>;
+export type CalendarMonth = z.infer<typeof CalendarMonthSchema>;
 
 /**
  * Extract the bare value strings from a field's options, regardless of whether
@@ -613,6 +685,8 @@ export interface ResolvedType {
   fields: Record<string, Field>;
   /** Field ordering */
   fieldOrder: string[];
+  /** Default calendar id for this type's date fields */
+  calendarDefault: string | undefined;
   /** Body section definitions */
   bodySections: BodySection[];
   /** Whether this type can self-nest */
@@ -647,6 +721,8 @@ export interface ResolvedConfig {
   dateFormat: string;
   /** Default coarsest date precision allowed for date fields (defaults to 'day') */
   dateGranularity: 'day' | 'month' | 'year';
+  /** Named custom calendars available to date fields */
+  calendars: Record<string, Calendar>;
   /**
    * Max Levenshtein distance cap for the `unlinked-mention` audit fuzzy tier
    * (#622). Defaults to 2. A CLI flag (`--mention-fuzzy-threshold`) overrides

--- a/tests/ts/commands/custom-calendar.test.ts
+++ b/tests/ts/commands/custom-calendar.test.ts
@@ -104,7 +104,7 @@ describe('custom calendars', () => {
     });
   });
 
-  it('uses calendar day length for relative-date d offsets and rejects w offsets', async () => {
+  it('uses calendar day length for relative-date d offsets and degrades w offsets during list', async () => {
     await writeEvent('Anchor', { when: 'AR 1-01-01' });
     await writeEvent('Plus Hours', {
       position: [{ kind: 'equal', ref: '[[Anchor]]', field: 'when', offset: '340h' }],
@@ -135,9 +135,75 @@ describe('custom calendars', () => {
     await writeEvent('Bad Week', {
       position: [{ kind: 'equal', ref: '[[Anchor]]', field: 'when', offset: '1w' }],
     });
-    const rejected = await runCLI(['list', 'event', '--sort', 'position'], vaultDir);
-    expect(rejected.exitCode).not.toBe(0);
-    expect(rejected.stderr + rejected.stdout).toContain('unsupported calendar offset unit "w"');
+    const listed = await runCLI(['list', 'event', '--fields', 'position', '--output', 'json'], vaultDir);
+    expect(listed.exitCode).toBe(0);
+    const listedRows = JSON.parse(listed.stdout) as Array<{
+      _name: string;
+      position?: { resolved: string | null; resolution: string };
+    }>;
+    expect(listedRows.map((row) => row._name)).toEqual(
+      expect.arrayContaining(['Anchor', 'Plus Hours', 'Plus Days', 'Bad Week'])
+    );
+    expect(listedRows.find((row) => row._name === 'Bad Week')!.position).toMatchObject({
+      resolved: null,
+      resolution: 'invalid-offset',
+    });
+
+    const textListed = await runCLI(['list', 'event', '--fields', 'position'], vaultDir);
+    expect(textListed.exitCode).toBe(0);
+    expect(textListed.stdout).toContain('Bad Week');
+  });
+
+  it('rejects JSON writes when a relative-date w offset resolves to a calendar chain', async () => {
+    await writeEvent('Anchor', { when: 'AR 1-01-01' });
+
+    const created = await runCLI(
+      [
+        'new',
+        'event',
+        '--no-template',
+        '--json',
+        JSON.stringify({
+          name: 'Bad Week',
+          position: [{ kind: 'equal', ref: '[[Anchor]]', field: 'when', offset: '1w' }],
+        }),
+      ],
+      vaultDir
+    );
+    expect(created.exitCode).not.toBe(0);
+    const createdOutput = JSON.parse(created.stdout) as { errors: Array<{ message: string }> };
+    expect(createdOutput.errors[0]!.message).toContain('unsupported calendar offset unit "w"');
+
+    await writeEvent('Editable', { position: [{ kind: 'equal', ref: '[[Anchor]]', field: 'when', offset: '1d' }] });
+    const edited = await runCLI(
+      [
+        'edit',
+        'Editable',
+        '--json',
+        JSON.stringify({
+          position: [{ kind: 'equal', ref: '[[Anchor]]', field: 'when', offset: '1w' }],
+        }),
+      ],
+      vaultDir
+    );
+    expect(edited.exitCode).not.toBe(0);
+    const editedOutput = JSON.parse(edited.stdout) as { errors: Array<{ message: string }> };
+    expect(editedOutput.errors[0]!.message).toContain('unsupported calendar offset unit "w"');
+
+    const unresolved = await runCLI(
+      [
+        'new',
+        'event',
+        '--no-template',
+        '--json',
+        JSON.stringify({
+          name: 'Lazy Bad Week',
+          position: [{ kind: 'equal', ref: '[[Missing Anchor]]', field: 'when', offset: '1w' }],
+        }),
+      ],
+      vaultDir
+    );
+    expect(unresolved.exitCode).toBe(0);
   });
 
   it('carries rounded calendar minutes across the day boundary', async () => {

--- a/tests/ts/commands/custom-calendar.test.ts
+++ b/tests/ts/commands/custom-calendar.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runCLI, TEST_SCHEMA } from '../fixtures/setup.js';
+
+describe('custom calendars', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-custom-calendar-'));
+    await mkdir(join(vaultDir, '.bwrb'), { recursive: true });
+    await mkdir(join(vaultDir, 'Events'), { recursive: true });
+    await writeFile(
+      join(vaultDir, '.bwrb', 'schema.json'),
+      JSON.stringify(calendarSchema(), null, 2)
+    );
+  });
+
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('sorts and filters calendar dates by linear hours and emits JSON metadata', async () => {
+    await writeEvent('Future', { when: 'AR 3019-09-02 266:50' });
+    await writeEvent('Early AR', { when: 'AR 960-06-01' });
+    await writeEvent('Old BH', { when: 'BH 12-01-01' });
+
+    const sorted = await runCLI(['list', 'event', '--sort', 'when', '--output', 'json'], vaultDir);
+    expect(sorted.exitCode).toBe(0);
+    const rows = JSON.parse(sorted.stdout) as Array<{
+      _name: string;
+      when: { value: string; calendar: string; linear: number };
+    }>;
+    expect(rows.map((row) => row._name)).toEqual(['Old BH', 'Early AR', 'Future']);
+    expect(rows[0]!.when.value).toBe('BH 12-01-01');
+    expect(rows[0]!.when.calendar).toBe('tmi');
+    expect(rows[0]!.when.linear).toBeLessThan(0);
+    expect(rows[2]!.when.value).toBe('AR 3019-09-02 266:50');
+
+    const filtered = await runCLI(
+      ['list', 'event', '--where', "when > 'AR 1000-01-01'", '--output', 'json'],
+      vaultDir
+    );
+    expect(filtered.exitCode).toBe(0);
+    const filteredRows = JSON.parse(filtered.stdout) as Array<{ _name: string }>;
+    expect(filteredRows.map((row) => row._name)).toEqual(['Future']);
+  });
+
+  it('validates calendar ranges during creation and audit', async () => {
+    const created = await runCLI(
+      [
+        'new',
+        'event',
+        '--no-template',
+        '--json',
+        JSON.stringify({ name: 'Bad', when: 'AR 3019-14-01' }),
+      ],
+      vaultDir
+    );
+    expect(created.exitCode).not.toBe(0);
+    expect(created.stdout + created.stderr).toContain('month');
+    expect(created.stdout + created.stderr).toContain('1-12');
+
+    await writeEvent('Hand Edited', { when: 'AR 3019-14-01' });
+    const audit = await runCLI(['audit', 'event', '--output', 'json'], vaultDir);
+    expect(audit.exitCode).not.toBe(0);
+    const output = JSON.parse(audit.stdout) as {
+      files: Array<{ issues: Array<{ code: string; message: string }> }>;
+    };
+    const issue = output.files.flatMap((file) => file.issues).find((item) => item.code === 'invalid-date-format');
+    expect(issue?.message).toContain('month');
+    expect(issue?.message).toContain('1-12');
+  });
+
+  it('rejects calendar schemas with more than two eras', async () => {
+    const schema = calendarSchema();
+    const calendars = (schema.config as { calendars: Record<string, { eras: unknown[] }> }).calendars;
+    calendars.tmi!.eras = [
+      { name: 'Before Humans', shortName: 'BH', backwards: true },
+      { name: 'After Humans', shortName: 'AR' },
+      { name: 'Far Future', shortName: 'FF' },
+    ];
+    await writeFile(join(vaultDir, '.bwrb', 'schema.json'), JSON.stringify(schema, null, 2));
+
+    const rejected = await runCLI(['list', 'event'], vaultDir);
+    expect(rejected.exitCode).not.toBe(0);
+    expect(rejected.stderr + rejected.stdout).toContain(
+      'Custom calendar eras support at most 2 eras'
+    );
+  });
+
+  it('applies type-level calendar_default to date fields', async () => {
+    await writeEvent('Defaulted', { inherited_when: 'AR 1-01-01' });
+    const listed = await runCLI(['list', 'event', '--fields', 'inherited_when', '--output', 'json'], vaultDir);
+    expect(listed.exitCode).toBe(0);
+    const rows = JSON.parse(listed.stdout) as Array<{
+      inherited_when: { value: string; calendar: string; linear: number };
+    }>;
+    expect(rows[0]!.inherited_when).toMatchObject({
+      value: 'AR 1-01-01',
+      calendar: 'tmi',
+      linear: 0,
+    });
+  });
+
+  it('uses calendar day length for relative-date d offsets and rejects w offsets', async () => {
+    await writeEvent('Anchor', { when: 'AR 1-01-01' });
+    await writeEvent('Plus Hours', {
+      position: [{ kind: 'equal', ref: '[[Anchor]]', field: 'when', offset: '340h' }],
+    });
+    await writeEvent('Plus Days', {
+      position: [{ kind: 'equal', ref: '[[Anchor]]', field: 'when', offset: '2d' }],
+    });
+
+    const sorted = await runCLI(['list', 'event', '--sort', 'position', '--output', 'json'], vaultDir);
+    expect(sorted.exitCode).toBe(0);
+    const rows = JSON.parse(sorted.stdout) as Array<{
+      _name: string;
+      position?: { resolved: string; calendar?: string; linear?: number };
+    }>;
+    const plusHours = rows.find((row) => row._name === 'Plus Hours')!;
+    const plusDays = rows.find((row) => row._name === 'Plus Days')!;
+    expect(plusHours.position).toMatchObject({
+      resolved: 'AR 1-01-02 4:00',
+      calendar: 'tmi',
+      linear: 340,
+    });
+    expect(plusDays.position).toMatchObject({
+      resolved: 'AR 1-02-01',
+      calendar: 'tmi',
+      linear: 672,
+    });
+
+    await writeEvent('Bad Week', {
+      position: [{ kind: 'equal', ref: '[[Anchor]]', field: 'when', offset: '1w' }],
+    });
+    const rejected = await runCLI(['list', 'event', '--sort', 'position'], vaultDir);
+    expect(rejected.exitCode).not.toBe(0);
+    expect(rejected.stderr + rejected.stdout).toContain('unsupported calendar offset unit "w"');
+  });
+
+  it('carries rounded calendar minutes across the day boundary', async () => {
+    await writeEvent('Anchor', { when: 'AR 1-01-01' });
+    await writeEvent('Boundary', {
+      position: [
+        {
+          kind: 'equal',
+          ref: '[[Anchor]]',
+          field: 'when',
+          offset: { amount: 20159.9994, unit: 'min' },
+        },
+      ],
+    });
+
+    const listed = await runCLI(['list', 'event', '--fields', 'position', '--output', 'json'], vaultDir);
+    expect(listed.exitCode).toBe(0);
+    const rows = JSON.parse(listed.stdout) as Array<{
+      _name: string;
+      position?: { resolved: string; calendar?: string; linear?: number };
+    }>;
+    const boundary = rows.find((row) => row._name === 'Boundary')!;
+    expect(boundary.position).toMatchObject({
+      resolved: 'AR 1-01-02',
+      calendar: 'tmi',
+    });
+    expect(boundary.position?.linear).toBeCloseTo(335.99999, 5);
+  });
+
+  async function writeEvent(
+    name: string,
+    fields: { when?: string; inherited_when?: string; position?: unknown }
+  ): Promise<void> {
+    const lines = ['---', 'type: event', `name: ${JSON.stringify(name)}`];
+    if (fields.when) lines.push(`when: ${JSON.stringify(fields.when)}`);
+    if (fields.inherited_when) lines.push(`inherited_when: ${JSON.stringify(fields.inherited_when)}`);
+    if (fields.position !== undefined) {
+      lines.push(`position: ${JSON.stringify(fields.position)}`);
+    }
+    lines.push('---', '');
+    await writeFile(join(vaultDir, 'Events', `${name}.md`), lines.join('\n'));
+  }
+});
+
+function calendarSchema(): Record<string, unknown> {
+  return {
+    ...TEST_SCHEMA,
+    config: {
+      ...TEST_SCHEMA.config,
+      calendars: {
+        tmi: {
+          label: 'TMI lunar calendar',
+          hoursInDay: 336,
+          eras: [
+            { name: 'Before Humans', shortName: 'BH', backwards: true },
+            { name: 'After Humans', shortName: 'AR' },
+          ],
+          months: Array.from({ length: 12 }, (_, index) => ({
+            name: `Month ${index + 1}`,
+            shortName: `M${index + 1}`,
+            days: 2,
+          })),
+        },
+      },
+    },
+    types: {
+      ...TEST_SCHEMA.types,
+      event: {
+        output_dir: 'Events',
+        filename: '{name}',
+        calendar_default: 'tmi',
+        fields: {
+          name: { prompt: 'text', required: true },
+          when: { prompt: 'date', calendar: 'tmi' },
+          inherited_when: { prompt: 'date' },
+          position: { prompt: 'relative-date', source: 'event' },
+        },
+      },
+    },
+  };
+}

--- a/tests/ts/commands/schema.test.ts
+++ b/tests/ts/commands/schema.test.ts
@@ -1280,6 +1280,51 @@ status: paused
       }
     });
 
+    it('should render date field calendars in type details text and JSON', async () => {
+      const tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-calendar-schema-list-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify({
+          version: 2,
+          config: {
+            calendars: {
+              tmi: {
+                label: 'TMI lunar calendar',
+                eras: [{ name: 'After Humans', shortName: 'AR' }],
+                months: [{ name: 'Month 1', shortName: 'M1', days: 2 }],
+              },
+            },
+          },
+          types: {
+            event: {
+              output_dir: 'Events',
+              fields: {
+                name: { prompt: 'text', required: true },
+                when: { prompt: 'date', calendar: 'tmi' },
+              },
+            },
+          },
+        })
+      );
+
+      try {
+        const text = await runCLI(['schema', 'list', 'event'], tempVaultDir);
+        expect(text.exitCode).toBe(0);
+        expect(text.stdout).toMatch(/when:\s+date\s+\(calendar: tmi\)/);
+
+        const jsonResult = await runCLI(['schema', 'list', 'event', '--output', 'json'], tempVaultDir);
+        expect(jsonResult.exitCode).toBe(0);
+        const json = JSON.parse(jsonResult.stdout);
+        expect(json.fields.when).toMatchObject({
+          type: 'date',
+          calendar: 'tmi',
+        });
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
     it('should support --type alias for type details', async () => {
       const result = await runCLI(['schema', 'list', '--type', 'idea'], vaultDir);
 


### PR DESCRIPTION
## What

`config.calendars` lets a vault define non-Gregorian calendars (eras including backwards counting, arbitrary months, hours-in-day); `date` fields opt in via `calendar: <id>` or a type-level `calendar_default`.

```json
"calendars": {
  "tmi": {
    "hoursInDay": 336,
    "eras": [{ "name": "Before Humans", "shortName": "BH", "backwards": true },
             { "name": "After Humans", "shortName": "AR" }],
    "months": [{ "name": "Month One", "days": 2 }, ...]
  }
}
```

- Canonical string `AR 3019-09-02 266:50` parses, validates (range errors name the field, value, and valid range), formats, and sorts via linear hours; `list --output json` emits `{value, calendar, linear}`.
- Backwards eras sort correctly before forward eras; cross-calendar comparisons are diagnostics, not crashes.
- Relative-date integration (builds on #789): calendar-anchored chains resolve `d` as `hoursInDay`; `w` is rejected at write time when detectable and degrades to a `resolution: "invalid-offset"` diagnostic at query time otherwise — one bad note never makes a vault unlistable.
- v1 limits (validated + documented): max 2 eras (one backwards), no leap cycles.

Spec: `plans/features/custom-calendars.md`.

## Verification

- Full CI parity green locally (2,805 tests).
- Blind acceptance test: fresh agent defined a 336-hour lunar calendar from docs alone and passed all five scenarios, including exact 672-linear-hour offset math on a `2d` chain and era-crossing sort. Its findings (list-wide failure on one bad offset — the blocker, write-time `w` rejection, calendar id missing from `schema list`) are fixed in the final commit; non-blocking follow-ups filed as #790 and #791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)