### PR TITLE
feat: add native document forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Document forks** — `bwrb new --fork <target>` creates a sibling document with a fresh stable ID and immutable `forked-from` provenance while preserving the source body and prior work.
+
 ## [0.2.2] - 2026-07-04
 
 Patch release for unlinked-mention precision, mention-linking controls, and relation-resolution fixes.

--- a/docs-site/src/content/docs/reference/commands/new.md
+++ b/docs-site/src/content/docs/reference/commands/new.md
@@ -23,6 +23,10 @@ bwrb new [options] [type]
 | `--no-instances` | Skip instance scaffolding (when template has instances) |
 | `--owner <wikilink>` | Owner note for owned types (e.g., `"[[My Novel]]"`) |
 | `--standalone` | Create as standalone (skip owner selection for ownable types) |
+| `--fork <target>` | Create a sibling document forked from an exact path, name, alias, or stable UUID |
+| `--label <label>` | Name the fork `<source> — <label>` |
+| `--name <name>` | Set the fork's frontmatter name and filename explicitly |
+| `--output <text\|json>` | Set fork output format (default: `text`; only valid with `--fork`) |
 
 ## Examples
 
@@ -154,13 +158,51 @@ JSON output for templates with instances includes an `instances` object:
 }
 ```
 
+### Document forks
+
+Forks are ordinary Markdown notes with a small lineage marker. They live beside
+their immediate source, receive a fresh `id`, and store the source UUID in
+`forked-from`:
+
+```bash
+# Creates "Launch Brief — concise.md" beside the source
+bwrb new --fork "Launch Brief" --label concise
+
+# Exact paths and stable UUIDs are accepted too
+bwrb new --fork "Briefs/Launch Brief.md" --name "Launch Brief v2"
+bwrb new --fork 8f48f6a8-55c1-4ea7-9f4b-96735ed24af3 --label alternate
+
+# Script-friendly output
+bwrb new --fork "Launch Brief" --label alternate --output json
+```
+
+Targets are exact: bwrb never substitutes a fuzzy near-match. Duplicate names
+or aliases must be disambiguated with a path or UUID. A legacy source without an
+`id` receives one before the fork is written; an invalid existing ID is rejected
+without modification.
+
+The child copies the source body and frontmatter, then:
+
+- replaces `id`, `name`, and any inherited `forked-from`;
+- removes `prev` and `next` navigation fields;
+- resets schema fields marked `reset_on_fork` and applies their defaults;
+- clears the type's alias-role field so two notes do not claim one identity;
+- preserves unknown schema-drift fields and reports them as warnings.
+
+Without `--name`, `--label` supplies the suffix in `<source> — <label>`. In an
+interactive terminal, omitting both prompts with `<source> (fork)` as the
+default. `--non-interactive` and `--output json` require `--name` or `--label`.
+Fork mode cannot be combined with a positional type, `--type`, templates,
+`--json`, instance scaffolding, or ownership-selection flags. An owned note can
+only be forked when its owner's field permits multiple children.
+
 ## Behavior
 
 1. **Type resolution**: Prompts for type if not specified (with subtype navigation)
 2. **Template loading**: Loads matching template if available (unless `--no-template`)
 3. **Field prompts**: Prompts for each field defined in schema/template
 4. **File creation**: Creates file in the type's `output_dir`
-5. **System fields**: Writes `id` and `name` as bwrb-managed frontmatter fields. The reserved `forked-from` provenance field cannot be supplied through `--json`, templates, or schema fields/defaults; only lineage-aware system workflows may inject it
+5. **System fields**: Writes `id` and `name` as bwrb-managed frontmatter fields. The reserved `forked-from` provenance field cannot be supplied through `--json`, templates, or schema fields/defaults; `new --fork` is the lineage-aware workflow that injects it
 6. **Output**: Returns path to created file
 
 ## Template Discovery

--- a/docs/product/system-frontmatter.md
+++ b/docs/product/system-frontmatter.md
@@ -8,8 +8,7 @@ These fields are written by bwrb and are always allowed in frontmatter:
 
 - `id`
 - `name`
-- `forked-from` (immediate source note UUID; hand-authored until a native fork
-  workflow ships)
+- `forked-from` (immediate source note UUID, written by `bwrb new --fork`)
 
 Audit/validation behavior:
 
@@ -28,8 +27,7 @@ These fields are system-managed and must not be mutated by automated fixes:
 Reserved fields cannot be supplied through ordinary JSON creation, JSON or
 interactive edit, or template defaults/prompt fields. Audit fixes also leave
 them untouched. Schema defaults and static values cannot author
-`forked-from`; lineage-aware system workflows inject it after ordinary defaults
-are resolved.
+`forked-from`; `bwrb new --fork` injects it after ordinary defaults are resolved.
 
 ## Policy
 

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -158,6 +158,19 @@ Some fields are written by bwrb regardless of schema:
 - `name`: written by `bwrb new` as the note title; `bwrb audit` does not treat it as an unknown field even if the schema does not declare it.
 - `forked-from`: reserved immediate-source UUID for document lineage. It is not a wikilink. Agents may encounter hand-authored values, but must not set or modify it through ordinary `new --json`, `edit`, or template input.
 
+Create a document fork when preserving an earlier draft matters:
+
+```bash
+bwrb new --fork "Briefs/Launch Brief" --label concise --output json
+bwrb new --fork 8f48f6a8-55c1-4ea7-9f4b-96735ed24af3 --name "Launch Brief v2" --output json
+```
+
+Fork targets are exact path, name, alias, or stable UUID matches. For agents,
+always provide `--name` or `--label` and use `--output json`; the result contains
+`path`, the child's fresh `id`, `forked_from`, and `warnings`. Do not combine
+fork mode with a type, template, `--json`, instance, or ownership-selection
+flag. The child is a normal note beside its source, not a hidden snapshot.
+
 ## Core Commands for Agents
 
 ### Querying Notes

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -3,7 +3,13 @@ import { relative } from 'path';
 import { loadSchema, getTypeDefByPath, formatUnknownTypeError } from '../lib/schema.js';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts } from '../lib/command.js';
-import { configurePromptMode, promptSelection, printError } from '../lib/prompt.js';
+import {
+  configurePromptMode,
+  promptSelection,
+  printError,
+  printSuccess,
+  printWarning,
+} from '../lib/prompt.js';
 import {
   printJson,
   jsonSuccess,
@@ -23,6 +29,7 @@ import { resolveTypePath } from './new/type-selection.js';
 import { createNoteInteractive } from './new/interactive.js';
 import type { NewCommandOptions } from './new/types.js';
 import { JsonCommandError } from './new/errors.js';
+import { forkNote } from './new/fork.js';
 
 export const newCommand = new Command('new')
   .description('Create a new note (interactive type navigation if type omitted)')
@@ -37,6 +44,10 @@ export const newCommand = new Command('new')
   .option('--no-instances', 'Skip instance scaffolding (when template has instances)')
   .option('--owner <wikilink>', 'Owner note for owned types (e.g., "[[My Novel]]")')
   .option('--standalone', 'Create as standalone (skip owner selection for ownable types)')
+  .option('--fork <target>', 'Create a new document forked from an exact note target')
+  .option('--label <label>', 'Name a fork as "<source> — <label>"')
+  .option('--name <name>', 'Set the fork name and filename explicitly')
+  .option('--output <format>', 'Fork output format: text or json')
   .addHelpText('after', `
 Examples:
   bwrb new                    # Interactive type selection
@@ -63,6 +74,11 @@ Non-interactive (JSON) mode:
   bwrb new task --json '{"name": "Fix bug", "status": "in-progress"}'
   bwrb new task --json '{"name": "Bug"}' --template bug-report
 
+Document forks:
+  bwrb new --fork "Plans/Launch Brief" --label alternative
+  bwrb new --fork 8f48f6a8-55c1-4ea7-9f4b-96735ed24af3 --name "Launch Brief v2"
+  bwrb new --fork "Launch Brief" --label concise --output json
+
 Body sections (JSON mode):
   bwrb new task --json '{"name": "Fix bug", "_body": {"Steps": ["Step 1", "Step 2"]}}'
   bwrb new task --json '{"name": "Quick capture", "_body": "## Notes\\n\\n- Captured from a script."}'
