### PR TITLE
Fix stdin cleanup after prompt-mode commands

### DIFF
--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -57,10 +57,6 @@ function printEditSuccess(path: string, updatedFields: string[], jsonMode: boole
   printSuccess(`Updated: ${path}${updatedText}`);
 }
 
-function exitEditSuccess(): never {
-  process.exit(ExitCodes.SUCCESS);
-}
-
 // ============================================================================
 // Command Definition
 // ============================================================================
@@ -217,7 +213,7 @@ Precedence (for --open app mode):
               await openNote(vaultDir, query, appMode, schema.config, false);
             }
           }
-          exitEditSuccess();
+          return;
         }
       }
 
@@ -315,7 +311,7 @@ Precedence (for --open app mode):
           const appMode = resolveAppMode(appModeInput, schema.config);
           await openNote(vaultDir, targetFile.path, appMode, schema.config, true);
         }
-        exitEditSuccess();
+        return;
       } else {
         // Interactive mode
         await editNoteInteractive(schema, vaultDir, targetFile.path);
@@ -326,7 +322,7 @@ Precedence (for --open app mode):
           const appMode = resolveAppMode(appModeInput, schema.config);
           await openNote(vaultDir, targetFile.path, appMode, schema.config, false);
         }
-        exitEditSuccess();
+        return;
       }
     } catch (err) {
       if (err instanceof UserCancelledError) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { configCommand } from './commands/config.js';
 import { dashboardCommand } from './commands/dashboard.js';
 import { initCommand } from './commands/init.js';
 import { handleCompletionRequest } from './lib/completion.js';
+import { cleanupPromptMode } from './lib/prompt.js';
 import { BWRB_VERSION } from './version.js';
 
 const program = new Command();
@@ -50,6 +51,9 @@ if (completionsIndex !== -1) {
     .version(BWRB_VERSION)
     .option('-v, --vault <path>', 'Path to the vault directory')
     .option('--non-interactive', 'Disable interactive prompts and require explicit non-interactive flags')
+    .hook('postAction', () => {
+      cleanupPromptMode();
+    })
     .enablePositionalOptions();
 
   // Help output order follows registration order.

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -49,9 +49,21 @@ interface PromptModeContext {
 
 const NON_INTERACTIVE_CONFIRM_TIMEOUT_MS = 500;
 let promptModeContext: PromptModeContext = { forcedNonInteractive: false };
+let promptModeConfigured = false;
 
 export function configurePromptMode(context: PromptModeContext): void {
   promptModeContext = context;
+  promptModeConfigured = true;
+}
+
+export function cleanupPromptMode(): void {
+  if (promptModeConfigured && !process.stdin.isTTY) {
+    process.stdin.pause();
+    process.stdin.unref?.();
+  }
+
+  promptModeContext = { forcedNonInteractive: false };
+  promptModeConfigured = false;
 }
 
 function isInteractive(): boolean {

--- a/tests/ts/commands/bulk.test.ts
+++ b/tests/ts/commands/bulk.test.ts
@@ -2,57 +2,8 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from
 import { mkdtemp, rm, mkdir, writeFile, readFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { spawn } from 'child_process';
-import { createTestVault, cleanupTestVault, runCLI, TEST_SCHEMA, CLI_PATH, PROJECT_ROOT, withTestCliNodeOptions } from '../fixtures/setup.js';
+import { createTestVault, cleanupTestVault, runCLI, runCLIWithOpenStdin, TEST_SCHEMA } from '../fixtures/setup.js';
 import { parseNote } from '../../../src/lib/frontmatter.js';
-
-const CLI_SRC_PATH = join(PROJECT_ROOT, 'src/index.ts');
-const TSX_BIN = join(PROJECT_ROOT, 'node_modules', '.bin', 'tsx');
-const USE_DIST = process.env.BWRB_TEST_DIST === '1';
-
-async function runCLIWithOpenStdin(
-  args: string[],
-  vaultDir: string,
-  timeoutMs = USE_DIST ? 1500 : 4000
-): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const fullArgs = vaultDir ? ['--vault', vaultDir, ...args] : args;
-
-  const cliCommand = USE_DIST ? 'node' : TSX_BIN;
-  const cliArgs = USE_DIST ? [CLI_PATH, ...fullArgs] : [CLI_SRC_PATH, ...fullArgs];
-
-  return await new Promise((resolve, reject) => {
-    const proc = spawn(cliCommand, cliArgs, {
-      cwd: PROJECT_ROOT,
-      env: withTestCliNodeOptions({ ...process.env, FORCE_COLOR: '0' }),
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    let stdout = '';
-    let stderr = '';
-
-    const timeout = setTimeout(() => {
-      proc.kill('SIGKILL');
-      reject(new Error('Process timed out waiting for non-interactive confirmation'));
-    }, timeoutMs);
-
-    proc.stdout.on('data', (data) => {
-      stdout += data.toString();
-    });
-
-    proc.stderr.on('data', (data) => {
-      stderr += data.toString();
-    });
-
-    proc.on('close', (code) => {
-      clearTimeout(timeout);
-      resolve({
-        stdout: stdout.trim(),
-        stderr: stderr.trim(),
-        exitCode: code ?? 0,
-      });
-    });
-  });
-}
 
 describe('bulk command', () => {
   let vaultDir: string;
@@ -362,6 +313,27 @@ describe('bulk command', () => {
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('Updated');
         expect(result.stdout).not.toContain('Are you sure');
+      } finally {
+        await cleanupTestVault(tempVaultDir);
+      }
+    });
+
+    it('exits promptly after stdin confirmation succeeds with stdin left open (#795)', async () => {
+      const tempVaultDir = await createTestVault();
+      try {
+        const result = await runCLIWithOpenStdin([
+          'bulk',
+          '--all',
+          '--set', 'custom-field=test',
+          '--execute'
+        ], tempVaultDir, 'y\n');
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Updated');
+        expect(result.stderr).toBe('');
+
+        const updated = await readFile(join(tempVaultDir, 'Ideas', 'Sample Idea.md'), 'utf-8');
+        expect(updated).toContain('custom-field: test');
       } finally {
         await cleanupTestVault(tempVaultDir);
       }

--- a/tests/ts/commands/delete.test.ts
+++ b/tests/ts/commands/delete.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { existsSync } from 'fs';
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join } from 'path';
-import { createTestVault, cleanupTestVault, runCLI, waitForFile } from '../fixtures/setup.js';
+import { createTestVault, cleanupTestVault, runCLI, runCLIWithOpenStdin, waitForFile } from '../fixtures/setup.js';
 
 describe('delete command', () => {
   let vaultDir: string;
@@ -58,6 +58,22 @@ describe('delete command', () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Deleted');
+      expect(existsSync(filePath)).toBe(false);
+    });
+
+    it('exits promptly after stdin confirmation succeeds with stdin left open (#795)', async () => {
+      const filePath = join(vaultDir, 'Ideas', 'Sample Idea.md');
+      expect(existsSync(filePath)).toBe(true);
+
+      const result = await runCLIWithOpenStdin(
+        ['delete', 'Ideas/Sample Idea.md'],
+        vaultDir,
+        'y\n'
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Deleted: Ideas/Sample Idea.md');
+      expect(result.stderr).toBe('');
       expect(existsSync(filePath)).toBe(false);
     });
   });

--- a/tests/ts/fixtures/setup.ts
+++ b/tests/ts/fixtures/setup.ts
@@ -473,3 +473,76 @@ export async function runCLI(
     }`
   );
 }
+
+export async function runCLIWithOpenStdin(
+  args: string[],
+  vaultDir?: string,
+  stdin?: string,
+  {
+    cwd = PROJECT_ROOT,
+    env = {},
+    timeoutMs = USE_DIST ? 2_500 : 6_000,
+  }: Pick<RunCLIOptions, 'cwd' | 'env' | 'timeoutMs'> = {}
+): Promise<CLIResult> {
+  const fullArgs = vaultDir ? ['--vault', vaultDir, ...args] : args;
+  const cliCommand = USE_DIST ? 'node' : TSX_BIN;
+  const cliArgs = USE_DIST ? [CLI_PATH, ...fullArgs] : [CLI_SRC_PATH, ...fullArgs];
+  const mergedEnv = withTestCliNodeOptions({
+    ...process.env,
+    NO_COLOR: '1',
+    ...env,
+  });
+
+  return await new Promise((resolve, reject) => {
+    const proc = spawn(cliCommand, cliArgs, {
+      cwd,
+      env: mergedEnv,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      proc.kill('SIGKILL');
+      reject(
+        new Error(
+          `runCLIWithOpenStdin exceeded ${timeoutMs}ms: ${cliCommand} ${cliArgs.join(' ')}`
+        )
+      );
+    }, timeoutMs);
+
+    proc.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    if (stdin !== undefined) {
+      proc.stdin.write(stdin);
+    }
+
+    proc.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        exitCode: code ?? 0,
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- add centralized prompt-mode cleanup after Commander actions to pause/unref non-TTY stdin handles
- route edit JSON success through the centralized cleanup instead of an explicit success exit
- add open-stdin regression coverage for bulk/delete confirmation success paths

## Validation

- pnpm build
- pnpm verify:pack
- pnpm typecheck
- pnpm lint
- pnpm knip
- focused source tests: vitest run tests/ts/commands/edit.test.ts tests/ts/commands/bulk.test.ts tests/ts/commands/delete.test.ts
- focused dist tests: BWRB_TEST_DIST=1 vitest run tests/ts/commands/edit.test.ts tests/ts/commands/bulk.test.ts tests/ts/commands/delete.test.ts
- broader non-PTY tests: pnpm test -- --exclude='**/*.pty.test.ts'
- built CLI smoke checks with disposable vaults and stdin intentionally left open for edit JSON, bulk confirm, and delete confirm

Closes #795
