### PR TITLE
Unify open JSON metadata helpers

### DIFF
--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -6,7 +6,7 @@
  */
 
 import { Command } from 'commander';
-import { basename, isAbsolute, join, relative } from 'path';
+import { basename, isAbsolute, relative } from 'path';
 import fs from 'fs/promises';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts, resolveGlobalPickerMode } from '../lib/command.js';
@@ -16,7 +16,15 @@ import { printJson, jsonSuccess, jsonError, ExitCodes, exitWithResolutionError }
 import { buildNoteIndex, type ManagedFile } from '../lib/navigation.js';
 import { parsePickerMode, resolveAndPick, type PickerMode } from '../lib/picker.js';
 import { editNoteFromJson, editNoteInteractive } from '../lib/edit.js';
-import { openNote, resolveAppMode, parseAppMode, type AppMode } from './open.js';
+import {
+  getOpenResultData,
+  openNote,
+  resolveAppMode,
+  parseAppMode,
+  OpenConfigurationError,
+  type AppMode,
+  type OpenResultData,
+} from './open.js';
 import { resolveTargets, hasAnyTargeting, type TargetingOptions } from '../lib/targeting.js';
 import { UserCancelledError } from '../lib/errors.js';
 import type { ResolvedConfig } from '../types/schema.js';
