### PR TITLE
Fix edit JSON output with --open

### DIFF
--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -6,7 +6,7 @@
  */
 
 import { Command } from 'commander';
-import { basename, isAbsolute, relative } from 'path';
+import { basename, isAbsolute, join, relative } from 'path';
 import fs from 'fs/promises';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts, resolveGlobalPickerMode } from '../lib/command.js';
@@ -16,9 +16,10 @@ import { printJson, jsonSuccess, jsonError, ExitCodes, exitWithResolutionError }
 import { buildNoteIndex, type ManagedFile } from '../lib/navigation.js';
 import { parsePickerMode, resolveAndPick, type PickerMode } from '../lib/picker.js';
 import { editNoteFromJson, editNoteInteractive } from '../lib/edit.js';
-import { openNote, resolveAppMode, parseAppMode } from './open.js';
+import { openNote, resolveAppMode, parseAppMode, type AppMode } from './open.js';
 import { resolveTargets, hasAnyTargeting, type TargetingOptions } from '../lib/targeting.js';
 import { UserCancelledError } from '../lib/errors.js';
+import type { ResolvedConfig } from '../types/schema.js';
 
 // ============================================================================
 // Types
@@ -45,9 +46,60 @@ function resolveEditJsonMode(options: EditOptions, globalOutput?: string): boole
   return requested === 'json';
 }
 
