### PR TITLE
Protect fork lineage during delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Bowerbird are documented in this file.
 
 - **Document forks** — `bwrb new --fork <target>` creates a sibling document with a fresh stable ID and immutable `forked-from` provenance while preserving the source body and prior work.
 - **Fork lineage inspection** — `bwrb list --lineage <target>` renders the complete connected fork component—including sibling and cousin branches—in tree, paths, link, content, or JSON form, resolving targets by exact path, name, alias, or case-insensitive UUID.
+- **Fork-safe deletion** — `bwrb delete` refuses notes with direct fork children or duplicate identities unless `--force` is supplied; forced deletion leaves child `forked-from` provenance intact for audit.
 
 ## [0.2.2] - 2026-07-04
 

--- a/docs-site/src/content/docs/changelog.md
+++ b/docs-site/src/content/docs/changelog.md
@@ -13,6 +13,7 @@ For the complete changelog with all details, see [CHANGELOG.md](https://github.c
 
 - **Document forks** — `bwrb new --fork <target>` creates an ordinary sibling note with a fresh ID and immutable immediate-source provenance
 - **Fork lineage inspection** — `bwrb list --lineage <target>` renders the complete connected fork component, including sibling and cousin branches, as a tree, paths, links, content, or structured JSON
+- **Fork-safe deletion** — `bwrb delete` refuses notes with direct fork children or duplicate identities unless forced, preserving child provenance for audit when the parent is deliberately removed
 
 ### 0.2.2
 

--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -86,7 +86,7 @@ Delete semantics in repair mode:
 | `owned-ambiguous-owner` | A note whose basename is declared as **owned by two or more distinct owners for an owned field whose child type matches the note's own type** (error; **never auto-fixable**). Ownership is genuinely ambiguous, so the note is **not** auto-restored under a guessed owner — `--fix --auto --execute` leaves it untouched and reports it for **manual resolution** (remove the duplicate `owned` declaration, or rename the note so each owner's declaration is unique). A correctly-filed note of a *different* type that merely shares a basename with such a declaration is **not** flagged — the matching declarations don't apply to it |
 | `invalid-forked-from` | Reserved `forked-from` provenance is not a UUID string (error; flag-only) |
 | `missing-lineage-id` | A note declares `forked-from` but lacks its own valid UUID `id` (error; flag-only) |
-| `dangling-forked-from` | `forked-from` references a UUID not present on any discovered note (warning; flag-only). Provenance is retained because the source may be restored later |
+| `dangling-forked-from` | `forked-from` references a UUID not present on any discovered note (warning; flag-only). Provenance is retained because the source may be restored later; this is also the deliberate result of deleting a fork parent with `bwrb delete --force` |
 | `duplicate-note-id` | Two or more notes use the same stable UUID `id` (error; flag-only) |
 | `fork-cycle` | Following immediate `forked-from` references forms a cycle (error; flag-only). Traversal is cycle-safe and always terminates |
 | `format-violation` | Field value doesn't match expected format (wikilink, etc.) |

--- a/docs-site/src/content/docs/reference/commands/delete.md
+++ b/docs-site/src/content/docs/reference/commands/delete.md
@@ -65,6 +65,42 @@ bwrb delete --type task --execute
 bwrb delete --type idea "Specific Name" --execute
 ```
 
+### Fork-lineage safety
+
+Without `--force`, delete refuses any note that has a direct document fork. The
+check applies to single, scoped, bulk, execute, and dry-run modes; bulk deletion
+is all-or-nothing when any selected note is blocked. Duplicate stable IDs also
+refuse deletion because the parent identity is ambiguous.
+
+```text
+Error: Refusing to delete Ideas/Launch Brief.md: fork lineage would be orphaned
+  Ideas/Launch Brief.md: 1 direct fork child
+    - Ideas/Launch Brief — concise.md
+Use --force to delete anyway; child fork provenance will be left dangling.
+```
+
+JSON refusals include a machine-readable `reason` (`has-fork-children` or
+`duplicate-identity`) and the affected paths:
+
+```json
+{
+  "success": false,
+  "error": "Refusing to delete Ideas/Launch Brief.md: fork lineage would be orphaned",
+  "code": 1,
+  "data": {
+    "path": "Ideas/Launch Brief.md",
+    "reason": "has-fork-children",
+    "childCount": 1,
+    "children": [{ "path": "Ideas/Launch Brief — concise.md" }]
+  }
+}
+```
+
+`--force` is the sole override. It deletes only the selected note: children are
+not deleted or reparented, and their `forked-from` value stays intact. A later
+`bwrb audit` reports that retained provenance as `dangling-forked-from`, so the
+source can still be restored deliberately.
+
 ## Examples
 
 ### Single-file Mode

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -171,6 +171,12 @@ always provide `--name` or `--label` and use `--output json`; the result contain
 fork mode with a type, template, `--json`, instance, or ownership-selection
 flag. The child is a normal note beside its source, not a hidden snapshot.
 
+Deleting a document with direct fork children refuses unless `--force` is
+supplied. With `--force`, bwrb deletes only the selected document: children keep
+their `forked-from` value, which surfaces as `dangling-forked-from` in
+`bwrb audit`. Use `bwrb list --lineage <target> --output json` before forcing a
+parent deletion when an agent needs to enumerate the affected family.
+
 ## Core Commands for Agents
 
 ### Querying Notes

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -41,6 +41,12 @@ import {
   type TargetingOptions,
 } from '../lib/targeting.js';
 import { unregisterIssuedNotePath } from '../lib/note-id.js';
+import { buildVaultNoteSnapshot } from '../lib/discovery.js';
+import {
+  assessDeleteLineage,
+  type DeleteLineageBlock,
+} from '../lib/delete-lineage-guard.js';
+import { withLineageMutationLocks } from '../lib/lineage-lock.js';
 
 // ============================================================================
 // Types
@@ -146,7 +152,7 @@ export const deleteCommand = new Command('delete')
   .option('-x, --execute', 'Actually delete files (default is dry-run for bulk operations)')
   .option('--dry-run', 'Preview deletions without removing files')
   // Original options
-  .option('-f, --force', 'Skip confirmation prompt (single-file mode)')
+  .option('-f, --force', 'Skip confirmation and fork-lineage safety checks')
   .option('--picker <mode>', 'Selection mode: auto (default), fzf, numbered, none')
   .option('--output <format>', 'Output format: text (default) or json')
   .addHelpText('after', `
@@ -188,6 +194,8 @@ Examples:
   bwrb delete --output json --force "My Note"   # Scripting mode (single file)
 
 Note: Deletion is permanent. The file is removed from the filesystem.