@@ -47,26 +55,7 @@ function resolveEditJsonMode(options: EditOptions, globalOutput?: string): boole
 }
 
 interface EditOpenJsonData {
-  open: {
-    relativePath: string;
-    fullPath: string;
-  };
-}
-
-class EditValidationError extends Error {}
-
-function getOpenPrintJsonData(vaultDir: string, notePath: string): EditOpenJsonData {
-  const fullPath = isAbsolute(notePath) ? notePath : join(vaultDir, notePath);
-  const relativePath = isAbsolute(notePath)
-    ? notePath.replace(`${vaultDir}/`, '')
-    : notePath;
-
-  return {
-    open: {
-      relativePath,
-      fullPath,
-    },
-  };
+  open: OpenResultData;
 }
 
 async function openAfterEdit(
@@ -76,16 +65,12 @@ async function openAfterEdit(
   config: ResolvedConfig,
   jsonMode: boolean
 ): Promise<EditOpenJsonData | undefined> {
-  if (jsonMode && appMode === 'print') {
-    return getOpenPrintJsonData(vaultDir, notePath);
-  }
-
-  if (jsonMode && appMode === 'editor' && !config.editor) {
-    throw new EditValidationError('No terminal editor configured. Set $EDITOR or config.editor.');
-  }
-
-  if (jsonMode && appMode === 'visual' && !config.visual) {
-    throw new EditValidationError('No GUI editor configured. Set $VISUAL or config.visual.');
+  if (jsonMode) {
+    const openData = getOpenResultData(vaultDir, notePath, appMode, config);
+    if (appMode !== 'print') {
+      await openNote(vaultDir, notePath, appMode, config, false);
+    }
+    return { open: openData };
   }
 
   await openNote(vaultDir, notePath, appMode, config, false);
@@ -398,7 +383,7 @@ Precedence (for --open app mode):
         process.exit(1);
       }
       const message = err instanceof Error ? err.message : String(err);
-      if (err instanceof EditValidationError) {
+      if (err instanceof OpenConfigurationError) {
         if (jsonMode) {
           printJson(jsonError(message));
           process.exit(ExitCodes.VALIDATION_ERROR);

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -8,7 +8,7 @@
  */
 
 import { Command } from "commander";
-import { basename, join } from "node:path";
+import { basename, isAbsolute, relative, resolve } from "node:path";
 import { spawn } from "node:child_process";
 import { loadSchema, detectObsidianVault } from "../lib/schema.js";
 import { resolveVaultDirWithSelection } from "../lib/vaultSelection.js";
@@ -33,6 +33,17 @@ import { UserCancelledError } from "../lib/errors.js";
 // - obsidian: Open via Obsidian URI
 // - print: Print path to stdout (for scripting)
 export type AppMode = "system" | "editor" | "visual" | "obsidian" | "print";
+
+export interface OpenPathData {
+  relativePath: string;
+  fullPath: string;
+}
+
+export interface OpenResultData extends OpenPathData {
+  app?: string;
+}
+
+export class OpenConfigurationError extends Error {}
 
 /**
  * Parse app mode from string. Returns undefined if value is undefined/empty,
@@ -80,6 +91,56 @@ export function resolveAppMode(
   return config.openWith;
 }
 
+function resolveOpenPath(vaultDir: string, notePath: string): OpenPathData {
+  const fullPath = isAbsolute(notePath) ? resolve(notePath) : resolve(vaultDir, notePath);
+  return {
+    relativePath: relative(vaultDir, fullPath),
+    fullPath,
+  };
+}
+
+function missingOpenAppMessage(appMode: AppMode): string | undefined {
+  if (appMode === "editor") {
+    return "No terminal editor configured. Set $EDITOR or config.editor.";
+  }
+  if (appMode === "visual") {
+    return "No GUI editor configured. Set $VISUAL or config.visual.";
+  }
+  return undefined;
+}
+
+function resolveOpenAppMetadata(appMode: AppMode, config: ResolvedConfig): string | undefined {
+  switch (appMode) {
+    case "print":
+      return undefined;
+    case "system":
+      return "system";
+    case "obsidian":
+      return "obsidian";
+    case "editor":
+      if (!config.editor) {
+        throw new OpenConfigurationError(missingOpenAppMessage(appMode)!);
+      }
+      return config.editor;
+    case "visual":
+      if (!config.visual) {
+        throw new OpenConfigurationError(missingOpenAppMessage(appMode)!);
+      }
+      return config.visual;
+  }
+}
+
+export function getOpenResultData(
+  vaultDir: string,
+  notePath: string,
+  appMode: AppMode,
+  config: ResolvedConfig
+): OpenResultData {
+  const pathData = resolveOpenPath(vaultDir, notePath);
+  const app = resolveOpenAppMetadata(appMode, config);
+  return app ? { ...pathData, app } : pathData;
+}
+
 /**
  * Open a note in the specified application.
  * 
@@ -96,63 +157,57 @@ export async function openNote(
   config: ResolvedConfig,
   jsonMode: boolean = false
 ): Promise<void> {
-  // Normalize path - if absolute, use as-is; if relative, join with vaultDir
-  const fullPath = notePath.startsWith('/') ? notePath : join(vaultDir, notePath);
-  const relativePath = notePath.startsWith('/') ? notePath.replace(vaultDir + '/', '') : notePath;
+  let openData: OpenResultData;
+  try {
+    openData = getOpenResultData(vaultDir, notePath, appMode, config);
+  } catch (err) {
+    if (err instanceof OpenConfigurationError) {
+      if (jsonMode) {
+        printJson(jsonError(err.message));
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+      exitWithError(err.message);
+    }
+    throw err;
+  }
 
   switch (appMode) {
     case "print":
       if (jsonMode) {
-        printJson({ success: true, data: { relativePath, fullPath } });
+        printJson({ success: true, data: openData });
       } else {
-        console.log(fullPath);
+        console.log(openData.fullPath);
       }
       return;
 
     case "system":
-      await openWithSystem(fullPath);
+      await openWithSystem(openData.fullPath);
       if (jsonMode) {
-        printJson({ success: true, data: { relativePath, fullPath, app: "system" } });
+        printJson({ success: true, data: openData });
       }
       return;
 
     case "obsidian":
-      await openInObsidian(vaultDir, relativePath, config);
+      await openInObsidian(vaultDir, openData.relativePath, config);
       if (jsonMode) {
-        printJson({ success: true, data: { relativePath, fullPath, app: "obsidian" } });
+        printJson({ success: true, data: openData });
       }
       return;
 
     case "editor": {
-      const editorCmd = config.editor;
-      if (!editorCmd) {
-        const error = "No terminal editor configured. Set $EDITOR or config.editor.";
-        if (jsonMode) {
-          printJson(jsonError(error));
-          process.exit(ExitCodes.VALIDATION_ERROR);
-        }
-        exitWithError(error);
-      }
-      await openWithCommand(editorCmd!, fullPath, jsonMode);
+      const editorCmd = openData.app!;
+      await openWithCommand(editorCmd, openData.fullPath, jsonMode);
       if (jsonMode) {
-        printJson({ success: true, data: { relativePath, fullPath, app: editorCmd } });
+        printJson({ success: true, data: openData });
       }
       return;
     }
 
     case "visual": {
-      const visualCmd = config.visual;
-      if (!visualCmd) {
-        const error = "No GUI editor configured. Set $VISUAL or config.visual.";
-        if (jsonMode) {
-          printJson(jsonError(error));
-          process.exit(ExitCodes.VALIDATION_ERROR);
-        }
-        exitWithError(error);
-      }
-      await openWithCommand(visualCmd!, fullPath, jsonMode);
+      const visualCmd = openData.app!;
+      await openWithCommand(visualCmd, openData.fullPath, jsonMode);
       if (jsonMode) {
-        printJson({ success: true, data: { relativePath, fullPath, app: visualCmd } });
+        printJson({ success: true, data: openData });
       }
       return;
     }

--- a/tests/ts/commands/edit.test.ts
+++ b/tests/ts/commands/edit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { readFile, writeFile, mkdir, mkdtemp, rm } from 'fs/promises';
+import { chmod, readFile, writeFile, mkdir, mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { spawn } from 'child_process';
@@ -80,6 +80,29 @@ function parseSingleJsonObject(stdout: string): Record<string, unknown> {
   expect(trimmed).toMatch(/^\{/);
   expect(trimmed).toMatch(/\}$/);
   return JSON.parse(trimmed) as Record<string, unknown>;
+}
+
+async function setVaultConfig(
+  vaultDir: string,
+  config: Record<string, unknown>
+): Promise<void> {
+  const schemaPath = join(vaultDir, '.bwrb', 'schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as {
+    config?: Record<string, unknown>;
+  };
+  schema.config = { ...schema.config, ...config };
+  await writeFile(schemaPath, JSON.stringify(schema, null, 2));
+}
+
+async function writeExecutableScript(
+  vaultDir: string,
+  name: string,
+  body: string
+): Promise<string> {
+  const scriptPath = join(vaultDir, name);
+  await writeFile(scriptPath, `#!/bin/sh\n${body}\n`, 'utf-8');
+  await chmod(scriptPath, 0o755);
+  return scriptPath;
 }
 
 describe('edit command', () => {
@@ -1342,6 +1365,32 @@ describe('edit positional app mode (#711)', () => {
     });
   });
 
+  it('emits one JSON success object with app metadata for --open --app editor', async () => {
+    const editor = await writeExecutableScript(vaultDir, 'fake-editor-success.sh', 'exit 0');
+    await setVaultConfig(vaultDir, { editor });
+
+    const result = await runCLI(
+      ['edit', 'Sample Idea', '--json', '{"status":"backlog"}', '--open', '--app', 'editor'],
+      vaultDir,
+      undefined,
+      { env: { EDITOR: '', VISUAL: '', BWRB_DEFAULT_APP: '' } }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    const json = parseSingleJsonObject(result.stdout);
+    expect(json.success).toBe(true);
+    expect(json.path).toBe('Ideas/Sample Idea.md');
+    expect(json.updated).toEqual(['status']);
+    expect(json.data).toEqual({
+      open: {
+        relativePath: 'Ideas/Sample Idea.md',
+        fullPath: join(vaultDir, 'Ideas/Sample Idea.md'),
+        app: editor,
+      },
+    });
+  });
+
   it('lets --app flag take precedence over positional mode', async () => {
     const result = await runCLI(
       ['edit', 'Sample Idea', 'system', '--open', '--app', 'print', '--json', '{}'],
@@ -1375,6 +1424,65 @@ describe('edit positional app mode (#711)', () => {
     expect(json.error).toBe('No terminal editor configured. Set $EDITOR or config.editor.');
 
     const updated = await readFile(filePath, 'utf-8');
+    expect(updated).toContain('status: backlog');
+  });
+
+  it('emits one JSON error when edit succeeds but --open --app visual has no visual configured', async () => {
+    const result = await runCLI(
+      ['edit', 'Sample Idea', '--json', '{"status":"backlog"}', '--open', '--app', 'visual'],
+      vaultDir,
+      undefined,
+      { env: { EDITOR: '', VISUAL: '', BWRB_DEFAULT_APP: '' } }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('');
+    const json = parseSingleJsonObject(result.stdout);
+    expect(json.success).toBe(false);
+    expect(json.error).toBe('No GUI editor configured. Set $VISUAL or config.visual.');
+
+    const updated = await readFile(join(vaultDir, 'Ideas/Sample Idea.md'), 'utf-8');
+    expect(updated).toContain('status: backlog');
+  });
+
+  it('emits one JSON error for absolute-path --open --app visual without duplicate success', async () => {
+    const absolutePath = join(vaultDir, 'Ideas/Sample Idea.md');
+    const result = await runCLI(
+      ['edit', absolutePath, '--json', '{"status":"backlog"}', '--open', '--app', 'visual'],
+      vaultDir,
+      undefined,
+      { env: { EDITOR: '', VISUAL: '', BWRB_DEFAULT_APP: '' } }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('');
+    const json = parseSingleJsonObject(result.stdout);
+    expect(json.success).toBe(false);
+    expect(json.error).toBe('No GUI editor configured. Set $VISUAL or config.visual.');
+    expect(result.stdout).not.toContain('"path"');
+
+    const updated = await readFile(absolutePath, 'utf-8');
+    expect(updated).toContain('status: backlog');
+  });
+
+  it('emits one JSON error with IO exit code when a configured editor exits non-zero', async () => {
+    const editor = await writeExecutableScript(vaultDir, 'fake-editor-failure.sh', 'exit 7');
+    await setVaultConfig(vaultDir, { editor });
+
+    const result = await runCLI(
+      ['edit', 'Sample Idea', '--json', '{"status":"backlog"}', '--open', '--app', 'editor'],
+      vaultDir,
+      undefined,
+      { env: { EDITOR: '', VISUAL: '', BWRB_DEFAULT_APP: '' } }
+    );
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toBe('');
+    const json = parseSingleJsonObject(result.stdout);
+    expect(json.success).toBe(false);
+    expect(json.error).toContain('fake-editor-failure.sh exited with code 7');
+
+    const updated = await readFile(join(vaultDir, 'Ideas/Sample Idea.md'), 'utf-8');
     expect(updated).toContain('status: backlog');
   });
 

--- a/tests/ts/commands/open.test.ts
+++ b/tests/ts/commands/open.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
-import { mkdir, writeFile } from 'fs/promises';
+import { chmod, mkdir, readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { createTestVault, cleanupTestVault, runCLI } from '../fixtures/setup.js';
 import { parseAppMode, resolveAppMode } from '../../../src/commands/open.js';
@@ -7,6 +7,36 @@ import type { ResolvedConfig } from '../../../src/types/schema.js';
 
 // Note: We can't test actually opening Obsidian/editors as they require the apps.
 // This file tests query resolution, error handling, and validation.
+
+function parseSingleJsonObject(stdout: string): Record<string, unknown> {
+  const trimmed = stdout.trim();
+  expect(trimmed).toMatch(/^\{/);
+  expect(trimmed).toMatch(/\}$/);
+  return JSON.parse(trimmed) as Record<string, unknown>;
+}
+
+async function setVaultConfig(
+  vaultDir: string,
+  config: Record<string, unknown>
+): Promise<void> {
+  const schemaPath = join(vaultDir, '.bwrb', 'schema.json');
+  const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as {
+    config?: Record<string, unknown>;
+  };
+  schema.config = { ...schema.config, ...config };
+  await writeFile(schemaPath, JSON.stringify(schema, null, 2));
+}
+
+async function writeExecutableScript(
+  vaultDir: string,
+  name: string,
+  body: string
+): Promise<string> {
+  const scriptPath = join(vaultDir, name);
+  await writeFile(scriptPath, `#!/bin/sh\n${body}\n`, 'utf-8');
+  await chmod(scriptPath, 0o755);
+  return scriptPath;
+}
 
 describe('parseAppMode', () => {
   it('should return undefined for undefined/empty input', () => {
@@ -164,9 +194,45 @@ describe('open command', () => {
       const result = await runCLI(['open', 'Sample Idea', '--app', 'print', '--output', 'json'], vaultDir);
 
       expect(result.exitCode).toBe(0);
-      const json = JSON.parse(result.stdout);
+      const json = parseSingleJsonObject(result.stdout);
       expect(json.success).toBe(true);
-      expect(json.data.relativePath).toBe('Ideas/Sample Idea.md');
+      expect(json.data).toEqual({
+        relativePath: 'Ideas/Sample Idea.md',
+        fullPath: join(vaultDir, 'Ideas/Sample Idea.md'),
+      });
+    });
+
+    it('keeps JSON success compatible for --app editor and --app visual', async () => {
+      const tempVaultDir = await createTestVault();
+      try {
+        const editor = await writeExecutableScript(tempVaultDir, 'open-editor-success.sh', 'exit 0');
+        const visual = await writeExecutableScript(tempVaultDir, 'open-visual-success.sh', 'exit 0');
+        await setVaultConfig(tempVaultDir, { editor, visual });
+
+        for (const [appMode, app] of [
+          ['editor', editor],
+          ['visual', visual],
+        ] as const) {
+          const result = await runCLI(
+            ['open', 'Sample Idea', '--app', appMode, '--output', 'json'],
+            tempVaultDir,
+            undefined,
+            { env: { EDITOR: '', VISUAL: '', BWRB_DEFAULT_APP: '' } }
+          );
+
+          expect(result.exitCode).toBe(0);
+          expect(result.stderr).toBe('');
+          const json = parseSingleJsonObject(result.stdout);
+          expect(json.success).toBe(true);
+          expect(json.data).toEqual({
+            relativePath: 'Ideas/Sample Idea.md',
+            fullPath: join(tempVaultDir, 'Ideas/Sample Idea.md'),
+            app,
+          });
+        }
+      } finally {
+        await cleanupTestVault(tempVaultDir);
+      }
     });
 
     it('should output JSON error on no match with --output json', async () => {


### PR DESCRIPTION
## Summary
- share open path/app metadata generation between `open` and edit-after-open JSON flows
- include configured `editor`/`visual` app metadata in `edit --json --open` success payloads while preserving a single JSON object
- add coverage for editor/visual JSON success, missing visual config, absolute-path open failures, and runtime editor command failures

Closes #799

## Verification
- `npx pnpm@10.11.0 build`
- `npx pnpm@10.11.0 verify:pack`
- `npx pnpm@10.11.0 typecheck`
- `npx pnpm@10.11.0 lint`
- `npx pnpm@10.11.0 knip`
- `npx pnpm@10.11.0 test -- tests/ts/commands/edit.test.ts tests/ts/commands/open.test.ts`
- `npx pnpm@10.11.0 test -- --exclude='**/*.pty.test.ts'`
- `BWRB_TEST_DIST=1 npx pnpm@10.11.0 test -- tests/ts/commands/edit.test.ts tests/ts/commands/open.test.ts`
- built CLI throwaway-vault probe covering edit/open editor metadata, missing visual config, absolute-path visual failure, and runtime editor command failure