-function printEditSuccess(path: string, updatedFields: string[], jsonMode: boolean): void {
+interface EditOpenJsonData {
+  open: {
+    relativePath: string;
+    fullPath: string;
+  };
+}
+
+class EditValidationError extends Error {}
+
+function getOpenPrintJsonData(vaultDir: string, notePath: string): EditOpenJsonData {
+  const fullPath = isAbsolute(notePath) ? notePath : join(vaultDir, notePath);
+  const relativePath = isAbsolute(notePath)
+    ? notePath.replace(`${vaultDir}/`, '')
+    : notePath;
+
+  return {
+    open: {
+      relativePath,
+      fullPath,
+    },
+  };
+}
+
+async function openAfterEdit(
+  vaultDir: string,
+  notePath: string,
+  appMode: AppMode,
+  config: ResolvedConfig,
+  jsonMode: boolean
+): Promise<EditOpenJsonData | undefined> {
+  if (jsonMode && appMode === 'print') {
+    return getOpenPrintJsonData(vaultDir, notePath);
+  }
+
+  if (jsonMode && appMode === 'editor' && !config.editor) {
+    throw new EditValidationError('No terminal editor configured. Set $EDITOR or config.editor.');
+  }
+
+  if (jsonMode && appMode === 'visual' && !config.visual) {
+    throw new EditValidationError('No GUI editor configured. Set $VISUAL or config.visual.');
+  }
+
+  await openNote(vaultDir, notePath, appMode, config, false);
+  return undefined;
+}
+
+function printEditSuccess(
+  path: string,
+  updatedFields: string[],
+  jsonMode: boolean,
+  data?: EditOpenJsonData
+): void {
   if (jsonMode) {
-    printJson(jsonSuccess({ path, updated: updatedFields }));
+    printJson(jsonSuccess({ path, updated: updatedFields, ...(data ? { data } : {}) }));
     return;
   }
 
@@ -200,11 +252,17 @@ Precedence (for --open app mode):
           // It's a valid absolute path - use it directly.
           if (patchMode) {
             const editResult = await editNoteFromJson(schema, vaultDir, query, options.json!, { jsonMode });
-            printEditSuccess(relative(vaultDir, query), editResult.updatedFields, jsonMode);
+            let openData: EditOpenJsonData | undefined;
             if (options.open) {
               const appMode = resolveAppMode(appModeInput, schema.config);
-              await openNote(vaultDir, query, appMode, schema.config, true);
+              if (!jsonMode) {
+                printEditSuccess(relative(vaultDir, query), editResult.updatedFields, jsonMode);
+                await openAfterEdit(vaultDir, query, appMode, schema.config, jsonMode);
+                return;
+              }
+              openData = await openAfterEdit(vaultDir, query, appMode, schema.config, jsonMode);
             }
+            printEditSuccess(relative(vaultDir, query), editResult.updatedFields, jsonMode, openData);
           } else {
             await editNoteInteractive(schema, vaultDir, query, {});
             printSuccess(`Updated ${basename(query, '.md')}`);
@@ -304,13 +362,19 @@ Precedence (for --open app mode):
       if (patchMode) {
         // JSON patch mode: non-interactive patch with selectable output format
         const editResult = await editNoteFromJson(schema, vaultDir, targetFile.path, options.json!, { jsonMode });
-        printEditSuccess(targetFile.relativePath, editResult.updatedFields, jsonMode);
+        let openData: EditOpenJsonData | undefined;
 
         // Open after edit if requested
         if (options.open) {
           const appMode = resolveAppMode(appModeInput, schema.config);
-          await openNote(vaultDir, targetFile.path, appMode, schema.config, true);
+          if (!jsonMode) {
+            printEditSuccess(targetFile.relativePath, editResult.updatedFields, jsonMode);
+            await openAfterEdit(vaultDir, targetFile.path, appMode, schema.config, jsonMode);
+            return;
+          }
+          openData = await openAfterEdit(vaultDir, targetFile.path, appMode, schema.config, jsonMode);
         }
+        printEditSuccess(targetFile.relativePath, editResult.updatedFields, jsonMode, openData);
         return;
       } else {
         // Interactive mode
@@ -334,6 +398,14 @@ Precedence (for --open app mode):
         process.exit(1);
       }
       const message = err instanceof Error ? err.message : String(err);
+      if (err instanceof EditValidationError) {
+        if (jsonMode) {
+          printJson(jsonError(message));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        printError(message);
+        process.exit(1);
+      }
       if (jsonMode) {
         printJson(jsonError(message));
         process.exit(ExitCodes.IO_ERROR);

--- a/tests/ts/commands/edit.test.ts
+++ b/tests/ts/commands/edit.test.ts
@@ -75,6 +75,13 @@ async function runEditWithOpenStdin(
   });
 }
 
+function parseSingleJsonObject(stdout: string): Record<string, unknown> {
+  const trimmed = stdout.trim();
+  expect(trimmed).toMatch(/^\{/);
+  expect(trimmed).toMatch(/\}$/);
+  return JSON.parse(trimmed) as Record<string, unknown>;
+}
+
 describe('edit command', () => {
   let vaultDir: string;
 
@@ -1314,15 +1321,25 @@ describe('edit positional app mode (#711)', () => {
     await cleanupTestVault(vaultDir);
   });
 
-  it('honors a positional mode with --open (edit <query> print --open --json {})', async () => {
+  it('emits one JSON success object for absolute-path --open print', async () => {
+    const absolutePath = join(vaultDir, 'Ideas/Sample Idea.md');
     const result = await runCLI(
-      ['edit', 'Sample Idea', 'print', '--open', '--json', '{}'],
+      ['edit', absolutePath, 'print', '--open', '--json', '{"status":"backlog"}'],
       vaultDir
     );
 
     expect(result.exitCode).toBe(0);
-    // Print mode emits the path after the edit completes.
-    expect(result.stdout + result.stderr).toContain('Sample Idea.md');
+    expect(result.stderr).toBe('');
+    const json = parseSingleJsonObject(result.stdout);
+    expect(json.success).toBe(true);
+    expect(json.path).toBe('Ideas/Sample Idea.md');
+    expect(json.updated).toEqual(['status']);
+    expect(json.data).toEqual({
+      open: {
+        relativePath: 'Ideas/Sample Idea.md',
+        fullPath: absolutePath,
+      },
+    });
   });
 
   it('lets --app flag take precedence over positional mode', async () => {
@@ -1333,6 +1350,32 @@ describe('edit positional app mode (#711)', () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout + result.stderr).toContain('Sample Idea.md');
+  });
+
+  it('emits one JSON error when edit succeeds but --open --app editor has no editor configured', async () => {
+    const id = 'e86251ed-c378-4f8e-a57c-8d9527624580';
+    const filePath = join(vaultDir, 'Ideas/Open Fails After Edit.md');
+    await writeFile(
+      filePath,
+      `---\ntype: idea\nid: ${id}\nstatus: raw\npriority: medium\n---\n`,
+      'utf-8'
+    );
+
+    const result = await runCLI(
+      ['edit', '--id', id, '--json', '{"status":"backlog"}', '--open', '--app', 'editor'],
+      vaultDir,
+      undefined,
+      { env: { EDITOR: '', VISUAL: '', BWRB_DEFAULT_APP: '' } }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('');
+    const json = parseSingleJsonObject(result.stdout);
+    expect(json.success).toBe(false);
+    expect(json.error).toBe('No terminal editor configured. Set $EDITOR or config.editor.');
+
+    const updated = await readFile(filePath, 'utf-8');
+    expect(updated).toContain('status: backlog');
   });
 
   it('errors on an invalid positional mode even without --open', async () => {


### PR DESCRIPTION
## Summary
- delay `edit --json` success output until requested `--open` work has succeeded
- fold `--open print` path data into the single edit success JSON payload instead of printing a second JSON object
- preserve a single JSON error when edit succeeds but `--open --app editor` cannot resolve an editor

Closes #796

## Verification
- `npx pnpm@10.11.0 test -- tests/ts/commands/edit.test.ts`
- `npx pnpm@10.11.0 build`
- `npx pnpm@10.11.0 verify:pack`
- `npx pnpm@10.11.0 typecheck`
- `npx pnpm@10.11.0 lint`
- `npx pnpm@10.11.0 knip`
- `npx pnpm@10.11.0 test -- --exclude='**/*.pty.test.ts'`
- built CLI disposable-vault checks:
  - `node dist/index.js --vault <tmp> edit 'Sample Idea' --json '{"status":"backlog"}' --open --app editor --output json` emitted exactly one JSON error and exited 1 while applying the edit
  - `node dist/index.js --vault <tmp> edit 'Sample Idea' print --json '{"status":"backlog"}' --open --output json` emitted exactly one JSON success object with `data.open`
