### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,25 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-07-09
+
+Patch release for document forking, lineage inspection, and fork-safe deletion.
+
 ### Added
 
+- **Relative-date fields** — schema-defined `relative-date` values position notes before, after, or equal to other notes, with query-time resolution and audit warnings for invalid chains (#789).
+- **Custom calendars** — vault schemas can define fictional or alternative calendars for native date validation, sorting, comparisons, JSON output, audit, and relative-date anchors (#792).
 - **Document forks** — `bwrb new --fork <target>` creates a sibling document with a fresh stable ID and immutable `forked-from` provenance while preserving the source body and prior work.
 - **Fork lineage inspection** — `bwrb list --lineage <target>` renders the complete connected fork component—including sibling and cousin branches—in tree, paths, link, content, or JSON form, resolving targets by exact path, name, alias, or case-insensitive UUID.
 - **Fork-safe deletion** — `bwrb delete` refuses notes with direct fork children or duplicate identities unless `--force` is supplied; forced deletion leaves child `forked-from` provenance intact for audit.
+
+### Changed
+
+- **Unified note discovery** — `bwrb list` is now the canonical surface for finding, filtering, inspecting, linking, and opening notes; `search` and `open` remain available as hidden compatibility commands (#801).
+
+### Fixed
+
+- **JSON-mode command completion** — resolved-target edits and prompt-mode commands now exit cleanly when stdin remains open, while `edit --json --open` emits one coherent JSON result with consistent open metadata (#794, #797, #798, #800).
 
 ## [0.2.2] - 2026-07-04
 

--- a/docs-site/src/content/docs/changelog.md
+++ b/docs-site/src/content/docs/changelog.md
@@ -9,11 +9,15 @@ For the complete changelog with all details, see [CHANGELOG.md](https://github.c
 
 ## Recent Highlights
 
-### Unreleased
+### 0.2.3
 
+- **Relative-date fields** — position notes before, after, or equal to other notes, with query-time resolution and audit warnings for invalid chains
+- **Custom calendars** — define fictional or alternative calendars for date validation, sorting, comparisons, JSON output, audit, and relative-date anchors
 - **Document forks** — `bwrb new --fork <target>` creates an ordinary sibling note with a fresh ID and immutable immediate-source provenance
 - **Fork lineage inspection** — `bwrb list --lineage <target>` renders the complete connected fork component, including sibling and cousin branches, as a tree, paths, links, content, or structured JSON
 - **Fork-safe deletion** — `bwrb delete` refuses notes with direct fork children or duplicate identities unless forced, preserving child provenance for audit when the parent is deliberately removed
+- **Unified note discovery** — `bwrb list` is the canonical surface for finding, filtering, inspecting, linking, and opening notes; `search` and `open` remain available for compatibility
+- **JSON-mode reliability** — edit, open, and prompt-mode commands exit cleanly with one coherent JSON result even when stdin remains open
 
 ### 0.2.2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bwrb",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Schema-driven note management for markdown vaults",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What changed

- bump the npm package version from `0.2.2` to `0.2.3`
- cut the accumulated changelog entries into the v0.2.3 release
- reconcile release highlights with every merge since v0.2.2: relative dates, custom calendars, JSON-mode reliability, unified note discovery, and document forking/lineage

## Why

Prepare the exact package metadata and release notes for the v0.2.3 npm and GitHub release.

## Validation

- `pnpm build`
- `pnpm verify:pack` (packaged CLI reports `0.2.3`)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm test -- --exclude='**/*.pty.test.ts'` — 2,974 passed, 3 skipped
- `git diff --check`