@@ -73,7 +89,9 @@ Template management:
 
 `)
   .action(async (positionalType: string | undefined, options: NewCommandOptions, cmd: Command) => {
-    const jsonMode = options.json !== undefined;
+    const forkMode = options.fork !== undefined;
+    const forkJsonMode = forkMode && options.output === 'json';
+    const jsonMode = options.json !== undefined || forkJsonMode;
     const typePath = options.type ?? positionalType;
 
     try {
@@ -87,6 +105,49 @@ Template management:
       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
       const schema = await loadSchema(vaultDir);
 
+      validateForkOptions(positionalType, options);
+
+      if (forkMode) {
+        const result = await forkNote(schema, vaultDir, {
+          target: options.fork!,
+          ...(options.name !== undefined ? { name: options.name } : {}),
+          ...(options.label !== undefined ? { label: options.label } : {}),
+          nonInteractive: globalOpts.nonInteractive === true || forkJsonMode,
+        });
+
+        const relativePath = relative(vaultDir, result.path);
+        if (forkJsonMode) {
+          const jsonOutput: Record<string, unknown> = {
+            path: relativePath,
+            id: result.id,
+            forked_from: result.forkedFrom,
+            warnings: result.warnings,
+          };
+          if (result.nameTransformed) jsonOutput.nameTransformed = result.nameTransformed;
+          if (result.pathLengthWarning) jsonOutput.pathLengthWarning = result.pathLengthWarning;
+          printJson(jsonSuccess(jsonOutput));
+        } else {
+          printSuccess(`Created fork: ${relativePath}`);
+          if (result.nameTransformed) {
+            printWarning(
+              `Warning: Note name was changed for the filename: "${result.nameTransformed.original}" -> "${result.nameTransformed.filename}"`
+            );
+          }
+          if (result.pathLengthWarning) {
+            printWarning(
+              `Warning: Note path is ${result.pathLengthWarning.length} characters; paths over ${result.pathLengthWarning.threshold} may be less portable: ${result.pathLengthWarning.path}`
+            );
+          }
+          for (const warning of result.warnings) printWarning(`Warning: ${warning}`);
+        }
+
+        if (options.open) {
+          const { openNote, resolveAppMode } = await import('./open.js');
+          await openNote(vaultDir, result.path, resolveAppMode(undefined, schema.config), schema.config, false);
+        }
+        return;
+      }
+
       if (globalOpts.nonInteractive && !jsonMode) {
         printError('bwrb new requires --json <frontmatter> when --non-interactive is set.');
         process.exit(1);
@@ -99,7 +160,7 @@ Template management:
         }
 
         let template: Template | null = null;
-        if (!options.noTemplate && options.template) {
+        if (!options.noTemplate && typeof options.template === 'string') {
           template = await findTemplateByName(vaultDir, typePath, options.template);
           if (!template) {
             printJson(jsonError(`Template not found: ${options.template}`));
@@ -215,11 +276,11 @@ async function resolveTemplateResolution(
 ): Promise<InheritedTemplateResolution> {
   let templateResolution: InheritedTemplateResolution = createEmptyTemplateResolution();
 
-  if (options.noTemplate) {
+  if (options.noTemplate || options.template === false) {
     return templateResolution;
   }
 
-  if (options.template) {
+  if (typeof options.template === 'string') {
     templateResolution = await resolveTemplateWithInheritance(vaultDir, resolvedPath, schema, {
       templateName: options.template,
     });
@@ -256,4 +317,42 @@ async function resolveTemplateResolution(
   }
 
   return templateResolution;
+}
+
+function validateForkOptions(
+  positionalType: string | undefined,
+  options: NewCommandOptions
+): void {
+  const forkMode = options.fork !== undefined;
+  const forkOnlyFlags = [
+    options.label !== undefined ? '--label' : undefined,
+    options.name !== undefined ? '--name' : undefined,
+    options.output !== undefined ? '--output' : undefined,
+  ].filter((flag): flag is string => Boolean(flag));
+
+  if (!forkMode && forkOnlyFlags.length > 0) {
+    throw new Error(`${forkOnlyFlags.join(', ')} can only be used with --fork <target>.`);
+  }
+  if (!forkMode) return;
+
+  if (!options.fork?.trim()) throw new Error('--fork <target> cannot be empty.');
+  if (options.output !== undefined && options.output !== 'text' && options.output !== 'json') {
+    throw new Error(`Invalid --output format '${options.output}'. Expected text or json.`);
+  }
+  if (options.name !== undefined && !options.name.trim()) throw new Error('--name cannot be empty.');
+  if (options.label !== undefined && !options.label.trim()) throw new Error('--label cannot be empty.');
+
+  const conflicts = [
+    positionalType !== undefined ? 'positional type' : undefined,
+    options.type !== undefined ? '--type' : undefined,
+    options.template !== undefined ? (options.template === false ? '--no-template' : '--template') : undefined,
+    options.instances === false ? '--no-instances' : undefined,
+    options.json !== undefined ? '--json' : undefined,
+    options.owner !== undefined ? '--owner' : undefined,
+    options.standalone ? '--standalone' : undefined,
+  ].filter((flag): flag is string => Boolean(flag));
+
+  if (conflicts.length > 0) {
+    throw new Error(`--fork cannot be combined with ${conflicts.join(', ')}.`);
+  }
 }

--- a/src/commands/new/fork.ts
+++ b/src/commands/new/fork.ts
@@ -3,7 +3,12 @@ import { basename, dirname, isAbsolute, relative, resolve, sep } from 'path';
 import type { LoadedSchema } from '../../types/schema.js';
 import type { ManagedFile, NoteIndex } from '../../lib/navigation.js';
 import { buildNoteIndex } from '../../lib/navigation.js';
-import { parseNote, writeNote, writeNoteExclusive } from '../../lib/frontmatter.js';
+import {
+  insertFrontmatterScalarPreservingBytes,
+  parseNote,
+  writeFileAtomic,
+  writeNoteExclusive,
+} from '../../lib/frontmatter.js';
 import {
   generateUniqueNoteId,
   isValidNoteId,
@@ -16,7 +21,7 @@ import {
   getFieldsForType,
   resolveTypeFromFrontmatter,
 } from '../../lib/schema.js';
-import { applyDefaults } from '../../lib/validation.js';
+import { applyDefaults, normalizeDateFields } from '../../lib/validation.js';
 import { isBwrbBuiltinFrontmatterField } from '../../lib/frontmatter/systemFields.js';
 import { buildNotePath } from './paths.js';
 import { promptInput } from '../../lib/prompt.js';
@@ -68,11 +73,14 @@ export async function forkNote(
   options: ForkNoteOptions
 ): Promise<ForkNoteResult> {
   const source = await resolveForkSource(schema, vaultDir, options.target);
+  if (isValidNoteId(source.frontmatter.id)) {
+    await assertSourceIdUnique(schema, vaultDir, source.file.path, source.frontmatter.id);
+  }
   assertOwnedForkAllowed(schema, source.file);
 
   const sourceName = resolveSourceName(source);
   const childName = await resolveChildName(sourceName, options);
-  const sourceId = await ensureSourceId(vaultDir, source.file.path);
+  const sourceId = await ensureSourceId(schema, vaultDir, source.file.path);
 
   // Re-read after a possible ID backfill so the child copies the source's
   // current frontmatter rather than a stale pre-lock snapshot.
@@ -83,12 +91,16 @@ export async function forkNote(
   }
 
   const warnings = collectSchemaDriftWarnings(schema, currentType, current.frontmatter);
-  const frontmatter = buildForkFrontmatter(
+  const frontmatter = normalizeDateFields(
     schema,
     currentType,
-    current.frontmatter,
-    childName,
-    sourceId
+    buildForkFrontmatter(
+      schema,
+      currentType,
+      current.frontmatter,
+      childName,
+      sourceId
+    )
   );
   const childId = await generateUniqueNoteId(vaultDir);
   frontmatter.id = childId;
@@ -286,7 +298,11 @@ async function resolveChildName(sourceName: string, options: ForkNoteOptions): P
   return selected.trim();
 }
 
-async function ensureSourceId(vaultDir: string, sourcePath: string): Promise<string> {
+async function ensureSourceId(
+  schema: LoadedSchema,
+  vaultDir: string,
+  sourcePath: string
+): Promise<string> {
   return withSourceIdLock(vaultDir, async () => {
     const parsed = await parseNote(sourcePath);
     const existing = parsed.frontmatter.id;
@@ -294,21 +310,70 @@ async function ensureSourceId(vaultDir: string, sourcePath: string): Promise<str
       if (!isValidNoteId(existing)) {
         throw new Error(`Fork source has an invalid id and was not modified: ${relative(vaultDir, sourcePath)}`);
       }
+      await assertSourceIdUnique(schema, vaultDir, sourcePath, existing);
       return existing;
     }
 
     const id = await generateUniqueNoteId(vaultDir);
-    const nextFrontmatter = { ...parsed.frontmatter, id };
-    const order = buildBackfillFieldOrder(parsed.frontmatter);
-    await writeNote(sourcePath, nextFrontmatter, parsed.body, order);
+    const collisions = await findNotesWithId(schema, vaultDir, id);
+    if (collisions.length > 0) {
+      throw new Error('Generated source ID collides with an existing note; retry the command.');
+    }
+    const nextRaw = insertFrontmatterScalarPreservingBytes(parsed.raw, 'id', id);
+    await writeFileAtomic(sourcePath, nextRaw);
     try {
       await registerIssuedNoteId(vaultDir, id, sourcePath);
     } catch (error) {
-      await writeNote(sourcePath, parsed.frontmatter, parsed.body, Object.keys(parsed.frontmatter));
+      await writeFileAtomic(sourcePath, parsed.raw);
       throw error;
     }
     return id;
   });
+}
+
+async function assertSourceIdUnique(
+  schema: LoadedSchema,
+  vaultDir: string,
+  sourcePath: string,
+  id: string
+): Promise<void> {
+  const matches = await findNotesWithId(schema, vaultDir, id);
+  const otherMatches = matches.filter(file => resolve(file.path) !== resolve(sourcePath));
+  if (otherMatches.length === 0) return;
+
+  const candidates = Array.from(new Set([
+    relative(vaultDir, sourcePath),
+    ...matches.map(file => file.relativePath),
+  ]))
+    .sort()
+    .join(', ');
+  throw new Error(
+    `Cannot fork source ${relative(vaultDir, sourcePath)}: id ${id} is duplicated; matches: ${candidates}`
+  );
+}
+
+async function findNotesWithId(
+  schema: LoadedSchema,
+  vaultDir: string,
+  id: string
+): Promise<ManagedFile[]> {
+  const normalized = normalizeNoteId(id);
+  const index = await buildNoteIndex(schema, vaultDir);
+  const matches: ManagedFile[] = [];
+  for (const file of index.allFiles) {
+    try {
+      const parsed = await parseNote(file.path);
+      if (
+        isValidNoteId(parsed.frontmatter.id) &&
+        normalizeNoteId(parsed.frontmatter.id) === normalized
+      ) {
+        matches.push(file);
+      }
+    } catch {
+      // An unrelated unreadable note cannot be a confirmed identity match.
+    }
+  }
+  return matches;
 }
 
 async function withSourceIdLock<T>(vaultDir: string, task: () => Promise<T>): Promise<T> {
@@ -397,14 +462,6 @@ function assertOwnedForkAllowed(schema: LoadedSchema, file: ManagedFile): void {
       `Cannot fork owned note ${file.relativePath}: owner field '${file.ownership.fieldName}' is single-valued.`
     );
   }
-}
-
-function buildBackfillFieldOrder(frontmatter: Record<string, unknown>): string[] {
-  const keys = Object.keys(frontmatter);
-  const typeIndex = keys.indexOf('type');
-  if (typeIndex >= 0) keys.splice(typeIndex + 1, 0, 'id');
-  else keys.unshift('id');
-  return keys;
 }
 
 function buildForkFieldOrder(

--- a/src/commands/new/fork.ts
+++ b/src/commands/new/fork.ts
@@ -1,0 +1,428 @@
+import { mkdir, open, stat, unlink } from 'fs/promises';
+import { basename, dirname, isAbsolute, relative, resolve, sep } from 'path';
+import type { LoadedSchema } from '../../types/schema.js';
+import type { ManagedFile, NoteIndex } from '../../lib/navigation.js';
+import { buildNoteIndex } from '../../lib/navigation.js';
+import { parseNote, writeNote, writeNoteExclusive } from '../../lib/frontmatter.js';
+import {
+  generateUniqueNoteId,
+  isValidNoteId,
+  normalizeNoteId,
+  registerIssuedNoteId,
+} from '../../lib/note-id.js';
+import {
+  getAliasFieldName,
+  getEntityAliases,
+  getFieldsForType,
+  resolveTypeFromFrontmatter,
+} from '../../lib/schema.js';
+import { applyDefaults } from '../../lib/validation.js';
+import { isBwrbBuiltinFrontmatterField } from '../../lib/frontmatter/systemFields.js';
+import { buildNotePath } from './paths.js';
+import { promptInput } from '../../lib/prompt.js';
+import { UserCancelledError } from '../../lib/errors.js';
+
+const SOURCE_ID_LOCK = '.bwrb/locks/fork-source-id.lock';
+const LOCK_RETRY_MS = 20;
+const LOCK_ATTEMPTS = 250;
+const STALE_LOCK_MS = 30_000;
+const PORTABLE_PATH_WARNING_LENGTH = 200;
+const PORTABLE_PATH_MAX_LENGTH = 260;
+const STRUCTURAL_FIELDS = new Set(['type', 'id', 'name', 'forked-from', 'prev', 'next']);
+
+export interface ForkNoteOptions {
+  target: string;
+  name?: string;
+  label?: string;
+  nonInteractive: boolean;
+}
+
+export interface ForkNoteResult {
+  path: string;
+  id: string;
+  forkedFrom: string;
+  warnings: string[];
+  nameTransformed?: {
+    original: string;
+    sanitized: string;
+    filename: string;
+  };
+  pathLengthWarning?: {
+    path: string;
+    length: number;
+    threshold: number;
+    max: number;
+  };
+}
+
+interface ResolvedForkSource {
+  file: ManagedFile;
+  frontmatter: Record<string, unknown>;
+  body: string;
+  typeName: string;
+}
+
+export async function forkNote(
+  schema: LoadedSchema,
+  vaultDir: string,
+  options: ForkNoteOptions
+): Promise<ForkNoteResult> {
+  const source = await resolveForkSource(schema, vaultDir, options.target);
+  assertOwnedForkAllowed(schema, source.file);
+
+  const sourceName = resolveSourceName(source);
+  const childName = await resolveChildName(sourceName, options);
+  const sourceId = await ensureSourceId(vaultDir, source.file.path);
+
+  // Re-read after a possible ID backfill so the child copies the source's
+  // current frontmatter rather than a stale pre-lock snapshot.
+  const current = await parseNote(source.file.path);
+  const currentType = resolveTypeFromFrontmatter(schema, current.frontmatter);
+  if (!currentType) {
+    throw new Error(`Fork source no longer has a valid schema type: ${source.file.relativePath}`);
+  }
+
+  const warnings = collectSchemaDriftWarnings(schema, currentType, current.frontmatter);
+  const frontmatter = buildForkFrontmatter(
+    schema,
+    currentType,
+    current.frontmatter,
+    childName,
+    sourceId
+  );
+  const childId = await generateUniqueNoteId(vaultDir);
+  frontmatter.id = childId;
+
+  const pathResult = buildNotePath(dirname(source.file.path), childName, 'interactive');
+  const relativePath = relative(vaultDir, pathResult.path);
+  if (relativePath.length > PORTABLE_PATH_MAX_LENGTH) {
+    throw new Error(
+      `Note path is ${relativePath.length} characters, exceeding the portable limit of ${PORTABLE_PATH_MAX_LENGTH}: ${relativePath}`
+    );
+  }
+
+  const pathLengthWarning = relativePath.length > PORTABLE_PATH_WARNING_LENGTH
+    ? {
+        path: relativePath,
+        length: relativePath.length,
+        threshold: PORTABLE_PATH_WARNING_LENGTH,
+        max: PORTABLE_PATH_MAX_LENGTH,
+      }
+    : undefined;
+
+  const orderedFields = buildForkFieldOrder(current.frontmatter, frontmatter);
+  try {
+    await writeNoteExclusive(pathResult.path, frontmatter, current.body, orderedFields);
+  } catch (error) {
+    if (isFileExistsError(error)) {
+      throw new Error(`File already exists: ${relativePath}`);
+    }
+    throw error;
+  }
+
+  try {
+    await registerIssuedNoteId(vaultDir, childId, pathResult.path);
+  } catch (error) {
+    // A note without a registry row is not a completed creation. Roll it back;
+    // the source ID backfill intentionally remains durable.
+    await unlink(pathResult.path).catch(() => undefined);
+    throw error;
+  }
+
+  return {
+    path: pathResult.path,
+    id: childId,
+    forkedFrom: sourceId,
+    warnings,
+    ...(pathResult.nameTransformed ? { nameTransformed: pathResult.nameTransformed } : {}),
+    ...(pathLengthWarning ? { pathLengthWarning } : {}),
+  };
+}
+
+async function resolveForkSource(
+  schema: LoadedSchema,
+  vaultDir: string,
+  target: string
+): Promise<ResolvedForkSource> {
+  const index = await buildNoteIndex(schema, vaultDir);
+  const idMatches: ManagedFile[] = [];
+  const parsedByPath = new Map<string, Awaited<ReturnType<typeof parseNote>>>();
+
+  for (const file of index.allFiles) {
+    try {
+      const parsed = await parseNote(file.path);
+      parsedByPath.set(file.path, parsed);
+      if (
+        isValidNoteId(target) &&
+        isValidNoteId(parsed.frontmatter.id) &&
+        normalizeNoteId(parsed.frontmatter.id) === normalizeNoteId(target)
+      ) {
+        idMatches.push(file);
+      }
+    } catch {
+      // Exact path/name resolution below will produce a useful parse error if
+      // this malformed note is the requested source.
+    }
+  }
+
+  let file: ManagedFile | undefined;
+  if (idMatches.length > 1) {
+    throwAmbiguousTarget(target, idMatches);
+  }
+  if (idMatches.length === 1) {
+    file = idMatches[0];
+  } else {
+    file = resolveExactFile(schema, index, vaultDir, target, parsedByPath);
+  }
+
+  if (!file) {
+    throw new Error(`No exact note found for fork target: ${target}`);
+  }
+
+  let parsed = parsedByPath.get(file.path);
+  if (!parsed) {
+    try {
+      parsed = await parseNote(file.path);
+    } catch (error) {
+      throw new Error(
+        `Cannot read fork source ${file.relativePath}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+  const typeName = resolveTypeFromFrontmatter(schema, parsed.frontmatter);
+  if (!typeName) {
+    throw new Error(`Fork source does not have a valid schema type: ${file.relativePath}`);
+  }
+  return { file, frontmatter: parsed.frontmatter, body: parsed.body, typeName };
+}
+
+function resolveExactFile(
+  schema: LoadedSchema,
+  index: NoteIndex,
+  vaultDir: string,
+  target: string,
+  parsedByPath: Map<string, Awaited<ReturnType<typeof parseNote>>>
+): ManagedFile | undefined {
+  if (isAbsolute(target)) {
+    const absolute = resolve(target);
+    const root = resolve(vaultDir);
+    if (absolute !== root && !absolute.startsWith(`${root}${sep}`)) return undefined;
+    const relativeTarget = relative(root, absolute);
+    const withExtension = relativeTarget.endsWith('.md') ? relativeTarget : `${relativeTarget}.md`;
+    return index.byPath.get(relativeTarget) ?? index.byPath.get(withExtension);
+  }
+
+  const normalizedTarget = target.replace(/^\.\//, '');
+  const cleanTarget = normalizedTarget.replace(/\.md$/, '');
+  const withExtension = `${cleanTarget}.md`;
+
+  const pathMatch = index.byPath.get(normalizedTarget) ?? index.byPath.get(withExtension);
+  if (pathMatch) return pathMatch;
+
+  const basenameMatches = exactMapMatches(index.byBasename, cleanTarget);
+  if (basenameMatches.length > 1) throwAmbiguousTarget(target, basenameMatches);
+  if (basenameMatches.length === 1) return basenameMatches[0];
+
+  // A frontmatter name can intentionally differ from the filename. It remains
+  // an exact identity surface, never a fuzzy one.
+  const requested = cleanTarget.toLowerCase();
+  const nameMatches: ManagedFile[] = [];
+  for (const file of index.allFiles) {
+    const name = parsedByPath.get(file.path)?.frontmatter.name;
+    if (typeof name === 'string' && name.toLowerCase() === requested) {
+      nameMatches.push(file);
+    }
+  }
+  if (nameMatches.length > 1) throwAmbiguousTarget(target, nameMatches);
+  if (nameMatches.length === 1) return nameMatches[0];
+
+  // Aliases are the final exact tier: a real path, basename, or frontmatter
+  // name always wins over an alias claiming the same surface.
+  const aliasMatches: ManagedFile[] = [];
+  for (const file of index.allFiles) {
+    const parsed = parsedByPath.get(file.path);
+    if (!parsed) continue;
+    const typeName = resolveTypeFromFrontmatter(schema, parsed.frontmatter);
+    if (!typeName) continue;
+    const aliases = getEntityAliases(schema, typeName, parsed.frontmatter);
+    if (aliases.some(alias => alias.toLowerCase() === requested)) aliasMatches.push(file);
+  }
+  if (aliasMatches.length > 1) throwAmbiguousTarget(target, aliasMatches);
+  return aliasMatches[0];
+}
+
+function exactMapMatches(
+  map: Map<string, ManagedFile[]>,
+  target: string
+): ManagedFile[] {
+  const direct = map.get(target);
+  if (direct) return direct;
+  const lower = target.toLowerCase();
+  return Array.from(map.entries())
+    .filter(([key]) => key.toLowerCase() === lower)
+    .flatMap(([, files]) => files);
+}
+
+function throwAmbiguousTarget(target: string, files: ManagedFile[]): never {
+  const candidates = files.map(file => file.relativePath).sort().join(', ');
+  throw new Error(`Ambiguous fork target "${target}"; matches: ${candidates}`);
+}
+
+function resolveSourceName(source: ResolvedForkSource): string {
+  const name = source.frontmatter.name;
+  if (typeof name === 'string' && name.trim()) return name.trim();
+  return basename(source.file.relativePath, '.md');
+}
+
+async function resolveChildName(sourceName: string, options: ForkNoteOptions): Promise<string> {
+  if (options.name?.trim()) return options.name.trim();
+  if (options.label?.trim()) return `${sourceName} — ${options.label.trim()}`;
+  if (options.nonInteractive) {
+    throw new Error('Fork creation requires --name <name> or --label <label> in non-interactive mode.');
+  }
+  const selected = await promptInput('Fork name:', `${sourceName} (fork)`);
+  if (selected === null) throw new UserCancelledError();
+  if (!selected.trim()) throw new Error('Fork name cannot be empty.');
+  return selected.trim();
+}
+
+async function ensureSourceId(vaultDir: string, sourcePath: string): Promise<string> {
+  return withSourceIdLock(vaultDir, async () => {
+    const parsed = await parseNote(sourcePath);
+    const existing = parsed.frontmatter.id;
+    if (existing !== undefined) {
+      if (!isValidNoteId(existing)) {
+        throw new Error(`Fork source has an invalid id and was not modified: ${relative(vaultDir, sourcePath)}`);
+      }
+      return existing;
+    }
+
+    const id = await generateUniqueNoteId(vaultDir);
+    const nextFrontmatter = { ...parsed.frontmatter, id };
+    const order = buildBackfillFieldOrder(parsed.frontmatter);
+    await writeNote(sourcePath, nextFrontmatter, parsed.body, order);
+    try {
+      await registerIssuedNoteId(vaultDir, id, sourcePath);
+    } catch (error) {
+      await writeNote(sourcePath, parsed.frontmatter, parsed.body, Object.keys(parsed.frontmatter));
+      throw error;
+    }
+    return id;
+  });
+}
+
+async function withSourceIdLock<T>(vaultDir: string, task: () => Promise<T>): Promise<T> {
+  const lockPath = resolve(vaultDir, SOURCE_ID_LOCK);
+  await mkdir(dirname(lockPath), { recursive: true });
+
+  for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
+    try {
+      const handle = await open(lockPath, 'wx');
+      try {
+        await handle.writeFile(`${process.pid}\n`, 'utf-8');
+        return await task();
+      } finally {
+        await handle.close().catch(() => undefined);
+        await unlink(lockPath).catch(() => undefined);
+      }
+    } catch (error) {
+      if (!isFileExistsError(error)) throw error;
+      if (await isStaleLock(lockPath)) {
+        await unlink(lockPath).catch(() => undefined);
+        continue;
+      }
+      await delay(LOCK_RETRY_MS);
+    }
+  }
+  throw new Error('Timed out waiting to assign the fork source ID; retry the command.');
+}
+
+async function isStaleLock(lockPath: string): Promise<boolean> {
+  try {
+    const info = await stat(lockPath);
+    return Date.now() - info.mtimeMs > STALE_LOCK_MS;
+  } catch {
+    return false;
+  }
+}
+
+function buildForkFrontmatter(
+  schema: LoadedSchema,
+  typeName: string,
+  source: Record<string, unknown>,
+  childName: string,
+  sourceId: string
+): Record<string, unknown> {
+  const fields = getFieldsForType(schema, typeName);
+  const aliasField = getAliasFieldName(schema, typeName);
+  const copied: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(source)) {
+    if (key === 'id' || key === 'forked-from' || key === 'prev' || key === 'next') continue;
+    if (key === aliasField) continue;
+    if (!STRUCTURAL_FIELDS.has(key) && fields[key]?.reset_on_fork === true) continue;
+    copied[key] = value;
+  }
+
+  const withDefaults = applyDefaults(schema, typeName, copied);
+  // Alias defaults must not duplicate the source's identity aliases.
+  if (aliasField) delete withDefaults[aliasField];
+  withDefaults.name = childName;
+  withDefaults['forked-from'] = sourceId;
+  return withDefaults;
+}
+
+function collectSchemaDriftWarnings(
+  schema: LoadedSchema,
+  typeName: string,
+  frontmatter: Record<string, unknown>
+): string[] {
+  const fields = getFieldsForType(schema, typeName);
+  const unknown = Object.keys(frontmatter).filter(
+    key => !fields[key] && !isBwrbBuiltinFrontmatterField(key) && key !== 'prev' && key !== 'next'
+  );
+  if (unknown.length === 0) return [];
+  return [
+    `Copied schema-drift field${unknown.length === 1 ? '' : 's'} unchanged: ${unknown.sort().join(', ')}`,
+  ];
+}
+
+function assertOwnedForkAllowed(schema: LoadedSchema, file: ManagedFile): void {
+  if (!file.ownership) return;
+  const ownedField = schema.ownership.owns
+    .get(file.ownership.ownerType)
+    ?.find(field => field.fieldName === file.ownership?.fieldName);
+  if (ownedField && !ownedField.multiple) {
+    throw new Error(
+      `Cannot fork owned note ${file.relativePath}: owner field '${file.ownership.fieldName}' is single-valued.`
+    );
+  }
+}
+
+function buildBackfillFieldOrder(frontmatter: Record<string, unknown>): string[] {
+  const keys = Object.keys(frontmatter);
+  const typeIndex = keys.indexOf('type');
+  if (typeIndex >= 0) keys.splice(typeIndex + 1, 0, 'id');
+  else keys.unshift('id');
+  return keys;
+}
+
+function buildForkFieldOrder(
+  source: Record<string, unknown>,
+  child: Record<string, unknown>
+): string[] {
+  const sourceKeys = Object.keys(source).filter(key => key in child && key !== 'id' && key !== 'forked-from');
+  const order = ['id', 'forked-from', ...sourceKeys];
+  for (const key of Object.keys(child)) {
+    if (!order.includes(key)) order.push(key);
+  }
+  return order;
+}
+
+function isFileExistsError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'EEXIST';
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolveDelay => setTimeout(resolveDelay, ms));
+}