+      Notes with direct fork children refuse deletion unless --force is used.
+      Forced deletion leaves child forked-from provenance dangling for audit.
       Use version control (git) to recover deleted notes if needed.`)
   .action(async (query: string | undefined, options: DeleteOptions, cmd: Command) => {
     const jsonMode = options.output === 'json';
@@ -374,6 +382,7 @@ async function handleSingleDelete(
   await deleteResolvedFile({
     file: result.file,
     vaultDir,
+    schema,
     options,
     jsonMode,
     dryRun: !!options.dryRun,
@@ -493,6 +502,7 @@ async function handleScopedDelete(
   await deleteResolvedFile({
     file: resolution.file,
     vaultDir,
+    schema,
     options,
     jsonMode,
     dryRun: isDryRun,
@@ -558,6 +568,14 @@ async function handleBulkDelete(
     }
     process.exitCode = ExitCodes.SUCCESS;
     return;
+  }
+
+  if (!options.force) {
+    const assessment = await assessCurrentDeleteLineage(schema, vaultDir, files);
+    if (assessment.length > 0) {
+      reportLineageRefusal(assessment, jsonMode, true);
+      return;
+    }
   }
 
   // Dry-run mode: show what would be deleted
@@ -641,14 +659,34 @@ async function handleBulkDelete(
   const deleted: string[] = [];
   const errors: Array<{ path: string; error: string }> = [];
 
-  for (const file of files) {
+  const deleteFiles = async (): Promise<void> => {
+    for (const file of files) {
+      try {
+        await unlink(file.path);
+        await unregisterIssuedNotePath(vaultDir, file.relativePath);
+        deleted.push(file.relativePath);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        errors.push({ path: file.relativePath, error: message });
+      }
+    }
+  };
+
+  if (options.force) {
+    await deleteFiles();
+  } else {
     try {
-      await unlink(file.path);
-      await unregisterIssuedNotePath(vaultDir, file.relativePath);
-      deleted.push(file.relativePath);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      errors.push({ path: file.relativePath, error: message });
+      await withLineageMutationLocks(vaultDir, files.map(file => file.path), async () => {
+        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, files);
+        if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
+        await deleteFiles();
+      });
+    } catch (error) {
+      if (error instanceof LineageDeleteRefusalError) {
+        reportLineageRefusal(error.blocked, jsonMode, true);
+        return;
+      }
+      throw error;
     }
   }
 
@@ -718,12 +756,14 @@ function buildNoteIndexFromFiles(files: ManagedFile[]): NoteIndex {
 async function deleteResolvedFile({
   file,
   vaultDir,
+  schema,
   options,
   jsonMode,
   dryRun,
 }: {
   file: ManagedFile;
   vaultDir: string;
+  schema: Awaited<ReturnType<typeof loadSchema>>;
   options: DeleteOptions;
   jsonMode: boolean;
   dryRun: boolean;
@@ -741,6 +781,14 @@ async function deleteResolvedFile({
     printError(error);
     process.exitCode = ExitCodes.VALIDATION_ERROR;
     return;
+  }
+
+  if (!options.force) {
+    const assessment = await assessCurrentDeleteLineage(schema, vaultDir, [file]);
+    if (assessment.length > 0) {
+      reportLineageRefusal(assessment, jsonMode, false);
+      return;
+    }
   }
 
   if (dryRun) {
@@ -804,9 +852,27 @@ async function deleteResolvedFile({
     }
   }
 
-  // Delete the file
-  await unlink(fullPath);
-  await unregisterIssuedNotePath(vaultDir, relativePath);
+  // Delete the file. Non-force deletion rechecks under the same path-keyed
+  // lock used by `new --fork`, after every prompt and backlink scan has ended.
+  if (options.force) {
+    await unlink(fullPath);
+    await unregisterIssuedNotePath(vaultDir, relativePath);
+  } else {
+    try {
+      await withLineageMutationLocks(vaultDir, [fullPath], async () => {
+        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, [file]);
+        if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
+        await unlink(fullPath);
+        await unregisterIssuedNotePath(vaultDir, relativePath);
+      });
+    } catch (error) {
+      if (error instanceof LineageDeleteRefusalError) {
+        reportLineageRefusal(error.blocked, jsonMode, false);
+        return;
+      }
+      throw error;
+    }
+  }
 
   // Success output
   if (jsonMode) {
@@ -824,4 +890,65 @@ async function deleteResolvedFile({
       printWarning(`Note: ${backlinks.length} note(s) still contain links to this file.`);
     }
   }
+}
+
+class LineageDeleteRefusalError extends Error {
+  constructor(readonly blocked: DeleteLineageBlock[]) {
+    super('Fork-lineage deletion refused');
+    this.name = 'LineageDeleteRefusalError';
+  }
+}
+
+async function assessCurrentDeleteLineage(
+  schema: Awaited<ReturnType<typeof loadSchema>>,
+  vaultDir: string,
+  files: ManagedFile[]
+): Promise<DeleteLineageBlock[]> {
+  const snapshot = await buildVaultNoteSnapshot(schema, vaultDir);
+  const assessment = assessDeleteLineage(snapshot, files.map(file => file.path));
+  if (assessment.missing.length > 0) {
+    const error = new Error(
+      `File not found or no longer managed: ${assessment.missing
+        .map(path => files.find(file => file.path === path)?.relativePath ?? path)
+        .join(', ')}`
+    ) as NodeJS.ErrnoException;
+    error.code = 'ENOENT';
+    throw error;
+  }
+  return assessment.blocked;
+}
+
+function reportLineageRefusal(
+  blocked: DeleteLineageBlock[],
+  jsonMode: boolean,
+  bulk: boolean
+): void {
+  const message = blocked.length === 1
+    ? `Refusing to delete ${blocked[0]!.path}: fork lineage would be orphaned`
+    : `Refusing to delete ${blocked.length} notes: fork lineage would be orphaned`;
+
+  if (jsonMode) {
+    printJson(jsonError(message, {
+      code: ExitCodes.VALIDATION_ERROR,
+      data: bulk ? { blocked } : blocked[0],
+    }));
+  } else {
+    printError(message);
+    for (const item of blocked) {
+      if (item.reason === 'has-fork-children') {
+        console.error(`  ${item.path}: ${item.childCount} direct fork child${item.childCount === 1 ? '' : 'ren'}`);
+        for (const child of item.children ?? []) {
+          console.error(`    - ${child.path}`);
+        }
+      } else {
+        console.error(`  ${item.path}: note id ${item.id} is duplicated`);
+        for (const duplicate of item.duplicates ?? []) {
+          console.error(`    - ${duplicate}`);
+        }
+      }
+    }
+    console.error('Use --force to delete anyway; child fork provenance will be left dangling.');
+  }
+
+  process.exitCode = ExitCodes.VALIDATION_ERROR;
 }

--- a/src/commands/new/fork.ts
+++ b/src/commands/new/fork.ts
@@ -26,6 +26,7 @@ import { buildNotePath } from './paths.js';
 import { promptInput } from '../../lib/prompt.js';
 import { UserCancelledError } from '../../lib/errors.js';
 import { resolveExactNoteTarget } from '../../lib/exact-note-target.js';
+import { withLineageMutationLocks } from '../../lib/lineage-lock.js';
 
 const SOURCE_ID_LOCK = '.bwrb/locks/fork-source-id.lock';
 const LOCK_RETRY_MS = 20;
@@ -80,75 +81,81 @@ export async function forkNote(
 
   const sourceName = resolveSourceName(source);
   const childName = await resolveChildName(sourceName, options);
-  const sourceId = await ensureSourceId(schema, vaultDir, source.file.path);
 
-  // Re-read after a possible ID backfill so the child copies the source's
-  // current frontmatter rather than a stale pre-lock snapshot.
-  const current = await parseNote(source.file.path);
-  const currentType = resolveTypeFromFrontmatter(schema, current.frontmatter);
-  if (!currentType) {
-    throw new Error(`Fork source no longer has a valid schema type: ${source.file.relativePath}`);
-  }
+  return withLineageMutationLocks(vaultDir, [source.file.path], async () => {
+    // The path-keyed lock begins before legacy ID backfill and remains held
+    // through the child registry append. A concurrent non-force delete either
+    // removes the source first or observes this completed child.
+    const sourceId = await ensureSourceId(schema, vaultDir, source.file.path);
 
-  const warnings = collectSchemaDriftWarnings(schema, currentType, current.frontmatter);
-  const frontmatter = normalizeDateFields(
-    schema,
-    currentType,
-    buildForkFrontmatter(
+    // Re-read after a possible ID backfill so the child copies the source's
+    // current frontmatter rather than a stale pre-lock snapshot.
+    const current = await parseNote(source.file.path);
+    const currentType = resolveTypeFromFrontmatter(schema, current.frontmatter);
+    if (!currentType) {
+      throw new Error(`Fork source no longer has a valid schema type: ${source.file.relativePath}`);
+    }
+
+    const warnings = collectSchemaDriftWarnings(schema, currentType, current.frontmatter);
+    const frontmatter = normalizeDateFields(
       schema,
       currentType,
-      current.frontmatter,
-      childName,
-      sourceId
-    )
-  );
-  const childId = await generateUniqueNoteId(vaultDir);
-  frontmatter.id = childId;
-
-  const pathResult = buildNotePath(dirname(source.file.path), childName, 'interactive');
-  const relativePath = relative(vaultDir, pathResult.path);
-  if (relativePath.length > PORTABLE_PATH_MAX_LENGTH) {
-    throw new Error(
-      `Note path is ${relativePath.length} characters, exceeding the portable limit of ${PORTABLE_PATH_MAX_LENGTH}: ${relativePath}`
+      buildForkFrontmatter(
+        schema,
+        currentType,
+        current.frontmatter,
+        childName,
+        sourceId
+      )
     );
-  }
+    const childId = await generateUniqueNoteId(vaultDir);
+    frontmatter.id = childId;
 
-  const pathLengthWarning = relativePath.length > PORTABLE_PATH_WARNING_LENGTH
-    ? {
-        path: relativePath,
-        length: relativePath.length,
-        threshold: PORTABLE_PATH_WARNING_LENGTH,
-        max: PORTABLE_PATH_MAX_LENGTH,
-      }
-    : undefined;
-
-  const orderedFields = buildForkFieldOrder(current.frontmatter, frontmatter);
-  try {
-    await writeNoteExclusive(pathResult.path, frontmatter, current.body, orderedFields);
-  } catch (error) {
-    if (isFileExistsError(error)) {
-      throw new Error(`File already exists: ${relativePath}`);
+    const pathResult = buildNotePath(dirname(source.file.path), childName, 'interactive');
+    const relativePath = relative(vaultDir, pathResult.path);
+    if (relativePath.length > PORTABLE_PATH_MAX_LENGTH) {
+      throw new Error(
+        `Note path is ${relativePath.length} characters, exceeding the portable limit of ${PORTABLE_PATH_MAX_LENGTH}: ${relativePath}`
+      );
     }
-    throw error;
-  }
 
-  try {
-    await registerIssuedNoteId(vaultDir, childId, pathResult.path);
-  } catch (error) {
-    // A note without a registry row is not a completed creation. Roll it back;
-    // the source ID backfill intentionally remains durable.
-    await unlink(pathResult.path).catch(() => undefined);
-    throw error;
-  }
+    const pathLengthWarning = relativePath.length > PORTABLE_PATH_WARNING_LENGTH
+      ? {
+          path: relativePath,
+          length: relativePath.length,
+          threshold: PORTABLE_PATH_WARNING_LENGTH,
+          max: PORTABLE_PATH_MAX_LENGTH,
+        }
+      : undefined;
 
-  return {
-    path: pathResult.path,
-    id: childId,
-    forkedFrom: sourceId,
-    warnings,
-    ...(pathResult.nameTransformed ? { nameTransformed: pathResult.nameTransformed } : {}),
-    ...(pathLengthWarning ? { pathLengthWarning } : {}),
-  };
+    const orderedFields = buildForkFieldOrder(current.frontmatter, frontmatter);
+    try {
+      await writeNoteExclusive(pathResult.path, frontmatter, current.body, orderedFields);
+    } catch (error) {
+      if (isFileExistsError(error)) {
+        throw new Error(`File already exists: ${relativePath}`);
+      }
+      throw error;
+    }
+
+    try {
+      await registerIssuedNoteId(vaultDir, childId, pathResult.path);
+    } catch (error) {
+      // A note without a registry row is not a completed creation. Roll it
+      // back; the source ID backfill intentionally remains durable.
+      await unlink(pathResult.path).catch(() => undefined);
+      throw error;
+    }
+
+    return {
+      path: pathResult.path,
+      id: childId,
+      forkedFrom: sourceId,
+      warnings,
+      ...(pathResult.nameTransformed ? { nameTransformed: pathResult.nameTransformed } : {}),
+      ...(pathLengthWarning ? { pathLengthWarning } : {}),
+    };
+  });
 }
 
 async function resolveForkSource(

--- a/src/lib/delete-lineage-guard.ts
+++ b/src/lib/delete-lineage-guard.ts
@@ -1,0 +1,91 @@
+import { resolve } from 'path';
+import type { VaultNoteSnapshot, VaultNoteSnapshotEntry } from './discovery.js';
+import { buildLineageMaps } from './lineage.js';
+import { isValidNoteId, normalizeNoteId } from './note-id.js';
+
+export type DeleteLineageBlockReason = 'has-fork-children' | 'duplicate-identity';
+
+export interface DeleteLineageChild {
+  path: string;
+  id?: string;
+}
+
+export interface DeleteLineageBlock {
+  path: string;
+  reason: DeleteLineageBlockReason;
+  id?: string;
+  childCount?: number;
+  children?: DeleteLineageChild[];
+  duplicates?: string[];
+}
+
+export interface DeleteLineageAssessment {
+  blocked: DeleteLineageBlock[];
+  missing: string[];
+}
+
+/**
+ * Assess direct fork edges for delete targets using one coherent vault
+ * snapshot. This deliberately does not traverse: a direct child is enough to
+ * refuse, and cycles therefore remain finite (a self-edge blocks itself).
+ */
+export function assessDeleteLineage(
+  snapshot: VaultNoteSnapshot,
+  targetPaths: string[]
+): DeleteLineageAssessment {
+  const maps = buildLineageMaps(snapshot);
+  const notesByPath = new Map(
+    snapshot.notes.map(note => [resolve(note.path), note] as const)
+  );
+  const blocked: DeleteLineageBlock[] = [];
+  const missing: string[] = [];
+
+  for (const targetPath of [...targetPaths].sort(comparePath)) {
+    const target = notesByPath.get(resolve(targetPath));
+    if (!target) {
+      missing.push(targetPath);
+      continue;
+    }
+
+    const id = target.frontmatter?.id;
+    if (!isValidNoteId(id)) continue;
+
+    const identity = normalizeNoteId(id);
+    const identityMatches = maps.notesById.get(identity) ?? [];
+    if (identityMatches.length > 1) {
+      blocked.push({
+        path: target.relativePath,
+        reason: 'duplicate-identity',
+        id,
+        duplicates: identityMatches.map(note => note.relativePath).sort(comparePath),
+      });
+      continue;
+    }
+
+    const children = (maps.childrenByParentId.get(identity) ?? []).map(toChild);
+    if (children.length > 0) {
+      blocked.push({
+        path: target.relativePath,
+        reason: 'has-fork-children',
+        id,
+        childCount: children.length,
+        children,
+      });
+    }
+  }
+
+  blocked.sort((a, b) => comparePath(a.path, b.path));
+  return { blocked, missing };
+}
+
+function toChild(note: VaultNoteSnapshotEntry): DeleteLineageChild {
+  const id = note.frontmatter?.id;
+  return {
+    path: note.relativePath,
+    ...(isValidNoteId(id) ? { id } : {}),
+  };
+}
+
+function comparePath(a: string, b: string): number {
+  return a.localeCompare(b, 'en');
+}

--- a/src/lib/lineage-lock.ts
+++ b/src/lib/lineage-lock.ts
@@ -1,10 +1,44 @@
-import { createHash } from 'crypto';
-import { mkdir, open, stat, unlink } from 'fs/promises';
-import { dirname, relative, resolve } from 'path';
+import { createHash, randomUUID } from 'crypto';
+import { mkdir, open, readFile, readdir, rename, stat, unlink } from 'fs/promises';
+import { basename, dirname, relative, resolve } from 'path';
 
 const LOCK_RETRY_MS = 20;
 const LOCK_ATTEMPTS = 1_500;
 const STALE_LOCK_MS = 30_000;
+const HEARTBEAT_MS = 10_000;
+const LOCK_VERSION = 1;
+
+interface LineageLockOptions {
+  retryMs: number;
+  attempts: number;
+  staleMs: number;
+  heartbeatMs: number;
+}
+
+interface LockMetadata {
+  version: number;
+  pid: number;
+  token: string;
+  createdAt: number;
+  heartbeatAt: number;
+  pathKey: string;
+}
+
+interface LockSnapshot {
+  raw: string;
+  metadata: LockMetadata | null;
+  device: number;
+  inode: number;
+  modifiedAt: number;
+  size: number;
+}
+
+const DEFAULT_OPTIONS: LineageLockOptions = {
+  retryMs: LOCK_RETRY_MS,
+  attempts: LOCK_ATTEMPTS,
+  staleMs: STALE_LOCK_MS,
+  heartbeatMs: HEARTBEAT_MS,
+};
 
 /**
  * Serialize mutations that can create or remove fork edges for a source file.
@@ -16,8 +50,10 @@ const STALE_LOCK_MS = 30_000;
 export async function withLineageMutationLocks<T>(
   vaultDir: string,
   sourcePaths: string[],
-  task: () => Promise<T>
+  task: () => Promise<T>,
+  optionOverrides: Partial<LineageLockOptions> = {}
 ): Promise<T> {
+  const options = { ...DEFAULT_OPTIONS, ...optionOverrides };
   const lockPaths = Array.from(new Set(
     sourcePaths.map(sourcePath => getLineageMutationLockPath(vaultDir, sourcePath))
   )).sort((a, b) => a.localeCompare(b, 'en'));
@@ -25,7 +61,7 @@ export async function withLineageMutationLocks<T>(
   const releases: Array<() => Promise<void>> = [];
   try {
     for (const lockPath of lockPaths) {
-      releases.push(await acquireLock(lockPath));
+      releases.push(await acquireLock(lockPath, options));
     }
     return await task();
   } finally {
@@ -54,43 +90,283 @@ export function getLineageMutationLockPath(vaultDir: string, sourcePath: string)
   return resolve(vaultRoot, '.bwrb', 'locks', `lineage-source-${key}.lock`);
 }
 
-async function acquireLock(lockPath: string): Promise<() => Promise<void>> {
+async function acquireLock(
+  lockPath: string,
+  options: LineageLockOptions
+): Promise<() => Promise<void>> {
   await mkdir(dirname(lockPath), { recursive: true });
+  const recoveryPath = `${lockPath}.recovery`;
 
-  for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
+  for (let attempt = 0; attempt < options.attempts; attempt++) {
+    if (await recoveryIsInProgress(recoveryPath, options)) {
+      await delay(options.retryMs);
+      continue;
+    }
+
+    const token = randomUUID();
+    const now = Date.now();
+    const metadata: LockMetadata = {
+      version: LOCK_VERSION,
+      pid: process.pid,
+      token,
+      createdAt: now,
+      heartbeatAt: now,
+      pathKey: basename(lockPath),
+    };
+
     try {
       const handle = await open(lockPath, 'wx');
       try {
-        await handle.writeFile(`${process.pid}\n`, 'utf-8');
+        await handle.writeFile(`${JSON.stringify(metadata)}\n`, 'utf-8');
+
+        // A stale-lock reaper may have started between our first recovery-marker
+        // check and the exclusive create. It will re-check our live metadata and
+        // leave us alone, but we do not enter the critical section until that
+        // recovery pass has finished.
+        if (await pathExists(recoveryPath)) {
+          await handle.close().catch(() => undefined);
+          await unlinkIfOwned(lockPath, token);
+          await delay(options.retryMs);
+          continue;
+        }
+
+        await cleanupQuarantines(lockPath);
+        return createRelease(lockPath, handle, metadata, options);
       } catch (error) {
         await handle.close().catch(() => undefined);
-        await unlink(lockPath).catch(() => undefined);
+        await unlinkIfOwned(lockPath, token);
         throw error;
       }
-      let released = false;
-      return async () => {
-        if (released) return;
-        released = true;
-        await handle.close().catch(() => undefined);
-        await unlink(lockPath).catch(() => undefined);
-      };
     } catch (error) {
       if (!isFileExistsError(error)) throw error;
-      if (await isStaleLock(lockPath)) {
-        await unlink(lockPath).catch(() => undefined);
+      const snapshot = await readLockSnapshot(lockPath);
+      if (snapshot && await isRecoverable(snapshot, options.staleMs)) {
+        await recoverStaleLock(lockPath, recoveryPath, options);
         continue;
       }
-      await delay(LOCK_RETRY_MS);
+      await delay(options.retryMs);
     }
   }
 
   throw new Error('Timed out waiting for a fork-lineage mutation lock; retry the command.');
 }
 
-async function isStaleLock(lockPath: string): Promise<boolean> {
+function createRelease(
+  lockPath: string,
+  handle: Awaited<ReturnType<typeof open>>,
+  metadata: LockMetadata,
+  options: LineageLockOptions
+): () => Promise<void> {
+  let released = false;
+  let heartbeatRunning = false;
+  const timer = setInterval(() => {
+    if (released || heartbeatRunning) return;
+    heartbeatRunning = true;
+    void heartbeatOwnedLock(lockPath, handle, metadata.token)
+      .finally(() => { heartbeatRunning = false; });
+  }, Math.max(1, Math.min(options.heartbeatMs, Math.max(1, options.staleMs / 3))));
+  timer.unref();
+
+  return async () => {
+    if (released) return;
+    released = true;
+    clearInterval(timer);
+    await handle.close().catch(() => undefined);
+    await unlinkIfOwned(lockPath, metadata.token);
+  };
+}
+
+async function heartbeatOwnedLock(
+  lockPath: string,
+  handle: Awaited<ReturnType<typeof open>>,
+  token: string
+): Promise<void> {
+  const snapshot = await readLockSnapshot(lockPath);
+  if (snapshot?.metadata?.token !== token) return;
+
+  // Touch the inode opened by this holder, not whatever might have appeared at
+  // the path after the ownership check. The immutable JSON records when the
+  // heartbeat began; mtime records its current pulse.
+  const now = new Date();
+  await handle.utimes(now, now).catch(() => undefined);
+}
+
+async function recoverStaleLock(
+  lockPath: string,
+  recoveryPath: string,
+  options: LineageLockOptions
+): Promise<void> {
+  const recovery = await acquireRecoveryMarker(recoveryPath, options);
+  if (!recovery) return;
+
   try {
-    const info = await stat(lockPath);
-    return Date.now() - info.mtimeMs > STALE_LOCK_MS;
+    const snapshot = await readLockSnapshot(lockPath);
+    if (!snapshot || !await isRecoverable(snapshot, options.staleMs)) return;
+
+    // The fixed recovery marker prevents acquisitions and competing reapers
+    // while the stale inode is atomically moved out of the lock pathname.
+    const quarantinePath = `${lockPath}.quarantine-${process.pid}-${randomUUID()}`;
+    try {
+      await rename(lockPath, quarantinePath);
+      await unlink(quarantinePath).catch(() => undefined);
+    } catch (error) {
+      if (!isFileMissingError(error)) throw error;
+    }
+    await cleanupQuarantines(lockPath);
+  } finally {
+    await recovery();
+  }
+}
+
+async function acquireRecoveryMarker(
+  recoveryPath: string,
+  options: LineageLockOptions
+): Promise<(() => Promise<void>) | null> {
+  const token = randomUUID();
+  const now = Date.now();
+  const metadata: LockMetadata = {
+    version: LOCK_VERSION,
+    pid: process.pid,
+    token,
+    createdAt: now,
+    heartbeatAt: now,
+    pathKey: basename(recoveryPath),
+  };
+
+  try {
+    const handle = await open(recoveryPath, 'wx');
+    try {
+      await handle.writeFile(`${JSON.stringify(metadata)}\n`, 'utf-8');
+    } finally {
+      await handle.close();
+    }
+    return async () => {
+      await unlinkIfOwned(recoveryPath, token);
+    };
+  } catch (error) {
+    if (!isFileExistsError(error)) throw error;
+    const snapshot = await readLockSnapshot(recoveryPath);
+    if (snapshot && await isRecoverable(snapshot, options.staleMs)) {
+      await unlinkIfUnchanged(recoveryPath, snapshot);
+    }
+    return null;
+  }
+}
+
+async function recoveryIsInProgress(
+  recoveryPath: string,
+  options: LineageLockOptions
+): Promise<boolean> {
+  const snapshot = await readLockSnapshot(recoveryPath);
+  if (!snapshot) return false;
+  if (await isRecoverable(snapshot, options.staleMs)) {
+    await unlinkIfUnchanged(recoveryPath, snapshot);
+    return pathExists(recoveryPath);
+  }
+  return true;
+}
+
+async function isRecoverable(snapshot: LockSnapshot, staleMs: number): Promise<boolean> {
+  if (Date.now() - snapshot.modifiedAt <= staleMs) return false;
+
+  // Corrupt/missing owner data is recoverable only once the TTL expires. For
+  // valid metadata, a live PID wins over timestamps: an active process must not
+  // lose a long critical section because its event loop paused or mtime changed.
+  if (!snapshot.metadata) return true;
+  return !isProcessAlive(snapshot.metadata.pid);
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ESRCH') return false;
+    // EPERM means the process exists but is owned by another user. Unknown
+    // platform errors are also treated as live: local vault locking prefers a
+    // deterministic timeout over stealing another process's lock. PID reuse can
+    // therefore cause a conservative false-positive, never concurrent owners.
+    return true;
+  }
+}
+
+async function readLockSnapshot(lockPath: string): Promise<LockSnapshot | null> {
+  try {
+    const [raw, info] = await Promise.all([
+      readFile(lockPath, 'utf-8'),
+      stat(lockPath),
+    ]);
+    return {
+      raw,
+      metadata: parseLockMetadata(raw),
+      device: info.dev,
+      inode: info.ino,
+      modifiedAt: info.mtimeMs,
+      size: info.size,
+    };
+  } catch (error) {
+    if (isFileMissingError(error)) return null;
+    return null;
+  }
+}
+
+function parseLockMetadata(raw: string): LockMetadata | null {
+  try {
+    const value = JSON.parse(raw) as Partial<LockMetadata>;
+    if (
+      value.version !== LOCK_VERSION ||
+      !Number.isSafeInteger(value.pid) ||
+      (value.pid ?? 0) <= 0 ||
+      typeof value.token !== 'string' || value.token.length === 0 ||
+      typeof value.createdAt !== 'number' || !Number.isFinite(value.createdAt) ||
+      typeof value.heartbeatAt !== 'number' || !Number.isFinite(value.heartbeatAt) ||
+      typeof value.pathKey !== 'string' || value.pathKey.length === 0
+    ) return null;
+    return value as LockMetadata;
+  } catch {
+    return null;
+  }
+}
+
+async function unlinkIfOwned(lockPath: string, token: string): Promise<boolean> {
+  const snapshot = await readLockSnapshot(lockPath);
+  if (snapshot?.metadata?.token !== token) return false;
+  return unlinkIfUnchanged(lockPath, snapshot);
+}
+
+async function unlinkIfUnchanged(lockPath: string, expected: LockSnapshot): Promise<boolean> {
+  const current = await readLockSnapshot(lockPath);
+  if (!current || !snapshotsMatch(current, expected)) return false;
+  try {
+    await unlink(lockPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function snapshotsMatch(left: LockSnapshot, right: LockSnapshot): boolean {
+  return left.raw === right.raw &&
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.modifiedAt === right.modifiedAt &&
+    left.size === right.size;
+}
+
+async function cleanupQuarantines(lockPath: string): Promise<void> {
+  const directory = dirname(lockPath);
+  const prefix = `${basename(lockPath)}.quarantine-`;
+  const entries = await readdir(directory).catch(() => []);
+  await Promise.all(entries
+    .filter(entry => entry.startsWith(prefix))
+    .map(entry => unlink(resolve(directory, entry)).catch(() => undefined)));
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
   } catch {
     return false;
   }
@@ -99,6 +375,11 @@ async function isStaleLock(lockPath: string): Promise<boolean> {
 function isFileExistsError(error: unknown): boolean {
   return error instanceof Error && 'code' in error &&
     (error as NodeJS.ErrnoException).code === 'EEXIST';
+}
+
+function isFileMissingError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT';
 }
 
 function delay(ms: number): Promise<void> {

--- a/src/lib/lineage-lock.ts
+++ b/src/lib/lineage-lock.ts
@@ -1,0 +1,106 @@
+import { createHash } from 'crypto';
+import { mkdir, open, stat, unlink } from 'fs/promises';
+import { dirname, relative, resolve } from 'path';
+
+const LOCK_RETRY_MS = 20;
+const LOCK_ATTEMPTS = 1_500;
+const STALE_LOCK_MS = 30_000;
+
+/**
+ * Serialize mutations that can create or remove fork edges for a source file.
+ *
+ * The key is the source's canonical vault-relative path rather than its UUID:
+ * legacy notes without IDs must participate in the same critical section as
+ * the fork that may assign their first ID.
+ */
+export async function withLineageMutationLocks<T>(
+  vaultDir: string,
+  sourcePaths: string[],
+  task: () => Promise<T>
+): Promise<T> {
+  const lockPaths = Array.from(new Set(
+    sourcePaths.map(sourcePath => getLineageMutationLockPath(vaultDir, sourcePath))
+  )).sort((a, b) => a.localeCompare(b, 'en'));
+
+  const releases: Array<() => Promise<void>> = [];
+  try {
+    for (const lockPath of lockPaths) {
+      releases.push(await acquireLock(lockPath));
+    }
+    return await task();
+  } finally {
+    for (let index = releases.length - 1; index >= 0; index--) {
+      await releases[index]!();
+    }
+  }
+}
+
+export function getLineageMutationLockPath(vaultDir: string, sourcePath: string): string {
+  const vaultRoot = resolve(vaultDir);
+  const absoluteSource = resolve(sourcePath);
+  const relativeSource = relative(vaultRoot, absoluteSource).replace(/\\/g, '/');
+  if (
+    relativeSource === '' ||
+    relativeSource === '..' ||
+    relativeSource.startsWith('../') ||
+    relativeSource.startsWith('/')
+  ) {
+    throw new Error(`Lineage lock source must be a file inside the vault: ${sourcePath}`);
+  }
+
+  // Lower-casing intentionally over-serializes case-only path variants. That
+  // is safer on case-insensitive filesystems and the digest remains portable.
+  const key = createHash('sha256').update(relativeSource.normalize('NFC').toLowerCase()).digest('hex');
+  return resolve(vaultRoot, '.bwrb', 'locks', `lineage-source-${key}.lock`);
+}
+
+async function acquireLock(lockPath: string): Promise<() => Promise<void>> {
+  await mkdir(dirname(lockPath), { recursive: true });
+
+  for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt++) {
+    try {
+      const handle = await open(lockPath, 'wx');
+      try {
+        await handle.writeFile(`${process.pid}\n`, 'utf-8');
+      } catch (error) {
+        await handle.close().catch(() => undefined);
+        await unlink(lockPath).catch(() => undefined);
+        throw error;
+      }
+      let released = false;
+      return async () => {
+        if (released) return;
+        released = true;
+        await handle.close().catch(() => undefined);
+        await unlink(lockPath).catch(() => undefined);
+      };
+    } catch (error) {
+      if (!isFileExistsError(error)) throw error;
+      if (await isStaleLock(lockPath)) {
+        await unlink(lockPath).catch(() => undefined);
+        continue;
+      }
+      await delay(LOCK_RETRY_MS);
+    }
+  }
+
+  throw new Error('Timed out waiting for a fork-lineage mutation lock; retry the command.');
+}
+
+async function isStaleLock(lockPath: string): Promise<boolean> {
+  try {
+    const info = await stat(lockPath);
+    return Date.now() - info.mtimeMs > STALE_LOCK_MS;
+  } catch {
+    return false;
+  }
+}
+
+function isFileExistsError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'EEXIST';
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolveDelay => setTimeout(resolveDelay, ms));
+}

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -47,6 +47,8 @@ export interface JsonSuccess<T = unknown> {
 export interface JsonError {
   success: false;
   error: string;
+  /** Optional machine-readable context for structured validation failures. */
+  data?: unknown;
   errors?: Array<{
     field: string;
     value?: unknown;

--- a/tests/ts/commands/delete-lineage.test.ts
+++ b/tests/ts/commands/delete-lineage.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync } from 'fs';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+import {
+  cleanupTestVault,
+  createTestVault,
+  runCLI,
+} from '../fixtures/setup.js';
+
+const A = 'AAAAAAAA-1111-4111-8111-111111111111';
+const B = 'bbbbbbbb-2222-4222-8222-222222222222';
+const C = 'cccccccc-3333-4333-8333-333333333333';
+
+function idea(id: string | undefined, parent?: string): string {
+  return `---
+type: idea
+${id === undefined ? '' : `id: ${id}\n`}${parent === undefined ? '' : `forked-from: ${parent}\n`}status: raw
+priority: medium
+---
+`;
+}
+
+describe('delete fork-lineage safety', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  it('blocks roots and middles, permits leaves, and lists stable child paths', async () => {
+    const root = join(vaultDir, 'Ideas/Root.md');
+    const middle = join(vaultDir, 'Ideas/Middle.md');
+    const leaf = join(vaultDir, 'Ideas/Leaf.md');
+    const idlessChild = join(vaultDir, 'Ideas/Idless Child.md');
+    await writeFile(root, idea(A));
+    await writeFile(middle, idea(B, A.toLowerCase()));
+    await writeFile(leaf, idea(C, B));
+    await writeFile(idlessChild, idea(undefined, A));
+
+    const rootResult = await runCLI(['delete', 'Root', '--dry-run'], vaultDir);
+    expect(rootResult.exitCode).toBe(1);
+    expect(rootResult.stderr).toContain('2 direct fork children');
+    expect(rootResult.stderr.indexOf('Ideas/Idless Child.md'))
+      .toBeLessThan(rootResult.stderr.indexOf('Ideas/Middle.md'));
+
+    const middleResult = await runCLI([
+      'delete', '--type', 'idea', 'Middle', '--dry-run',
+    ], vaultDir);
+    expect(middleResult.exitCode).toBe(1);
+    expect(middleResult.stderr).toContain('Ideas/Leaf.md');
+
+    const leafResult = await runCLI(['delete', 'Leaf'], vaultDir, 'y\n');
+    expect(leafResult.exitCode, leafResult.stderr || leafResult.stdout).toBe(0);
+    expect(existsSync(leaf)).toBe(false);
+    expect(existsSync(root)).toBe(true);
+    expect(existsSync(middle)).toBe(true);
+  });
+
+  it('returns machine-readable JSON for child and duplicate refusals', async () => {
+    const parent = join(vaultDir, 'Ideas/Parent.md');
+    await writeFile(parent, idea(A));
+    await writeFile(join(vaultDir, 'Ideas/Child.md'), idea(B, A));
+
+    const childResult = await runCLI([
+      'delete', 'Parent', '--dry-run', '--output', 'json',
+    ], vaultDir);
+    expect(childResult.exitCode).toBe(1);
+    expect(JSON.parse(childResult.stdout)).toMatchObject({
+      success: false,
+      code: 1,
+      data: {
+        path: 'Ideas/Parent.md',
+        reason: 'has-fork-children',
+        childCount: 1,
+        children: [{ path: 'Ideas/Child.md', id: B }],
+      },
+    });
+
+    await writeFile(join(vaultDir, 'Ideas/Duplicate.md'), idea(A.toLowerCase()));
+    const duplicateResult = await runCLI([
+      'delete', 'Ideas/Parent.md', '--dry-run', '--output', 'json',
+    ], vaultDir);
+    expect(duplicateResult.exitCode).toBe(1);
+    expect(JSON.parse(duplicateResult.stdout)).toMatchObject({
+      success: false,
+      data: {
+        reason: 'duplicate-identity',
+        duplicates: ['Ideas/Duplicate.md', 'Ideas/Parent.md'],
+      },
+    });
+
+    const forced = await runCLI([
+      'delete', 'Ideas/Parent.md', '--force', '--output', 'json',
+    ], vaultDir);
+    expect(forced.exitCode).toBe(0);
+    expect(existsSync(parent)).toBe(false);
+    expect(existsSync(join(vaultDir, 'Ideas/Duplicate.md'))).toBe(true);
+    expect(existsSync(join(vaultDir, 'Ideas/Child.md'))).toBe(true);
+  });
+
+  it('guards actual single, scoped, bulk, and non-interactive flows before prompts or partial deletion', async () => {
+    const parent = join(vaultDir, 'Ideas/Parent.md');
+    const child = join(vaultDir, 'Ideas/Child.md');
+    const baseline = join(vaultDir, 'Ideas/Sample Idea.md');
+    await writeFile(parent, idea(A));
+    await writeFile(child, idea(B, A));
+
+    const attempts = [
+      ['delete', 'Parent'],
+      ['delete', '--type', 'idea', 'Parent', '--execute'],
+      ['delete', '--type', 'idea', '--execute'],
+      ['--non-interactive', 'delete', 'Parent'],
+    ];
+    for (const args of attempts) {
+      const result = await runCLI(args, vaultDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('fork lineage would be orphaned');
+      expect(existsSync(parent)).toBe(true);
+      expect(existsSync(child)).toBe(true);
+      expect(existsSync(baseline)).toBe(true);
+    }
+  });
+
+  it('allows non-force deletion when the target id is missing or malformed', async () => {
+    const missing = join(vaultDir, 'Ideas/Missing ID.md');
+    const malformed = join(vaultDir, 'Ideas/Malformed ID.md');
+    await writeFile(missing, idea(undefined));
+    await writeFile(malformed, idea('not-a-uuid'));
+
+    for (const target of ['Missing ID', 'Malformed ID']) {
+      const result = await runCLI(['delete', target], vaultDir, 'y\n');
+      expect(result.exitCode, result.stderr || result.stdout).toBe(0);
+    }
+    expect(existsSync(missing)).toBe(false);
+    expect(existsSync(malformed)).toBe(false);
+  });
+
+  it('makes bulk dry-run all-or-nothing and reports each blocked target', async () => {
+    await writeFile(join(vaultDir, 'Ideas/Parent.md'), idea(A));
+    await writeFile(join(vaultDir, 'Ideas/Child.md'), idea(B, A));
+    const result = await runCLI([
+      'delete', '--type', 'idea', '--output', 'json',
+    ], vaultDir);
+
+    expect(result.exitCode).toBe(1);
+    const output = JSON.parse(result.stdout);
+    expect(output.data.blocked).toEqual([expect.objectContaining({
+      path: 'Ideas/Parent.md',
+      reason: 'has-fork-children',
+    })]);
+    expect(output.error).not.toContain('would be deleted');
+    expect(existsSync(join(vaultDir, 'Ideas/Parent.md'))).toBe(true);
+    expect(existsSync(join(vaultDir, 'Ideas/Child.md'))).toBe(true);
+  });
+
+  it('treats self and two-node cycles as blocking direct-child edges', async () => {
+    await writeFile(join(vaultDir, 'Ideas/Self.md'), idea(A, A));
+    await writeFile(join(vaultDir, 'Ideas/Cycle A.md'), idea(B, C));
+    await writeFile(join(vaultDir, 'Ideas/Cycle B.md'), idea(C, B));
+
+    for (const target of ['Self', 'Cycle A', 'Cycle B']) {
+      const result = await runCLI(['delete', target, '--dry-run'], vaultDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('direct fork child');
+    }
+  });
+
+  it('--force deletes only the parent and leaves an audit-visible dangling reference', async () => {
+    const parent = join(vaultDir, 'Ideas/Parent.md');
+    const child = join(vaultDir, 'Ideas/Child.md');
+    await writeFile(parent, idea(A));
+    await writeFile(child, idea(B, A));
+
+    const deleted = await runCLI([
+      'delete', 'Parent', '--force', '--output', 'json',
+    ], vaultDir);
+    expect(deleted.exitCode, deleted.stderr || deleted.stdout).toBe(0);
+    expect(existsSync(parent)).toBe(false);
+    expect(existsSync(child)).toBe(true);
+    expect(await readFile(child, 'utf-8')).toContain(`forked-from: ${A}`);
+
+    const audit = await runCLI([
+      'audit', 'idea', '--only', 'dangling-forked-from', '--output', 'json',
+    ], vaultDir);
+    const issues = JSON.parse(audit.stdout).files
+      .flatMap((file: { issues: Array<{ code: string }> }) => file.issues);
+    expect(issues).toContainEqual(expect.objectContaining({ code: 'dangling-forked-from' }));
+  });
+
+  it('applies the guard to owned paths discovered under owner folders', async () => {
+    const ownerDir = join(vaultDir, 'Projects/Lineage Project');
+    const researchDir = join(ownerDir, 'research');
+    await mkdir(researchDir, { recursive: true });
+    await writeFile(join(ownerDir, 'Lineage Project.md'), `---\ntype: project\nstatus: active\n---\n`);
+    const parent = join(researchDir, 'Owned Parent.md');
+    await writeFile(parent, `---\ntype: research\nid: ${A}\nowner: "[[Lineage Project]]"\n---\n`);
+    await writeFile(join(researchDir, 'Owned Child.md'), `---\ntype: research\nid: ${B}\nforked-from: ${A}\nowner: "[[Lineage Project]]"\n---\n`);
+
+    const result = await runCLI([
+      'delete', 'Projects/Lineage Project/research/Owned Parent', '--dry-run',
+    ], vaultDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Owned Child.md');
+    expect(existsSync(parent)).toBe(true);
+  });
+});
+
+describe.sequential('fork versus delete lineage lock', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    await cleanupTestVault(vaultDir);
+  });
+
+  it.each([
+    ['legacy id-less', false],
+    ['valid id', true],
+  ])('never reports delete success with a concurrently created dangling child (%s)', async (_label, withId) => {
+    for (let iteration = 0; iteration < 6; iteration++) {
+      const sourceName = `Race Source ${withId ? 'ID' : 'Legacy'} ${iteration}`;
+      const childName = `Race Child ${withId ? 'ID' : 'Legacy'} ${iteration}`;
+      const sourcePath = join(vaultDir, `Ideas/${sourceName}.md`);
+      const childPath = join(vaultDir, `Ideas/${childName}.md`);
+      const sourceId = `aaaaaaaa-1111-4111-8111-${String(iteration).padStart(12, '0')}`;
+      await writeFile(sourcePath, idea(withId ? sourceId : undefined));
+
+      const [forked, deleted] = await Promise.all([
+        runCLI([
+          'new', '--fork', sourceName, '--name', childName, '--output', 'json',
+        ], vaultDir),
+        runCLI(['delete', sourceName], vaultDir, 'y\n'),
+      ]);
+
+      if (deleted.exitCode === 0) {
+        expect(forked.exitCode).toBe(1);
+        expect(existsSync(sourcePath)).toBe(false);
+        expect(existsSync(childPath)).toBe(false);
+      } else {
+        expect(forked.exitCode, forked.stderr || forked.stdout).toBe(0);
+        expect(deleted.stderr).toContain('fork lineage would be orphaned');
+        expect(existsSync(sourcePath)).toBe(true);
+        expect(existsSync(childPath)).toBe(true);
+      }
+    }
+  }, 60_000);
+});

--- a/tests/ts/lib/delete-lineage-guard.test.ts
+++ b/tests/ts/lib/delete-lineage-guard.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { assessDeleteLineage } from '../../../src/lib/delete-lineage-guard.js';
+import type { VaultNoteSnapshot, VaultNoteSnapshotEntry } from '../../../src/lib/discovery.js';
+
+const A = 'AAAAAAAA-1111-4111-8111-111111111111';
+const B = 'bbbbbbbb-2222-4222-8222-222222222222';
+
+function note(path: string, id?: unknown, parent?: unknown): VaultNoteSnapshotEntry {
+  return {
+    path: `/vault/${path}`,
+    relativePath: path,
+    frontmatter: {
+      type: 'idea',
+      ...(id !== undefined ? { id } : {}),
+      ...(parent !== undefined ? { 'forked-from': parent } : {}),
+    },
+  };
+}
+
+function snapshot(...notes: VaultNoteSnapshotEntry[]): VaultNoteSnapshot {
+  return { notes };
+}
+
+describe('delete lineage guard', () => {
+  it('allows a leaf and a target with a missing or malformed id', () => {
+    const leaf = note('Leaf.md', B, A);
+    const missing = note('Missing.md');
+    const malformed = note('Malformed.md', 'not-a-uuid');
+
+    expect(assessDeleteLineage(snapshot(leaf, missing, malformed), [
+      leaf.path,
+      missing.path,
+      malformed.path,
+    ])).toEqual({ blocked: [], missing: [] });
+  });
+
+  it('blocks direct children case-insensitively even when child ids are absent or malformed', () => {
+    const parent = note('Parent.md', A);
+    const missingId = note('Child A.md', undefined, A.toLowerCase());
+    const malformedId = note('Child B.md', 'bad', A.toLowerCase());
+    const result = assessDeleteLineage(snapshot(malformedId, parent, missingId), [parent.path]);
+
+    expect(result.missing).toEqual([]);
+    expect(result.blocked).toEqual([{
+      path: 'Parent.md',
+      reason: 'has-fork-children',
+      id: A,
+      childCount: 2,
+      children: [
+        { path: 'Child A.md' },
+        { path: 'Child B.md' },
+      ],
+    }]);
+  });
+
+  it('blocks duplicate target identity without children', () => {
+    const first = note('A.md', A);
+    const second = note('B.md', A.toLowerCase());
+    const result = assessDeleteLineage(snapshot(second, first), [first.path]);
+
+    expect(result.blocked).toEqual([{
+      path: 'A.md',
+      reason: 'duplicate-identity',
+      id: A,
+      duplicates: ['A.md', 'B.md'],
+    }]);
+  });
+
+  it('bounds self and two-note cycles while ignoring unrelated components', () => {
+    const self = note('Self.md', A, A);
+    const otherParent = note('Other.md', B);
+    const unrelatedChild = note('Other Child.md', undefined, B);
+    const result = assessDeleteLineage(
+      snapshot(unrelatedChild, otherParent, self),
+      [self.path]
+    );
+
+    expect(result.blocked[0]).toMatchObject({
+      path: 'Self.md',
+      reason: 'has-fork-children',
+      childCount: 1,
+    });
+    expect(result.blocked[0]?.children).toEqual([{ path: 'Self.md', id: A }]);
+  });
+
+  it('reports targets that vanished from the authoritative snapshot', () => {
+    expect(assessDeleteLineage(snapshot(), ['/vault/Gone.md'])).toEqual({
+      blocked: [],
+      missing: ['/vault/Gone.md'],
+    });
+  });
+});

--- a/tests/ts/lib/lineage-lock.test.ts
+++ b/tests/ts/lib/lineage-lock.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { existsSync } from 'fs';
-import { mkdtemp, mkdir, rm, utimes, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { mkdtemp, mkdir, readFile, readdir, rm, stat, unlink, utimes, writeFile } from 'fs/promises';
+import { basename, join } from 'path';
 import { tmpdir } from 'os';
 import {
   getLineageMutationLockPath,
@@ -73,7 +73,147 @@ describe('lineage mutation lock', () => {
     await withLineageMutationLocks(vaultDir, [source], async () => undefined);
     expect(existsSync(lockPath)).toBe(false);
   });
+
+  it('never steals an active lock whose mtime was forced beyond the stale threshold', async () => {
+    const source = join(vaultDir, 'Source.md');
+    const lockPath = getLineageMutationLockPath(vaultDir, source);
+    let releaseFirst!: () => void;
+    const barrier = new Promise<void>(resolve => { releaseFirst = resolve; });
+    let active = 0;
+    let maxActive = 0;
+
+    const first = withLineageMutationLocks(vaultDir, [source], async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await barrier;
+      active--;
+    });
+    while (!existsSync(lockPath)) await delay(1);
+
+    const old = new Date(Date.now() - 31_000);
+    await utimes(lockPath, old, old);
+    const second = withLineageMutationLocks(vaultDir, [source], async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      active--;
+    });
+
+    await delay(75);
+    expect(maxActive).toBe(1);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(maxActive).toBe(1);
+  });
+
+  it('heartbeats a held lock well below a configurable stale threshold', async () => {
+    const source = join(vaultDir, 'Source.md');
+    const lockPath = getLineageMutationLockPath(vaultDir, source);
+
+    await withLineageMutationLocks(vaultDir, [source], async () => {
+      const initial = (await stat(lockPath)).mtimeMs;
+      await delay(80);
+      const heartbeat = (await stat(lockPath)).mtimeMs;
+      expect(heartbeat).toBeGreaterThan(initial);
+      expect(Date.now() - heartbeat).toBeLessThan(60);
+    }, { staleMs: 90, heartbeatMs: 10 });
+  });
+
+  it('recovers stale locks owned by dead PIDs and stale corrupt locks', async () => {
+    const source = join(vaultDir, 'Source.md');
+    const lockPath = getLineageMutationLockPath(vaultDir, source);
+    await mkdir(join(vaultDir, '.bwrb', 'locks'), { recursive: true });
+    await writeFile(lockPath, lockMetadata(lockPath, deadPid(), 'dead-owner'));
+    const old = new Date(Date.now() - 31_000);
+    await utimes(lockPath, old, old);
+
+    await withLineageMutationLocks(vaultDir, [source], async () => undefined);
+    expect(existsSync(lockPath)).toBe(false);
+
+    await writeFile(lockPath, 'not-json\n');
+    await utimes(lockPath, old, old);
+    await withLineageMutationLocks(vaultDir, [source], async () => undefined);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('does not recover a fresh corrupt lock', async () => {
+    const source = join(vaultDir, 'Source.md');
+    const lockPath = getLineageMutationLockPath(vaultDir, source);
+    await mkdir(join(vaultDir, '.bwrb', 'locks'), { recursive: true });
+    await writeFile(lockPath, 'not-json\n');
+
+    await expect(withLineageMutationLocks(
+      vaultDir,
+      [source],
+      async () => undefined,
+      { attempts: 8, retryMs: 2, staleMs: 100 }
+    )).rejects.toThrow('Timed out waiting for a fork-lineage mutation lock');
+    expect(await readFile(lockPath, 'utf-8')).toBe('not-json\n');
+  });
+
+  it('does not let an old holder release a replacement lock with another token', async () => {
+    const source = join(vaultDir, 'Source.md');
+    const lockPath = getLineageMutationLockPath(vaultDir, source);
+    const replacement = lockMetadata(lockPath, process.pid, 'replacement-owner');
+
+    await withLineageMutationLocks(vaultDir, [source], async () => {
+      await unlink(lockPath);
+      await writeFile(lockPath, replacement);
+    });
+
+    expect(await readFile(lockPath, 'utf-8')).toBe(replacement);
+    await unlink(lockPath);
+  });
+
+  it.each([2, 10])('admits only one of %i contenders after stale-owner recovery and leaves no artifacts', async contenderCount => {
+    const source = join(vaultDir, 'Source.md');
+    const lockPath = getLineageMutationLockPath(vaultDir, source);
+    const lockDirectory = join(vaultDir, '.bwrb', 'locks');
+    await mkdir(lockDirectory, { recursive: true });
+    await writeFile(lockPath, lockMetadata(lockPath, deadPid(), 'crashed-owner'));
+    const old = new Date(Date.now() - 31_000);
+    await utimes(lockPath, old, old);
+
+    let active = 0;
+    let maxActive = 0;
+    await Promise.all(Array.from({ length: contenderCount }, () =>
+      withLineageMutationLocks(vaultDir, [source], async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await delay(10);
+        active--;
+      }, { retryMs: 2 })
+    ));
+
+    expect(maxActive).toBe(1);
+    const artifacts = (await readdir(lockDirectory))
+      .filter(entry => entry.startsWith(basename(lockPath)));
+    expect(artifacts).toEqual([]);
+  });
 });
+
+function lockMetadata(lockPath: string, pid: number, token: string): string {
+  const now = Date.now() - 31_000;
+  return `${JSON.stringify({
+    version: 1,
+    pid,
+    token,
+    createdAt: now,
+    heartbeatAt: now,
+    pathKey: basename(lockPath),
+  })}\n`;
+}
+
+function deadPid(): number {
+  const candidates = [2_147_483_647, 2_000_000_000, 1_500_000_000];
+  for (const pid of candidates) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ESRCH') return pid;
+    }
+  }
+  throw new Error('Could not find an unused PID for stale-lock testing');
+}
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));

--- a/tests/ts/lib/lineage-lock.test.ts
+++ b/tests/ts/lib/lineage-lock.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync } from 'fs';
+import { mkdtemp, mkdir, rm, utimes, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  getLineageMutationLockPath,
+  withLineageMutationLocks,
+} from '../../../src/lib/lineage-lock.js';
+
+describe('lineage mutation lock', () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await mkdtemp(join(tmpdir(), 'bwrb-lineage-lock-'));
+  });
+
+  afterEach(async () => {
+    await rm(vaultDir, { recursive: true, force: true });
+  });
+
+  it('uses a stable vault-relative path key and cleans up after success and failure', async () => {
+    const source = join(vaultDir, 'Ideas', 'Source.md');
+    const sameSource = join(vaultDir, 'Ideas', '.', 'Source.md');
+    expect(getLineageMutationLockPath(vaultDir, source))
+      .toBe(getLineageMutationLockPath(vaultDir, sameSource));
+
+    const lockPath = getLineageMutationLockPath(vaultDir, source);
+    await withLineageMutationLocks(vaultDir, [source], async () => {
+      expect(existsSync(lockPath)).toBe(true);
+    });
+    expect(existsSync(lockPath)).toBe(false);
+
+    await expect(withLineageMutationLocks(vaultDir, [source], async () => {
+      throw new Error('boom');
+    })).rejects.toThrow('boom');
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('acquires multiple locks in deterministic order without deadlock', async () => {
+    const a = join(vaultDir, 'A.md');
+    const b = join(vaultDir, 'B.md');
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const firstBarrier = new Promise<void>(resolve => { releaseFirst = resolve; });
+
+    const first = withLineageMutationLocks(vaultDir, [b, a], async () => {
+      order.push('first-start');
+      await firstBarrier;
+      order.push('first-end');
+    });
+    while (!order.includes('first-start')) await delay(1);
+
+    const second = withLineageMutationLocks(vaultDir, [a, b], async () => {
+      order.push('second');
+    });
+    await delay(50);
+    expect(order).toEqual(['first-start']);
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(['first-start', 'first-end', 'second']);
+  });
+
+  it('removes a lock older than the shared 30-second stale threshold', async () => {
+    const source = join(vaultDir, 'Source.md');
+    const lockPath = getLineageMutationLockPath(vaultDir, source);
+    await mkdir(join(vaultDir, '.bwrb', 'locks'), { recursive: true });
+    await writeFile(lockPath, 'stale\n');
+    const old = new Date(Date.now() - 31_000);
+    await utimes(lockPath, old, old);
+
+    await withLineageMutationLocks(vaultDir, [source], async () => undefined);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+});
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary

- refuse non-force deletion of notes with direct fork children or duplicate stable IDs
- coordinate `new --fork` and non-force delete with path-keyed lineage mutation locks
- preserve forced-delete behavior while leaving child provenance visible to audit
- document the contract and add guard, lock, CLI-mode, ownership, and race coverage

## Verification

- `pnpm build`
- `pnpm verify:pack`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm test -- --exclude='**/*.pty.test.ts'` (2967 passed, 3 skipped)
- `BWRB_TEST_DIST=1 pnpm test -- tests/ts/commands/delete-lineage.test.ts` (10 passed)