--- a/src/commands/new/types.ts
+++ b/src/commands/new/types.ts
@@ -6,11 +6,15 @@ export interface NewCommandOptions {
   open?: boolean;
   json?: string;
   type?: string;
-  template?: string;
+  template?: string | boolean;
   noTemplate?: boolean;
   instances?: boolean;
   owner?: string;
   standalone?: boolean;
+  fork?: string;
+  label?: string;
+  name?: string;
+  output?: string;
 }
 
 export type CreationMode = 'interactive' | 'json';

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -269,7 +269,7 @@ async function resolveVaultDirForCompletion(options: { vault?: string }): Promis
  * Only includes options that make sense to complete.
  */
 const COMMAND_OPTIONS: Record<string, string[]> = {
-  new: ['--type', '-t', '--vault', '-v', '--non-interactive', '--template', '--json', '--help'],
+  new: ['--type', '-t', '--vault', '-v', '--non-interactive', '--template', '--no-template', '--no-instances', '--owner', '--standalone', '--json', '--open', '-o', '--fork', '--label', '--name', '--output', '--help'],
   edit: ['--type', '-t', '--path', '-p', '--where', '-w', '--id', '--body', '-b', '--picker', '--json', '--output', '--open', '--app', '--vault', '-v', '--non-interactive', '--help'],
   list: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--name', '--fuzzy', '--matches', '--threshold', '--context', '-C', '--no-context', '--case-sensitive', '-S', '--regex', '-E', '--text', '--id', '--fields', '--sort', '--desc', '--limit', '--count', '--output', '--open', '-o', '--app', '--picker', '--preview', '--vault', '-v', '--non-interactive', '--json', '--help'],
   recent: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--limit', '--output', '--vault', '-v', '--non-interactive', '--help'],
@@ -378,6 +378,9 @@ function isValueOption(option: string): boolean {
     '--where', '-w',
     '--output', '-o',
     '--template',
+    '--fork',
+    '--label',
+    '--name',
     '--app',
     '--set',
     '--vault', '-v',

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -1,8 +1,12 @@
 import matter from 'gray-matter';
-import { stringify } from 'yaml';
-import { readFile, writeFile, mkdir, open, unlink } from 'fs/promises';
-import { dirname } from 'path';
+import { isMap, stringify } from 'yaml';
+import type { Pair, Scalar, YAMLMap } from 'yaml';
+import { readFile, writeFile, mkdir, open, unlink, rename, stat } from 'fs/promises';
+import { basename, dirname, join } from 'path';
+import { randomUUID } from 'crypto';
 import type { BodySection } from '../types/schema.js';
+import { readStructuralFrontmatterFromRaw } from './audit/structural.js';
+import { detectEol } from './audit/value-utils.js';
 
 /**
  * Convert a YAML-parsed Date to YYYY-MM-DD string using UTC components.
@@ -68,6 +72,82 @@ export async function parseNote(filePath: string): Promise<ParsedNote> {
 export function parseFrontmatter(content: string): Record<string, unknown> {
   const { data } = matter(content);
   return normalizeMatterValue(data) as Record<string, unknown>;
+}
+
+/**
+ * Insert a plain scalar into a note's top-level frontmatter without
+ * reserializing any existing YAML.
+ *
+ * This is intentionally narrow: callers must supply a plain-safe key and
+ * value. The original bytes (including BOM, EOL style, comments, anchors,
+ * quote style, block scalars, and body) are otherwise left untouched.
+ */
+export function insertFrontmatterScalarPreservingBytes(
+  content: string,
+  key: string,
+  value: string
+): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(key)) {
+    throw new Error(`Cannot insert unsafe frontmatter key: ${key}`);
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(value)) {
+    throw new Error(`Cannot insert non-plain frontmatter value for ${key}`);
+  }
+
+  const structural = readStructuralFrontmatterFromRaw(content);
+  const block = structural.primaryBlock;
+  const doc = structural.doc;
+  if (
+    !block ||
+    !structural.atTop ||
+    !doc ||
+    structural.yamlErrors.length > 0 ||
+    !isMap(doc.contents)
+  ) {
+    throw new Error('Cannot insert field: note does not have valid top-level mapping frontmatter');
+  }
+
+  const map = doc.contents as YAMLMap;
+  const pairs = map.items as Pair[];
+  if (pairs.some(pair => String((pair.key as Scalar | null | undefined)?.value ?? '') === key)) {
+    throw new Error(`Cannot insert field: frontmatter already contains '${key}'`);
+  }
+
+  const yaml = structural.yaml ?? '';
+  const typePair = pairs.find(
+    pair => String((pair.key as Scalar | null | undefined)?.value ?? '') === 'type'
+  );
+  const typeEnd = (typePair?.value as { range?: [number, number, number] } | null | undefined)
+    ?.range?.[2];
+  const insertionOffset = typeof typeEnd === 'number' ? typeEnd : yaml.length;
+  const insertionPoint = block.yamlStart + insertionOffset;
+  const eol = detectEol(content);
+  const before = content.slice(0, insertionPoint);
+  const separator = before.endsWith('\n') ? '' : eol;
+  return `${before}${separator}${key}: ${value}${eol}${content.slice(insertionPoint)}`;
+}
+
+/** Replace a UTF-8 file atomically via a same-directory temporary file. */
+export async function writeFileAtomic(filePath: string, content: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  const mode = await stat(filePath).then(info => info.mode).catch(() => undefined);
+  const tempPath = join(
+    dirname(filePath),
+    `.${basename(filePath)}.bwrb-${process.pid}-${randomUUID()}.tmp`
+  );
+  const handle = await open(tempPath, 'wx', mode);
+  let renamed = false;
+
+  try {
+    await handle.writeFile(content, 'utf-8');
+    await handle.sync();
+    await handle.close();
+    await rename(tempPath, filePath);
+    renamed = true;
+  } finally {
+    await handle.close().catch(() => undefined);
+    if (!renamed) await unlink(tempPath).catch(() => undefined);
+  }
 }
 
 /**

--- a/tests/ts/commands/new-fork.pty.test.ts
+++ b/tests/ts/commands/new-fork.pty.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  Keys,
+  readVaultFile,
+  shouldSkipPtyTests,
+  vaultFileExists,
+  withTempVault,
+} from '../lib/pty-helpers.js';
+
+const describePty = shouldSkipPtyTests() ? describe.skip : describe;
+
+describePty('new --fork interactive naming', () => {
+  it('offers the source-derived default and creates it on Enter', async () => {
+    await withTempVault(
+      ['new', '--fork', 'Source'],
+      async (proc, vaultPath) => {
+        await proc.waitFor('Fork name:', 10_000);
+        await proc.waitFor('Source (fork)', 5_000);
+        proc.write(Keys.ENTER);
+        await proc.waitFor('Created fork: Ideas/Source (fork).md', 10_000);
+
+        expect(await vaultFileExists(vaultPath, 'Ideas/Source (fork).md')).toBe(true);
+        const content = await readVaultFile(vaultPath, 'Ideas/Source (fork).md');
+        expect(content).toContain('name: Source (fork)');
+        expect(content).toContain('forked-from: 11111111-1111-4111-8111-111111111111');
+      },
+      {
+        schema: {
+          version: 2,
+          types: {
+            idea: {
+              output_dir: 'Ideas',
+              fields: {
+                type: { value: 'idea' },
+                status: { prompt: 'select', options: ['raw'], default: 'raw' },
+              },
+              field_order: ['type', 'status'],
+            },
+          },
+        },
+        files: [{
+          path: 'Ideas/Source.md',
+          content: `---
+type: idea
+id: 11111111-1111-4111-8111-111111111111
+name: Source
+status: raw
+---
+Original body
+`,
+        }],
+      }
+    );
+  }, 30_000);
+});

--- a/tests/ts/commands/new-fork.test.ts
+++ b/tests/ts/commands/new-fork.test.ts
@@ -82,6 +82,42 @@ Words worth keeping.
     expect(fork.body).toBe('## Draft\n\nWords worth keeping.\n');
   });
 
+  it('normalizes reset date defaults exactly like ordinary new and stays audit-clean', async () => {
+    const schemaPath = join(vaultDir, '.bwrb/schema.json');
+    const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as any;
+    schema.types.task.fields.deadline.default = '12/25/2026';
+    schema.types.task.fields.deadline.reset_on_fork = true;
+    await writeFile(schemaPath, JSON.stringify(schema, null, 2));
+
+    const ordinary = await runCLI([
+      'new', 'task', '--json', '{"name":"Ordinary Date Default"}', '--no-template',
+    ], vaultDir);
+    expect(ordinary.exitCode, ordinary.stderr || ordinary.stdout).toBe(0);
+
+    const sourcePath = join(vaultDir, 'Objectives/Tasks/Fork Date Source.md');
+    await writeFile(sourcePath, `---\ntype: task\nid: ${SOURCE_ID}\nname: Fork Date Source\nstatus: backlog\ndeadline: 2026-01-01\n---\n`);
+    const forked = await runCLI([
+      'new', '--fork', 'Fork Date Source', '--name', 'Fork Date Default', '--output', 'json',
+    ], vaultDir);
+    expect(forked.exitCode, forked.stderr || forked.stdout).toBe(0);
+
+    const ordinaryOutput = JSON.parse(ordinary.stdout);
+    const forkOutput = JSON.parse(forked.stdout);
+    const ordinaryNote = await parseNote(join(vaultDir, ordinaryOutput.path));
+    const forkNote = await parseNote(join(vaultDir, forkOutput.path));
+    expect(ordinaryNote.frontmatter.deadline).toBe('2026-12-25');
+    expect(forkNote.frontmatter.deadline).toBe(ordinaryNote.frontmatter.deadline);
+
+    for (const notePath of [ordinaryOutput.path, forkOutput.path]) {
+      const audit = await runCLI(['audit', '--path', notePath, '--output', 'json'], vaultDir);
+      const output = JSON.parse(audit.stdout) as {
+        files: Array<{ issues: Array<{ code: string }> }>;
+      };
+      expect(output.files.flatMap(file => file.issues).map(issue => issue.code))
+        .not.toContain('invalid-date-format');
+    }
+  });
+
   it('resolves exact relative and absolute paths, frontmatter names, and aliases', async () => {
     const schemaPath = join(vaultDir, '.bwrb/schema.json');
     const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as any;
@@ -112,6 +148,44 @@ Body
       expect(result.exitCode, `${targets[index]}: ${result.stderr || result.stdout}`).toBe(0);
       expect(JSON.parse(result.stdout).forked_from).toBe(SOURCE_ID);
     }
+  });
+
+  it('rejects a duplicated source UUID for path, name, and alias targets without writing', async () => {
+    const schemaPath = join(vaultDir, '.bwrb/schema.json');
+    const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as any;
+    schema.types.idea.fields.aliases = { prompt: 'list', alias: true };
+    schema.types.idea.field_order.push('aliases');
+    await writeFile(schemaPath, JSON.stringify(schema, null, 2));
+
+    const firstPath = join(vaultDir, 'Ideas/Identity A.md');
+    const secondPath = join(vaultDir, 'Ideas/Identity B.md');
+    const firstRaw = `---\ntype: idea\nid: ${SOURCE_ID}\nname: Duplicate Named Source\naliases: [Duplicate Source Alias]\nstatus: raw\n---\nFirst\n`;
+    const secondRaw = `---\ntype: idea\nid: ${SOURCE_ID.toLowerCase()}\nname: Other Source\nstatus: raw\n---\nSecond\n`;
+    await writeFile(firstPath, firstRaw);
+    await writeFile(secondPath, secondRaw);
+    const registryPath = join(vaultDir, '.bwrb/ids.jsonl');
+    const registryBefore = await readFile(registryPath, 'utf-8').catch(() => null);
+
+    const attempts = [
+      { target: 'Ideas/Identity A', name: 'Rejected Path', json: true },
+      { target: 'Duplicate Named Source', name: 'Rejected Name', json: true },
+      { target: 'Duplicate Source Alias', name: 'Rejected Alias', json: false },
+    ];
+    for (const attempt of attempts) {
+      const args = ['new', '--fork', attempt.target, '--name', attempt.name];
+      if (attempt.json) args.push('--output', 'json');
+      const result = await runCLI(args, vaultDir);
+      expect(result.exitCode).toBe(1);
+      const message = attempt.json ? JSON.parse(result.stdout).error : result.stderr;
+      expect(message).toContain('id ABCDEF12-3456-4789-ABCD-EF1234567890 is duplicated');
+      expect(message).toContain('Ideas/Identity A.md');
+      expect(message).toContain('Ideas/Identity B.md');
+      await expect(readFile(join(vaultDir, `Ideas/${attempt.name}.md`), 'utf-8')).rejects.toThrow();
+    }
+
+    expect(await readFile(firstPath, 'utf-8')).toBe(firstRaw);
+    expect(await readFile(secondPath, 'utf-8')).toBe(secondRaw);
+    expect(await readFile(registryPath, 'utf-8').catch(() => null)).toBe(registryBefore);
   });
 
   it('never fuzzy-substitutes and reports ambiguous exact basenames', async () => {
@@ -154,6 +228,24 @@ Body
       .trim().split('\n').map(line => JSON.parse(line))
       .filter(row => row.path === 'Ideas/Sample Idea.md');
     expect(sourceRows).toHaveLength(1);
+  });
+
+  it('backfills a missing ID without changing any other source byte', async () => {
+    const sourcePath = join(vaultDir, 'Ideas/Precious YAML.md');
+    const original = '\uFEFF---\r\n# keep this header\r\ntype: "idea" # keep quotes\r\n# belongs to status\r\nstatus: &raw raw\r\nstatus-copy: *raw\r\ndescription: |-\r\n  first line\r\n  second line\r\n---\r\nBody with punctuation: --- and # characters.\r\n';
+    await writeFile(sourcePath, original);
+
+    const result = await runCLI([
+      'new', '--fork', 'Precious YAML', '--name', 'Preserved Child', '--output', 'json',
+    ], vaultDir);
+
+    expect(result.exitCode, result.stderr || result.stdout).toBe(0);
+    const output = JSON.parse(result.stdout);
+    const updated = await readFile(sourcePath, 'utf-8');
+    expect(updated).toContain(`type: "idea" # keep quotes\r\nid: ${output.forked_from}\r\n# belongs to status`);
+    expect(updated.replace(`id: ${output.forked_from}\r\n`, '')).toBe(original);
+    expect(await readFile(join(vaultDir, 'Ideas/Preserved Child.md'), 'utf-8'))
+      .toContain(`forked-from: ${output.forked_from}`);
   });
 
   it('rejects a malformed source ID without changing the source', async () => {

--- a/tests/ts/commands/new-fork.test.ts
+++ b/tests/ts/commands/new-fork.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+import {
+  cleanupTestVault,
+  createTestVault,
+  runCLI,
+} from '../fixtures/setup.js';
+import { parseNote } from '../../../src/lib/frontmatter.js';
+
+const SOURCE_ID = 'ABCDEF12-3456-4789-ABCD-EF1234567890';
+
+describe('new --fork', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  it('forks by case-insensitive UUID, copies content, resets state and aliases, and reports drift', async () => {
+    const schemaPath = join(vaultDir, '.bwrb/schema.json');
+    const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as any;
+    schema.types.idea.fields.status.reset_on_fork = true;
+    schema.types.idea.fields.status.default = 'raw';
+    schema.types.idea.fields.aliases = { prompt: 'list', alias: true };
+    schema.types.idea.field_order.push('aliases');
+    await writeFile(schemaPath, JSON.stringify(schema, null, 2));
+
+    const sourcePath = join(vaultDir, 'Ideas/Source.md');
+    await writeFile(sourcePath, `---
+type: idea
+id: ${SOURCE_ID}
+name: A Different Name
+status: settled
+priority: high
+aliases:
+  - Source Alias
+prev: Old
+next: New
+legacy-field: keep me
+---
+## Draft
+
+Words worth keeping.
+`);
+
+    const result = await runCLI([
+      'new', '--fork', SOURCE_ID.toLowerCase(), '--name', 'Forked Draft', '--output', 'json',
+    ], vaultDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    const output = JSON.parse(result.stdout);
+    expect(output).toMatchObject({
+      success: true,
+      path: 'Ideas/Forked Draft.md',
+      forked_from: SOURCE_ID,
+    });
+    expect(output.id).not.toBe(SOURCE_ID);
+    expect(output).not.toHaveProperty('root_id');
+    expect(output.warnings).toEqual([
+      'Copied schema-drift field unchanged: legacy-field',
+    ]);
+
+    const fork = await parseNote(join(vaultDir, output.path));
+    expect(fork.frontmatter).toMatchObject({
+      type: 'idea',
+      id: output.id,
+      name: 'Forked Draft',
+      status: 'raw',
+      priority: 'high',
+      'forked-from': SOURCE_ID,
+      'legacy-field': 'keep me',
+    });
+    expect(fork.frontmatter).not.toHaveProperty('aliases');
+    expect(fork.frontmatter).not.toHaveProperty('prev');
+    expect(fork.frontmatter).not.toHaveProperty('next');
+    expect(fork.body).toBe('## Draft\n\nWords worth keeping.\n');
+  });
+
+  it('resolves exact relative and absolute paths, frontmatter names, and aliases', async () => {
+    const schemaPath = join(vaultDir, '.bwrb/schema.json');
+    const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as any;
+    schema.types.idea.fields.aliases = { prompt: 'list', alias: true };
+    schema.types.idea.field_order.push('aliases');
+    await writeFile(schemaPath, JSON.stringify(schema, null, 2));
+    const sourcePath = join(vaultDir, 'Ideas/Path Source.md');
+    await writeFile(sourcePath, `---
+type: idea
+id: ${SOURCE_ID}
+name: Frontmatter Source
+status: raw
+aliases: [Alternate Source]
+---
+Body
+`);
+
+    const targets = [
+      'Ideas/Path Source',
+      sourcePath,
+      'Frontmatter Source',
+      'Alternate Source',
+    ];
+    for (let index = 0; index < targets.length; index++) {
+      const result = await runCLI([
+        'new', '--fork', targets[index]!, '--name', `Resolved ${index}`, '--output', 'json',
+      ], vaultDir);
+      expect(result.exitCode, `${targets[index]}: ${result.stderr || result.stdout}`).toBe(0);
+      expect(JSON.parse(result.stdout).forked_from).toBe(SOURCE_ID);
+    }
+  });
+
+  it('never fuzzy-substitutes and reports ambiguous exact basenames', async () => {
+    await mkdir(join(vaultDir, 'Ideas/Nested'), { recursive: true });
+    await writeFile(join(vaultDir, 'Ideas/Duplicate.md'), `---\ntype: idea\nstatus: raw\n---\n`);
+    await writeFile(join(vaultDir, 'Ideas/Nested/Duplicate.md'), `---\ntype: idea\nstatus: raw\n---\n`);
+
+    const ambiguous = await runCLI([
+      'new', '--fork', 'Duplicate', '--label', 'v2', '--output', 'json',
+    ], vaultDir);
+    expect(ambiguous.exitCode).toBe(1);
+    expect(JSON.parse(ambiguous.stdout).error).toContain('Ambiguous fork target');
+    expect(JSON.parse(ambiguous.stdout).error).toContain('Ideas/Duplicate.md');
+
+    const fuzzy = await runCLI([
+      'new', '--fork', 'Sample Ide', '--label', 'v2', '--output', 'json',
+    ], vaultDir);
+    expect(fuzzy.exitCode).toBe(1);
+    expect(JSON.parse(fuzzy.stdout).error).toContain('No exact note found');
+  });
+
+  it('backfills a missing source ID once across concurrent forks', async () => {
+    const sourcePath = join(vaultDir, 'Ideas/Sample Idea.md');
+    const [first, second] = await Promise.all([
+      runCLI(['new', '--fork', 'Sample Idea', '--name', 'Concurrent A', '--output', 'json'], vaultDir),
+      runCLI(['new', '--fork', 'Sample Idea', '--name', 'Concurrent B', '--output', 'json'], vaultDir),
+    ]);
+    expect(first.exitCode, first.stderr || first.stdout).toBe(0);
+    expect(second.exitCode, second.stderr || second.stdout).toBe(0);
+
+    const source = await parseNote(sourcePath);
+    const firstOutput = JSON.parse(first.stdout);
+    const secondOutput = JSON.parse(second.stdout);
+    expect(source.frontmatter.id).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(firstOutput.forked_from).toBe(source.frontmatter.id);
+    expect(secondOutput.forked_from).toBe(source.frontmatter.id);
+
+    const registry = await readFile(join(vaultDir, '.bwrb/ids.jsonl'), 'utf-8');
+    const sourceRows = registry
+      .trim().split('\n').map(line => JSON.parse(line))
+      .filter(row => row.path === 'Ideas/Sample Idea.md');
+    expect(sourceRows).toHaveLength(1);
+  });
+
+  it('rejects a malformed source ID without changing the source', async () => {
+    const sourcePath = join(vaultDir, 'Ideas/Bad ID.md');
+    const original = `---\ntype: idea\nid: not-a-uuid\nstatus: raw\n---\nBody\n`;
+    await writeFile(sourcePath, original);
+    const result = await runCLI([
+      'new', '--fork', 'Bad ID', '--label', 'v2', '--output', 'json',
+    ], vaultDir);
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout).error).toContain('invalid id');
+    expect(await readFile(sourcePath, 'utf-8')).toBe(original);
+  });
+
+  it('uses exclusive child creation for repeated and concurrent names', async () => {
+    const sourcePath = join(vaultDir, 'Ideas/Collision Source.md');
+    await writeFile(sourcePath, `---\ntype: idea\nid: ${SOURCE_ID}\nstatus: raw\n---\n`);
+    const results = await Promise.all([
+      runCLI(['new', '--fork', 'Collision Source', '--name', 'Same Child', '--output', 'json'], vaultDir),
+      runCLI(['new', '--fork', 'Collision Source', '--name', 'Same Child', '--output', 'json'], vaultDir),
+    ]);
+    expect(results.map(result => result.exitCode).sort()).toEqual([0, 1]);
+    const loser = results.find(result => result.exitCode !== 0)!;
+    expect(JSON.parse(loser.stdout).error).toContain('File already exists');
+
+    const registry = await readFile(join(vaultDir, '.bwrb/ids.jsonl'), 'utf-8');
+    const childRows = registry
+      .trim().split('\n').map(line => JSON.parse(line))
+      .filter(row => row.path === 'Ideas/Same Child.md');
+    expect(childRows).toHaveLength(1);
+  });
+
+  it('requires explicit naming in non-interactive and JSON output modes', async () => {
+    const json = await runCLI([
+      'new', '--fork', 'Sample Idea', '--output', 'json',
+    ], vaultDir);
+    expect(json.exitCode).toBe(1);
+    expect(JSON.parse(json.stdout).error).toContain('requires --name <name> or --label <label>');
+
+    const nonInteractive = await runCLI([
+      '--non-interactive', 'new', '--fork', 'Sample Idea',
+    ], vaultDir);
+    expect(nonInteractive.exitCode).toBe(1);
+    expect(nonInteractive.stderr).toContain('requires --name <name> or --label <label>');
+  });
+
+  it.each([
+    ['idea'],
+    ['--type', 'idea'],
+    ['--template', 'default'],
+    ['--no-template'],
+    ['--no-instances'],
+    ['--json', '{"name":"No"}'],
+    ['--owner', '[[Owner]]'],
+    ['--standalone'],
+  ])('rejects incompatible fork arguments: %s', async (...conflict) => {
+    const result = await runCLI([
+      'new', ...conflict, '--fork', 'Sample Idea', '--label', 'v2', '--output', 'json',
+    ], vaultDir);
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout).error).toContain('--fork cannot be combined');
+  });
+
+  it('rejects fork-only options outside fork mode', async () => {
+    for (const option of [['--label', 'x'], ['--name', 'x'], ['--output', 'json']]) {
+      const result = await runCLI(['new', 'idea', ...option], vaultDir);
+      expect(result.exitCode).toBe(1);
+      expect(`${result.stdout}\n${result.stderr}`).toContain('can only be used with --fork');
+    }
+  });
+
+  it('blocks single-valued owned forks and permits multiple-owned siblings', async () => {
+    const schemaPath = join(vaultDir, '.bwrb/schema.json');
+    const sourcePath = join(vaultDir, 'Projects/My Project/research/Owned.md');
+    await mkdir(join(vaultDir, 'Projects/My Project/research'), { recursive: true });
+    await writeFile(join(vaultDir, 'Projects/My Project/My Project.md'), `---\ntype: project\nstatus: raw\n---\n`);
+    await writeFile(sourcePath, `---\ntype: research\nid: ${SOURCE_ID}\nname: Owned\nowner: "[[My Project]]"\n---\n`);
+
+    const blocked = await runCLI([
+      'new', '--fork', 'Projects/My Project/research/Owned', '--label', 'v2', '--output', 'json',
+    ], vaultDir);
+    expect(blocked.exitCode).toBe(1);
+    expect(JSON.parse(blocked.stdout).error).toContain('single-valued');
+
+    const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as any;
+    schema.types.project.fields.research.multiple = true;
+    await writeFile(schemaPath, JSON.stringify(schema, null, 2));
+    const allowed = await runCLI([
+      'new', '--fork', 'Projects/My Project/research/Owned', '--label', 'v2', '--output', 'json',
+    ], vaultDir);
+    expect(allowed.exitCode, allowed.stderr || allowed.stdout).toBe(0);
+    expect(JSON.parse(allowed.stdout).path).toBe('Projects/My Project/research/Owned — v2.md');
+  });
+
+  it('prints useful text output and honors --open', async () => {
+    const sourcePath = join(vaultDir, 'Ideas/Open Source.md');
+    await writeFile(sourcePath, `---\ntype: idea\nid: ${SOURCE_ID}\nname: Open Source\nstatus: raw\n---\n`);
+    const result = await runCLI([
+      'new', '--fork', 'Open Source', '--label', 'review', '--open',
+    ], vaultDir, undefined, { env: { BWRB_DEFAULT_APP: 'print' } });
+    expect(result.exitCode, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toContain('Created fork: Ideas/Open Source — review.md');
+    expect(result.stdout).toContain(join(vaultDir, 'Ideas/Open Source — review.md'));
+  });
+
+  it('creates lineage that passes the lineage audit checks', async () => {
+    const sourcePath = join(vaultDir, 'Ideas/Audit Source.md');
+    await writeFile(sourcePath, `---\ntype: idea\nid: ${SOURCE_ID}\nname: Audit Source\nstatus: raw\n---\n`);
+    const created = await runCLI([
+      'new', '--fork', 'Audit Source', '--label', 'clean', '--output', 'json',
+    ], vaultDir);
+    expect(created.exitCode, created.stderr || created.stdout).toBe(0);
+
+    const audit = await runCLI([
+      'audit', '--path', 'Ideas/Audit Source — clean.md', '--output', 'json',
+    ], vaultDir);
+    expect(audit.exitCode, audit.stderr || audit.stdout).toBe(0);
+    const lineageCodes = (JSON.parse(audit.stdout).files as Array<{ issues: Array<{ code: string }> }>)
+      .flatMap(file => file.issues)
+      .map(issue => issue.code)
+      .filter(code => code.includes('fork') || code.includes('lineage') || code.includes('note-id'));
+    expect(lineageCodes).toEqual([]);
+  });
+});

--- a/tests/ts/commands/new.test.ts
+++ b/tests/ts/commands/new.test.ts
@@ -98,6 +98,9 @@ describe('new command', () => {
       expect(result.stdout).toContain('--template');
       expect(result.stdout).toContain('--type');
       expect(result.stdout).toContain('--no-template');
+      expect(result.stdout).toContain('--fork <target>');
+      expect(result.stdout).toContain('--label <label>');
+      expect(result.stdout).toContain('--name <name>');
     });
   });
 

--- a/tests/ts/lib/frontmatter.test.ts
+++ b/tests/ts/lib/frontmatter.test.ts
@@ -6,6 +6,7 @@ import {
   parseFrontmatter,
   serializeFrontmatter,
   buildNoteContent,
+  insertFrontmatterScalarPreservingBytes,
   writeNote,
   writeNoteExclusive,
   generateBodySections,
@@ -98,6 +99,27 @@ Body content`;
       expect(content).toContain('---');
       expect(content).toContain('type: idea');
       expect(content).toContain('Body content');
+    });
+  });
+
+  describe('insertFrontmatterScalarPreservingBytes', () => {
+    it('inserts after type while preserving every other byte, including CRLF and YAML syntax', () => {
+      const original = '\uFEFF---\r\n# note header\r\ntype: "idea" # quoted on purpose\r\n# belongs to status\r\nstatus: &raw raw\r\nstatus-copy: *raw\r\ndescription: |-\r\n  first line\r\n  second line\r\n---\r\nBody with  ---  and punctuation.\r\n';
+      const id = '11111111-1111-4111-8111-111111111111';
+
+      const inserted = insertFrontmatterScalarPreservingBytes(original, 'id', id);
+
+      expect(inserted).toContain(`type: "idea" # quoted on purpose\r\nid: ${id}\r\n# belongs to status`);
+      expect(inserted.replace(`id: ${id}\r\n`, '')).toBe(original);
+    });
+
+    it('refuses malformed, non-mapping, and already-present fields', () => {
+      expect(() => insertFrontmatterScalarPreservingBytes('---\nid: old\n---\n', 'id', 'new'))
+        .toThrow("already contains 'id'");
+      expect(() => insertFrontmatterScalarPreservingBytes('---\n[one, two]\n---\n', 'id', 'new'))
+        .toThrow('valid top-level mapping frontmatter');
+      expect(() => insertFrontmatterScalarPreservingBytes('---\ntype: [\n---\n', 'id', 'new'))
+        .toThrow('valid top-level mapping frontmatter');
     });
   });
 


### PR DESCRIPTION
## Summary
- add `bwrb new --fork <target>` with exact path/name/alias/UUID resolution
- backfill legacy source IDs safely, create sibling children exclusively, and preserve immediate-source provenance
- apply reset/default/alias and ownership contracts while preserving schema drift with warnings
- document the command and update completion/agent guidance

## Verification
- `pnpm build`
- `pnpm verify:pack`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm test -- --exclude='**/*.pty.test.ts'` (2,878 passed, 3 skipped)\n- focused PTY: interactive fork name default (1 passed)\n- built `dist/index.js` disposable-vault smoke: create, source-ID backfill, collision refusal, audit