### PR TITLE
Harden lineage locks across processes and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,33 @@ jobs:
         env:
           BWRB_TEST_DIST: 1
 
+  windows_lock_tests:
+    name: Windows Lock Tests
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run focused lineage lock tests
+        run: pnpm exec vitest run tests/ts/lib/lineage-lock.test.ts tests/ts/lib/lineage-lock-cross-process.test.ts tests/ts/lib/note-id-lock.test.ts tests/ts/commands/delete-lineage.test.ts
+
   test-pty:
     name: PTY Tests
     runs-on: ubuntu-latest

--- a/.task-sweep/logs/claude-fable-5-plan-20260710-103418-issue-807.log
+++ b/.task-sweep/logs/claude-fable-5-plan-20260710-103418-issue-807.log
@@ -1,0 +1,6 @@
+model_requested: anthropic/claude-fable-5
+model_returned: anthropic/claude-5-fable-20260609
+finish_reason: stop
+output: .task-sweep/logs/claude-fable-5-plan-output-20260710-103418-issue-807.md
+chars: 7822 words: 1124
+preview: # Implementation Plan — Issue #807\n\n## 1. Production changes for Windows semantics (keep minimal)\n\n**Principle: preserve fail-closed timeout behavior.** Windows sharing violations during recovery should be treated as "holder may be alive" and retried within the acquisition loop — never as license to steal.\n\nSmallest set of changes:\n\n- **Classify errors in `readLockSnapshot` instead of swallowing everything.** Distinguish: `ENOENT` (gone, retry acquire), `EBUSY`/`EPERM`/`EACCES` on Windows (likely open handle → treat as live holder, back off), parse errors (corrupt → existing quarantine path). Return a discriminated result (`{ kind: 'missing' | 'busy' | 'corrupt' | 'ok', ... }`) rather than `null`. This is the single most important seam.\n- **Recovery rename/unlink:** wrap the quarantine `re

--- a/.task-sweep/logs/claude-fable-5-plan-output-20260710-103418-issue-807.md
+++ b/.task-sweep/logs/claude-fable-5-plan-output-20260710-103418-issue-807.md
@@ -1,0 +1,65 @@
+# Implementation Plan — Issue #807
+
+## 1. Production changes for Windows semantics (keep minimal)
+
+**Principle: preserve fail-closed timeout behavior.** Windows sharing violations during recovery should be treated as "holder may be alive" and retried within the acquisition loop — never as license to steal.
+
+Smallest set of changes:
+
+- **Classify errors in `readLockSnapshot` instead of swallowing everything.** Distinguish: `ENOENT` (gone, retry acquire), `EBUSY`/`EPERM`/`EACCES` on Windows (likely open handle → treat as live holder, back off), parse errors (corrupt → existing quarantine path). Return a discriminated result (`{ kind: 'missing' | 'busy' | 'corrupt' | 'ok', ... }`) rather than `null`. This is the single most important seam.
+- **Recovery rename/unlink:** wrap the quarantine `rename` and `unlink` in a small retry that treats `EBUSY`/`EPERM`/`EACCES`/`ENOTEMPTY` as transient; after N attempts, fall through to the normal wait loop (fail-closed). On Windows a rename of an open file fails — that's evidence the holder is alive, which is the correct outcome.
+- **Identity check in token-safe release:** on Windows, `ino`/`dev` from `fs.stat` are frequently 0 or unstable across filesystems. Gate the inode/dev comparison behind `stat.ino !== 0 && stat.dev !== 0` (or a platform check), falling back to token + mtime + size. Do not weaken the token check itself.
+- **`process.kill(pid, 0)`** works on Windows Node for liveness (throws `ESRCH` for dead PIDs); no change needed, but add a test asserting the semantics you rely on. Note the known caveat: PID reuse — TTL + heartbeat already mitigates; document it in a comment, don't engineer around it.
+- **`handle.utimes` heartbeat:** verify on Windows CI; if it fails on open handles (unlikely), fall back to path-based `utimes` on the owned lock. Don't preemptively change.
+
+Do **not** add flock/LockFileEx native bindings or restructure the metadata format.
+
+## 2. Deterministic cross-process test harness
+
+Design a small child-process fixture, not in-process promises:
+
+- **Fixture script** (`tests/ts/fixtures/lock-holder.mjs` or `.ts` run via `tsx`/compiled): a child that acquires the lock on a given path, writes structured events (`acquired`, `heartbeat`, `entered-critical`, `exited-critical`, `released`) to stdout as NDJSON, and responds to stdin commands (`hold`, `release`, `crash` via `process.exit(1)` without cleanup, `kill` self via SIGKILL where supported / `process.abort()` on Windows).
+- **Injectable timing:** thread TTL/heartbeat/poll intervals through env vars (`BWRB_LOCK_TTL_MS` etc.) read by `lineage-lock.ts` (or an options object the fixture passes). Use ~50–200ms values in tests.
+- **Scenarios (all real `spawn`, deterministic via event handshakes, not sleeps):**
+  1. *Live-holder protection:* child A acquires + heartbeats; child B attempts with short timeout → B times out; assert lock file still owned by A's token.
+  2. *Dead-holder recovery + successor ownership:* A acquires then `crash`es; B acquires after TTL; assert B's token in lock file, no `.recovery`/`.quarantine-*` residue after B releases.
+  3. *No overlap:* N=4 children loop through the critical section appending `enter:<pid>`/`exit:<pid>` to a shared journal file (append-only writes); parent asserts strict alternation — every `enter` is followed by its own `exit` before any other `enter`. Bounded iterations (e.g., 20 each) keep it deterministic-enough and fast.
+  4. *Cleanup:* after all children exit, lock dir contains no lock/recovery/quarantine artifacts.
+- **Mutation-kill check:** verify the harness fails on a broken implementation by temporarily (in a review note, not committed) disabling the token check — scenario 3 should catch overlap. Mention this validation in the PR description; don't commit a mutation-testing framework.
+- Run these under the regular non-PTY suite; they must pass on both OSes. Guard flaky primitives (e.g., SIGKILL) with platform-appropriate crash modes.
+
+## 3. CI shape
+
+- Add a **separate matrix job or standalone `windows-tests` job** in `ci.yml`: `windows-latest`, Node 22, pnpm 10.11.0, running **only** build + typecheck + a focused test glob (`vitest run tests/ts/lib/lineage-lock* tests/ts/lib/note-id-lock* tests/ts/commands/delete-lineage*` plus the new cross-process file). Do not run PTY tests or the full suite on Windows.
+- Do **not** touch the existing required-check names (`Test`, `PTY Tests`, `Vercel`). The Windows job is additive; whether it becomes required is a repo-policy decision outside this PR — flag it in the PR description.
+- Cache pnpm store; use `vitest run` explicitly (no watch). Set generous but bounded timeouts (Windows FS is slower).
+
+## 4. Delete-disappearance contract
+
+- New typed error, e.g. `DeleteTargetDisappearedError` in the delete/lineage module, thrown by `assessCurrentDeleteLineage` (or the call site) **only** when the target was present at selection but missing under lock. Carry `{ paths: string[], retryable: true }`.
+- **Text:** `Target was deleted by another process while waiting for the lock: <relative-path>. Re-run to confirm.` Exit with the existing validation/retryable error class, not generic IO.
+- **JSON:** `{ success: false, error: "<same text>", code: "TARGET_DISAPPEARED", retryable: true, paths: ["..."] }`. Yes to `retryable` and paths; skip a separate `reason` field — the code is the reason. Confirm `TARGET_DISAPPEARED` fits the existing error-code enum conventions before inventing it; if codes are a closed set, extend it in one place.
+- **Do not change** initial-selection `ENOENT` behavior (`File not found or already deleted`, `IO_ERROR`).
+- Bulk path: if bulk delete flows through the same under-lock assessor, classify per-path — disappeared targets reported with the new code, others processed normally. If bulk uses a different assessor, cover only the shared path and note the gap.
+
+## 5. Verification, docs, failure modes
+
+**Focused checks:**
+- New `tests/ts/lib/lineage-lock-crossproc.test.ts` (scenarios above).
+- New delete test: acquire the lock from a helper child, delete the target file out-of-band, release; assert delete emits the new text/JSON code and leaves no lock artifacts.
+- Existing lineage-lock, note-id-lock, delete-lineage suites unchanged and green.
+- Real CLI: `bwrb delete <path>` and `--json` variant against the staged disappearance scenario.
+
+**Full parity in exact order:** build → verify:pack → typecheck → lint → knip → non-PTY tests.
+
+**Docs:** update `docs-site/src/content/docs/` delete command page with the new error text/JSON code; update `docs/skill/SKILL.md` since command behavior (error contract) changes. Changelog entry per repo convention.
+
+**Likely failure modes:** knip flagging the child fixture as unused (add to knip entry config); Windows CI pnpm/tsx path issues; test flakes from too-tight TTLs on slow Windows runners (use handshakes, not timing assertions); fixture zombie processes (always `kill` in `afterEach`); NDJSON stdout buffering (flush per line, read incrementally).
+
+## 6. Scope traps / #820 boundaries
+
+- **Do not** generalize the lock into an edit/identity-write primitive, add write-intent modes, or refactor `withOwnershipFileLock`'s public API for future consumers. The only shareable artifact is the injectable-timing option and error-classified `readLockSnapshot`, both of which #807 needs anyway.
+- Do not reopen or re-test the #817 old-holder/successor fix beyond the successor scenario already in the cross-process harness (which covers it as a side effect — fine, but don't duplicate `note-id-lock.test.ts` logic).
+- Do not touch fork/adopt logic; only the delete under-lock recheck classification.
+- Keep the Windows job additive; changing required checks or branch protection is out of scope.
+- Open a **draft PR** only; do not mark ready or merge.

--- a/.task-sweep/logs/claude-fable-5-plan-prompt-20260710-103418-issue-807.md
+++ b/.task-sweep/logs/claude-fable-5-plan-prompt-20260710-103418-issue-807.md
@@ -1,0 +1,88 @@
+# TaskSweep early planning packet — BWRB issue #807
+
+You are advising on a repository task before implementation. You have no tools. Do not claim to inspect anything outside this packet. Give concise advice to another implementation agent; do not mutate anything or broaden beyond the issue.
+
+## Normalized task
+
+- ID/source: GitHub issue #807, `https://github.com/3mdistal/bwrb/issues/807`
+- Title: Harden lineage lock portability and cross-process errors
+- Repo/base: `3mdistal/bwrb`, `origin/main` at `55dfc19887d9442fe0d3c94b28ac01b18c7012a0`
+- Branch/lane: `codex/807-lineage-lock-hardening` in an isolated worktree
+- Problem: PR #806 added path-keyed cross-process locks for `new --fork` and non-force delete. Current tests prove ownership, heartbeats, stale/dead recovery, token-safe release, contenders, and CLI races on the local platform, but the issue still asks for explicit Windows/open-handle coverage, a deterministic cross-process stress harness, and a stable error when a delete target disappears while the command waits for its authoritative lock.
+- Desired outcome:
+  1. The shared lineage/ownership lock preserves mutual exclusion and cleans its lock/recovery/quarantine artifacts on supported POSIX and Windows environments, with a focused Windows CI lane or equivalent harness.
+  2. A deterministic multi-process test—not merely in-process promises or probabilistic CLI races—proves live-holder protection, dead-holder recovery, successor ownership, no overlapping critical sections, and cleanup.
+  3. Non-force delete classifies a target that disappears between initial selection and the under-lock recheck with stable documented text and JSON behavior, rather than a generic raw or misleading `ENOENT`.
+  4. Existing fork, adopt, delete-lineage, note-ID-lock, and full repository suites remain green.
+- Manual successful story: As a vault owner running competing BWRB processes, a crashed lineage mutator cannot leave the vault permanently locked and live/successor holders cannot overlap or have their locks stolen. If another process deletes my target while my non-force delete waits, BWRB returns a clear retryable result and leaves no lock debris.
+- Merge is authorized only after the full TaskSweep and repository-policy gates. The implementer must open a draft PR and must not ready or merge it.
+
+## Repo facts and standards
+
+- TypeScript ESM Commander CLI; Node 22; pnpm 10.11.0.
+- Required checks: `Test`, `PTY Tests`, `Vercel`; strict up-to-date branch protection; zero required approvals.
+- Full local parity in exact order: build, verify:pack, typecheck, lint, knip, non-PTY test suite.
+- Canonical user docs live in `docs-site/src/content/docs/`; bundled agent guidance is `docs/skill/SKILL.md` when command behavior changes.
+- Current `.github/workflows/ci.yml` runs Linux/Ubuntu only. A Windows-focused job must avoid silently testing a different contract and must remain practical for PR CI.
+- Use `pnpm test`/Vitest run semantics; do not invoke watch mode.
+
+## Current implementation
+
+### Ownership-safe shared lock
+
+`src/lib/lineage-lock.ts` now exposes `withLineageMutationLocks` and `withOwnershipFileLock`. It:
+
+- derives deterministic SHA-256 lock paths from normalized vault-relative source paths;
+- writes JSON metadata `{ version, pid, token, createdAt, heartbeatAt, pathKey }` under exclusive `open(..., 'wx')`;
+- heartbeats the owned open handle with `handle.utimes`;
+- checks process liveness with `process.kill(pid, 0)` after TTL expiry;
+- uses a fixed `.recovery` ownership marker, rechecks stale state, renames stale locks to unique `.quarantine-*` paths, unlinks quarantine, and cleans stale quarantine files;
+- releases only when the token plus snapshot raw/dev/inode/mtime/size still match;
+- sorts multi-lock acquisition to avoid deadlock.
+
+PR #817 generalized this primitive for the fixed note-ID assignment and registry lock paths after an independent tester reproduced an old-holder/successor overlap bug. New `tests/ts/lib/note-id-lock.test.ts` covers heartbeat and successor ownership in process, but not a true child-process stress harness. This partially satisfies #807; do not duplicate it or reopen the fixed race.
+
+Potential portability seams to examine:
+
+- `readLockSnapshot` catches every read/stat error and returns null, erasing distinctions such as Windows sharing/permission errors.
+- stale recovery renames then unlinks a lock pathname; Windows open-handle rules differ from POSIX.
+- `cleanupQuarantines` unlinks matching paths concurrently and ignores errors.
+- `process.kill(pid, 0)`, inode/dev identity, and open-handle `utimes` need actual Windows evidence.
+- tests currently synthesize dead PIDs and contenders in one Vitest process.
+
+### Delete disappearance behavior
+
+Single non-force delete resolves a file, performs prompts/backlink work, then:
+
+```ts
+await withLineageMutationLocks(vaultDir, [fullPath], async () => {
+  const assessment = await assessCurrentDeleteLineage(schema, vaultDir, [file]);
+  if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
+  await unlink(fullPath);
+  await unregisterIssuedNotePath(vaultDir, relativePath);
+});
+```
+
+`assessCurrentDeleteLineage` rebuilds a fresh snapshot. If the selected path is now missing it creates an `Error("File not found or no longer managed: ...")` and assigns `error.code = 'ENOENT'`. The outer delete command collapses all `ENOENT` errors to:
+
+- text: `File not found or already deleted`, exit validation error;
+- JSON: `{ success: false, error: "File not found or already deleted", code: IO_ERROR }`.
+
+The issue asks for stable classification of the specific between-selection-and-lock disappearance. Consider a narrow typed error with a retryable machine-readable payload/code and documented wording, without changing unrelated initial not-found behavior. Cover bulk and single paths if they share the same under-lock assessor.
+
+### Existing tests
+
+- `tests/ts/lib/lineage-lock.test.ts`: deterministic lock path, cleanup, ordered multi-lock acquisition, TTL recovery, live-holder protection, heartbeat, dead/corrupt recovery, token-safe replacement, 2/10 in-process contenders, recovery-marker ownership, timeout.
+- `tests/ts/lib/note-id-lock.test.ts`: both fixed note-ID lock paths, heartbeat/live holder, successor preservation and third-holder serialization.
+- `tests/ts/commands/delete-lineage.test.ts`: non-force guard behavior and a real CLI fork-versus-delete race, but no deterministic target-disappears-while-waiting scenario.
+
+## Planning questions
+
+Give a concise implementation plan covering:
+
+1. The smallest production-code changes needed for supported Windows semantics. Should recovery retry specific Windows sharing errors, avoid relying on inode identity when unavailable, or preserve current fail-closed timeout behavior?
+2. A deterministic cross-process Vitest/worker design that runs on POSIX and Windows, uses short injectable timing, proves no overlap and artifact cleanup, and would fail on a deliberately broken ownership implementation.
+3. The safest CI shape for Windows coverage without destabilizing unrelated PTY/full-suite jobs.
+4. A stable text/JSON contract and typed error for a delete target disappearing during the authoritative under-lock recheck, including whether the JSON payload should include `retryable`, `reason`, and target paths.
+5. Exact focused and real CLI checks, docs/changelog changes, and likely failure modes.
+6. Scope traps or conflicts with the later #820 edit/identity-write concurrency task. Keep #820 out of this PR unless a tiny reusable primitive is strictly necessary.

--- a/.task-sweep/logs/claude-fable-5-review-20260710-113900-issue-807.log
+++ b/.task-sweep/logs/claude-fable-5-review-20260710-113900-issue-807.log
@@ -1,0 +1,6 @@
+model_requested: anthropic/claude-fable-5
+model_returned: anthropic/claude-5-fable-20260609
+finish_reason: length
+output: /Users/alicemoore/Developer/bwrb-worktrees/issue-807-lineage-lock/.task-sweep/logs/claude-fable-5-review-output-20260710-113900-issue-807.md
+chars: 1995 words: 218
+preview: BLOCKERS\n\n## SPEC FIDELITY\n\n**Blocker**\n1. **Unrequested scope: committed agent artifacts.** `.task-sweep/logs/claude-fable-5-plan-20260710-103418-issue-807.log`, `...-plan-output-...md`, and `...-plan-prompt-...md` are internal planning logs/prompts (including the full planning packet and repo internals) committed into the repo. Nothing in the spec or repo conventions calls for shipping these; they are accidental artifacts and should be removed before merge.\n\n**Met**\n- Windows CI lane: additive `windows_lock_tests` job (`.github/workflows/ci.yml:151-176`); does not rename required checks, Node 22 / pnpm 10.11.0 per standards.\n- Deterministic real cross-process harness: `tests/ts/fixtures/lineage-lock-worker.ts` + `tests/ts/lib/lineage-lock-cross-process.test.ts` cover live-holder protecti

--- a/.task-sweep/logs/claude-fable-5-review-attempt2-20260710-113900-issue-807.log
+++ b/.task-sweep/logs/claude-fable-5-review-attempt2-20260710-113900-issue-807.log
@@ -1,0 +1,7 @@
+model_requested: anthropic/claude-fable-5
+model_returned: anthropic/claude-5-fable-20260609
+finish_reason: length
+output: /Users/alicemoore/Developer/bwrb-worktrees/issue-807-lineage-lock/.task-sweep/logs/claude-fable-5-review-output-attempt2-20260710-113900-issue-807.md
+chars: 0 words: 0
+warning: response content was empty/null; inspect finish_reason and increase --max-tokens if needed.
+preview: 

--- a/.task-sweep/logs/claude-fable-5-review-context-20260710-114400-issue-807.log
+++ b/.task-sweep/logs/claude-fable-5-review-context-20260710-114400-issue-807.log
@@ -1,0 +1,6 @@
+model_requested: anthropic/claude-fable-5
+model_returned: anthropic/claude-5-fable-20260609
+finish_reason: stop
+output: /Users/alicemoore/Developer/bwrb-worktrees/issue-807-lineage-lock/.task-sweep/logs/claude-fable-5-review-context-output-20260710-114400-issue-807.md
+chars: 3888 words: 489
+preview: NO BLOCKERS\n\n## SPEC FIDELITY\n\nAll three follow-up requirements are implemented and consistent with the acceptance evidence:\n\n- **Windows coverage**: additive `windows_lock_tests` job (`.github/workflows/ci.yml:151–177`) builds then runs the focused lock/delete suites; job name is new so required checks (`Test`, `PTY Tests`, `Vercel`) are untouched, per TaskSweep.\n- **Deterministic real cross-process stress**: `tests/ts/fixtures/lineage-lock-worker.ts` + `tests/ts/lib/lineage-lock-cross-process.test.ts` use real `spawn`, NDJSON handshakes (not sleeps), sentinel-based overlap detection, dead-holder crash/recovery, successor protection, and artifact cleanup assertions.\n- **Disappearance classification**: `DeleteTargetDisappearedError` (`src/commands/delete.ts:907–914`) is thrown only from th

--- a/.task-sweep/logs/claude-fable-5-review-context-output-20260710-114400-issue-807.md
+++ b/.task-sweep/logs/claude-fable-5-review-context-output-20260710-114400-issue-807.md
@@ -1,0 +1,26 @@
+NO BLOCKERS
+
+## SPEC FIDELITY
+
+All three follow-up requirements are implemented and consistent with the acceptance evidence:
+
+- **Windows coverage**: additive `windows_lock_tests` job (`.github/workflows/ci.yml:151–177`) builds then runs the focused lock/delete suites; job name is new so required checks (`Test`, `PTY Tests`, `Vercel`) are untouched, per TaskSweep.
+- **Deterministic real cross-process stress**: `tests/ts/fixtures/lineage-lock-worker.ts` + `tests/ts/lib/lineage-lock-cross-process.test.ts` use real `spawn`, NDJSON handshakes (not sleeps), sentinel-based overlap detection, dead-holder crash/recovery, successor protection, and artifact cleanup assertions.
+- **Disappearance classification**: `DeleteTargetDisappearedError` (`src/commands/delete.ts:907–914`) is thrown only from the under-lock recheck (`classifyMissingAsDisappeared=true` at 685, 868); initial-selection ENOENT path preserved (930–935). Docs (`docs-site/.../delete.md:104–133`), SKILL.md, and both changelogs match the implemented text/JSON (`code: 2`, `data.reason/retryable/paths`) and the built-CLI test assertions exactly.
+- **Scope**: no #820 edit-vs-lineage work; lock changes are fail-closed classification only. `.task-sweep/logs/` files are sanctioned per additional context.
+
+Note: merge remains contingent on the separately-running GitHub Windows gate, as the spec itself states. That is external to this packet and not a diff defect.
+
+## STANDARDS AND RISK
+
+No blockers. Non-blocking suggestions:
+
+1. **Self-heartbeat skipped on `busy`** (`src/lib/lineage-lock.ts:216–223`): if `readLockSnapshot` of the holder's *own* lock returns `busy`, `handle.utimes` is skipped. Persistent transient errors would let the mtime go stale; a holder that stops other liveness signals could degrade toward recovery pressure. Low likelihood (holder has the handle open), but consider heartbeating on `busy` since the handle identity check already protects against touching a replacement.
+2. **Release on `busy` leaves an orphan** (`unlinkIfOwned`, lines ~389–396): transient error during token-safe release returns `false` silently, leaving a live-PID lock that only clears after staleness. Fail-closed and self-healing, but worth a short retry or a debug log.
+3. **`readLockSnapshot` now rethrows unclassified errors** (lines ~365) where it previously returned `null`. This surfaces new failure modes on exotic filesystems (e.g., `EIO`, `EMFILE`). Acceptable, but confirm the acquisition loop's `continue` after `recoverStaleLock` doesn't skip attempt counting/delay under repeated transient recovery failures (loop body not fully visible in the diff).
+4. **Plural disappearance message untested/undocumented**: `Delete targets disappeared...` (delete.ts:911) has no test and no doc example; docs show only the single-target form.
+5. **CI job uses `pnpm exec vitest run`** (ci.yml:176) rather than `pnpm test`. The standard scopes `pnpm test` to local execution and the command is non-watch, so this is acceptable, but a focused `test:windows` script would keep invocation conventions in one place. Adding `pnpm typecheck` to the Windows job would also cheaply catch platform-conditional type issues.
+6. **Timing allowance in the JSON CLI test** (`expectStillRunningFor`, cross-process test ~line 342): acknowledged in the comment; residual flake risk on slow Windows runners. If it flakes, consider an observable selection-complete marker instead of the bounded alive check.
+7. **`chmod 0o000` test** (`lineage-lock.test.ts:153`) will pass on non-root runners but would silently succeed-to-read under root; the `skipIf(win32)` guard is right — consider also skipping when `process.getuid?.() === 0`.
+
+Docs-vs-implementation check: delete.md JSON example, SKILL.md contract, and both changelog entries all match the code and tests. Knip entry for the worker fixture is semantically justified per AGENTS.md.

--- a/.task-sweep/logs/claude-fable-5-review-context-prompt-20260710-114400-issue-807.md
+++ b/.task-sweep/logs/claude-fable-5-review-context-prompt-20260710-114400-issue-807.md
@@ -1,0 +1,1227 @@
+You are reviewing an embedded pull request diff for correctness bugs, missed edge cases, security issues, test gaps, documentation drift, runtime risk, and release risk.
+
+Review on two separate axes:
+- SPEC FIDELITY: missing or partial requirements, wrong behavior, and unrequested scope.
+- STANDARDS AND RISK: documented repo conventions plus correctness, security, tests, runtime behavior, and maintainability.
+
+The repo's documented standards override generic advice.
+
+Constraints:
+- Review only the embedded task/spec, standards, and diff below.
+- Do not use tools.
+- Do not edit files or take any repository/GitHub action.
+- Treat this as a PR readiness gate.
+- Cite file paths and line numbers where possible.
+- Start with exactly one verdict label: BLOCKERS, NON-BLOCKING, or NO BLOCKERS.
+- Separate blockers from non-blocking suggestions. Only blockers go back through the fix loop.
+- Report SPEC FIDELITY and STANDARDS AND RISK separately.
+- Review docs against implementation.
+- Keep the response short.
+
+BEGIN TASK / SPEC
+GitHub issue #807: Harden lineage lock portability and cross-process errors.
+Context: PR #806 added a path-keyed cross-process lock for new --fork and non-force delete. Existing local/Linux coverage handled active-owner protection, heartbeat, dead/corrupt recovery, token-safe release, in-process contenders, and CLI races.
+Required follow-up:
+- Add Windows CI or focused Windows harness, especially open-handle behavior during heartbeat, recovery rename, quarantine cleanup, and close-before-release unlink.
+- Add deterministic real cross-process stress, not only in-process contenders/CLI race repetitions.
+- Classify target disappearance between delete selection and authoritative under-lock recheck instead of generic ENOENT.
+Acceptance:
+- Shared lineage lock preserves mutual exclusion and cleans artifacts on supported Windows and POSIX.
+- Target removed during delete gets stable documented text and JSON errors.
+- Existing new --fork, delete-lineage, note-ID lock, adoption, and repository suites stay green.
+Scope: do not implement issue #820 edit-vs-lineage concurrency. One PR, docs/changelog/agent skill as repository conventions require.
+Evidence supplied by implementation and independent tester:
+- Exact Node 22 local parity: build, verify:pack, typecheck, lint, knip, 3030 tests passed/3 skipped.
+- Focused suites 29/29; repeated cross-process suite 5 times 20/20; delete regression 22/22.
+- Independent built-CLI bulk disappearance: exit 2, stable retry text, remaining target untouched.
+- Independent initial-no-match text/JSON unchanged: exit/code 1, no retryable data.
+- Canonical docs checks and 42-page Astro build pass.
+GitHub Windows execution is a separate gate still running and must pass before merge.
+END TASK / SPEC
+
+BEGIN REPO STANDARDS
+AGENTS.md:
+- Canonical user-facing behavior docs live under docs-site/src/content/docs/.
+- Update docs/skill/SKILL.md for changed CLI automation behavior.
+- CI source is .github/workflows/ci.yml; Node 22; pnpm 10.11.0.
+- Exact local parity order: pnpm build; pnpm verify:pack; pnpm typecheck; pnpm lint; pnpm knip; pnpm test -- --exclude='**/*.pty.test.ts'.
+- Always use pnpm test for local Vitest execution; CI commands must be non-watch.
+- Knip should use semantically justified entries/exports, not broad ignores.
+- Include the entire diff for external review because worktree paths may be inaccessible.
+TaskSweep:
+- Additive Windows job must not rename required checks.
+- Final reviewer has no tools; judge only this packet.
+- Blockers are concrete correctness/spec/repository-policy issues, not generic preferences.
+END REPO STANDARDS
+
+BEGIN DIFF
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 45b86a2..b7e2f26 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -148,6 +148,33 @@ jobs:
+         env:
+           BWRB_TEST_DIST: 1
+ 
++  windows_lock_tests:
++    name: Windows Lock Tests
++    runs-on: windows-latest
++    timeout-minutes: 15
++    steps:
++      - uses: actions/checkout@v4
++
++      - name: Install pnpm
++        uses: pnpm/action-setup@v4
++        with:
++          version: 10.11.0
++
++      - name: Setup Node.js
++        uses: actions/setup-node@v4
++        with:
++          node-version: 22
++          cache: pnpm
++
++      - name: Install dependencies
++        run: pnpm install --frozen-lockfile
++
++      - name: Build
++        run: pnpm build
++
++      - name: Run focused lineage lock tests
++        run: pnpm exec vitest run tests/ts/lib/lineage-lock.test.ts tests/ts/lib/lineage-lock-cross-process.test.ts tests/ts/lib/note-id-lock.test.ts tests/ts/commands/delete-lineage.test.ts
++
+   test-pty:
+     name: PTY Tests
+     runs-on: ubuntu-latest
+
+diff --git a/.task-sweep/logs/claude-fable-5-plan-20260710-103418-issue-807.log b/.task-sweep/logs/claude-fable-5-plan-20260710-103418-issue-807.log
+new file mode 100644
+index 0000000..1121db4
+--- /dev/null
++++ b/.task-sweep/logs/claude-fable-5-plan-20260710-103418-issue-807.log
+@@ -0,0 +1,6 @@
++model_requested: anthropic/claude-fable-5
++model_returned: anthropic/claude-5-fable-20260609
++finish_reason: stop
++output: .task-sweep/logs/claude-fable-5-plan-output-20260710-103418-issue-807.md
++chars: 7822 words: 1124
++preview: # Implementation Plan — Issue #807\n\n## 1. Production changes for Windows semantics (keep minimal)\n\n**Principle: preserve fail-closed timeout behavior.** Windows sharing violations during recovery should be treated as "holder may be alive" and retried within the acquisition loop — never as license to steal.\n\nSmallest set of changes:\n\n- **Classify errors in `readLockSnapshot` instead of swallowing everything.** Distinguish: `ENOENT` (gone, retry acquire), `EBUSY`/`EPERM`/`EACCES` on Windows (likely open handle → treat as live holder, back off), parse errors (corrupt → existing quarantine path). Return a discriminated result (`{ kind: 'missing' | 'busy' | 'corrupt' | 'ok', ... }`) rather than `null`. This is the single most important seam.\n- **Recovery rename/unlink:** wrap the quarantine `re
+
+diff --git a/.task-sweep/logs/claude-fable-5-plan-output-20260710-103418-issue-807.md b/.task-sweep/logs/claude-fable-5-plan-output-20260710-103418-issue-807.md
+new file mode 100644
+index 0000000..1a1e073
+--- /dev/null
++++ b/.task-sweep/logs/claude-fable-5-plan-output-20260710-103418-issue-807.md
+@@ -0,0 +1,65 @@
++# Implementation Plan — Issue #807
++
++## 1. Production changes for Windows semantics (keep minimal)
++
++**Principle: preserve fail-closed timeout behavior.** Windows sharing violations during recovery should be treated as "holder may be alive" and retried within the acquisition loop — never as license to steal.
++
++Smallest set of changes:
++
++- **Classify errors in `readLockSnapshot` instead of swallowing everything.** Distinguish: `ENOENT` (gone, retry acquire), `EBUSY`/`EPERM`/`EACCES` on Windows (likely open handle → treat as live holder, back off), parse errors (corrupt → existing quarantine path). Return a discriminated result (`{ kind: 'missing' | 'busy' | 'corrupt' | 'ok', ... }`) rather than `null`. This is the single most important seam.
++- **Recovery rename/unlink:** wrap the quarantine `rename` and `unlink` in a small retry that treats `EBUSY`/`EPERM`/`EACCES`/`ENOTEMPTY` as transient; after N attempts, fall through to the normal wait loop (fail-closed). On Windows a rename of an open file fails — that's evidence the holder is alive, which is the correct outcome.
++- **Identity check in token-safe release:** on Windows, `ino`/`dev` from `fs.stat` are frequently 0 or unstable across filesystems. Gate the inode/dev comparison behind `stat.ino !== 0 && stat.dev !== 0` (or a platform check), falling back to token + mtime + size. Do not weaken the token check itself.
++- **`process.kill(pid, 0)`** works on Windows Node for liveness (throws `ESRCH` for dead PIDs); no change needed, but add a test asserting the semantics you rely on. Note the known caveat: PID reuse — TTL + heartbeat already mitigates; document it in a comment, don't engineer around it.
++- **`handle.utimes` heartbeat:** verify on Windows CI; if it fails on open handles (unlikely), fall back to path-based `utimes` on the owned lock. Don't preemptively change.
++
++Do **not** add flock/LockFileEx native bindings or restructure the metadata format.
++
++## 2. Deterministic cross-process test harness
++
++Design a small child-process fixture, not in-process promises:
++
++- **Fixture script** (`tests/ts/fixtures/lock-holder.mjs` or `.ts` run via `tsx`/compiled): a child that acquires the lock on a given path, writes structured events (`acquired`, `heartbeat`, `entered-critical`, `exited-critical`, `released`) to stdout as NDJSON, and responds to stdin commands (`hold`, `release`, `crash` via `process.exit(1)` without cleanup, `kill` self via SIGKILL where supported / `process.abort()` on Windows).
++- **Injectable timing:** thread TTL/heartbeat/poll intervals through env vars (`BWRB_LOCK_TTL_MS` etc.) read by `lineage-lock.ts` (or an options object the fixture passes). Use ~50–200ms values in tests.
++- **Scenarios (all real `spawn`, deterministic via event handshakes, not sleeps):**
++  1. *Live-holder protection:* child A acquires + heartbeats; child B attempts with short timeout → B times out; assert lock file still owned by A's token.
++  2. *Dead-holder recovery + successor ownership:* A acquires then `crash`es; B acquires after TTL; assert B's token in lock file, no `.recovery`/`.quarantine-*` residue after B releases.
++  3. *No overlap:* N=4 children loop through the critical section appending `enter:<pid>`/`exit:<pid>` to a shared journal file (append-only writes); parent asserts strict alternation — every `enter` is followed by its own `exit` before any other `enter`. Bounded iterations (e.g., 20 each) keep it deterministic-enough and fast.
++  4. *Cleanup:* after all children exit, lock dir contains no lock/recovery/quarantine artifacts.
++- **Mutation-kill check:** verify the harness fails on a broken implementation by temporarily (in a review note, not committed) disabling the token check — scenario 3 should catch overlap. Mention this validation in the PR description; don't commit a mutation-testing framework.
++- Run these under the regular non-PTY suite; they must pass on both OSes. Guard flaky primitives (e.g., SIGKILL) with platform-appropriate crash modes.
++
++## 3. CI shape
++
++- Add a **separate matrix job or standalone `windows-tests` job** in `ci.yml`: `windows-latest`, Node 22, pnpm 10.11.0, running **only** build + typecheck + a focused test glob (`vitest run tests/ts/lib/lineage-lock* tests/ts/lib/note-id-lock* tests/ts/commands/delete-lineage*` plus the new cross-process file). Do not run PTY tests or the full suite on Windows.
++- Do **not** touch the existing required-check names (`Test`, `PTY Tests`, `Vercel`). The Windows job is additive; whether it becomes required is a repo-policy decision outside this PR — flag it in the PR description.
++- Cache pnpm store; use `vitest run` explicitly (no watch). Set generous but bounded timeouts (Windows FS is slower).
++
++## 4. Delete-disappearance contract
++
++- New typed error, e.g. `DeleteTargetDisappearedError` in the delete/lineage module, thrown by `assessCurrentDeleteLineage` (or the call site) **only** when the target was present at selection but missing under lock. Carry `{ paths: string[], retryable: true }`.
++- **Text:** `Target was deleted by another process while waiting for the lock: <relative-path>. Re-run to confirm.` Exit with the existing validation/retryable error class, not generic IO.
++- **JSON:** `{ success: false, error: "<same text>", code: "TARGET_DISAPPEARED", retryable: true, paths: ["..."] }`. Yes to `retryable` and paths; skip a separate `reason` field — the code is the reason. Confirm `TARGET_DISAPPEARED` fits the existing error-code enum conventions before inventing it; if codes are a closed set, extend it in one place.
++- **Do not change** initial-selection `ENOENT` behavior (`File not found or already deleted`, `IO_ERROR`).
++- Bulk path: if bulk delete flows through the same under-lock assessor, classify per-path — disappeared targets reported with the new code, others processed normally. If bulk uses a different assessor, cover only the shared path and note the gap.
++
++## 5. Verification, docs, failure modes
++
++**Focused checks:**
++- New `tests/ts/lib/lineage-lock-crossproc.test.ts` (scenarios above).
++- New delete test: acquire the lock from a helper child, delete the target file out-of-band, release; assert delete emits the new text/JSON code and leaves no lock artifacts.
++- Existing lineage-lock, note-id-lock, delete-lineage suites unchanged and green.
++- Real CLI: `bwrb delete <path>` and `--json` variant against the staged disappearance scenario.
++
++**Full parity in exact order:** build → verify:pack → typecheck → lint → knip → non-PTY tests.
++
++**Docs:** update `docs-site/src/content/docs/` delete command page with the new error text/JSON code; update `docs/skill/SKILL.md` since command behavior (error contract) changes. Changelog entry per repo convention.
++
++**Likely failure modes:** knip flagging the child fixture as unused (add to knip entry config); Windows CI pnpm/tsx path issues; test flakes from too-tight TTLs on slow Windows runners (use handshakes, not timing assertions); fixture zombie processes (always `kill` in `afterEach`); NDJSON stdout buffering (flush per line, read incrementally).
++
++## 6. Scope traps / #820 boundaries
++
++- **Do not** generalize the lock into an edit/identity-write primitive, add write-intent modes, or refactor `withOwnershipFileLock`'s public API for future consumers. The only shareable artifact is the injectable-timing option and error-classified `readLockSnapshot`, both of which #807 needs anyway.
++- Do not reopen or re-test the #817 old-holder/successor fix beyond the successor scenario already in the cross-process harness (which covers it as a side effect — fine, but don't duplicate `note-id-lock.test.ts` logic).
++- Do not touch fork/adopt logic; only the delete under-lock recheck classification.
++- Keep the Windows job additive; changing required checks or branch protection is out of scope.
++- Open a **draft PR** only; do not mark ready or merge.
+\ No newline at end of file
+
+diff --git a/.task-sweep/logs/claude-fable-5-plan-prompt-20260710-103418-issue-807.md b/.task-sweep/logs/claude-fable-5-plan-prompt-20260710-103418-issue-807.md
+new file mode 100644
+index 0000000..d4d4bcc
+--- /dev/null
++++ b/.task-sweep/logs/claude-fable-5-plan-prompt-20260710-103418-issue-807.md
+@@ -0,0 +1,88 @@
++# TaskSweep early planning packet — BWRB issue #807
++
++You are advising on a repository task before implementation. You have no tools. Do not claim to inspect anything outside this packet. Give concise advice to another implementation agent; do not mutate anything or broaden beyond the issue.
++
++## Normalized task
++
++- ID/source: GitHub issue #807, `https://github.com/3mdistal/bwrb/issues/807`
++- Title: Harden lineage lock portability and cross-process errors
++- Repo/base: `3mdistal/bwrb`, `origin/main` at `55dfc19887d9442fe0d3c94b28ac01b18c7012a0`
++- Branch/lane: `codex/807-lineage-lock-hardening` in an isolated worktree
++- Problem: PR #806 added path-keyed cross-process locks for `new --fork` and non-force delete. Current tests prove ownership, heartbeats, stale/dead recovery, token-safe release, contenders, and CLI races on the local platform, but the issue still asks for explicit Windows/open-handle coverage, a deterministic cross-process stress harness, and a stable error when a delete target disappears while the command waits for its authoritative lock.
++- Desired outcome:
++  1. The shared lineage/ownership lock preserves mutual exclusion and cleans its lock/recovery/quarantine artifacts on supported POSIX and Windows environments, with a focused Windows CI lane or equivalent harness.
++  2. A deterministic multi-process test—not merely in-process promises or probabilistic CLI races—proves live-holder protection, dead-holder recovery, successor ownership, no overlapping critical sections, and cleanup.
++  3. Non-force delete classifies a target that disappears between initial selection and the under-lock recheck with stable documented text and JSON behavior, rather than a generic raw or misleading `ENOENT`.
++  4. Existing fork, adopt, delete-lineage, note-ID-lock, and full repository suites remain green.
++- Manual successful story: As a vault owner running competing BWRB processes, a crashed lineage mutator cannot leave the vault permanently locked and live/successor holders cannot overlap or have their locks stolen. If another process deletes my target while my non-force delete waits, BWRB returns a clear retryable result and leaves no lock debris.
++- Merge is authorized only after the full TaskSweep and repository-policy gates. The implementer must open a draft PR and must not ready or merge it.
++
++## Repo facts and standards
++
++- TypeScript ESM Commander CLI; Node 22; pnpm 10.11.0.
++- Required checks: `Test`, `PTY Tests`, `Vercel`; strict up-to-date branch protection; zero required approvals.
++- Full local parity in exact order: build, verify:pack, typecheck, lint, knip, non-PTY test suite.
++- Canonical user docs live in `docs-site/src/content/docs/`; bundled agent guidance is `docs/skill/SKILL.md` when command behavior changes.
++- Current `.github/workflows/ci.yml` runs Linux/Ubuntu only. A Windows-focused job must avoid silently testing a different contract and must remain practical for PR CI.
++- Use `pnpm test`/Vitest run semantics; do not invoke watch mode.
++
++## Current implementation
++
++### Ownership-safe shared lock
++
++`src/lib/lineage-lock.ts` now exposes `withLineageMutationLocks` and `withOwnershipFileLock`. It:
++
++- derives deterministic SHA-256 lock paths from normalized vault-relative source paths;
++- writes JSON metadata `{ version, pid, token, createdAt, heartbeatAt, pathKey }` under exclusive `open(..., 'wx')`;
++- heartbeats the owned open handle with `handle.utimes`;
++- checks process liveness with `process.kill(pid, 0)` after TTL expiry;
++- uses a fixed `.recovery` ownership marker, rechecks stale state, renames stale locks to unique `.quarantine-*` paths, unlinks quarantine, and cleans stale quarantine files;
++- releases only when the token plus snapshot raw/dev/inode/mtime/size still match;
++- sorts multi-lock acquisition to avoid deadlock.
++
++PR #817 generalized this primitive for the fixed note-ID assignment and registry lock paths after an independent tester reproduced an old-holder/successor overlap bug. New `tests/ts/lib/note-id-lock.test.ts` covers heartbeat and successor ownership in process, but not a true child-process stress harness. This partially satisfies #807; do not duplicate it or reopen the fixed race.
++
++Potential portability seams to examine:
++
++- `readLockSnapshot` catches every read/stat error and returns null, erasing distinctions such as Windows sharing/permission errors.
++- stale recovery renames then unlinks a lock pathname; Windows open-handle rules differ from POSIX.
++- `cleanupQuarantines` unlinks matching paths concurrently and ignores errors.
++- `process.kill(pid, 0)`, inode/dev identity, and open-handle `utimes` need actual Windows evidence.
++- tests currently synthesize dead PIDs and contenders in one Vitest process.
++
++### Delete disappearance behavior
++
++Single non-force delete resolves a file, performs prompts/backlink work, then:
++
++```ts
++await withLineageMutationLocks(vaultDir, [fullPath], async () => {
++  const assessment = await assessCurrentDeleteLineage(schema, vaultDir, [file]);
++  if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
++  await unlink(fullPath);
++  await unregisterIssuedNotePath(vaultDir, relativePath);
++});
++```
++
++`assessCurrentDeleteLineage` rebuilds a fresh snapshot. If the selected path is now missing it creates an `Error("File not found or no longer managed: ...")` and assigns `error.code = 'ENOENT'`. The outer delete command collapses all `ENOENT` errors to:
++
++- text: `File not found or already deleted`, exit validation error;
++- JSON: `{ success: false, error: "File not found or already deleted", code: IO_ERROR }`.
++
++The issue asks for stable classification of the specific between-selection-and-lock disappearance. Consider a narrow typed error with a retryable machine-readable payload/code and documented wording, without changing unrelated initial not-found behavior. Cover bulk and single paths if they share the same under-lock assessor.
++
++### Existing tests
++
++- `tests/ts/lib/lineage-lock.test.ts`: deterministic lock path, cleanup, ordered multi-lock acquisition, TTL recovery, live-holder protection, heartbeat, dead/corrupt recovery, token-safe replacement, 2/10 in-process contenders, recovery-marker ownership, timeout.
++- `tests/ts/lib/note-id-lock.test.ts`: both fixed note-ID lock paths, heartbeat/live holder, successor preservation and third-holder serialization.
++- `tests/ts/commands/delete-lineage.test.ts`: non-force guard behavior and a real CLI fork-versus-delete race, but no deterministic target-disappears-while-waiting scenario.
++
++## Planning questions
++
++Give a concise implementation plan covering:
++
++1. The smallest production-code changes needed for supported Windows semantics. Should recovery retry specific Windows sharing errors, avoid relying on inode identity when unavailable, or preserve current fail-closed timeout behavior?
++2. A deterministic cross-process Vitest/worker design that runs on POSIX and Windows, uses short injectable timing, proves no overlap and artifact cleanup, and would fail on a deliberately broken ownership implementation.
++3. The safest CI shape for Windows coverage without destabilizing unrelated PTY/full-suite jobs.
++4. A stable text/JSON contract and typed error for a delete target disappearing during the authoritative under-lock recheck, including whether the JSON payload should include `retryable`, `reason`, and target paths.
++5. Exact focused and real CLI checks, docs/changelog changes, and likely failure modes.
++6. Scope traps or conflicts with the later #820 edit/identity-write concurrency task. Keep #820 out of this PR unless a tiny reusable primitive is strictly necessary.
+
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+index 333707c..d9529af 100644
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -10,6 +10,7 @@ All notable changes to Bowerbird are documented in this file.
+ 
+ ### Fixed
+ 
++- **Portable lineage mutation locking** — lineage and note-ID locks now fail closed on Windows sharing/permission errors, have deterministic real-process stress coverage plus a focused Windows CI lane, and return stable retryable text/JSON context when a non-force delete target disappears before its authoritative under-lock recheck (#807).
+ - **Body-only content targeting** — `--body` now excludes YAML frontmatter in both note filtering and detailed match reports while preserving original file line numbers and body-only context (#812).
+ 
+ ## [0.2.3] - 2026-07-09
+
+diff --git a/docs-site/src/content/docs/changelog.md b/docs-site/src/content/docs/changelog.md
+index 59fd1ea..38859b3 100644
+--- a/docs-site/src/content/docs/changelog.md
++++ b/docs-site/src/content/docs/changelog.md
+@@ -12,6 +12,7 @@ For the complete changelog with all details, see [CHANGELOG.md](https://github.c
+ ### Unreleased
+ 
+ - **Existing-note lineage adoption** — `bwrb lineage adopt <child> --from <parent>` adds a dry-run-first, lock-coordinated path for recording known derivation between existing same-type notes without rewriting their bodies or ordinary metadata
++- **Portable lineage mutation locking** — fork, adopt, delete, and note-ID coordination now have real cross-process stress coverage, a focused Windows CI lane, and stable retryable output when a non-force delete target disappears while waiting for its lock
+ 
+ ### 0.2.3
+ 
+
+diff --git a/docs-site/src/content/docs/reference/commands/delete.md b/docs-site/src/content/docs/reference/commands/delete.md
+index 00d2da6..c4fc95a 100644
+--- a/docs-site/src/content/docs/reference/commands/delete.md
++++ b/docs-site/src/content/docs/reference/commands/delete.md
+@@ -101,6 +101,36 @@ not deleted or reparented, and their `forked-from` value stays intact. A later
+ `bwrb audit` reports that retained provenance as `dangling-forked-from`, so the
+ source can still be restored deliberately.
+ 
++### Concurrent target disappearance
++
++Without `--force`, bwrb selects the requested notes and then rechecks them while
++holding the same lineage locks used by fork and adoption. If another process
++deletes a selected target before that authoritative recheck, the command stops
++without deleting any of the remaining selected notes and returns exit code `2`:
++
++```text
++Error: Delete target disappeared while waiting for the lineage lock; retry the command: Ideas/Launch Brief.md
++```
++
++JSON output keeps the numeric exit-code contract and adds stable retry context:
++
++```json
++{
++  "success": false,
++  "error": "Delete target disappeared while waiting for the lineage lock; retry the command: Ideas/Launch Brief.md",
++  "data": {
++    "reason": "target-disappeared",
++    "retryable": true,
++    "paths": ["Ideas/Launch Brief.md"]
++  },
++  "code": 2
++}
++```
++
++Re-resolve the target set before retrying. This is distinct from an initial
++not-found result: the note existed during selection but vanished while the
++command was coordinating its write.
++
+ ## Examples
+ 
+ ### Single-file Mode
+
+diff --git a/docs/skill/SKILL.md b/docs/skill/SKILL.md
+index 9479a35..eead77a 100644
+--- a/docs/skill/SKILL.md
++++ b/docs/skill/SKILL.md
+@@ -229,6 +229,12 @@ their `forked-from` value, which surfaces as `dangling-forked-from` in
+ `bwrb audit`. Use `bwrb list --lineage <target> --output json` before forcing a
+ parent deletion when an agent needs to enumerate the affected family.
+ 
++For non-force deletion, another process can remove a selected target while the
++command waits for its lineage lock. JSON reports numeric `code: 2` with
++`data.reason: "target-disappeared"`, `data.retryable: true`, and the selected
++`data.paths`. Re-resolve those paths before retrying; do not treat this as a
++successful or ordinary initial not-found result.
++
+ ## Core Commands for Agents
+ 
+ ### Querying Notes
+
+diff --git a/knip.jsonc b/knip.jsonc
+index b53571e..0b9f731 100644
+--- a/knip.jsonc
++++ b/knip.jsonc
+@@ -3,7 +3,11 @@
+ 
+   // Vitest plugin doesn't auto-detect globalTeardown from config
+   "vitest": {
+-    "entry": ["tests/ts/teardown.ts"]
++    "entry": [
++      "tests/ts/teardown.ts",
++      // Spawned as a real child process by the cross-process lock suite.
++      "tests/ts/fixtures/lineage-lock-worker.ts"
++    ]
+   },
+ 
+   // Ignore intentional public API exports and separate projects
+
+diff --git a/src/commands/delete.ts b/src/commands/delete.ts
+index e37d6b2..6907707 100644
+--- a/src/commands/delete.ts
++++ b/src/commands/delete.ts
+@@ -270,6 +270,11 @@ Note: Deletion is permanent. The file is removed from the filesystem.
+         return;
+       }
+ 
++      if (err instanceof DeleteTargetDisappearedError) {
++        reportDeleteTargetDisappeared(err, jsonMode);
++        return;
++      }
++
+       const message = err instanceof Error ? err.message : String(err);
+ 
+       // Handle specific error types
+@@ -677,7 +682,7 @@ async function handleBulkDelete(
+   } else {
+     try {
+       await withLineageMutationLocks(vaultDir, files.map(file => file.path), async () => {
+-        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, files);
++        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, files, true);
+         if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
+         await deleteFiles();
+       });
+@@ -860,7 +865,7 @@ async function deleteResolvedFile({
+   } else {
+     try {
+       await withLineageMutationLocks(vaultDir, [fullPath], async () => {
+-        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, [file]);
++        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, [file], true);
+         if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
+         await unlink(fullPath);
+         await unregisterIssuedNotePath(vaultDir, relativePath);
+@@ -899,18 +904,32 @@ class LineageDeleteRefusalError extends Error {
+   }
+ }
+ 
++class DeleteTargetDisappearedError extends Error {
++  constructor(readonly paths: string[]) {
++    super(paths.length === 1
++      ? `Delete target disappeared while waiting for the lineage lock; retry the command: ${paths[0]}`
++      : `Delete targets disappeared while waiting for lineage locks; retry the command: ${paths.join(', ')}`);
++    this.name = 'DeleteTargetDisappearedError';
++  }
++}
++
+ async function assessCurrentDeleteLineage(
+   schema: Awaited<ReturnType<typeof loadSchema>>,
+   vaultDir: string,
+-  files: ManagedFile[]
++  files: ManagedFile[],
++  classifyMissingAsDisappeared = false
+ ): Promise<DeleteLineageBlock[]> {
+   const snapshot = await buildVaultNoteSnapshot(schema, vaultDir);
+   const assessment = assessDeleteLineage(snapshot, files.map(file => file.path));
+   if (assessment.missing.length > 0) {
++    const missingPaths = assessment.missing.map(
++      path => files.find(file => file.path === path)?.relativePath ?? path
++    );
++    if (classifyMissingAsDisappeared) {
++      throw new DeleteTargetDisappearedError(missingPaths);
++    }
+     const error = new Error(
+-      `File not found or no longer managed: ${assessment.missing
+-        .map(path => files.find(file => file.path === path)?.relativePath ?? path)
+-        .join(', ')}`
++      `File not found or no longer managed: ${missingPaths.join(', ')}`
+     ) as NodeJS.ErrnoException;
+     error.code = 'ENOENT';
+     throw error;
+@@ -918,6 +937,25 @@ async function assessCurrentDeleteLineage(
+   return assessment.blocked;
+ }
+ 
++function reportDeleteTargetDisappeared(
++  error: DeleteTargetDisappearedError,
++  jsonMode: boolean
++): void {
++  if (jsonMode) {
++    printJson(jsonError(error.message, {
++      code: ExitCodes.IO_ERROR,
++      data: {
++        reason: 'target-disappeared',
++        retryable: true,
++        paths: error.paths,
++      },
++    }));
++  } else {
++    printError(error.message);
++  }
++  process.exitCode = ExitCodes.IO_ERROR;
++}
++
+ function reportLineageRefusal(
+   blocked: DeleteLineageBlock[],
+   jsonMode: boolean,
+
+diff --git a/src/lib/lineage-lock.ts b/src/lib/lineage-lock.ts
+index 47bbc2e..46a7633 100644
+--- a/src/lib/lineage-lock.ts
++++ b/src/lib/lineage-lock.ts
+@@ -33,6 +33,11 @@ interface LockSnapshot {
+   size: number;
+ }
+ 
++type LockSnapshotRead =
++  | { kind: 'present'; snapshot: LockSnapshot }
++  | { kind: 'missing' }
++  | { kind: 'busy' };
++
+ const DEFAULT_OPTIONS: OwnershipFileLockOptions = {
+   retryMs: LOCK_RETRY_MS,
+   attempts: LOCK_ATTEMPTS,
+@@ -166,8 +171,11 @@ async function acquireLock(
+       }
+     } catch (error) {
+       if (!isFileExistsError(error)) throw error;
+-      const snapshot = await readLockSnapshot(lockPath);
+-      if (snapshot && await isRecoverable(snapshot, options.staleMs)) {
++      const snapshotRead = await readLockSnapshot(lockPath);
++      if (
++        snapshotRead.kind === 'present' &&
++        await isRecoverable(snapshotRead.snapshot, options.staleMs)
++      ) {
+         await recoverStaleLock(lockPath, recoveryPath, options);
+         continue;
+       }
+@@ -208,8 +216,11 @@ async function heartbeatOwnedLock(
+   handle: Awaited<ReturnType<typeof open>>,
+   token: string
+ ): Promise<void> {
+-  const snapshot = await readLockSnapshot(lockPath);
+-  if (snapshot?.metadata?.token !== token) return;
++  const snapshotRead = await readLockSnapshot(lockPath);
++  if (
++    snapshotRead.kind !== 'present' ||
++    snapshotRead.snapshot.metadata?.token !== token
++  ) return;
+ 
+   // Touch the inode opened by this holder, not whatever might have appeared at
+   // the path after the ownership check. The immutable JSON records when the
+@@ -227,8 +238,11 @@ async function recoverStaleLock(
+   if (!recovery) return;
+ 
+   try {
+-    const snapshot = await readLockSnapshot(lockPath);
+-    if (!snapshot || !await isRecoverable(snapshot, options.staleMs)) return;
++    const snapshotRead = await readLockSnapshot(lockPath);
++    if (
++      snapshotRead.kind !== 'present' ||
++      !await isRecoverable(snapshotRead.snapshot, options.staleMs)
++    ) return;
+ 
+     // The fixed recovery marker prevents acquisitions and competing reapers
+     // while the stale inode is atomically moved out of the lock pathname.
+@@ -237,7 +251,12 @@ async function recoverStaleLock(
+       await rename(lockPath, quarantinePath);
+       await unlink(quarantinePath).catch(() => undefined);
+     } catch (error) {
+-      if (!isFileMissingError(error)) throw error;
++      if (isFileMissingError(error)) return;
++      // Windows can reject a rename while another process still has the lock
++      // open. That is evidence against stealing, not permission to do so. Let
++      // the outer acquisition loop retry until its ordinary timeout instead.
++      if (isTransientLockFilesystemError(error)) return;
++      throw error;
+     }
+     await cleanupQuarantines(lockPath);
+   } finally {
+@@ -272,9 +291,12 @@ async function acquireRecoveryMarker(
+     };
+   } catch (error) {
+     if (!isFileExistsError(error)) throw error;
+-    const snapshot = await readLockSnapshot(recoveryPath);
+-    if (snapshot && await isRecoverable(snapshot, options.staleMs)) {
+-      await unlinkIfUnchanged(recoveryPath, snapshot);
++    const snapshotRead = await readLockSnapshot(recoveryPath);
++    if (
++      snapshotRead.kind === 'present' &&
++      await isRecoverable(snapshotRead.snapshot, options.staleMs)
++    ) {
++      await unlinkIfUnchanged(recoveryPath, snapshotRead.snapshot);
+     }
+     return null;
+   }
+@@ -284,10 +306,11 @@ async function recoveryIsInProgress(
+   recoveryPath: string,
+   options: OwnershipFileLockOptions
+ ): Promise<boolean> {
+-  const snapshot = await readLockSnapshot(recoveryPath);
+-  if (!snapshot) return false;
+-  if (await isRecoverable(snapshot, options.staleMs)) {
+-    await unlinkIfUnchanged(recoveryPath, snapshot);
++  const snapshotRead = await readLockSnapshot(recoveryPath);
++  if (snapshotRead.kind === 'missing') return false;
++  if (snapshotRead.kind === 'busy') return true;
++  if (await isRecoverable(snapshotRead.snapshot, options.staleMs)) {
++    await unlinkIfUnchanged(recoveryPath, snapshotRead.snapshot);
+     return pathExists(recoveryPath);
+   }
+   return true;
+@@ -318,23 +341,30 @@ function isProcessAlive(pid: number): boolean {
+   }
+ }
+ 
+-async function readLockSnapshot(lockPath: string): Promise<LockSnapshot | null> {
++async function readLockSnapshot(lockPath: string): Promise<LockSnapshotRead> {
+   try {
+     const [raw, info] = await Promise.all([
+       readFile(lockPath, 'utf-8'),
+       stat(lockPath),
+     ]);
+     return {
+-      raw,
+-      metadata: parseLockMetadata(raw),
+-      device: info.dev,
+-      inode: info.ino,
+-      modifiedAt: info.mtimeMs,
+-      size: info.size,
++      kind: 'present',
++      snapshot: {
++        raw,
++        metadata: parseLockMetadata(raw),
++        device: info.dev,
++        inode: info.ino,
++        modifiedAt: info.mtimeMs,
++        size: info.size,
++      },
+     };
+   } catch (error) {
+-    if (isFileMissingError(error)) return null;
+-    return null;
++    if (isFileMissingError(error)) return { kind: 'missing' };
++    // Sharing/permission failures are common while Windows handles are open.
++    // Preserve that distinction so every caller fails closed rather than
++    // mistaking an unreadable lock or recovery marker for an absent one.
++    if (isTransientLockFilesystemError(error)) return { kind: 'busy' };
++    throw error;
+   }
+ }
+ 
+@@ -357,14 +387,20 @@ function parseLockMetadata(raw: string): LockMetadata | null {
+ }
+ 
+ async function unlinkIfOwned(lockPath: string, token: string): Promise<boolean> {
+-  const snapshot = await readLockSnapshot(lockPath);
+-  if (snapshot?.metadata?.token !== token) return false;
+-  return unlinkIfUnchanged(lockPath, snapshot);
++  const snapshotRead = await readLockSnapshot(lockPath);
++  if (
++    snapshotRead.kind !== 'present' ||
++    snapshotRead.snapshot.metadata?.token !== token
++  ) return false;
++  return unlinkIfUnchanged(lockPath, snapshotRead.snapshot);
+ }
+ 
+ async function unlinkIfUnchanged(lockPath: string, expected: LockSnapshot): Promise<boolean> {
+-  const current = await readLockSnapshot(lockPath);
+-  if (!current || !snapshotsMatch(current, expected)) return false;
++  const currentRead = await readLockSnapshot(lockPath);
++  if (
++    currentRead.kind !== 'present' ||
++    !snapshotsMatch(currentRead.snapshot, expected)
++  ) return false;
+   try {
+     await unlink(lockPath);
+     return true;
+@@ -394,8 +430,11 @@ async function pathExists(path: string): Promise<boolean> {
+   try {
+     await stat(path);
+     return true;
+-  } catch {
+-    return false;
++  } catch (error) {
++    if (isFileMissingError(error)) return false;
++    // An unreadable recovery marker must serialize acquisitions just like a
++    // readable one. The lock would rather wait than become two locks in a coat.
++    return true;
+   }
+ }
+ 
+@@ -409,6 +448,12 @@ function isFileMissingError(error: unknown): boolean {
+     (error as NodeJS.ErrnoException).code === 'ENOENT';
+ }
+ 
++function isTransientLockFilesystemError(error: unknown): boolean {
++  if (!(error instanceof Error) || !('code' in error)) return false;
++  const code = (error as NodeJS.ErrnoException).code;
++  return code === 'EBUSY' || code === 'EPERM' || code === 'EACCES' || code === 'ENOTEMPTY';
++}
++
+ function delay(ms: number): Promise<void> {
+   return new Promise(resolveDelay => setTimeout(resolveDelay, ms));
+ }
+
+diff --git a/tests/ts/fixtures/lineage-lock-worker.ts b/tests/ts/fixtures/lineage-lock-worker.ts
+new file mode 100644
+index 0000000..1ce5aba
+--- /dev/null
++++ b/tests/ts/fixtures/lineage-lock-worker.ts
+@@ -0,0 +1,99 @@
++import { appendFile, mkdir, open, unlink } from 'fs/promises';
++import { dirname } from 'path';
++import { createInterface } from 'readline';
++import {
++  withOwnershipFileLock,
++  type OwnershipFileLockOptions,
++} from '../../../src/lib/lineage-lock.js';
++
++type WorkerMode = 'hold' | 'stress';
++
++interface WorkerConfig {
++  mode: WorkerMode;
++  lockPath: string;
++  options: OwnershipFileLockOptions;
++  sentinelPath?: string;
++  journalPath?: string;
++  iterations?: number;
++}
++
++interface WorkerCommand {
++  command: 'start' | 'release' | 'crash';
++}
++
++const config = JSON.parse(process.argv[2] ?? '') as WorkerConfig;
++const commands = createInterface({ input: process.stdin, crlfDelay: Infinity })[Symbol.asyncIterator]();
++
++function send(event: string, data: Record<string, unknown> = {}): void {
++  process.stdout.write(`${JSON.stringify({ event, pid: process.pid, ...data })}\n`);
++}
++
++async function nextCommand(expected: WorkerCommand['command'][]): Promise<WorkerCommand> {
++  const result = await commands.next();
++  if (result.done) throw new Error(`stdin closed while waiting for ${expected.join(' or ')}`);
++  const command = JSON.parse(result.value) as WorkerCommand;
++  if (!expected.includes(command.command)) {
++    throw new Error(`Expected ${expected.join(' or ')}, received ${command.command}`);
++  }
++  return command;
++}
++
++async function hold(): Promise<void> {
++  await withOwnershipFileLock(config.lockPath, async () => {
++    send('acquired');
++    const command = await nextCommand(['release', 'crash']);
++    if (command.command === 'crash') {
++      // Deliberately bypass finally/release to leave a real dead-owner lock.
++      process.exit(70);
++    }
++  }, config.options, 'worker lock timeout');
++  send('released');
++}
++
++async function stress(): Promise<void> {
++  if (!config.sentinelPath || !config.journalPath || !config.iterations) {
++    throw new Error('Stress mode requires sentinelPath, journalPath, and iterations');
++  }
++
++  await mkdir(dirname(config.journalPath), { recursive: true });
++  for (let iteration = 0; iteration < config.iterations; iteration++) {
++    await withOwnershipFileLock(config.lockPath, async () => {
++      let sentinel: Awaited<ReturnType<typeof open>> | undefined;
++      try {
++        sentinel = await open(config.sentinelPath!, 'wx');
++      } catch (error) {
++        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
++          send('overlap', { iteration });
++        }
++        throw error;
++      }
++
++      try {
++        await appendFile(config.journalPath!, `${JSON.stringify({ event: 'enter', pid: process.pid, iteration })}\n`);
++        // Widen the critical section across two event-loop turns. The sentinel
++        // makes overlap detection deterministic even if journal appends race.
++        await new Promise<void>(resolve => setImmediate(resolve));
++        await new Promise<void>(resolve => setImmediate(resolve));
++        await appendFile(config.journalPath!, `${JSON.stringify({ event: 'exit', pid: process.pid, iteration })}\n`);
++      } finally {
++        await sentinel.close();
++        await unlink(config.sentinelPath!).catch(() => undefined);
++      }
++    }, config.options, 'worker lock timeout');
++  }
++  send('done');
++}
++
++async function main(): Promise<void> {
++  send('ready');
++  await nextCommand(['start']);
++  if (config.mode === 'hold') await hold();
++  else await stress();
++  process.stdin.destroy();
++}
++
++main().catch(error => {
++  send('fatal', { message: error instanceof Error ? error.message : String(error) });
++  process.exitCode = 1;
++  process.stdin.destroy();
++});
+
+diff --git a/tests/ts/lib/lineage-lock-cross-process.test.ts b/tests/ts/lib/lineage-lock-cross-process.test.ts
+new file mode 100644
+index 0000000..b732cff
+--- /dev/null
++++ b/tests/ts/lib/lineage-lock-cross-process.test.ts
+@@ -0,0 +1,392 @@
++import { afterEach, beforeEach, describe, expect, it } from 'vitest';
++import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
++import { existsSync } from 'fs';
++import { mkdtemp, readFile, readdir, rm, unlink } from 'fs/promises';
++import { tmpdir } from 'os';
++import { basename, join } from 'path';
++import {
++  getLineageMutationLockPath,
++  type OwnershipFileLockOptions,
++} from '../../../src/lib/lineage-lock.js';
++import { cleanupTestVault, createTestVault } from '../fixtures/setup.js';
++
++interface WorkerEvent {
++  event: string;
++  pid: number;
++  iteration?: number;
++  message?: string;
++}
++
++interface WorkerConfig {
++  mode: 'hold' | 'stress';
++  lockPath: string;
++  options: OwnershipFileLockOptions;
++  sentinelPath?: string;
++  journalPath?: string;
++  iterations?: number;
++}
++
++const PROJECT_ROOT = process.cwd();
++const TSX_CLI = join(PROJECT_ROOT, 'node_modules', 'tsx', 'dist', 'cli.mjs');
++const WORKER = join(PROJECT_ROOT, 'tests', 'ts', 'fixtures', 'lineage-lock-worker.ts');
++const EVENT_TIMEOUT_MS = process.platform === 'win32' ? 20_000 : 8_000;
++
++class LockWorker {
++  readonly process: ChildProcessWithoutNullStreams;
++  readonly events: WorkerEvent[] = [];
++  readonly exit: Promise<number | null>;
++  private readonly waiters = new Set<() => void>();
++  private stdoutBuffer = '';
++  private stderr = '';
++
++  constructor(config: WorkerConfig) {
++    this.process = spawn(process.execPath, [TSX_CLI, WORKER, JSON.stringify(config)], {
++      cwd: PROJECT_ROOT,
++      env: { ...process.env, NO_COLOR: '1' },
++      stdio: ['pipe', 'pipe', 'pipe'],
++    });
++    this.process.stdout.setEncoding('utf8');
++    this.process.stderr.setEncoding('utf8');
++    this.process.stdout.on('data', chunk => this.consumeStdout(chunk));
++    this.process.stderr.on('data', chunk => { this.stderr += chunk; });
++    this.exit = new Promise((resolve, reject) => {
++      this.process.once('error', reject);
++      this.process.once('close', code => {
++        for (const wake of this.waiters) wake();
++        resolve(code);
++      });
++    });
++  }
++
++  send(command: 'start' | 'release' | 'crash'): void {
++    this.process.stdin.write(`${JSON.stringify({ command })}\n`);
++  }
++
++  async waitFor(event: string): Promise<WorkerEvent> {
++    const deadline = Date.now() + EVENT_TIMEOUT_MS;
++    while (true) {
++      const index = this.events.findIndex(candidate => candidate.event === event);
++      if (index >= 0) return this.events.splice(index, 1)[0]!;
++
++      const remaining = deadline - Date.now();
++      if (remaining <= 0 || this.process.exitCode !== null) {
++        throw new Error(
++          `Worker ${this.process.pid ?? 'unknown'} did not emit ${event}; ` +
++          `exit=${this.process.exitCode}, stderr=${this.stderr}, events=${JSON.stringify(this.events)}`
++        );
++      }
++      await new Promise<void>((resolve, reject) => {
++        const wake = (): void => {
++          clearTimeout(timer);
++          this.waiters.delete(wake);
++          resolve();
++        };
++        const timer = setTimeout(() => {
++          this.waiters.delete(wake);
++          reject(new Error(`Timed out waiting for worker event ${event}; stderr=${this.stderr}`));
++        }, remaining);
++        this.waiters.add(wake);
++      });
++    }
++  }
++
++  kill(): void {
++    if (this.process.exitCode === null && this.process.signalCode === null) {
++      this.process.kill('SIGKILL');
++    }
++  }
++
++  private consumeStdout(chunk: string): void {
++    this.stdoutBuffer += chunk;
++    while (true) {
++      const newline = this.stdoutBuffer.indexOf('\n');
++      if (newline < 0) break;
++      const line = this.stdoutBuffer.slice(0, newline);
++      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
++      if (line.trim()) this.events.push(JSON.parse(line) as WorkerEvent);
++      for (const wake of this.waiters) wake();
++    }
++  }
++}
++
++class BuiltCli {
++  readonly process: ChildProcessWithoutNullStreams;
++  readonly exit: Promise<number | null>;
++  stdout = '';
++  stderr = '';
++  private readonly waiters = new Set<() => void>();
++
++  constructor(vaultDir: string, args: string[]) {
++    this.process = spawn(process.execPath, [join(PROJECT_ROOT, 'dist', 'index.js'), '--vault', vaultDir, ...args], {
++      cwd: PROJECT_ROOT,
++      env: { ...process.env, NO_COLOR: '1' },
++      stdio: ['pipe', 'pipe', 'pipe'],
++    });
++    this.process.stdout.setEncoding('utf8');
++    this.process.stderr.setEncoding('utf8');
++    this.process.stdout.on('data', chunk => {
++      this.stdout += chunk;
++      for (const wake of this.waiters) wake();
++    });
++    this.process.stderr.on('data', chunk => {
++      this.stderr += chunk;
++      for (const wake of this.waiters) wake();
++    });
++    this.exit = new Promise((resolve, reject) => {
++      this.process.once('error', reject);
++      this.process.once('close', code => {
++        for (const wake of this.waiters) wake();
++        resolve(code);
++      });
++    });
++  }
++
++  async waitForOutput(text: string): Promise<void> {
++    const deadline = Date.now() + EVENT_TIMEOUT_MS;
++    while (!`${this.stdout}\n${this.stderr}`.includes(text)) {
++      const remaining = deadline - Date.now();
++      if (remaining <= 0 || this.process.exitCode !== null) {
++        throw new Error(
++          `CLI did not print ${JSON.stringify(text)}; exit=${this.process.exitCode}, ` +
++          `stdout=${this.stdout}, stderr=${this.stderr}`
++        );
++      }
++      await new Promise<void>((resolve, reject) => {
++        const wake = (): void => {
++          clearTimeout(timer);
++          this.waiters.delete(wake);
++          resolve();
++        };
++        const timer = setTimeout(() => {
++          this.waiters.delete(wake);
++          reject(new Error(`Timed out waiting for CLI output ${JSON.stringify(text)}`));
++        }, remaining);
++        this.waiters.add(wake);
++      });
++    }
++  }
++
++  async expectStillRunningFor(ms: number): Promise<void> {
++    const exited = await Promise.race([
++      this.exit.then(() => true),
++      new Promise<false>(resolve => setTimeout(() => resolve(false), ms)),
++    ]);
++    if (exited) {
++      throw new Error(`CLI exited before reaching the held lock; stdout=${this.stdout}, stderr=${this.stderr}`);
++    }
++  }
++
++  kill(): void {
++    if (this.process.exitCode === null && this.process.signalCode === null) {
++      this.process.kill('SIGKILL');
++    }
++  }
++}
++
++describe.sequential('cross-process ownership file lock', () => {
++  let tempDir: string;
++  let lockPath: string;
++  const workers: LockWorker[] = [];
++  const clis: BuiltCli[] = [];
++  const vaults: string[] = [];
++
++  beforeEach(async () => {
++    tempDir = await mkdtemp(join(tmpdir(), 'bwrb-lock-cross-process-'));
++    lockPath = join(tempDir, '.bwrb', 'locks', 'shared.lock');
++  });
++
++  afterEach(async () => {
++    for (const worker of workers) worker.kill();
++    for (const cli of clis) cli.kill();
++    await Promise.allSettled(workers.map(worker => worker.exit));
++    await Promise.allSettled(clis.map(cli => cli.exit));
++    workers.length = 0;
++    clis.length = 0;
++    await Promise.all(vaults.map(vault => cleanupTestVault(vault)));
++    vaults.length = 0;
++    await rm(tempDir, { recursive: true, force: true });
++  });
++
++  it('protects a live open-handle holder and closes before artifact cleanup', async () => {
++    const holder = startWorker({
++      mode: 'hold',
++      lockPath,
++      options: { retryMs: 5, attempts: 200, staleMs: 60, heartbeatMs: 10 },
++    });
++    await holder.waitFor('ready');
++    holder.send('start');
++    const acquired = await holder.waitFor('acquired');
++
++    const contender = startWorker({
++      mode: 'hold',
++      lockPath,
++      options: { retryMs: 5, attempts: 15, staleMs: 60, heartbeatMs: 10 },
++    });
++    await contender.waitFor('ready');
++    contender.send('start');
++    const fatal = await contender.waitFor('fatal');
++    expect(fatal.message).toBe('worker lock timeout');
++    expect(await contender.exit).toBe(1);
++
++    const metadata = JSON.parse(await readFile(lockPath, 'utf8')) as { pid: number };
++    expect(metadata.pid).toBe(acquired.pid);
++
++    holder.send('release');
++    await holder.waitFor('released');
++    expect(await holder.exit).toBe(0);
++    await expectNoArtifacts(lockPath);
++  });
++
++  it('recovers a dead holder, protects its successor, and cleans recovery artifacts', async () => {
++    const crashed = startWorker({
++      mode: 'hold',
++      lockPath,
++      options: { retryMs: 5, attempts: 200, staleMs: 60, heartbeatMs: 10 },
++    });
++    await crashed.waitFor('ready');
++    crashed.send('start');
++    await crashed.waitFor('acquired');
++    crashed.send('crash');
++    expect(await crashed.exit).toBe(70);
++
++    const successor = startWorker({
++      mode: 'hold',
++      lockPath,
++      options: { retryMs: 5, attempts: 400, staleMs: 60, heartbeatMs: 10 },
++    });
++    await successor.waitFor('ready');
++    successor.send('start');
++    const acquired = await successor.waitFor('acquired');
++    expect((JSON.parse(await readFile(lockPath, 'utf8')) as { pid: number }).pid).toBe(acquired.pid);
++
++    const contender = startWorker({
++      mode: 'hold',
++      lockPath,
++      options: { retryMs: 5, attempts: 15, staleMs: 60, heartbeatMs: 10 },
++    });
++    await contender.waitFor('ready');
++    contender.send('start');
++    expect((await contender.waitFor('fatal')).message).toBe('worker lock timeout');
++    expect(await contender.exit).toBe(1);
++    expect((JSON.parse(await readFile(lockPath, 'utf8')) as { pid: number }).pid).toBe(acquired.pid);
++
++    successor.send('release');
++    await successor.waitFor('released');
++    expect(await successor.exit).toBe(0);
++    await expectNoArtifacts(lockPath);
++  });
++
++  it('serializes a deterministic multi-process critical-section stress run', async () => {
++    const journalPath = join(tempDir, 'journal.ndjson');
++    const sentinelPath = join(tempDir, 'critical-section.active');
++    const options = { retryMs: 2, attempts: 2_000, staleMs: 1_000, heartbeatMs: 50 };
++    const contenders = Array.from({ length: 4 }, () => startWorker({
++      mode: 'stress',
++      lockPath,
++      options,
++      sentinelPath,
++      journalPath,
++      iterations: 12,
++    }));
++
++    await Promise.all(contenders.map(worker => worker.waitFor('ready')));
++    for (const worker of contenders) worker.send('start');
++    await Promise.all(contenders.map(worker => worker.waitFor('done')));
++    expect(await Promise.all(contenders.map(worker => worker.exit))).toEqual([0, 0, 0, 0]);
++    expect(contenders.flatMap(worker => worker.events).find(event => event.event === 'overlap')).toBeUndefined();
++
++    const journal = (await readFile(journalPath, 'utf8')).trim().split('\n')
++      .map(line => JSON.parse(line) as { event: 'enter' | 'exit'; pid: number; iteration: number });
++    expect(journal).toHaveLength(4 * 12 * 2);
++    for (let index = 0; index < journal.length; index += 2) {
++      const enter = journal[index]!;
++      const exit = journal[index + 1]!;
++      expect(enter.event).toBe('enter');
++      expect(exit).toEqual({ event: 'exit', pid: enter.pid, iteration: enter.iteration });
++    }
++    expect(existsSync(sentinelPath)).toBe(false);
++    await expectNoArtifacts(lockPath);
++  });
++
++  it('classifies under-lock delete disappearance in the actual built CLI text and JSON contracts', async () => {
++    const vaultDir = await createTestVault();
++    vaults.push(vaultDir);
++
++    const textTarget = join(vaultDir, 'Ideas', 'Sample Idea.md');
++    const textLock = startWorker({
++      mode: 'hold',
++      lockPath: getLineageMutationLockPath(vaultDir, textTarget),
++      options: { retryMs: 5, attempts: 400, staleMs: 1_000, heartbeatMs: 50 },
++    });
++    await textLock.waitFor('ready');
++    textLock.send('start');
++    await textLock.waitFor('acquired');
++
++    const textCli = startCli(vaultDir, ['delete', 'Sample Idea']);
++    textCli.process.stdin.end('y\n');
++    await textCli.waitForOutput('File to delete: Ideas/Sample Idea.md');
++    await unlink(textTarget);
++    textLock.send('release');
++    await textLock.waitFor('released');
++
++    expect(await textCli.exit).toBe(2);
++    expect(textCli.stderr).toContain(
++      'Delete target disappeared while waiting for the lineage lock; retry the command: Ideas/Sample Idea.md'
++    );
++    expect(textCli.stderr).not.toContain('File not found or already deleted');
++    await expectNoArtifacts(getLineageMutationLockPath(vaultDir, textTarget));
++
++    const jsonTarget = join(vaultDir, 'Ideas', 'Another Idea.md');
++    const jsonLock = startWorker({
++      mode: 'hold',
++      lockPath: getLineageMutationLockPath(vaultDir, jsonTarget),
++      options: { retryMs: 5, attempts: 400, staleMs: 1_000, heartbeatMs: 50 },
++    });
++    await jsonLock.waitFor('ready');
++    jsonLock.send('start');
++    await jsonLock.waitFor('acquired');
++
++    const jsonCli = startCli(vaultDir, [
++      'delete', '--path', 'Ideas/Another Idea.md', '--execute', '--output', 'json',
++    ]);
++    jsonCli.process.stdin.end();
++    // The held lock has no observer hook. A bounded alive check is the one
++    // timing allowance in this test: built dist startup/selection is complete
++    // well before this on both local and focused Windows CI, and an early exit
++    // fails with its captured output instead of being silently retried.
++    await jsonCli.expectStillRunningFor(process.platform === 'win32' ? 2_000 : 750);
++    await unlink(jsonTarget);
++    jsonLock.send('release');
++    await jsonLock.waitFor('released');
++
++    expect(await jsonCli.exit).toBe(2);
++    expect(JSON.parse(jsonCli.stdout)).toEqual({
++      success: false,
++      error: 'Delete target disappeared while waiting for the lineage lock; retry the command: Ideas/Another Idea.md',
++      data: {
++        reason: 'target-disappeared',
++        retryable: true,
++        paths: ['Ideas/Another Idea.md'],
++      },
++      code: 2,
++    });
++    await expectNoArtifacts(getLineageMutationLockPath(vaultDir, jsonTarget));
++  });
++
++  function startWorker(config: WorkerConfig): LockWorker {
++    const worker = new LockWorker(config);
++    workers.push(worker);
++    return worker;
++  }
++
++  function startCli(vaultDir: string, args: string[]): BuiltCli {
++    const cli = new BuiltCli(vaultDir, args);
++    clis.push(cli);
++    return cli;
++  }
++});
++
++async function expectNoArtifacts(lockPath: string): Promise<void> {
++  const entries = await readdir(join(lockPath, '..')).catch(() => []);
++  expect(entries.filter(entry => entry.startsWith(basename(lockPath)))).toEqual([]);
++}
+
+diff --git a/tests/ts/lib/lineage-lock.test.ts b/tests/ts/lib/lineage-lock.test.ts
+index ebec030..0ee322e 100644
+--- a/tests/ts/lib/lineage-lock.test.ts
++++ b/tests/ts/lib/lineage-lock.test.ts
+@@ -1,6 +1,6 @@
+ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+ import { existsSync } from 'fs';
+-import { mkdtemp, mkdir, readFile, readdir, rm, stat, unlink, utimes, writeFile } from 'fs/promises';
++import { chmod, mkdtemp, mkdir, readFile, readdir, rm, stat, unlink, utimes, writeFile } from 'fs/promises';
+ import { basename, join } from 'path';
+ import { tmpdir } from 'os';
+ import {
+@@ -150,6 +150,26 @@ describe('lineage mutation lock', () => {
+     expect(await readFile(lockPath, 'utf-8')).toBe('not-json\n');
+   });
+ 
++  it.skipIf(process.platform === 'win32')('fails closed when an existing lock cannot be read', async () => {
++    const source = join(vaultDir, 'Source.md');
++    const lockPath = getLineageMutationLockPath(vaultDir, source);
++    await mkdir(join(vaultDir, '.bwrb', 'locks'), { recursive: true });
++    await writeFile(lockPath, lockMetadata(lockPath, deadPid(), 'unreadable-owner'));
++    await chmod(lockPath, 0o000);
++
++    try {
++      await expect(withLineageMutationLocks(
++        vaultDir,
++        [source],
++        async () => undefined,
++        { attempts: 8, retryMs: 2, staleMs: 1 }
++      )).rejects.toThrow('Timed out waiting for a fork-lineage mutation lock');
++      expect(existsSync(lockPath)).toBe(true);
++    } finally {
++      await chmod(lockPath, 0o600);
++    }
++  });
++
+   it('does not let an old holder release a replacement lock with another token', async () => {
+     const source = join(vaultDir, 'Source.md');
+     const lockPath = getLineageMutationLockPath(vaultDir, source);
+
+END DIFF
+
+ADDITIONAL CONTEXT
+The originating user explicitly requires both Fable passes to leave durable logs under `.task-sweep/logs/`. Those prompt, output, and metadata files are intentional task evidence, not accidental runtime artifacts. Do not classify their presence alone as unrequested scope. The metadata logs contain model/finish/output metadata and previews, not secrets.
+END ADDITIONAL CONTEXT

--- a/.task-sweep/logs/claude-fable-5-review-output-20260710-113900-issue-807.md
+++ b/.task-sweep/logs/claude-fable-5-review-output-20260710-113900-issue-807.md
@@ -1,0 +1,18 @@
+BLOCKERS
+
+## SPEC FIDELITY
+
+**Blocker**
+1. **Unrequested scope: committed agent artifacts.** `.task-sweep/logs/claude-fable-5-plan-20260710-103418-issue-807.log`, `...-plan-output-...md`, and `...-plan-prompt-...md` are internal planning logs/prompts (including the full planning packet and repo internals) committed into the repo. Nothing in the spec or repo conventions calls for shipping these; they are accidental artifacts and should be removed before merge.
+
+**Met**
+- Windows CI lane: additive `windows_lock_tests` job (`.github/workflows/ci.yml:151-176`); does not rename required checks, Node 22 / pnpm 10.11.0 per standards.
+- Deterministic real cross-process harness: `tests/ts/fixtures/lineage-lock-worker.ts` + `tests/ts/lib/lineage-lock-cross-process.test.ts` cover live-holder protection, dead-holder recovery, successor protection, 4×12 sentinel-verified stress, and artifact cleanup via real `spawn` with event handshakes.
+- Disappearance classification: `DeleteTargetDisappearedError` (`src/commands/delete.ts:907-914`) thrown only from under-lock call sites (`:685`, `:868` pass `true`); initial not-found path (`classifyMissingAsDisappeared` default false) preserves the existing `ENOENT`/`IO_ERROR` contract as required.
+- Docs/changelog/SKILL updated; `docs-site/.../delete.md:104-133` text and JSON exactly match implementation and the cross-process test assertions. No #820 scope creep observed.
+
+## STANDARDS AND RISK
+
+**Non-blocking**
+1. **Bulk-path test gap.** Bulk disappearance (`handleBulkDelete`, `src/commands/delete.ts:685`) has no automated test; only single-file text and `--path` JSON flows are exercised in `lineage-lock-cross-process.test.ts`. Independent tester evidence covers it, but a regression test would lock the contract in. Also, the local `catch` bodies in `handleBulkDelete`/`deleteResolvedFile` are not visible in this diff — confirm they rethrow `DeleteTargetDisappearedError` rather than collapsing it (evidence suggests they do).
+2. **Fragile

--- a/.task-sweep/logs/claude-fable-5-review-prompt-20260710-113900-issue-807.md
+++ b/.task-sweep/logs/claude-fable-5-review-prompt-20260710-113900-issue-807.md
@@ -1,0 +1,1224 @@
+You are reviewing an embedded pull request diff for correctness bugs, missed edge cases, security issues, test gaps, documentation drift, runtime risk, and release risk.
+
+Review on two separate axes:
+- SPEC FIDELITY: missing or partial requirements, wrong behavior, and unrequested scope.
+- STANDARDS AND RISK: documented repo conventions plus correctness, security, tests, runtime behavior, and maintainability.
+
+The repo's documented standards override generic advice.
+
+Constraints:
+- Review only the embedded task/spec, standards, and diff below.
+- Do not use tools.
+- Do not edit files or take any repository/GitHub action.
+- Treat this as a PR readiness gate.
+- Cite file paths and line numbers where possible.
+- Start with exactly one verdict label: BLOCKERS, NON-BLOCKING, or NO BLOCKERS.
+- Separate blockers from non-blocking suggestions. Only blockers go back through the fix loop.
+- Report SPEC FIDELITY and STANDARDS AND RISK separately.
+- Review docs against implementation.
+- Keep the response short.
+
+BEGIN TASK / SPEC
+GitHub issue #807: Harden lineage lock portability and cross-process errors.
+Context: PR #806 added a path-keyed cross-process lock for new --fork and non-force delete. Existing local/Linux coverage handled active-owner protection, heartbeat, dead/corrupt recovery, token-safe release, in-process contenders, and CLI races.
+Required follow-up:
+- Add Windows CI or focused Windows harness, especially open-handle behavior during heartbeat, recovery rename, quarantine cleanup, and close-before-release unlink.
+- Add deterministic real cross-process stress, not only in-process contenders/CLI race repetitions.
+- Classify target disappearance between delete selection and authoritative under-lock recheck instead of generic ENOENT.
+Acceptance:
+- Shared lineage lock preserves mutual exclusion and cleans artifacts on supported Windows and POSIX.
+- Target removed during delete gets stable documented text and JSON errors.
+- Existing new --fork, delete-lineage, note-ID lock, adoption, and repository suites stay green.
+Scope: do not implement issue #820 edit-vs-lineage concurrency. One PR, docs/changelog/agent skill as repository conventions require.
+Evidence supplied by implementation and independent tester:
+- Exact Node 22 local parity: build, verify:pack, typecheck, lint, knip, 3030 tests passed/3 skipped.
+- Focused suites 29/29; repeated cross-process suite 5 times 20/20; delete regression 22/22.
+- Independent built-CLI bulk disappearance: exit 2, stable retry text, remaining target untouched.
+- Independent initial-no-match text/JSON unchanged: exit/code 1, no retryable data.
+- Canonical docs checks and 42-page Astro build pass.
+GitHub Windows execution is a separate gate still running and must pass before merge.
+END TASK / SPEC
+
+BEGIN REPO STANDARDS
+AGENTS.md:
+- Canonical user-facing behavior docs live under docs-site/src/content/docs/.
+- Update docs/skill/SKILL.md for changed CLI automation behavior.
+- CI source is .github/workflows/ci.yml; Node 22; pnpm 10.11.0.
+- Exact local parity order: pnpm build; pnpm verify:pack; pnpm typecheck; pnpm lint; pnpm knip; pnpm test -- --exclude='**/*.pty.test.ts'.
+- Always use pnpm test for local Vitest execution; CI commands must be non-watch.
+- Knip should use semantically justified entries/exports, not broad ignores.
+- Include the entire diff for external review because worktree paths may be inaccessible.
+TaskSweep:
+- Additive Windows job must not rename required checks.
+- Final reviewer has no tools; judge only this packet.
+- Blockers are concrete correctness/spec/repository-policy issues, not generic preferences.
+END REPO STANDARDS
+
+BEGIN DIFF
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 45b86a2..b7e2f26 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -148,6 +148,33 @@ jobs:
+         env:
+           BWRB_TEST_DIST: 1
+ 
++  windows_lock_tests:
++    name: Windows Lock Tests
++    runs-on: windows-latest
++    timeout-minutes: 15
++    steps:
++      - uses: actions/checkout@v4
++
++      - name: Install pnpm
++        uses: pnpm/action-setup@v4
++        with:
++          version: 10.11.0
++
++      - name: Setup Node.js
++        uses: actions/setup-node@v4
++        with:
++          node-version: 22
++          cache: pnpm
++
++      - name: Install dependencies
++        run: pnpm install --frozen-lockfile
++
++      - name: Build
++        run: pnpm build
++
++      - name: Run focused lineage lock tests
++        run: pnpm exec vitest run tests/ts/lib/lineage-lock.test.ts tests/ts/lib/lineage-lock-cross-process.test.ts tests/ts/lib/note-id-lock.test.ts tests/ts/commands/delete-lineage.test.ts
++
+   test-pty:
+     name: PTY Tests
+     runs-on: ubuntu-latest
+
+diff --git a/.task-sweep/logs/claude-fable-5-plan-20260710-103418-issue-807.log b/.task-sweep/logs/claude-fable-5-plan-20260710-103418-issue-807.log
+new file mode 100644
+index 0000000..1121db4
+--- /dev/null
++++ b/.task-sweep/logs/claude-fable-5-plan-20260710-103418-issue-807.log
+@@ -0,0 +1,6 @@
++model_requested: anthropic/claude-fable-5
++model_returned: anthropic/claude-5-fable-20260609
++finish_reason: stop
++output: .task-sweep/logs/claude-fable-5-plan-output-20260710-103418-issue-807.md
++chars: 7822 words: 1124
++preview: # Implementation Plan — Issue #807\n\n## 1. Production changes for Windows semantics (keep minimal)\n\n**Principle: preserve fail-closed timeout behavior.** Windows sharing violations during recovery should be treated as "holder may be alive" and retried within the acquisition loop — never as license to steal.\n\nSmallest set of changes:\n\n- **Classify errors in `readLockSnapshot` instead of swallowing everything.** Distinguish: `ENOENT` (gone, retry acquire), `EBUSY`/`EPERM`/`EACCES` on Windows (likely open handle → treat as live holder, back off), parse errors (corrupt → existing quarantine path). Return a discriminated result (`{ kind: 'missing' | 'busy' | 'corrupt' | 'ok', ... }`) rather than `null`. This is the single most important seam.\n- **Recovery rename/unlink:** wrap the quarantine `re
+
+diff --git a/.task-sweep/logs/claude-fable-5-plan-output-20260710-103418-issue-807.md b/.task-sweep/logs/claude-fable-5-plan-output-20260710-103418-issue-807.md
+new file mode 100644
+index 0000000..1a1e073
+--- /dev/null
++++ b/.task-sweep/logs/claude-fable-5-plan-output-20260710-103418-issue-807.md
+@@ -0,0 +1,65 @@
++# Implementation Plan — Issue #807
++
++## 1. Production changes for Windows semantics (keep minimal)
++
++**Principle: preserve fail-closed timeout behavior.** Windows sharing violations during recovery should be treated as "holder may be alive" and retried within the acquisition loop — never as license to steal.
++
++Smallest set of changes:
++
++- **Classify errors in `readLockSnapshot` instead of swallowing everything.** Distinguish: `ENOENT` (gone, retry acquire), `EBUSY`/`EPERM`/`EACCES` on Windows (likely open handle → treat as live holder, back off), parse errors (corrupt → existing quarantine path). Return a discriminated result (`{ kind: 'missing' | 'busy' | 'corrupt' | 'ok', ... }`) rather than `null`. This is the single most important seam.
++- **Recovery rename/unlink:** wrap the quarantine `rename` and `unlink` in a small retry that treats `EBUSY`/`EPERM`/`EACCES`/`ENOTEMPTY` as transient; after N attempts, fall through to the normal wait loop (fail-closed). On Windows a rename of an open file fails — that's evidence the holder is alive, which is the correct outcome.
++- **Identity check in token-safe release:** on Windows, `ino`/`dev` from `fs.stat` are frequently 0 or unstable across filesystems. Gate the inode/dev comparison behind `stat.ino !== 0 && stat.dev !== 0` (or a platform check), falling back to token + mtime + size. Do not weaken the token check itself.
++- **`process.kill(pid, 0)`** works on Windows Node for liveness (throws `ESRCH` for dead PIDs); no change needed, but add a test asserting the semantics you rely on. Note the known caveat: PID reuse — TTL + heartbeat already mitigates; document it in a comment, don't engineer around it.
++- **`handle.utimes` heartbeat:** verify on Windows CI; if it fails on open handles (unlikely), fall back to path-based `utimes` on the owned lock. Don't preemptively change.
++
++Do **not** add flock/LockFileEx native bindings or restructure the metadata format.
++
++## 2. Deterministic cross-process test harness
++
++Design a small child-process fixture, not in-process promises:
++
++- **Fixture script** (`tests/ts/fixtures/lock-holder.mjs` or `.ts` run via `tsx`/compiled): a child that acquires the lock on a given path, writes structured events (`acquired`, `heartbeat`, `entered-critical`, `exited-critical`, `released`) to stdout as NDJSON, and responds to stdin commands (`hold`, `release`, `crash` via `process.exit(1)` without cleanup, `kill` self via SIGKILL where supported / `process.abort()` on Windows).
++- **Injectable timing:** thread TTL/heartbeat/poll intervals through env vars (`BWRB_LOCK_TTL_MS` etc.) read by `lineage-lock.ts` (or an options object the fixture passes). Use ~50–200ms values in tests.
++- **Scenarios (all real `spawn`, deterministic via event handshakes, not sleeps):**
++  1. *Live-holder protection:* child A acquires + heartbeats; child B attempts with short timeout → B times out; assert lock file still owned by A's token.
++  2. *Dead-holder recovery + successor ownership:* A acquires then `crash`es; B acquires after TTL; assert B's token in lock file, no `.recovery`/`.quarantine-*` residue after B releases.
++  3. *No overlap:* N=4 children loop through the critical section appending `enter:<pid>`/`exit:<pid>` to a shared journal file (append-only writes); parent asserts strict alternation — every `enter` is followed by its own `exit` before any other `enter`. Bounded iterations (e.g., 20 each) keep it deterministic-enough and fast.
++  4. *Cleanup:* after all children exit, lock dir contains no lock/recovery/quarantine artifacts.
++- **Mutation-kill check:** verify the harness fails on a broken implementation by temporarily (in a review note, not committed) disabling the token check — scenario 3 should catch overlap. Mention this validation in the PR description; don't commit a mutation-testing framework.
++- Run these under the regular non-PTY suite; they must pass on both OSes. Guard flaky primitives (e.g., SIGKILL) with platform-appropriate crash modes.
++
++## 3. CI shape
++
++- Add a **separate matrix job or standalone `windows-tests` job** in `ci.yml`: `windows-latest`, Node 22, pnpm 10.11.0, running **only** build + typecheck + a focused test glob (`vitest run tests/ts/lib/lineage-lock* tests/ts/lib/note-id-lock* tests/ts/commands/delete-lineage*` plus the new cross-process file). Do not run PTY tests or the full suite on Windows.
++- Do **not** touch the existing required-check names (`Test`, `PTY Tests`, `Vercel`). The Windows job is additive; whether it becomes required is a repo-policy decision outside this PR — flag it in the PR description.
++- Cache pnpm store; use `vitest run` explicitly (no watch). Set generous but bounded timeouts (Windows FS is slower).
++
++## 4. Delete-disappearance contract
++
++- New typed error, e.g. `DeleteTargetDisappearedError` in the delete/lineage module, thrown by `assessCurrentDeleteLineage` (or the call site) **only** when the target was present at selection but missing under lock. Carry `{ paths: string[], retryable: true }`.
++- **Text:** `Target was deleted by another process while waiting for the lock: <relative-path>. Re-run to confirm.` Exit with the existing validation/retryable error class, not generic IO.
++- **JSON:** `{ success: false, error: "<same text>", code: "TARGET_DISAPPEARED", retryable: true, paths: ["..."] }`. Yes to `retryable` and paths; skip a separate `reason` field — the code is the reason. Confirm `TARGET_DISAPPEARED` fits the existing error-code enum conventions before inventing it; if codes are a closed set, extend it in one place.
++- **Do not change** initial-selection `ENOENT` behavior (`File not found or already deleted`, `IO_ERROR`).
++- Bulk path: if bulk delete flows through the same under-lock assessor, classify per-path — disappeared targets reported with the new code, others processed normally. If bulk uses a different assessor, cover only the shared path and note the gap.
++
++## 5. Verification, docs, failure modes
++
++**Focused checks:**
++- New `tests/ts/lib/lineage-lock-crossproc.test.ts` (scenarios above).
++- New delete test: acquire the lock from a helper child, delete the target file out-of-band, release; assert delete emits the new text/JSON code and leaves no lock artifacts.
++- Existing lineage-lock, note-id-lock, delete-lineage suites unchanged and green.
++- Real CLI: `bwrb delete <path>` and `--json` variant against the staged disappearance scenario.
++
++**Full parity in exact order:** build → verify:pack → typecheck → lint → knip → non-PTY tests.
++
++**Docs:** update `docs-site/src/content/docs/` delete command page with the new error text/JSON code; update `docs/skill/SKILL.md` since command behavior (error contract) changes. Changelog entry per repo convention.
++
++**Likely failure modes:** knip flagging the child fixture as unused (add to knip entry config); Windows CI pnpm/tsx path issues; test flakes from too-tight TTLs on slow Windows runners (use handshakes, not timing assertions); fixture zombie processes (always `kill` in `afterEach`); NDJSON stdout buffering (flush per line, read incrementally).
++
++## 6. Scope traps / #820 boundaries
++
++- **Do not** generalize the lock into an edit/identity-write primitive, add write-intent modes, or refactor `withOwnershipFileLock`'s public API for future consumers. The only shareable artifact is the injectable-timing option and error-classified `readLockSnapshot`, both of which #807 needs anyway.
++- Do not reopen or re-test the #817 old-holder/successor fix beyond the successor scenario already in the cross-process harness (which covers it as a side effect — fine, but don't duplicate `note-id-lock.test.ts` logic).
++- Do not touch fork/adopt logic; only the delete under-lock recheck classification.
++- Keep the Windows job additive; changing required checks or branch protection is out of scope.
++- Open a **draft PR** only; do not mark ready or merge.
+\ No newline at end of file
+
+diff --git a/.task-sweep/logs/claude-fable-5-plan-prompt-20260710-103418-issue-807.md b/.task-sweep/logs/claude-fable-5-plan-prompt-20260710-103418-issue-807.md
+new file mode 100644
+index 0000000..d4d4bcc
+--- /dev/null
++++ b/.task-sweep/logs/claude-fable-5-plan-prompt-20260710-103418-issue-807.md
+@@ -0,0 +1,88 @@
++# TaskSweep early planning packet — BWRB issue #807
++
++You are advising on a repository task before implementation. You have no tools. Do not claim to inspect anything outside this packet. Give concise advice to another implementation agent; do not mutate anything or broaden beyond the issue.
++
++## Normalized task
++
++- ID/source: GitHub issue #807, `https://github.com/3mdistal/bwrb/issues/807`
++- Title: Harden lineage lock portability and cross-process errors
++- Repo/base: `3mdistal/bwrb`, `origin/main` at `55dfc19887d9442fe0d3c94b28ac01b18c7012a0`
++- Branch/lane: `codex/807-lineage-lock-hardening` in an isolated worktree
++- Problem: PR #806 added path-keyed cross-process locks for `new --fork` and non-force delete. Current tests prove ownership, heartbeats, stale/dead recovery, token-safe release, contenders, and CLI races on the local platform, but the issue still asks for explicit Windows/open-handle coverage, a deterministic cross-process stress harness, and a stable error when a delete target disappears while the command waits for its authoritative lock.
++- Desired outcome:
++  1. The shared lineage/ownership lock preserves mutual exclusion and cleans its lock/recovery/quarantine artifacts on supported POSIX and Windows environments, with a focused Windows CI lane or equivalent harness.
++  2. A deterministic multi-process test—not merely in-process promises or probabilistic CLI races—proves live-holder protection, dead-holder recovery, successor ownership, no overlapping critical sections, and cleanup.
++  3. Non-force delete classifies a target that disappears between initial selection and the under-lock recheck with stable documented text and JSON behavior, rather than a generic raw or misleading `ENOENT`.
++  4. Existing fork, adopt, delete-lineage, note-ID-lock, and full repository suites remain green.
++- Manual successful story: As a vault owner running competing BWRB processes, a crashed lineage mutator cannot leave the vault permanently locked and live/successor holders cannot overlap or have their locks stolen. If another process deletes my target while my non-force delete waits, BWRB returns a clear retryable result and leaves no lock debris.
++- Merge is authorized only after the full TaskSweep and repository-policy gates. The implementer must open a draft PR and must not ready or merge it.
++
++## Repo facts and standards
++
++- TypeScript ESM Commander CLI; Node 22; pnpm 10.11.0.
++- Required checks: `Test`, `PTY Tests`, `Vercel`; strict up-to-date branch protection; zero required approvals.
++- Full local parity in exact order: build, verify:pack, typecheck, lint, knip, non-PTY test suite.
++- Canonical user docs live in `docs-site/src/content/docs/`; bundled agent guidance is `docs/skill/SKILL.md` when command behavior changes.
++- Current `.github/workflows/ci.yml` runs Linux/Ubuntu only. A Windows-focused job must avoid silently testing a different contract and must remain practical for PR CI.
++- Use `pnpm test`/Vitest run semantics; do not invoke watch mode.
++
++## Current implementation
++
++### Ownership-safe shared lock
++
++`src/lib/lineage-lock.ts` now exposes `withLineageMutationLocks` and `withOwnershipFileLock`. It:
++
++- derives deterministic SHA-256 lock paths from normalized vault-relative source paths;
++- writes JSON metadata `{ version, pid, token, createdAt, heartbeatAt, pathKey }` under exclusive `open(..., 'wx')`;
++- heartbeats the owned open handle with `handle.utimes`;
++- checks process liveness with `process.kill(pid, 0)` after TTL expiry;
++- uses a fixed `.recovery` ownership marker, rechecks stale state, renames stale locks to unique `.quarantine-*` paths, unlinks quarantine, and cleans stale quarantine files;
++- releases only when the token plus snapshot raw/dev/inode/mtime/size still match;
++- sorts multi-lock acquisition to avoid deadlock.
++
++PR #817 generalized this primitive for the fixed note-ID assignment and registry lock paths after an independent tester reproduced an old-holder/successor overlap bug. New `tests/ts/lib/note-id-lock.test.ts` covers heartbeat and successor ownership in process, but not a true child-process stress harness. This partially satisfies #807; do not duplicate it or reopen the fixed race.
++
++Potential portability seams to examine:
++
++- `readLockSnapshot` catches every read/stat error and returns null, erasing distinctions such as Windows sharing/permission errors.
++- stale recovery renames then unlinks a lock pathname; Windows open-handle rules differ from POSIX.
++- `cleanupQuarantines` unlinks matching paths concurrently and ignores errors.
++- `process.kill(pid, 0)`, inode/dev identity, and open-handle `utimes` need actual Windows evidence.
++- tests currently synthesize dead PIDs and contenders in one Vitest process.
++
++### Delete disappearance behavior
++
++Single non-force delete resolves a file, performs prompts/backlink work, then:
++
++```ts
++await withLineageMutationLocks(vaultDir, [fullPath], async () => {
++  const assessment = await assessCurrentDeleteLineage(schema, vaultDir, [file]);
++  if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
++  await unlink(fullPath);
++  await unregisterIssuedNotePath(vaultDir, relativePath);
++});
++```
++
++`assessCurrentDeleteLineage` rebuilds a fresh snapshot. If the selected path is now missing it creates an `Error("File not found or no longer managed: ...")` and assigns `error.code = 'ENOENT'`. The outer delete command collapses all `ENOENT` errors to:
++
++- text: `File not found or already deleted`, exit validation error;
++- JSON: `{ success: false, error: "File not found or already deleted", code: IO_ERROR }`.
++
++The issue asks for stable classification of the specific between-selection-and-lock disappearance. Consider a narrow typed error with a retryable machine-readable payload/code and documented wording, without changing unrelated initial not-found behavior. Cover bulk and single paths if they share the same under-lock assessor.
++
++### Existing tests
++
++- `tests/ts/lib/lineage-lock.test.ts`: deterministic lock path, cleanup, ordered multi-lock acquisition, TTL recovery, live-holder protection, heartbeat, dead/corrupt recovery, token-safe replacement, 2/10 in-process contenders, recovery-marker ownership, timeout.
++- `tests/ts/lib/note-id-lock.test.ts`: both fixed note-ID lock paths, heartbeat/live holder, successor preservation and third-holder serialization.
++- `tests/ts/commands/delete-lineage.test.ts`: non-force guard behavior and a real CLI fork-versus-delete race, but no deterministic target-disappears-while-waiting scenario.
++
++## Planning questions
++
++Give a concise implementation plan covering:
++
++1. The smallest production-code changes needed for supported Windows semantics. Should recovery retry specific Windows sharing errors, avoid relying on inode identity when unavailable, or preserve current fail-closed timeout behavior?
++2. A deterministic cross-process Vitest/worker design that runs on POSIX and Windows, uses short injectable timing, proves no overlap and artifact cleanup, and would fail on a deliberately broken ownership implementation.
++3. The safest CI shape for Windows coverage without destabilizing unrelated PTY/full-suite jobs.
++4. A stable text/JSON contract and typed error for a delete target disappearing during the authoritative under-lock recheck, including whether the JSON payload should include `retryable`, `reason`, and target paths.
++5. Exact focused and real CLI checks, docs/changelog changes, and likely failure modes.
++6. Scope traps or conflicts with the later #820 edit/identity-write concurrency task. Keep #820 out of this PR unless a tiny reusable primitive is strictly necessary.
+
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+index 333707c..d9529af 100644
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -10,6 +10,7 @@ All notable changes to Bowerbird are documented in this file.
+ 
+ ### Fixed
+ 
++- **Portable lineage mutation locking** — lineage and note-ID locks now fail closed on Windows sharing/permission errors, have deterministic real-process stress coverage plus a focused Windows CI lane, and return stable retryable text/JSON context when a non-force delete target disappears before its authoritative under-lock recheck (#807).
+ - **Body-only content targeting** — `--body` now excludes YAML frontmatter in both note filtering and detailed match reports while preserving original file line numbers and body-only context (#812).
+ 
+ ## [0.2.3] - 2026-07-09
+
+diff --git a/docs-site/src/content/docs/changelog.md b/docs-site/src/content/docs/changelog.md
+index 59fd1ea..38859b3 100644
+--- a/docs-site/src/content/docs/changelog.md
++++ b/docs-site/src/content/docs/changelog.md
+@@ -12,6 +12,7 @@ For the complete changelog with all details, see [CHANGELOG.md](https://github.c
+ ### Unreleased
+ 
+ - **Existing-note lineage adoption** — `bwrb lineage adopt <child> --from <parent>` adds a dry-run-first, lock-coordinated path for recording known derivation between existing same-type notes without rewriting their bodies or ordinary metadata
++- **Portable lineage mutation locking** — fork, adopt, delete, and note-ID coordination now have real cross-process stress coverage, a focused Windows CI lane, and stable retryable output when a non-force delete target disappears while waiting for its lock
+ 
+ ### 0.2.3
+ 
+
+diff --git a/docs-site/src/content/docs/reference/commands/delete.md b/docs-site/src/content/docs/reference/commands/delete.md
+index 00d2da6..c4fc95a 100644
+--- a/docs-site/src/content/docs/reference/commands/delete.md
++++ b/docs-site/src/content/docs/reference/commands/delete.md
+@@ -101,6 +101,36 @@ not deleted or reparented, and their `forked-from` value stays intact. A later
+ `bwrb audit` reports that retained provenance as `dangling-forked-from`, so the
+ source can still be restored deliberately.
+ 
++### Concurrent target disappearance
++
++Without `--force`, bwrb selects the requested notes and then rechecks them while
++holding the same lineage locks used by fork and adoption. If another process
++deletes a selected target before that authoritative recheck, the command stops
++without deleting any of the remaining selected notes and returns exit code `2`:
++
++```text
++Error: Delete target disappeared while waiting for the lineage lock; retry the command: Ideas/Launch Brief.md
++```
++
++JSON output keeps the numeric exit-code contract and adds stable retry context:
++
++```json
++{
++  "success": false,
++  "error": "Delete target disappeared while waiting for the lineage lock; retry the command: Ideas/Launch Brief.md",
++  "data": {
++    "reason": "target-disappeared",
++    "retryable": true,
++    "paths": ["Ideas/Launch Brief.md"]
++  },
++  "code": 2
++}
++```
++
++Re-resolve the target set before retrying. This is distinct from an initial
++not-found result: the note existed during selection but vanished while the
++command was coordinating its write.
++
+ ## Examples
+ 
+ ### Single-file Mode
+
+diff --git a/docs/skill/SKILL.md b/docs/skill/SKILL.md
+index 9479a35..eead77a 100644
+--- a/docs/skill/SKILL.md
++++ b/docs/skill/SKILL.md
+@@ -229,6 +229,12 @@ their `forked-from` value, which surfaces as `dangling-forked-from` in
+ `bwrb audit`. Use `bwrb list --lineage <target> --output json` before forcing a
+ parent deletion when an agent needs to enumerate the affected family.
+ 
++For non-force deletion, another process can remove a selected target while the
++command waits for its lineage lock. JSON reports numeric `code: 2` with
++`data.reason: "target-disappeared"`, `data.retryable: true`, and the selected
++`data.paths`. Re-resolve those paths before retrying; do not treat this as a
++successful or ordinary initial not-found result.
++
+ ## Core Commands for Agents
+ 
+ ### Querying Notes
+
+diff --git a/knip.jsonc b/knip.jsonc
+index b53571e..0b9f731 100644
+--- a/knip.jsonc
++++ b/knip.jsonc
+@@ -3,7 +3,11 @@
+ 
+   // Vitest plugin doesn't auto-detect globalTeardown from config
+   "vitest": {
+-    "entry": ["tests/ts/teardown.ts"]
++    "entry": [
++      "tests/ts/teardown.ts",
++      // Spawned as a real child process by the cross-process lock suite.
++      "tests/ts/fixtures/lineage-lock-worker.ts"
++    ]
+   },
+ 
+   // Ignore intentional public API exports and separate projects
+
+diff --git a/src/commands/delete.ts b/src/commands/delete.ts
+index e37d6b2..6907707 100644
+--- a/src/commands/delete.ts
++++ b/src/commands/delete.ts
+@@ -270,6 +270,11 @@ Note: Deletion is permanent. The file is removed from the filesystem.
+         return;
+       }
+ 
++      if (err instanceof DeleteTargetDisappearedError) {
++        reportDeleteTargetDisappeared(err, jsonMode);
++        return;
++      }
++
+       const message = err instanceof Error ? err.message : String(err);
+ 
+       // Handle specific error types
+@@ -677,7 +682,7 @@ async function handleBulkDelete(
+   } else {
+     try {
+       await withLineageMutationLocks(vaultDir, files.map(file => file.path), async () => {
+-        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, files);
++        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, files, true);
+         if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
+         await deleteFiles();
+       });
+@@ -860,7 +865,7 @@ async function deleteResolvedFile({
+   } else {
+     try {
+       await withLineageMutationLocks(vaultDir, [fullPath], async () => {
+-        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, [file]);
++        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, [file], true);
+         if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
+         await unlink(fullPath);
+         await unregisterIssuedNotePath(vaultDir, relativePath);
+@@ -899,18 +904,32 @@ class LineageDeleteRefusalError extends Error {
+   }
+ }
+ 
++class DeleteTargetDisappearedError extends Error {
++  constructor(readonly paths: string[]) {
++    super(paths.length === 1
++      ? `Delete target disappeared while waiting for the lineage lock; retry the command: ${paths[0]}`
++      : `Delete targets disappeared while waiting for lineage locks; retry the command: ${paths.join(', ')}`);
++    this.name = 'DeleteTargetDisappearedError';
++  }
++}
++
+ async function assessCurrentDeleteLineage(
+   schema: Awaited<ReturnType<typeof loadSchema>>,
+   vaultDir: string,
+-  files: ManagedFile[]
++  files: ManagedFile[],
++  classifyMissingAsDisappeared = false
+ ): Promise<DeleteLineageBlock[]> {
+   const snapshot = await buildVaultNoteSnapshot(schema, vaultDir);
+   const assessment = assessDeleteLineage(snapshot, files.map(file => file.path));
+   if (assessment.missing.length > 0) {
++    const missingPaths = assessment.missing.map(
++      path => files.find(file => file.path === path)?.relativePath ?? path
++    );
++    if (classifyMissingAsDisappeared) {
++      throw new DeleteTargetDisappearedError(missingPaths);
++    }
+     const error = new Error(
+-      `File not found or no longer managed: ${assessment.missing
+-        .map(path => files.find(file => file.path === path)?.relativePath ?? path)
+-        .join(', ')}`
++      `File not found or no longer managed: ${missingPaths.join(', ')}`
+     ) as NodeJS.ErrnoException;
+     error.code = 'ENOENT';
+     throw error;
+@@ -918,6 +937,25 @@ async function assessCurrentDeleteLineage(
+   return assessment.blocked;
+ }
+ 
++function reportDeleteTargetDisappeared(
++  error: DeleteTargetDisappearedError,
++  jsonMode: boolean
++): void {
++  if (jsonMode) {
++    printJson(jsonError(error.message, {
++      code: ExitCodes.IO_ERROR,
++      data: {
++        reason: 'target-disappeared',
++        retryable: true,
++        paths: error.paths,
++      },
++    }));
++  } else {
++    printError(error.message);
++  }
++  process.exitCode = ExitCodes.IO_ERROR;
++}
++
+ function reportLineageRefusal(
+   blocked: DeleteLineageBlock[],
+   jsonMode: boolean,
+
+diff --git a/src/lib/lineage-lock.ts b/src/lib/lineage-lock.ts
+index 47bbc2e..46a7633 100644
+--- a/src/lib/lineage-lock.ts
++++ b/src/lib/lineage-lock.ts
+@@ -33,6 +33,11 @@ interface LockSnapshot {
+   size: number;
+ }
+ 
++type LockSnapshotRead =
++  | { kind: 'present'; snapshot: LockSnapshot }
++  | { kind: 'missing' }
++  | { kind: 'busy' };
++
+ const DEFAULT_OPTIONS: OwnershipFileLockOptions = {
+   retryMs: LOCK_RETRY_MS,
+   attempts: LOCK_ATTEMPTS,
+@@ -166,8 +171,11 @@ async function acquireLock(
+       }
+     } catch (error) {
+       if (!isFileExistsError(error)) throw error;
+-      const snapshot = await readLockSnapshot(lockPath);
+-      if (snapshot && await isRecoverable(snapshot, options.staleMs)) {
++      const snapshotRead = await readLockSnapshot(lockPath);
++      if (
++        snapshotRead.kind === 'present' &&
++        await isRecoverable(snapshotRead.snapshot, options.staleMs)
++      ) {
+         await recoverStaleLock(lockPath, recoveryPath, options);
+         continue;
+       }
+@@ -208,8 +216,11 @@ async function heartbeatOwnedLock(
+   handle: Awaited<ReturnType<typeof open>>,
+   token: string
+ ): Promise<void> {
+-  const snapshot = await readLockSnapshot(lockPath);
+-  if (snapshot?.metadata?.token !== token) return;
++  const snapshotRead = await readLockSnapshot(lockPath);
++  if (
++    snapshotRead.kind !== 'present' ||
++    snapshotRead.snapshot.metadata?.token !== token
++  ) return;
+ 
+   // Touch the inode opened by this holder, not whatever might have appeared at
+   // the path after the ownership check. The immutable JSON records when the
+@@ -227,8 +238,11 @@ async function recoverStaleLock(
+   if (!recovery) return;
+ 
+   try {
+-    const snapshot = await readLockSnapshot(lockPath);
+-    if (!snapshot || !await isRecoverable(snapshot, options.staleMs)) return;
++    const snapshotRead = await readLockSnapshot(lockPath);
++    if (
++      snapshotRead.kind !== 'present' ||
++      !await isRecoverable(snapshotRead.snapshot, options.staleMs)
++    ) return;
+ 
+     // The fixed recovery marker prevents acquisitions and competing reapers
+     // while the stale inode is atomically moved out of the lock pathname.
+@@ -237,7 +251,12 @@ async function recoverStaleLock(
+       await rename(lockPath, quarantinePath);
+       await unlink(quarantinePath).catch(() => undefined);
+     } catch (error) {
+-      if (!isFileMissingError(error)) throw error;
++      if (isFileMissingError(error)) return;
++      // Windows can reject a rename while another process still has the lock
++      // open. That is evidence against stealing, not permission to do so. Let
++      // the outer acquisition loop retry until its ordinary timeout instead.
++      if (isTransientLockFilesystemError(error)) return;
++      throw error;
+     }
+     await cleanupQuarantines(lockPath);
+   } finally {
+@@ -272,9 +291,12 @@ async function acquireRecoveryMarker(
+     };
+   } catch (error) {
+     if (!isFileExistsError(error)) throw error;
+-    const snapshot = await readLockSnapshot(recoveryPath);
+-    if (snapshot && await isRecoverable(snapshot, options.staleMs)) {
+-      await unlinkIfUnchanged(recoveryPath, snapshot);
++    const snapshotRead = await readLockSnapshot(recoveryPath);
++    if (
++      snapshotRead.kind === 'present' &&
++      await isRecoverable(snapshotRead.snapshot, options.staleMs)
++    ) {
++      await unlinkIfUnchanged(recoveryPath, snapshotRead.snapshot);
+     }
+     return null;
+   }
+@@ -284,10 +306,11 @@ async function recoveryIsInProgress(
+   recoveryPath: string,
+   options: OwnershipFileLockOptions
+ ): Promise<boolean> {
+-  const snapshot = await readLockSnapshot(recoveryPath);
+-  if (!snapshot) return false;
+-  if (await isRecoverable(snapshot, options.staleMs)) {
+-    await unlinkIfUnchanged(recoveryPath, snapshot);
++  const snapshotRead = await readLockSnapshot(recoveryPath);
++  if (snapshotRead.kind === 'missing') return false;
++  if (snapshotRead.kind === 'busy') return true;
++  if (await isRecoverable(snapshotRead.snapshot, options.staleMs)) {
++    await unlinkIfUnchanged(recoveryPath, snapshotRead.snapshot);
+     return pathExists(recoveryPath);
+   }
+   return true;
+@@ -318,23 +341,30 @@ function isProcessAlive(pid: number): boolean {
+   }
+ }
+ 
+-async function readLockSnapshot(lockPath: string): Promise<LockSnapshot | null> {
++async function readLockSnapshot(lockPath: string): Promise<LockSnapshotRead> {
+   try {
+     const [raw, info] = await Promise.all([
+       readFile(lockPath, 'utf-8'),
+       stat(lockPath),
+     ]);
+     return {
+-      raw,
+-      metadata: parseLockMetadata(raw),
+-      device: info.dev,
+-      inode: info.ino,
+-      modifiedAt: info.mtimeMs,
+-      size: info.size,
++      kind: 'present',
++      snapshot: {
++        raw,
++        metadata: parseLockMetadata(raw),
++        device: info.dev,
++        inode: info.ino,
++        modifiedAt: info.mtimeMs,
++        size: info.size,
++      },
+     };
+   } catch (error) {
+-    if (isFileMissingError(error)) return null;
+-    return null;
++    if (isFileMissingError(error)) return { kind: 'missing' };
++    // Sharing/permission failures are common while Windows handles are open.
++    // Preserve that distinction so every caller fails closed rather than
++    // mistaking an unreadable lock or recovery marker for an absent one.
++    if (isTransientLockFilesystemError(error)) return { kind: 'busy' };
++    throw error;
+   }
+ }
+ 
+@@ -357,14 +387,20 @@ function parseLockMetadata(raw: string): LockMetadata | null {
+ }
+ 
+ async function unlinkIfOwned(lockPath: string, token: string): Promise<boolean> {
+-  const snapshot = await readLockSnapshot(lockPath);
+-  if (snapshot?.metadata?.token !== token) return false;
+-  return unlinkIfUnchanged(lockPath, snapshot);
++  const snapshotRead = await readLockSnapshot(lockPath);
++  if (
++    snapshotRead.kind !== 'present' ||
++    snapshotRead.snapshot.metadata?.token !== token
++  ) return false;
++  return unlinkIfUnchanged(lockPath, snapshotRead.snapshot);
+ }
+ 
+ async function unlinkIfUnchanged(lockPath: string, expected: LockSnapshot): Promise<boolean> {
+-  const current = await readLockSnapshot(lockPath);
+-  if (!current || !snapshotsMatch(current, expected)) return false;
++  const currentRead = await readLockSnapshot(lockPath);
++  if (
++    currentRead.kind !== 'present' ||
++    !snapshotsMatch(currentRead.snapshot, expected)
++  ) return false;
+   try {
+     await unlink(lockPath);
+     return true;
+@@ -394,8 +430,11 @@ async function pathExists(path: string): Promise<boolean> {
+   try {
+     await stat(path);
+     return true;
+-  } catch {
+-    return false;
++  } catch (error) {
++    if (isFileMissingError(error)) return false;
++    // An unreadable recovery marker must serialize acquisitions just like a
++    // readable one. The lock would rather wait than become two locks in a coat.
++    return true;
+   }
+ }
+ 
+@@ -409,6 +448,12 @@ function isFileMissingError(error: unknown): boolean {
+     (error as NodeJS.ErrnoException).code === 'ENOENT';
+ }
+ 
++function isTransientLockFilesystemError(error: unknown): boolean {
++  if (!(error instanceof Error) || !('code' in error)) return false;
++  const code = (error as NodeJS.ErrnoException).code;
++  return code === 'EBUSY' || code === 'EPERM' || code === 'EACCES' || code === 'ENOTEMPTY';
++}
++
+ function delay(ms: number): Promise<void> {
+   return new Promise(resolveDelay => setTimeout(resolveDelay, ms));
+ }
+
+diff --git a/tests/ts/fixtures/lineage-lock-worker.ts b/tests/ts/fixtures/lineage-lock-worker.ts
+new file mode 100644
+index 0000000..1ce5aba
+--- /dev/null
++++ b/tests/ts/fixtures/lineage-lock-worker.ts
+@@ -0,0 +1,99 @@
++import { appendFile, mkdir, open, unlink } from 'fs/promises';
++import { dirname } from 'path';
++import { createInterface } from 'readline';
++import {
++  withOwnershipFileLock,
++  type OwnershipFileLockOptions,
++} from '../../../src/lib/lineage-lock.js';
++
++type WorkerMode = 'hold' | 'stress';
++
++interface WorkerConfig {
++  mode: WorkerMode;
++  lockPath: string;
++  options: OwnershipFileLockOptions;
++  sentinelPath?: string;
++  journalPath?: string;
++  iterations?: number;
++}
++
++interface WorkerCommand {
++  command: 'start' | 'release' | 'crash';
++}
++
++const config = JSON.parse(process.argv[2] ?? '') as WorkerConfig;
++const commands = createInterface({ input: process.stdin, crlfDelay: Infinity })[Symbol.asyncIterator]();
++
++function send(event: string, data: Record<string, unknown> = {}): void {
++  process.stdout.write(`${JSON.stringify({ event, pid: process.pid, ...data })}\n`);
++}
++
++async function nextCommand(expected: WorkerCommand['command'][]): Promise<WorkerCommand> {
++  const result = await commands.next();
++  if (result.done) throw new Error(`stdin closed while waiting for ${expected.join(' or ')}`);
++  const command = JSON.parse(result.value) as WorkerCommand;
++  if (!expected.includes(command.command)) {
++    throw new Error(`Expected ${expected.join(' or ')}, received ${command.command}`);
++  }
++  return command;
++}
++
++async function hold(): Promise<void> {
++  await withOwnershipFileLock(config.lockPath, async () => {
++    send('acquired');
++    const command = await nextCommand(['release', 'crash']);
++    if (command.command === 'crash') {
++      // Deliberately bypass finally/release to leave a real dead-owner lock.
++      process.exit(70);
++    }
++  }, config.options, 'worker lock timeout');
++  send('released');
++}
++
++async function stress(): Promise<void> {
++  if (!config.sentinelPath || !config.journalPath || !config.iterations) {
++    throw new Error('Stress mode requires sentinelPath, journalPath, and iterations');
++  }
++
++  await mkdir(dirname(config.journalPath), { recursive: true });
++  for (let iteration = 0; iteration < config.iterations; iteration++) {
++    await withOwnershipFileLock(config.lockPath, async () => {
++      let sentinel: Awaited<ReturnType<typeof open>> | undefined;
++      try {
++        sentinel = await open(config.sentinelPath!, 'wx');
++      } catch (error) {
++        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
++          send('overlap', { iteration });
++        }
++        throw error;
++      }
++
++      try {
++        await appendFile(config.journalPath!, `${JSON.stringify({ event: 'enter', pid: process.pid, iteration })}\n`);
++        // Widen the critical section across two event-loop turns. The sentinel
++        // makes overlap detection deterministic even if journal appends race.
++        await new Promise<void>(resolve => setImmediate(resolve));
++        await new Promise<void>(resolve => setImmediate(resolve));
++        await appendFile(config.journalPath!, `${JSON.stringify({ event: 'exit', pid: process.pid, iteration })}\n`);
++      } finally {
++        await sentinel.close();
++        await unlink(config.sentinelPath!).catch(() => undefined);
++      }
++    }, config.options, 'worker lock timeout');
++  }
++  send('done');
++}
++
++async function main(): Promise<void> {
++  send('ready');
++  await nextCommand(['start']);
++  if (config.mode === 'hold') await hold();
++  else await stress();
++  process.stdin.destroy();
++}
++
++main().catch(error => {
++  send('fatal', { message: error instanceof Error ? error.message : String(error) });
++  process.exitCode = 1;
++  process.stdin.destroy();
++});
+
+diff --git a/tests/ts/lib/lineage-lock-cross-process.test.ts b/tests/ts/lib/lineage-lock-cross-process.test.ts
+new file mode 100644
+index 0000000..b732cff
+--- /dev/null
++++ b/tests/ts/lib/lineage-lock-cross-process.test.ts
+@@ -0,0 +1,392 @@
++import { afterEach, beforeEach, describe, expect, it } from 'vitest';
++import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
++import { existsSync } from 'fs';
++import { mkdtemp, readFile, readdir, rm, unlink } from 'fs/promises';
++import { tmpdir } from 'os';
++import { basename, join } from 'path';
++import {
++  getLineageMutationLockPath,
++  type OwnershipFileLockOptions,
++} from '../../../src/lib/lineage-lock.js';
++import { cleanupTestVault, createTestVault } from '../fixtures/setup.js';
++
++interface WorkerEvent {
++  event: string;
++  pid: number;
++  iteration?: number;
++  message?: string;
++}
++
++interface WorkerConfig {
++  mode: 'hold' | 'stress';
++  lockPath: string;
++  options: OwnershipFileLockOptions;
++  sentinelPath?: string;
++  journalPath?: string;
++  iterations?: number;
++}
++
++const PROJECT_ROOT = process.cwd();
++const TSX_CLI = join(PROJECT_ROOT, 'node_modules', 'tsx', 'dist', 'cli.mjs');
++const WORKER = join(PROJECT_ROOT, 'tests', 'ts', 'fixtures', 'lineage-lock-worker.ts');
++const EVENT_TIMEOUT_MS = process.platform === 'win32' ? 20_000 : 8_000;
++
++class LockWorker {
++  readonly process: ChildProcessWithoutNullStreams;
++  readonly events: WorkerEvent[] = [];
++  readonly exit: Promise<number | null>;
++  private readonly waiters = new Set<() => void>();
++  private stdoutBuffer = '';
++  private stderr = '';
++
++  constructor(config: WorkerConfig) {
++    this.process = spawn(process.execPath, [TSX_CLI, WORKER, JSON.stringify(config)], {
++      cwd: PROJECT_ROOT,
++      env: { ...process.env, NO_COLOR: '1' },
++      stdio: ['pipe', 'pipe', 'pipe'],
++    });
++    this.process.stdout.setEncoding('utf8');
++    this.process.stderr.setEncoding('utf8');
++    this.process.stdout.on('data', chunk => this.consumeStdout(chunk));
++    this.process.stderr.on('data', chunk => { this.stderr += chunk; });
++    this.exit = new Promise((resolve, reject) => {
++      this.process.once('error', reject);
++      this.process.once('close', code => {
++        for (const wake of this.waiters) wake();
++        resolve(code);
++      });
++    });
++  }
++
++  send(command: 'start' | 'release' | 'crash'): void {
++    this.process.stdin.write(`${JSON.stringify({ command })}\n`);
++  }
++
++  async waitFor(event: string): Promise<WorkerEvent> {
++    const deadline = Date.now() + EVENT_TIMEOUT_MS;
++    while (true) {
++      const index = this.events.findIndex(candidate => candidate.event === event);
++      if (index >= 0) return this.events.splice(index, 1)[0]!;
++
++      const remaining = deadline - Date.now();
++      if (remaining <= 0 || this.process.exitCode !== null) {
++        throw new Error(
++          `Worker ${this.process.pid ?? 'unknown'} did not emit ${event}; ` +
++          `exit=${this.process.exitCode}, stderr=${this.stderr}, events=${JSON.stringify(this.events)}`
++        );
++      }
++      await new Promise<void>((resolve, reject) => {
++        const wake = (): void => {
++          clearTimeout(timer);
++          this.waiters.delete(wake);
++          resolve();
++        };
++        const timer = setTimeout(() => {
++          this.waiters.delete(wake);
++          reject(new Error(`Timed out waiting for worker event ${event}; stderr=${this.stderr}`));
++        }, remaining);
++        this.waiters.add(wake);
++      });
++    }
++  }
++
++  kill(): void {
++    if (this.process.exitCode === null && this.process.signalCode === null) {
++      this.process.kill('SIGKILL');
++    }
++  }
++
++  private consumeStdout(chunk: string): void {
++    this.stdoutBuffer += chunk;
++    while (true) {
++      const newline = this.stdoutBuffer.indexOf('\n');
++      if (newline < 0) break;
++      const line = this.stdoutBuffer.slice(0, newline);
++      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
++      if (line.trim()) this.events.push(JSON.parse(line) as WorkerEvent);
++      for (const wake of this.waiters) wake();
++    }
++  }
++}
++
++class BuiltCli {
++  readonly process: ChildProcessWithoutNullStreams;
++  readonly exit: Promise<number | null>;
++  stdout = '';
++  stderr = '';
++  private readonly waiters = new Set<() => void>();
++
++  constructor(vaultDir: string, args: string[]) {
++    this.process = spawn(process.execPath, [join(PROJECT_ROOT, 'dist', 'index.js'), '--vault', vaultDir, ...args], {
++      cwd: PROJECT_ROOT,
++      env: { ...process.env, NO_COLOR: '1' },
++      stdio: ['pipe', 'pipe', 'pipe'],
++    });
++    this.process.stdout.setEncoding('utf8');
++    this.process.stderr.setEncoding('utf8');
++    this.process.stdout.on('data', chunk => {
++      this.stdout += chunk;
++      for (const wake of this.waiters) wake();
++    });
++    this.process.stderr.on('data', chunk => {
++      this.stderr += chunk;
++      for (const wake of this.waiters) wake();
++    });
++    this.exit = new Promise((resolve, reject) => {
++      this.process.once('error', reject);
++      this.process.once('close', code => {
++        for (const wake of this.waiters) wake();
++        resolve(code);
++      });
++    });
++  }
++
++  async waitForOutput(text: string): Promise<void> {
++    const deadline = Date.now() + EVENT_TIMEOUT_MS;
++    while (!`${this.stdout}\n${this.stderr}`.includes(text)) {
++      const remaining = deadline - Date.now();
++      if (remaining <= 0 || this.process.exitCode !== null) {
++        throw new Error(
++          `CLI did not print ${JSON.stringify(text)}; exit=${this.process.exitCode}, ` +
++          `stdout=${this.stdout}, stderr=${this.stderr}`
++        );
++      }
++      await new Promise<void>((resolve, reject) => {
++        const wake = (): void => {
++          clearTimeout(timer);
++          this.waiters.delete(wake);
++          resolve();
++        };
++        const timer = setTimeout(() => {
++          this.waiters.delete(wake);
++          reject(new Error(`Timed out waiting for CLI output ${JSON.stringify(text)}`));
++        }, remaining);
++        this.waiters.add(wake);
++      });
++    }
++  }
++
++  async expectStillRunningFor(ms: number): Promise<void> {
++    const exited = await Promise.race([
++      this.exit.then(() => true),
++      new Promise<false>(resolve => setTimeout(() => resolve(false), ms)),
++    ]);
++    if (exited) {
++      throw new Error(`CLI exited before reaching the held lock; stdout=${this.stdout}, stderr=${this.stderr}`);
++    }
++  }
++
++  kill(): void {
++    if (this.process.exitCode === null && this.process.signalCode === null) {
++      this.process.kill('SIGKILL');
++    }
++  }
++}
++
++describe.sequential('cross-process ownership file lock', () => {
++  let tempDir: string;
++  let lockPath: string;
++  const workers: LockWorker[] = [];
++  const clis: BuiltCli[] = [];
++  const vaults: string[] = [];
++
++  beforeEach(async () => {
++    tempDir = await mkdtemp(join(tmpdir(), 'bwrb-lock-cross-process-'));
++    lockPath = join(tempDir, '.bwrb', 'locks', 'shared.lock');
++  });
++
++  afterEach(async () => {
++    for (const worker of workers) worker.kill();
++    for (const cli of clis) cli.kill();
++    await Promise.allSettled(workers.map(worker => worker.exit));
++    await Promise.allSettled(clis.map(cli => cli.exit));
++    workers.length = 0;
++    clis.length = 0;
++    await Promise.all(vaults.map(vault => cleanupTestVault(vault)));
++    vaults.length = 0;
++    await rm(tempDir, { recursive: true, force: true });
++  });
++
++  it('protects a live open-handle holder and closes before artifact cleanup', async () => {
++    const holder = startWorker({
++      mode: 'hold',
++      lockPath,
++      options: { retryMs: 5, attempts: 200, staleMs: 60, heartbeatMs: 10 },
++    });
++    await holder.waitFor('ready');
++    holder.send('start');
++    const acquired = await holder.waitFor('acquired');
++
++    const contender = startWorker({
++      mode: 'hold',
++      lockPath,
++      options: { retryMs: 5, attempts: 15, staleMs: 60, heartbeatMs: 10 },
++    });
++    await contender.waitFor('ready');
++    contender.send('start');
++    const fatal = await contender.waitFor('fatal');
++    expect(fatal.message).toBe('worker lock timeout');
++    expect(await contender.exit).toBe(1);
++
++    const metadata = JSON.parse(await readFile(lockPath, 'utf8')) as { pid: number };
++    expect(metadata.pid).toBe(acquired.pid);
++
++    holder.send('release');
++    await holder.waitFor('released');
++    expect(await holder.exit).toBe(0);
++    await expectNoArtifacts(lockPath);
++  });
++
++  it('recovers a dead holder, protects its successor, and cleans recovery artifacts', async () => {
++    const crashed = startWorker({
++      mode: 'hold',
++      lockPath,
++      options: { retryMs: 5, attempts: 200, staleMs: 60, heartbeatMs: 10 },
++    });
++    await crashed.waitFor('ready');
++    crashed.send('start');
++    await crashed.waitFor('acquired');
++    crashed.send('crash');
++    expect(await crashed.exit).toBe(70);
++
++    const successor = startWorker({
++      mode: 'hold',
++      lockPath,
++      options: { retryMs: 5, attempts: 400, staleMs: 60, heartbeatMs: 10 },
++    });
++    await successor.waitFor('ready');
++    successor.send('start');
++    const acquired = await successor.waitFor('acquired');
++    expect((JSON.parse(await readFile(lockPath, 'utf8')) as { pid: number }).pid).toBe(acquired.pid);
++
++    const contender = startWorker({
++      mode: 'hold',
++      lockPath,
++      options: { retryMs: 5, attempts: 15, staleMs: 60, heartbeatMs: 10 },
++    });
++    await contender.waitFor('ready');
++    contender.send('start');
++    expect((await contender.waitFor('fatal')).message).toBe('worker lock timeout');
++    expect(await contender.exit).toBe(1);
++    expect((JSON.parse(await readFile(lockPath, 'utf8')) as { pid: number }).pid).toBe(acquired.pid);
++
++    successor.send('release');
++    await successor.waitFor('released');
++    expect(await successor.exit).toBe(0);
++    await expectNoArtifacts(lockPath);
++  });
++
++  it('serializes a deterministic multi-process critical-section stress run', async () => {
++    const journalPath = join(tempDir, 'journal.ndjson');
++    const sentinelPath = join(tempDir, 'critical-section.active');
++    const options = { retryMs: 2, attempts: 2_000, staleMs: 1_000, heartbeatMs: 50 };
++    const contenders = Array.from({ length: 4 }, () => startWorker({
++      mode: 'stress',
++      lockPath,
++      options,
++      sentinelPath,
++      journalPath,
++      iterations: 12,
++    }));
++
++    await Promise.all(contenders.map(worker => worker.waitFor('ready')));
++    for (const worker of contenders) worker.send('start');
++    await Promise.all(contenders.map(worker => worker.waitFor('done')));
++    expect(await Promise.all(contenders.map(worker => worker.exit))).toEqual([0, 0, 0, 0]);
++    expect(contenders.flatMap(worker => worker.events).find(event => event.event === 'overlap')).toBeUndefined();
++
++    const journal = (await readFile(journalPath, 'utf8')).trim().split('\n')
++      .map(line => JSON.parse(line) as { event: 'enter' | 'exit'; pid: number; iteration: number });
++    expect(journal).toHaveLength(4 * 12 * 2);
++    for (let index = 0; index < journal.length; index += 2) {
++      const enter = journal[index]!;
++      const exit = journal[index + 1]!;
++      expect(enter.event).toBe('enter');
++      expect(exit).toEqual({ event: 'exit', pid: enter.pid, iteration: enter.iteration });
++    }
++    expect(existsSync(sentinelPath)).toBe(false);
++    await expectNoArtifacts(lockPath);
++  });
++
++  it('classifies under-lock delete disappearance in the actual built CLI text and JSON contracts', async () => {
++    const vaultDir = await createTestVault();
++    vaults.push(vaultDir);
++
++    const textTarget = join(vaultDir, 'Ideas', 'Sample Idea.md');
++    const textLock = startWorker({
++      mode: 'hold',
++      lockPath: getLineageMutationLockPath(vaultDir, textTarget),
++      options: { retryMs: 5, attempts: 400, staleMs: 1_000, heartbeatMs: 50 },
++    });
++    await textLock.waitFor('ready');
++    textLock.send('start');
++    await textLock.waitFor('acquired');
++
++    const textCli = startCli(vaultDir, ['delete', 'Sample Idea']);
++    textCli.process.stdin.end('y\n');
++    await textCli.waitForOutput('File to delete: Ideas/Sample Idea.md');
++    await unlink(textTarget);
++    textLock.send('release');
++    await textLock.waitFor('released');
++
++    expect(await textCli.exit).toBe(2);
++    expect(textCli.stderr).toContain(
++      'Delete target disappeared while waiting for the lineage lock; retry the command: Ideas/Sample Idea.md'
++    );
++    expect(textCli.stderr).not.toContain('File not found or already deleted');
++    await expectNoArtifacts(getLineageMutationLockPath(vaultDir, textTarget));
++
++    const jsonTarget = join(vaultDir, 'Ideas', 'Another Idea.md');
++    const jsonLock = startWorker({
++      mode: 'hold',
++      lockPath: getLineageMutationLockPath(vaultDir, jsonTarget),
++      options: { retryMs: 5, attempts: 400, staleMs: 1_000, heartbeatMs: 50 },
++    });
++    await jsonLock.waitFor('ready');
++    jsonLock.send('start');
++    await jsonLock.waitFor('acquired');
++
++    const jsonCli = startCli(vaultDir, [
++      'delete', '--path', 'Ideas/Another Idea.md', '--execute', '--output', 'json',
++    ]);
++    jsonCli.process.stdin.end();
++    // The held lock has no observer hook. A bounded alive check is the one
++    // timing allowance in this test: built dist startup/selection is complete
++    // well before this on both local and focused Windows CI, and an early exit
++    // fails with its captured output instead of being silently retried.
++    await jsonCli.expectStillRunningFor(process.platform === 'win32' ? 2_000 : 750);
++    await unlink(jsonTarget);
++    jsonLock.send('release');
++    await jsonLock.waitFor('released');
++
++    expect(await jsonCli.exit).toBe(2);
++    expect(JSON.parse(jsonCli.stdout)).toEqual({
++      success: false,
++      error: 'Delete target disappeared while waiting for the lineage lock; retry the command: Ideas/Another Idea.md',
++      data: {
++        reason: 'target-disappeared',
++        retryable: true,
++        paths: ['Ideas/Another Idea.md'],
++      },
++      code: 2,
++    });
++    await expectNoArtifacts(getLineageMutationLockPath(vaultDir, jsonTarget));
++  });
++
++  function startWorker(config: WorkerConfig): LockWorker {
++    const worker = new LockWorker(config);
++    workers.push(worker);
++    return worker;
++  }
++
++  function startCli(vaultDir: string, args: string[]): BuiltCli {
++    const cli = new BuiltCli(vaultDir, args);
++    clis.push(cli);
++    return cli;
++  }
++});
++
++async function expectNoArtifacts(lockPath: string): Promise<void> {
++  const entries = await readdir(join(lockPath, '..')).catch(() => []);
++  expect(entries.filter(entry => entry.startsWith(basename(lockPath)))).toEqual([]);
++}
+
+diff --git a/tests/ts/lib/lineage-lock.test.ts b/tests/ts/lib/lineage-lock.test.ts
+index ebec030..0ee322e 100644
+--- a/tests/ts/lib/lineage-lock.test.ts
++++ b/tests/ts/lib/lineage-lock.test.ts
+@@ -1,6 +1,6 @@
+ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+ import { existsSync } from 'fs';
+-import { mkdtemp, mkdir, readFile, readdir, rm, stat, unlink, utimes, writeFile } from 'fs/promises';
++import { chmod, mkdtemp, mkdir, readFile, readdir, rm, stat, unlink, utimes, writeFile } from 'fs/promises';
+ import { basename, join } from 'path';
+ import { tmpdir } from 'os';
+ import {
+@@ -150,6 +150,26 @@ describe('lineage mutation lock', () => {
+     expect(await readFile(lockPath, 'utf-8')).toBe('not-json\n');
+   });
+ 
++  it.skipIf(process.platform === 'win32')('fails closed when an existing lock cannot be read', async () => {
++    const source = join(vaultDir, 'Source.md');
++    const lockPath = getLineageMutationLockPath(vaultDir, source);
++    await mkdir(join(vaultDir, '.bwrb', 'locks'), { recursive: true });
++    await writeFile(lockPath, lockMetadata(lockPath, deadPid(), 'unreadable-owner'));
++    await chmod(lockPath, 0o000);
++
++    try {
++      await expect(withLineageMutationLocks(
++        vaultDir,
++        [source],
++        async () => undefined,
++        { attempts: 8, retryMs: 2, staleMs: 1 }
++      )).rejects.toThrow('Timed out waiting for a fork-lineage mutation lock');
++      expect(existsSync(lockPath)).toBe(true);
++    } finally {
++      await chmod(lockPath, 0o600);
++    }
++  });
++
+   it('does not let an old holder release a replacement lock with another token', async () => {
+     const source = join(vaultDir, 'Source.md');
+     const lockPath = getLineageMutationLockPath(vaultDir, source);
+
+END DIFF
+

--- a/.task-sweep/logs/claude-fable-5-review-remediation-20260710-115000-issue-807.log
+++ b/.task-sweep/logs/claude-fable-5-review-remediation-20260710-115000-issue-807.log
@@ -1,0 +1,6 @@
+model_requested: anthropic/claude-fable-5
+model_returned: anthropic/claude-5-fable-20260609
+finish_reason: stop
+output: /Users/alicemoore/Developer/bwrb-worktrees/issue-807-lineage-lock/.task-sweep/logs/claude-fable-5-review-remediation-output-20260710-115000-issue-807.md
+chars: 2834 words: 394
+preview: NO BLOCKERS\n\n## SPEC FIDELITY\n\n**Windows spawn fix (setup.ts):** Correct. `node_modules/.bin/tsx` is a POSIX shell shim (a `.cmd` on Windows, which `spawn` cannot exec without `shell: true`). Invoking `process.execPath` with `tsx/dist/cli.mjs` as the script is fully portable, pins the child to the same Node binary running the tests, and preserves the dist/source mode split exactly (`USE_DIST` → `dist/index.js`, else tsx + `src/index.ts`). Both call sites (`runCLI`, `runCLIWithOpenStdin`) were updated consistently.\n\n**Windows timeout fix (lineage-lock test):** Correct in intent and preserves test integrity. The prior interactive flow (`stdin.end('y\n')` + `waitForOutput` on the prompt) was the Windows-flaky observer; the interactive prompt itself is not the property under test — the propert

--- a/.task-sweep/logs/claude-fable-5-review-remediation-output-20260710-115000-issue-807.md
+++ b/.task-sweep/logs/claude-fable-5-review-remediation-output-20260710-115000-issue-807.md
@@ -1,0 +1,21 @@
+NO BLOCKERS
+
+## SPEC FIDELITY
+
+**Windows spawn fix (setup.ts):** Correct. `node_modules/.bin/tsx` is a POSIX shell shim (a `.cmd` on Windows, which `spawn` cannot exec without `shell: true`). Invoking `process.execPath` with `tsx/dist/cli.mjs` as the script is fully portable, pins the child to the same Node binary running the tests, and preserves the dist/source mode split exactly (`USE_DIST` → `dist/index.js`, else tsx + `src/index.ts`). Both call sites (`runCLI`, `runCLIWithOpenStdin`) were updated consistently.
+
+**Windows timeout fix (lineage-lock test):** Correct in intent and preserves test integrity. The prior interactive flow (`stdin.end('y\n')` + `waitForOutput` on the prompt) was the Windows-flaky observer; the interactive prompt itself is not the property under test — the property is "file removed while blocked on lock → exit 2 with exact text." Switching to `--path ... --execute` removes the fragile observer while the downstream assertions (exit 2, exact text) remain outside this diff. Critically, the failure mode of the bounded `expectStillRunningFor` heuristic is fail-safe: if the CLI hasn't reached the lock wait before `unlink`, the test fails with a different error/output — it cannot falsely pass. Parity with the JSON sibling's evidence mechanism is a consistency improvement. 115/115 targeted and 3030-pass full parity corroborate.
+
+## STANDARDS AND RISK
+
+Non-blocking observations:
+
+1. **Hardcoded internal tsx path.** `node_modules/tsx/dist/cli.mjs` reaches into the package's internal layout rather than its declared bin/exports. It works under pnpm's symlinked layout today, but would break silently on a tsx restructure. Consider `createRequire(import.meta.url).resolve('tsx/cli')` (tsx exports `./cli`) for a contract-backed resolution.
+
+2. **Timing-based liveness is a heuristic, not a synchronization point.** `expectStillRunningFor(2000/750)` can flake under heavy CI load (child slow to reach the lock wait). As noted above the flake direction is a false failure, not a false pass, and the non-interactive path genuinely has no public contention observer — the inline comment documents this honestly. Acceptable; just expect occasional retries on loaded runners.
+
+3. **Coverage shift, not loss.** The interactive-confirm ("y") path is no longer exercised under lock contention in this specific test. Fine as long as interactive delete confirmation is covered elsewhere in the suite (the 3030-test parity run suggests it is); worth a one-line confirmation in the PR description.
+
+4. Platform-conditional wait (2s Windows vs 750ms) adds ~1–2s wall time per run on Windows only; bounded and proportionate.
+
+**Verdict:** The delta resolves both cited Windows failures at their root causes (shell-shim spawn, interactive-output observer) without weakening product assertions. Ready to proceed.

--- a/.task-sweep/logs/claude-fable-5-review-remediation-prompt-20260710-115000-issue-807.md
+++ b/.task-sweep/logs/claude-fable-5-review-remediation-prompt-20260710-115000-issue-807.md
@@ -1,0 +1,83 @@
+You are performing a focused follow-up review after a CI fix loop. A prior full embedded review of BWRB PR #821 returned NO BLOCKERS using anthropic/claude-fable-5. The real Windows runner then failed because a shared test helper spawned the POSIX node_modules/.bin/tsx path, and because an interactive text-race observer timed out on Windows. Review only the remediation delta embedded below for correctness, regression risk, test validity, and whether it resolves those Windows failures without weakening product assertions.
+
+Constraints:
+- No tools or edits.
+- This is a PR readiness gate.
+- Start with exactly one of: BLOCKERS, NON-BLOCKING, NO BLOCKERS.
+- Separate SPEC FIDELITY from STANDARDS AND RISK.
+- Block only on concrete correctness, test-integrity, or repository-standard issues.
+- Keep the response concise.
+
+Context and evidence:
+- BWRB is Node 22, TypeScript ESM, pnpm 10.11.0.
+- Source-mode CLI tests must launch tsx portably; dist-mode tests must launch dist/index.js.
+- After this delta, targeted tests passed 115/115.
+- Exact full parity after this delta passed: build, verify:pack, typecheck, lint, knip, and 3030 passed/3 skipped across 114 files.
+- The text disappearance test remains a real built dist CLI invocation, still asserts exit 2 and exact text, and now uses the same bounded lock-wait evidence already used by its JSON sibling.
+- Durable .task-sweep logs committed alongside the delta are explicitly required by the originating user and are out of review scope here.
+
+BEGIN REMEDIATION DIFF
+diff --git a/tests/ts/fixtures/setup.ts b/tests/ts/fixtures/setup.ts
+index fd36863..5d25aff 100644
+--- a/tests/ts/fixtures/setup.ts
++++ b/tests/ts/fixtures/setup.ts
+@@ -9,7 +9,7 @@ import { BASELINE_SCHEMA } from './schemas.js';
+ export const PROJECT_ROOT = process.cwd();
+ export const CLI_PATH = join(PROJECT_ROOT, 'dist/index.js');
+ const CLI_SRC_PATH = join(PROJECT_ROOT, 'src/index.ts');
+-const TSX_BIN = join(PROJECT_ROOT, 'node_modules', '.bin', 'tsx');
++const TSX_CLI = join(PROJECT_ROOT, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+ 
+ const USE_DIST = process.env.BWRB_TEST_DIST === '1';
+ const NODE_DEP0205_SUPPRESSION = '--disable-warning=DEP0205';
+@@ -431,8 +431,10 @@ export async function runCLI(
+     retries = RUN_CLI_RETRIES,
+   } = options;
+ 
+-  const cliCommand = USE_DIST ? 'node' : TSX_BIN;
+-  const cliArgs = USE_DIST ? [CLI_PATH, ...fullArgs] : [CLI_SRC_PATH, ...fullArgs];
++  const cliCommand = process.execPath;
++  const cliArgs = USE_DIST
++    ? [CLI_PATH, ...fullArgs]
++    : [TSX_CLI, CLI_SRC_PATH, ...fullArgs];
+ 
+   const childEnv: Record<string, string> = Object.fromEntries(
+     Object.entries(process.env).filter(
+@@ -485,8 +487,10 @@ export async function runCLIWithOpenStdin(
+   }: Pick<RunCLIOptions, 'cwd' | 'env' | 'timeoutMs'> = {}
+ ): Promise<CLIResult> {
+   const fullArgs = vaultDir ? ['--vault', vaultDir, ...args] : args;
+-  const cliCommand = USE_DIST ? 'node' : TSX_BIN;
+-  const cliArgs = USE_DIST ? [CLI_PATH, ...fullArgs] : [CLI_SRC_PATH, ...fullArgs];
++  const cliCommand = process.execPath;
++  const cliArgs = USE_DIST
++    ? [CLI_PATH, ...fullArgs]
++    : [TSX_CLI, CLI_SRC_PATH, ...fullArgs];
+   const mergedEnv = withTestCliNodeOptions({
+     ...process.env,
+     NO_COLOR: '1',
+diff --git a/tests/ts/lib/lineage-lock-cross-process.test.ts b/tests/ts/lib/lineage-lock-cross-process.test.ts
+index b732cff..60148c1 100644
+--- a/tests/ts/lib/lineage-lock-cross-process.test.ts
++++ b/tests/ts/lib/lineage-lock-cross-process.test.ts
+@@ -322,9 +322,14 @@ describe.sequential('cross-process ownership file lock', () => {
+     textLock.send('start');
+     await textLock.waitFor('acquired');
+ 
+-    const textCli = startCli(vaultDir, ['delete', 'Sample Idea']);
+-    textCli.process.stdin.end('y\n');
+-    await textCli.waitForOutput('File to delete: Ideas/Sample Idea.md');
++    const textCli = startCli(vaultDir, [
++      'delete', '--path', 'Ideas/Sample Idea.md', '--execute',
++    ]);
++    textCli.process.stdin.end();
++    // This non-interactive invocation has no public observer for lock
++    // contention. A bounded alive check proves the process reached the held
++    // lock before the target is removed; an early exit reports captured output.
++    await textCli.expectStillRunningFor(process.platform === 'win32' ? 2_000 : 750);
+     await unlink(textTarget);
+     textLock.send('release');
+     await textLock.waitFor('released');
+
+END REMEDIATION DIFF
+

--- a/.task-sweep/logs/claude-fable-5-review-windows-paths-20260710-120100-issue-807.log
+++ b/.task-sweep/logs/claude-fable-5-review-windows-paths-20260710-120100-issue-807.log
@@ -1,0 +1,6 @@
+model_requested: anthropic/claude-fable-5
+model_returned: anthropic/claude-5-fable-20260609
+finish_reason: stop
+output: /Users/alicemoore/Developer/bwrb-worktrees/issue-807-lineage-lock/.task-sweep/logs/claude-fable-5-review-windows-paths-output-20260710-120100-issue-807.md
+chars: 2267 words: 288
+preview: NO BLOCKERS\n\nSPEC FIDELITY\n- Normalization is correctly applied at logical-path construction sites: `relative()` output in `collectAllMarkdownFiles`, every `join()`-built vault-relative path in `collectPooledFiles` and `collectOwnedFiles` (including `entryRel`, `ownerFolderRel`, `ownerNoteRel`, owned-field folder rels, and `ownedRelativePath`).\n- Re-normalizing after each `join()` is correct, not redundant: `path.join` on Windows re-introduces backslashes even when inputs are forward-slash, so wrapping the outermost `join`/helper call is the right placement.\n- Absolute filesystem paths stay native: `fullPath`, `rootDir`, `fullOwnerDir`, `ownerNotePath`, and `ownedFieldFolder` are untouched, and `join(vaultDir, normalizedOutputDir)` with a forward-slash relative segment is handled correctly

--- a/.task-sweep/logs/claude-fable-5-review-windows-paths-output-20260710-120100-issue-807.md
+++ b/.task-sweep/logs/claude-fable-5-review-windows-paths-output-20260710-120100-issue-807.md
@@ -1,0 +1,14 @@
+NO BLOCKERS
+
+SPEC FIDELITY
+- Normalization is correctly applied at logical-path construction sites: `relative()` output in `collectAllMarkdownFiles`, every `join()`-built vault-relative path in `collectPooledFiles` and `collectOwnedFiles` (including `entryRel`, `ownerFolderRel`, `ownerNoteRel`, owned-field folder rels, and `ownedRelativePath`).
+- Re-normalizing after each `join()` is correct, not redundant: `path.join` on Windows re-introduces backslashes even when inputs are forward-slash, so wrapping the outermost `join`/helper call is the right placement.
+- Absolute filesystem paths stay native: `fullPath`, `rootDir`, `fullOwnerDir`, `ownerNotePath`, and `ownedFieldFolder` are untouched, and `join(vaultDir, normalizedOutputDir)` with a forward-slash relative segment is handled correctly by `path.win32.join`. Requirement satisfied.
+- Exclusion matching (`shouldExcludePath` / `ignoreMatcher`) now consistently receives forward-slash logical paths, fixing a real latent Windows bug beyond the assertion failures: `ignore`-style matchers silently fail to match backslash paths.
+- Evidence is consistent: focused Windows-relevant suites 124/124 and exact full parity (3030 pass / 3 expected skips) support no POSIX regression.
+
+STANDARDS AND RISK
+- The diff does not show an import or definition of `toPosixPath`. Passing build/typecheck/lint in the evidence implies it exists or was imported outside this hunk; worth confirming the import landed in this file rather than relying on an incidental existing symbol. Non-blocking given the green typecheck.
+- Confirm `toPosixPath` is an identity on POSIX (e.g., `sep`-based split/join or platform-gated) rather than an unconditional `replace(/\\/g, '/')`. The latter would mangle legitimate POSIX filenames containing literal backslashes — an edge case, and the 3030-test parity suggests no practical regression, but the implementation choice matters for the "POSIX behavior unchanged" guarantee.
+- `toPosixPath(outputDir)` on the schema-provided `outputDir` is defensive (config values should already be forward-slash) and harmless; fine to keep.
+- The Windows runner's strict forward-slash assertions should remain as-is; this delta is the correct fix direction (normalize production output, not the tests).

--- a/.task-sweep/logs/claude-fable-5-review-windows-paths-prompt-20260710-120100-issue-807.md
+++ b/.task-sweep/logs/claude-fable-5-review-windows-paths-prompt-20260710-120100-issue-807.md
@@ -1,0 +1,109 @@
+You are performing the second focused follow-up review in a BWRB PR #821 Windows CI fix loop. Prior full review and first remediation review both returned NO BLOCKERS using anthropic/claude-fable-5. The real Windows runner then exposed that discovered vault-relative paths used backslashes, violating the command's stable forward-slash text/JSON contract and failing delete-lineage/disappearance assertions. Review only the production remediation delta below.
+
+Constraints:
+- No tools or edits.
+- Start with exactly one of: BLOCKERS, NON-BLOCKING, NO BLOCKERS.
+- Separate SPEC FIDELITY from STANDARDS AND RISK.
+- Block only concrete correctness, cross-platform, compatibility, or test-integrity defects.
+- Keep concise.
+
+Required behavior:
+- ManagedFile.relativePath and ownership ownerPath are vault-relative logical paths and must use forward slashes on every OS.
+- Absolute filesystem paths must remain native.
+- Ignore/exclusion matching expects forward-slash logical paths.
+- Existing POSIX behavior must remain unchanged.
+- The Windows runner should retain strict forward-slash assertions; do not suggest weakening them.
+
+Evidence after this delta:
+- Node 22 focused discovery/navigation/ownership/delete/cross-process suites: 124/124 pass.
+- Exact full parity: build, verify:pack, typecheck, lint, knip, then 3030 pass/3 expected skips across 114 files.
+- This normalizes at the relative-path construction sites only; filesystem joins for absolute paths remain native.
+
+BEGIN PATH NORMALIZATION DIFF
+diff --git a/src/lib/discovery.ts b/src/lib/discovery.ts
+index 427e439..0fb4e70 100644
+--- a/src/lib/discovery.ts
++++ b/src/lib/discovery.ts
+@@ -328,7 +328,7 @@ export async function collectAllMarkdownFiles(
+   
+   for (const entry of entries) {
+     const fullPath = join(dir, entry.name);
+-    const relativePath = relative(baseDir, fullPath);
++    const relativePath = toPosixPath(relative(baseDir, fullPath));
+     
+     // Skip hidden directories (starting with .)
+     if (entry.isDirectory() && entry.name.startsWith('.')) continue;
+@@ -1164,7 +1164,7 @@ export async function collectPooledFiles(
+   ignoreMatcher: Ignore | null,
+   boundaries?: PooledScanBoundaries
+ ): Promise<ManagedFile[]> {
+-  const normalizedOutputDir = outputDir.replace(/\/$/, '');
++  const normalizedOutputDir = toPosixPath(outputDir).replace(/\/$/, '');
+   const rootDir = join(vaultDir, normalizedOutputDir);
+   if (!existsSync(rootDir)) return [];
+ 
+@@ -1178,7 +1178,7 @@ export async function collectPooledFiles(
+     const entries = await readdir(dir, { withFileTypes: true });
+ 
+     for (const entry of entries) {
+-      const entryRel = join(relDir, entry.name);
++      const entryRel = toPosixPath(join(relDir, entry.name));
+ 
+       if (entry.isDirectory()) {
+         // Never descend into hidden/system directories.
+@@ -1231,7 +1231,7 @@ async function collectOwnedFiles(
+   const ownerOutputDir = getOutputDirFromSchema(schema, ownerTypeName);
+   if (!ownerOutputDir) return [];
+ 
+-  const normalizedOwnerOutputDir = ownerOutputDir.replace(/\/$/, '');
++  const normalizedOwnerOutputDir = toPosixPath(ownerOutputDir).replace(/\/$/, '');
+   const files: ManagedFile[] = [];
+   const fullOwnerDir = join(vaultDir, normalizedOwnerOutputDir);
+ 
+@@ -1248,22 +1248,24 @@ async function collectOwnedFiles(
+     // Skip hidden directories
+     if (entry.name.startsWith('.')) continue;
+ 
+-    const ownerFolderRel = join(normalizedOwnerOutputDir, entry.name);
++    const ownerFolderRel = toPosixPath(join(normalizedOwnerOutputDir, entry.name));
+     if (shouldExcludePath(ownerFolderRel, excluded, ignoreMatcher, true)) continue;
+ 
+     // Check if this folder has an owner note (e.g., drafts/My Novel/My Novel.md)
+     const ownerNotePath = join(fullOwnerDir, entry.name, `${entry.name}.md`);
+-    const ownerNoteRel = join(normalizedOwnerOutputDir, entry.name, `${entry.name}.md`);
++    const ownerNoteRel = toPosixPath(
++      join(normalizedOwnerOutputDir, entry.name, `${entry.name}.md`)
++    );
+ 
+     if (shouldExcludePath(ownerNoteRel, excluded, ignoreMatcher)) continue;
+     if (!existsSync(ownerNotePath)) continue;
+ 
+     // For each owned field, look for the owned field subfolder
+     for (const ownedField of ownedFields) {
+-      const ownedFieldFolderRel = getOwnedChildFolderFromOwnerDir(
++      const ownedFieldFolderRel = toPosixPath(getOwnedChildFolderFromOwnerDir(
+         join(normalizedOwnerOutputDir, entry.name),
+         ownedField.fieldName
+-      );
++      ));
+       if (shouldExcludePath(ownedFieldFolderRel, excluded, ignoreMatcher, true)) continue;
+ 
+       const ownedFieldFolder = getOwnedChildFolderFromOwnerDir(
+@@ -1277,11 +1279,11 @@ async function collectOwnedFiles(
+       for (const childEntry of childEntries) {
+         if (!childEntry.isFile() || !childEntry.name.endsWith('.md')) continue;
+ 
+-        const relativePath = getOwnedChildFolderFromOwnerDir(
++        const relativePath = toPosixPath(getOwnedChildFolderFromOwnerDir(
+           join(normalizedOwnerOutputDir, entry.name),
+           ownedField.fieldName
+-        );
+-        const ownedRelativePath = join(relativePath, childEntry.name);
++        ));
++        const ownedRelativePath = toPosixPath(join(relativePath, childEntry.name));
+         if (shouldExcludePath(ownedRelativePath, excluded, ignoreMatcher)) continue;
+ 
+         files.push({
+
+END PATH NORMALIZATION DIFF
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Fixed
 
+- **Portable lineage mutation locking** — lineage and note-ID locks now fail closed on Windows sharing/permission errors, have deterministic real-process stress coverage plus a focused Windows CI lane, and return stable retryable text/JSON context when a non-force delete target disappears before its authoritative under-lock recheck (#807).
 - **Body-only content targeting** — `--body` now excludes YAML frontmatter in both note filtering and detailed match reports while preserving original file line numbers and body-only context (#812).
 
 ## [0.2.3] - 2026-07-09

--- a/docs-site/src/content/docs/changelog.md
+++ b/docs-site/src/content/docs/changelog.md
@@ -12,6 +12,7 @@ For the complete changelog with all details, see [CHANGELOG.md](https://github.c
 ### Unreleased
 
 - **Existing-note lineage adoption** — `bwrb lineage adopt <child> --from <parent>` adds a dry-run-first, lock-coordinated path for recording known derivation between existing same-type notes without rewriting their bodies or ordinary metadata
+- **Portable lineage mutation locking** — fork, adopt, delete, and note-ID coordination now have real cross-process stress coverage, a focused Windows CI lane, and stable retryable output when a non-force delete target disappears while waiting for its lock
 
 ### 0.2.3
 

--- a/docs-site/src/content/docs/reference/commands/delete.md
+++ b/docs-site/src/content/docs/reference/commands/delete.md
@@ -101,6 +101,36 @@ not deleted or reparented, and their `forked-from` value stays intact. A later
 `bwrb audit` reports that retained provenance as `dangling-forked-from`, so the
 source can still be restored deliberately.
 
+### Concurrent target disappearance
+
+Without `--force`, bwrb selects the requested notes and then rechecks them while
+holding the same lineage locks used by fork and adoption. If another process
+deletes a selected target before that authoritative recheck, the command stops
+without deleting any of the remaining selected notes and returns exit code `2`:
+
+```text
+Error: Delete target disappeared while waiting for the lineage lock; retry the command: Ideas/Launch Brief.md
+```
+
+JSON output keeps the numeric exit-code contract and adds stable retry context:
+
+```json
+{
+  "success": false,
+  "error": "Delete target disappeared while waiting for the lineage lock; retry the command: Ideas/Launch Brief.md",
+  "data": {
+    "reason": "target-disappeared",
+    "retryable": true,
+    "paths": ["Ideas/Launch Brief.md"]
+  },
+  "code": 2
+}
+```
+
+Re-resolve the target set before retrying. This is distinct from an initial
+not-found result: the note existed during selection but vanished while the
+command was coordinating its write.
+
 ## Examples
 
 ### Single-file Mode

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -229,6 +229,12 @@ their `forked-from` value, which surfaces as `dangling-forked-from` in
 `bwrb audit`. Use `bwrb list --lineage <target> --output json` before forcing a
 parent deletion when an agent needs to enumerate the affected family.
 
+For non-force deletion, another process can remove a selected target while the
+command waits for its lineage lock. JSON reports numeric `code: 2` with
+`data.reason: "target-disappeared"`, `data.retryable: true`, and the selected
+`data.paths`. Re-resolve those paths before retrying; do not treat this as a
+successful or ordinary initial not-found result.
+
 ## Core Commands for Agents
 
 ### Querying Notes

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -3,7 +3,11 @@
 
   // Vitest plugin doesn't auto-detect globalTeardown from config
   "vitest": {
-    "entry": ["tests/ts/teardown.ts"]
+    "entry": [
+      "tests/ts/teardown.ts",
+      // Spawned as a real child process by the cross-process lock suite.
+      "tests/ts/fixtures/lineage-lock-worker.ts"
+    ]
   },
 
   // Ignore intentional public API exports and separate projects

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -270,6 +270,11 @@ Note: Deletion is permanent. The file is removed from the filesystem.
         return;
       }
 
+      if (err instanceof DeleteTargetDisappearedError) {
+        reportDeleteTargetDisappeared(err, jsonMode);
+        return;
+      }
+
       const message = err instanceof Error ? err.message : String(err);
 
       // Handle specific error types
@@ -677,7 +682,7 @@ async function handleBulkDelete(
   } else {
     try {
       await withLineageMutationLocks(vaultDir, files.map(file => file.path), async () => {
-        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, files);
+        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, files, true);
         if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
         await deleteFiles();
       });
@@ -860,7 +865,7 @@ async function deleteResolvedFile({
   } else {
     try {
       await withLineageMutationLocks(vaultDir, [fullPath], async () => {
-        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, [file]);
+        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, [file], true);
         if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
         await unlink(fullPath);
         await unregisterIssuedNotePath(vaultDir, relativePath);
@@ -899,23 +904,56 @@ class LineageDeleteRefusalError extends Error {
   }
 }
 
+class DeleteTargetDisappearedError extends Error {
+  constructor(readonly paths: string[]) {
+    super(paths.length === 1
+      ? `Delete target disappeared while waiting for the lineage lock; retry the command: ${paths[0]}`
+      : `Delete targets disappeared while waiting for lineage locks; retry the command: ${paths.join(', ')}`);
+    this.name = 'DeleteTargetDisappearedError';
+  }
+}
+
 async function assessCurrentDeleteLineage(
   schema: Awaited<ReturnType<typeof loadSchema>>,
   vaultDir: string,
-  files: ManagedFile[]
+  files: ManagedFile[],
+  classifyMissingAsDisappeared = false
 ): Promise<DeleteLineageBlock[]> {
   const snapshot = await buildVaultNoteSnapshot(schema, vaultDir);
   const assessment = assessDeleteLineage(snapshot, files.map(file => file.path));
   if (assessment.missing.length > 0) {
+    const missingPaths = assessment.missing.map(
+      path => files.find(file => file.path === path)?.relativePath ?? path
+    );
+    if (classifyMissingAsDisappeared) {
+      throw new DeleteTargetDisappearedError(missingPaths);
+    }
     const error = new Error(
-      `File not found or no longer managed: ${assessment.missing
-        .map(path => files.find(file => file.path === path)?.relativePath ?? path)
-        .join(', ')}`
+      `File not found or no longer managed: ${missingPaths.join(', ')}`
     ) as NodeJS.ErrnoException;
     error.code = 'ENOENT';
     throw error;
   }
   return assessment.blocked;
+}
+
+function reportDeleteTargetDisappeared(
+  error: DeleteTargetDisappearedError,
+  jsonMode: boolean
+): void {
+  if (jsonMode) {
+    printJson(jsonError(error.message, {
+      code: ExitCodes.IO_ERROR,
+      data: {
+        reason: 'target-disappeared',
+        retryable: true,
+        paths: error.paths,
+      },
+    }));
+  } else {
+    printError(error.message);
+  }
+  process.exitCode = ExitCodes.IO_ERROR;
 }
 
 function reportLineageRefusal(

--- a/src/lib/discovery.ts
+++ b/src/lib/discovery.ts
@@ -328,7 +328,7 @@ export async function collectAllMarkdownFiles(
   
   for (const entry of entries) {
     const fullPath = join(dir, entry.name);
-    const relativePath = relative(baseDir, fullPath);
+    const relativePath = toPosixPath(relative(baseDir, fullPath));
     
     // Skip hidden directories (starting with .)
     if (entry.isDirectory() && entry.name.startsWith('.')) continue;
@@ -1164,7 +1164,7 @@ export async function collectPooledFiles(
   ignoreMatcher: Ignore | null,
   boundaries?: PooledScanBoundaries
 ): Promise<ManagedFile[]> {
-  const normalizedOutputDir = outputDir.replace(/\/$/, '');
+  const normalizedOutputDir = toPosixPath(outputDir).replace(/\/$/, '');
   const rootDir = join(vaultDir, normalizedOutputDir);
   if (!existsSync(rootDir)) return [];
 
@@ -1178,7 +1178,7 @@ export async function collectPooledFiles(
     const entries = await readdir(dir, { withFileTypes: true });
 
     for (const entry of entries) {
-      const entryRel = join(relDir, entry.name);
+      const entryRel = toPosixPath(join(relDir, entry.name));
 
       if (entry.isDirectory()) {
         // Never descend into hidden/system directories.
@@ -1231,7 +1231,7 @@ async function collectOwnedFiles(
   const ownerOutputDir = getOutputDirFromSchema(schema, ownerTypeName);
   if (!ownerOutputDir) return [];
 
-  const normalizedOwnerOutputDir = ownerOutputDir.replace(/\/$/, '');
+  const normalizedOwnerOutputDir = toPosixPath(ownerOutputDir).replace(/\/$/, '');
   const files: ManagedFile[] = [];
   const fullOwnerDir = join(vaultDir, normalizedOwnerOutputDir);
 
@@ -1248,22 +1248,24 @@ async function collectOwnedFiles(
     // Skip hidden directories
     if (entry.name.startsWith('.')) continue;
 
-    const ownerFolderRel = join(normalizedOwnerOutputDir, entry.name);
+    const ownerFolderRel = toPosixPath(join(normalizedOwnerOutputDir, entry.name));
     if (shouldExcludePath(ownerFolderRel, excluded, ignoreMatcher, true)) continue;
 
     // Check if this folder has an owner note (e.g., drafts/My Novel/My Novel.md)
     const ownerNotePath = join(fullOwnerDir, entry.name, `${entry.name}.md`);
-    const ownerNoteRel = join(normalizedOwnerOutputDir, entry.name, `${entry.name}.md`);
+    const ownerNoteRel = toPosixPath(
+      join(normalizedOwnerOutputDir, entry.name, `${entry.name}.md`)
+    );
 
     if (shouldExcludePath(ownerNoteRel, excluded, ignoreMatcher)) continue;
     if (!existsSync(ownerNotePath)) continue;
 
     // For each owned field, look for the owned field subfolder
     for (const ownedField of ownedFields) {
-      const ownedFieldFolderRel = getOwnedChildFolderFromOwnerDir(
+      const ownedFieldFolderRel = toPosixPath(getOwnedChildFolderFromOwnerDir(
         join(normalizedOwnerOutputDir, entry.name),
         ownedField.fieldName
-      );
+      ));
       if (shouldExcludePath(ownedFieldFolderRel, excluded, ignoreMatcher, true)) continue;
 
       const ownedFieldFolder = getOwnedChildFolderFromOwnerDir(
@@ -1277,11 +1279,11 @@ async function collectOwnedFiles(
       for (const childEntry of childEntries) {
         if (!childEntry.isFile() || !childEntry.name.endsWith('.md')) continue;
 
-        const relativePath = getOwnedChildFolderFromOwnerDir(
+        const relativePath = toPosixPath(getOwnedChildFolderFromOwnerDir(
           join(normalizedOwnerOutputDir, entry.name),
           ownedField.fieldName
-        );
-        const ownedRelativePath = join(relativePath, childEntry.name);
+        ));
+        const ownedRelativePath = toPosixPath(join(relativePath, childEntry.name));
         if (shouldExcludePath(ownedRelativePath, excluded, ignoreMatcher)) continue;
 
         files.push({

--- a/src/lib/lineage-lock.ts
+++ b/src/lib/lineage-lock.ts
@@ -33,6 +33,11 @@ interface LockSnapshot {
   size: number;
 }
 
+type LockSnapshotRead =
+  | { kind: 'present'; snapshot: LockSnapshot }
+  | { kind: 'missing' }
+  | { kind: 'busy' };
+
 const DEFAULT_OPTIONS: OwnershipFileLockOptions = {
   retryMs: LOCK_RETRY_MS,
   attempts: LOCK_ATTEMPTS,
@@ -166,8 +171,11 @@ async function acquireLock(
       }
     } catch (error) {
       if (!isFileExistsError(error)) throw error;
-      const snapshot = await readLockSnapshot(lockPath);
-      if (snapshot && await isRecoverable(snapshot, options.staleMs)) {
+      const snapshotRead = await readLockSnapshot(lockPath);
+      if (
+        snapshotRead.kind === 'present' &&
+        await isRecoverable(snapshotRead.snapshot, options.staleMs)
+      ) {
         await recoverStaleLock(lockPath, recoveryPath, options);
         continue;
       }
@@ -208,8 +216,11 @@ async function heartbeatOwnedLock(
   handle: Awaited<ReturnType<typeof open>>,
   token: string
 ): Promise<void> {
-  const snapshot = await readLockSnapshot(lockPath);
-  if (snapshot?.metadata?.token !== token) return;
+  const snapshotRead = await readLockSnapshot(lockPath);
+  if (
+    snapshotRead.kind !== 'present' ||
+    snapshotRead.snapshot.metadata?.token !== token
+  ) return;
 
   // Touch the inode opened by this holder, not whatever might have appeared at
   // the path after the ownership check. The immutable JSON records when the
@@ -227,8 +238,11 @@ async function recoverStaleLock(
   if (!recovery) return;
 
   try {
-    const snapshot = await readLockSnapshot(lockPath);
-    if (!snapshot || !await isRecoverable(snapshot, options.staleMs)) return;
+    const snapshotRead = await readLockSnapshot(lockPath);
+    if (
+      snapshotRead.kind !== 'present' ||
+      !await isRecoverable(snapshotRead.snapshot, options.staleMs)
+    ) return;
 
     // The fixed recovery marker prevents acquisitions and competing reapers
     // while the stale inode is atomically moved out of the lock pathname.
@@ -237,7 +251,12 @@ async function recoverStaleLock(
       await rename(lockPath, quarantinePath);
       await unlink(quarantinePath).catch(() => undefined);
     } catch (error) {
-      if (!isFileMissingError(error)) throw error;
+      if (isFileMissingError(error)) return;
+      // Windows can reject a rename while another process still has the lock
+      // open. That is evidence against stealing, not permission to do so. Let
+      // the outer acquisition loop retry until its ordinary timeout instead.
+      if (isTransientLockFilesystemError(error)) return;
+      throw error;
     }
     await cleanupQuarantines(lockPath);
   } finally {
@@ -272,9 +291,12 @@ async function acquireRecoveryMarker(
     };
   } catch (error) {
     if (!isFileExistsError(error)) throw error;
-    const snapshot = await readLockSnapshot(recoveryPath);
-    if (snapshot && await isRecoverable(snapshot, options.staleMs)) {
-      await unlinkIfUnchanged(recoveryPath, snapshot);
+    const snapshotRead = await readLockSnapshot(recoveryPath);
+    if (
+      snapshotRead.kind === 'present' &&
+      await isRecoverable(snapshotRead.snapshot, options.staleMs)
+    ) {
+      await unlinkIfUnchanged(recoveryPath, snapshotRead.snapshot);
     }
     return null;
   }
@@ -284,10 +306,11 @@ async function recoveryIsInProgress(
   recoveryPath: string,
   options: OwnershipFileLockOptions
 ): Promise<boolean> {
-  const snapshot = await readLockSnapshot(recoveryPath);
-  if (!snapshot) return false;
-  if (await isRecoverable(snapshot, options.staleMs)) {
-    await unlinkIfUnchanged(recoveryPath, snapshot);
+  const snapshotRead = await readLockSnapshot(recoveryPath);
+  if (snapshotRead.kind === 'missing') return false;
+  if (snapshotRead.kind === 'busy') return true;
+  if (await isRecoverable(snapshotRead.snapshot, options.staleMs)) {
+    await unlinkIfUnchanged(recoveryPath, snapshotRead.snapshot);
     return pathExists(recoveryPath);
   }
   return true;
@@ -318,23 +341,30 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-async function readLockSnapshot(lockPath: string): Promise<LockSnapshot | null> {
+async function readLockSnapshot(lockPath: string): Promise<LockSnapshotRead> {
   try {
     const [raw, info] = await Promise.all([
       readFile(lockPath, 'utf-8'),
       stat(lockPath),
     ]);
     return {
-      raw,
-      metadata: parseLockMetadata(raw),
-      device: info.dev,
-      inode: info.ino,
-      modifiedAt: info.mtimeMs,
-      size: info.size,
+      kind: 'present',
+      snapshot: {
+        raw,
+        metadata: parseLockMetadata(raw),
+        device: info.dev,
+        inode: info.ino,
+        modifiedAt: info.mtimeMs,
+        size: info.size,
+      },
     };
   } catch (error) {
-    if (isFileMissingError(error)) return null;
-    return null;
+    if (isFileMissingError(error)) return { kind: 'missing' };
+    // Sharing/permission failures are common while Windows handles are open.
+    // Preserve that distinction so every caller fails closed rather than
+    // mistaking an unreadable lock or recovery marker for an absent one.
+    if (isTransientLockFilesystemError(error)) return { kind: 'busy' };
+    throw error;
   }
 }
 
@@ -357,14 +387,20 @@ function parseLockMetadata(raw: string): LockMetadata | null {
 }
 
 async function unlinkIfOwned(lockPath: string, token: string): Promise<boolean> {
-  const snapshot = await readLockSnapshot(lockPath);
-  if (snapshot?.metadata?.token !== token) return false;
-  return unlinkIfUnchanged(lockPath, snapshot);
+  const snapshotRead = await readLockSnapshot(lockPath);
+  if (
+    snapshotRead.kind !== 'present' ||
+    snapshotRead.snapshot.metadata?.token !== token
+  ) return false;
+  return unlinkIfUnchanged(lockPath, snapshotRead.snapshot);
 }
 
 async function unlinkIfUnchanged(lockPath: string, expected: LockSnapshot): Promise<boolean> {
-  const current = await readLockSnapshot(lockPath);
-  if (!current || !snapshotsMatch(current, expected)) return false;
+  const currentRead = await readLockSnapshot(lockPath);
+  if (
+    currentRead.kind !== 'present' ||
+    !snapshotsMatch(currentRead.snapshot, expected)
+  ) return false;
   try {
     await unlink(lockPath);
     return true;
@@ -394,8 +430,11 @@ async function pathExists(path: string): Promise<boolean> {
   try {
     await stat(path);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    if (isFileMissingError(error)) return false;
+    // An unreadable recovery marker must serialize acquisitions just like a
+    // readable one. The lock would rather wait than become two locks in a coat.
+    return true;
   }
 }
 
@@ -407,6 +446,12 @@ function isFileExistsError(error: unknown): boolean {
 function isFileMissingError(error: unknown): boolean {
   return error instanceof Error && 'code' in error &&
     (error as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+function isTransientLockFilesystemError(error: unknown): boolean {
+  if (!(error instanceof Error) || !('code' in error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'EBUSY' || code === 'EPERM' || code === 'EACCES' || code === 'ENOTEMPTY';
 }
 
 function delay(ms: number): Promise<void> {

--- a/tests/ts/fixtures/lineage-lock-worker.ts
+++ b/tests/ts/fixtures/lineage-lock-worker.ts
@@ -1,0 +1,99 @@
+import { appendFile, mkdir, open, unlink } from 'fs/promises';
+import { dirname } from 'path';
+import { createInterface } from 'readline';
+import {
+  withOwnershipFileLock,
+  type OwnershipFileLockOptions,
+} from '../../../src/lib/lineage-lock.js';
+
+type WorkerMode = 'hold' | 'stress';
+
+interface WorkerConfig {
+  mode: WorkerMode;
+  lockPath: string;
+  options: OwnershipFileLockOptions;
+  sentinelPath?: string;
+  journalPath?: string;
+  iterations?: number;
+}
+
+interface WorkerCommand {
+  command: 'start' | 'release' | 'crash';
+}
+
+const config = JSON.parse(process.argv[2] ?? '') as WorkerConfig;
+const commands = createInterface({ input: process.stdin, crlfDelay: Infinity })[Symbol.asyncIterator]();
+
+function send(event: string, data: Record<string, unknown> = {}): void {
+  process.stdout.write(`${JSON.stringify({ event, pid: process.pid, ...data })}\n`);
+}
+
+async function nextCommand(expected: WorkerCommand['command'][]): Promise<WorkerCommand> {
+  const result = await commands.next();
+  if (result.done) throw new Error(`stdin closed while waiting for ${expected.join(' or ')}`);
+  const command = JSON.parse(result.value) as WorkerCommand;
+  if (!expected.includes(command.command)) {
+    throw new Error(`Expected ${expected.join(' or ')}, received ${command.command}`);
+  }
+  return command;
+}
+
+async function hold(): Promise<void> {
+  await withOwnershipFileLock(config.lockPath, async () => {
+    send('acquired');
+    const command = await nextCommand(['release', 'crash']);
+    if (command.command === 'crash') {
+      // Deliberately bypass finally/release to leave a real dead-owner lock.
+      process.exit(70);
+    }
+  }, config.options, 'worker lock timeout');
+  send('released');
+}
+
+async function stress(): Promise<void> {
+  if (!config.sentinelPath || !config.journalPath || !config.iterations) {
+    throw new Error('Stress mode requires sentinelPath, journalPath, and iterations');
+  }
+
+  await mkdir(dirname(config.journalPath), { recursive: true });
+  for (let iteration = 0; iteration < config.iterations; iteration++) {
+    await withOwnershipFileLock(config.lockPath, async () => {
+      let sentinel: Awaited<ReturnType<typeof open>> | undefined;
+      try {
+        sentinel = await open(config.sentinelPath!, 'wx');
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          send('overlap', { iteration });
+        }
+        throw error;
+      }
+
+      try {
+        await appendFile(config.journalPath!, `${JSON.stringify({ event: 'enter', pid: process.pid, iteration })}\n`);
+        // Widen the critical section across two event-loop turns. The sentinel
+        // makes overlap detection deterministic even if journal appends race.
+        await new Promise<void>(resolve => setImmediate(resolve));
+        await new Promise<void>(resolve => setImmediate(resolve));
+        await appendFile(config.journalPath!, `${JSON.stringify({ event: 'exit', pid: process.pid, iteration })}\n`);
+      } finally {
+        await sentinel.close();
+        await unlink(config.sentinelPath!).catch(() => undefined);
+      }
+    }, config.options, 'worker lock timeout');
+  }
+  send('done');
+}
+
+async function main(): Promise<void> {
+  send('ready');
+  await nextCommand(['start']);
+  if (config.mode === 'hold') await hold();
+  else await stress();
+  process.stdin.destroy();
+}
+
+main().catch(error => {
+  send('fatal', { message: error instanceof Error ? error.message : String(error) });
+  process.exitCode = 1;
+  process.stdin.destroy();
+});

--- a/tests/ts/fixtures/setup.ts
+++ b/tests/ts/fixtures/setup.ts
@@ -9,7 +9,7 @@ import { BASELINE_SCHEMA } from './schemas.js';
 export const PROJECT_ROOT = process.cwd();
 export const CLI_PATH = join(PROJECT_ROOT, 'dist/index.js');
 const CLI_SRC_PATH = join(PROJECT_ROOT, 'src/index.ts');
-const TSX_BIN = join(PROJECT_ROOT, 'node_modules', '.bin', 'tsx');
+const TSX_CLI = join(PROJECT_ROOT, 'node_modules', 'tsx', 'dist', 'cli.mjs');
 
 const USE_DIST = process.env.BWRB_TEST_DIST === '1';
 const NODE_DEP0205_SUPPRESSION = '--disable-warning=DEP0205';
@@ -431,8 +431,10 @@ export async function runCLI(
     retries = RUN_CLI_RETRIES,
   } = options;
 
-  const cliCommand = USE_DIST ? 'node' : TSX_BIN;
-  const cliArgs = USE_DIST ? [CLI_PATH, ...fullArgs] : [CLI_SRC_PATH, ...fullArgs];
+  const cliCommand = process.execPath;
+  const cliArgs = USE_DIST
+    ? [CLI_PATH, ...fullArgs]
+    : [TSX_CLI, CLI_SRC_PATH, ...fullArgs];
 
   const childEnv: Record<string, string> = Object.fromEntries(
     Object.entries(process.env).filter(
@@ -485,8 +487,10 @@ export async function runCLIWithOpenStdin(
   }: Pick<RunCLIOptions, 'cwd' | 'env' | 'timeoutMs'> = {}
 ): Promise<CLIResult> {
   const fullArgs = vaultDir ? ['--vault', vaultDir, ...args] : args;
-  const cliCommand = USE_DIST ? 'node' : TSX_BIN;
-  const cliArgs = USE_DIST ? [CLI_PATH, ...fullArgs] : [CLI_SRC_PATH, ...fullArgs];
+  const cliCommand = process.execPath;
+  const cliArgs = USE_DIST
+    ? [CLI_PATH, ...fullArgs]
+    : [TSX_CLI, CLI_SRC_PATH, ...fullArgs];
   const mergedEnv = withTestCliNodeOptions({
     ...process.env,
     NO_COLOR: '1',

--- a/tests/ts/lib/lineage-lock-cross-process.test.ts
+++ b/tests/ts/lib/lineage-lock-cross-process.test.ts
@@ -322,9 +322,14 @@ describe.sequential('cross-process ownership file lock', () => {
     textLock.send('start');
     await textLock.waitFor('acquired');
 
-    const textCli = startCli(vaultDir, ['delete', 'Sample Idea']);
-    textCli.process.stdin.end('y\n');
-    await textCli.waitForOutput('File to delete: Ideas/Sample Idea.md');
+    const textCli = startCli(vaultDir, [
+      'delete', '--path', 'Ideas/Sample Idea.md', '--execute',
+    ]);
+    textCli.process.stdin.end();
+    // This non-interactive invocation has no public observer for lock
+    // contention. A bounded alive check proves the process reached the held
+    // lock before the target is removed; an early exit reports captured output.
+    await textCli.expectStillRunningFor(process.platform === 'win32' ? 2_000 : 750);
     await unlink(textTarget);
     textLock.send('release');
     await textLock.waitFor('released');

--- a/tests/ts/lib/lineage-lock-cross-process.test.ts
+++ b/tests/ts/lib/lineage-lock-cross-process.test.ts
@@ -1,0 +1,392 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import { existsSync } from 'fs';
+import { mkdtemp, readFile, readdir, rm, unlink } from 'fs/promises';
+import { tmpdir } from 'os';
+import { basename, join } from 'path';
+import {
+  getLineageMutationLockPath,
+  type OwnershipFileLockOptions,
+} from '../../../src/lib/lineage-lock.js';
+import { cleanupTestVault, createTestVault } from '../fixtures/setup.js';
+
+interface WorkerEvent {
+  event: string;
+  pid: number;
+  iteration?: number;
+  message?: string;
+}
+
+interface WorkerConfig {
+  mode: 'hold' | 'stress';
+  lockPath: string;
+  options: OwnershipFileLockOptions;
+  sentinelPath?: string;
+  journalPath?: string;
+  iterations?: number;
+}
+
+const PROJECT_ROOT = process.cwd();
+const TSX_CLI = join(PROJECT_ROOT, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+const WORKER = join(PROJECT_ROOT, 'tests', 'ts', 'fixtures', 'lineage-lock-worker.ts');
+const EVENT_TIMEOUT_MS = process.platform === 'win32' ? 20_000 : 8_000;
+
+class LockWorker {
+  readonly process: ChildProcessWithoutNullStreams;
+  readonly events: WorkerEvent[] = [];
+  readonly exit: Promise<number | null>;
+  private readonly waiters = new Set<() => void>();
+  private stdoutBuffer = '';
+  private stderr = '';
+
+  constructor(config: WorkerConfig) {
+    this.process = spawn(process.execPath, [TSX_CLI, WORKER, JSON.stringify(config)], {
+      cwd: PROJECT_ROOT,
+      env: { ...process.env, NO_COLOR: '1' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    this.process.stdout.setEncoding('utf8');
+    this.process.stderr.setEncoding('utf8');
+    this.process.stdout.on('data', chunk => this.consumeStdout(chunk));
+    this.process.stderr.on('data', chunk => { this.stderr += chunk; });
+    this.exit = new Promise((resolve, reject) => {
+      this.process.once('error', reject);
+      this.process.once('close', code => {
+        for (const wake of this.waiters) wake();
+        resolve(code);
+      });
+    });
+  }
+
+  send(command: 'start' | 'release' | 'crash'): void {
+    this.process.stdin.write(`${JSON.stringify({ command })}\n`);
+  }
+
+  async waitFor(event: string): Promise<WorkerEvent> {
+    const deadline = Date.now() + EVENT_TIMEOUT_MS;
+    while (true) {
+      const index = this.events.findIndex(candidate => candidate.event === event);
+      if (index >= 0) return this.events.splice(index, 1)[0]!;
+
+      const remaining = deadline - Date.now();
+      if (remaining <= 0 || this.process.exitCode !== null) {
+        throw new Error(
+          `Worker ${this.process.pid ?? 'unknown'} did not emit ${event}; ` +
+          `exit=${this.process.exitCode}, stderr=${this.stderr}, events=${JSON.stringify(this.events)}`
+        );
+      }
+      await new Promise<void>((resolve, reject) => {
+        const wake = (): void => {
+          clearTimeout(timer);
+          this.waiters.delete(wake);
+          resolve();
+        };
+        const timer = setTimeout(() => {
+          this.waiters.delete(wake);
+          reject(new Error(`Timed out waiting for worker event ${event}; stderr=${this.stderr}`));
+        }, remaining);
+        this.waiters.add(wake);
+      });
+    }
+  }
+
+  kill(): void {
+    if (this.process.exitCode === null && this.process.signalCode === null) {
+      this.process.kill('SIGKILL');
+    }
+  }
+
+  private consumeStdout(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    while (true) {
+      const newline = this.stdoutBuffer.indexOf('\n');
+      if (newline < 0) break;
+      const line = this.stdoutBuffer.slice(0, newline);
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      if (line.trim()) this.events.push(JSON.parse(line) as WorkerEvent);
+      for (const wake of this.waiters) wake();
+    }
+  }
+}
+
+class BuiltCli {
+  readonly process: ChildProcessWithoutNullStreams;
+  readonly exit: Promise<number | null>;
+  stdout = '';
+  stderr = '';
+  private readonly waiters = new Set<() => void>();
+
+  constructor(vaultDir: string, args: string[]) {
+    this.process = spawn(process.execPath, [join(PROJECT_ROOT, 'dist', 'index.js'), '--vault', vaultDir, ...args], {
+      cwd: PROJECT_ROOT,
+      env: { ...process.env, NO_COLOR: '1' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    this.process.stdout.setEncoding('utf8');
+    this.process.stderr.setEncoding('utf8');
+    this.process.stdout.on('data', chunk => {
+      this.stdout += chunk;
+      for (const wake of this.waiters) wake();
+    });
+    this.process.stderr.on('data', chunk => {
+      this.stderr += chunk;
+      for (const wake of this.waiters) wake();
+    });
+    this.exit = new Promise((resolve, reject) => {
+      this.process.once('error', reject);
+      this.process.once('close', code => {
+        for (const wake of this.waiters) wake();
+        resolve(code);
+      });
+    });
+  }
+
+  async waitForOutput(text: string): Promise<void> {
+    const deadline = Date.now() + EVENT_TIMEOUT_MS;
+    while (!`${this.stdout}\n${this.stderr}`.includes(text)) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0 || this.process.exitCode !== null) {
+        throw new Error(
+          `CLI did not print ${JSON.stringify(text)}; exit=${this.process.exitCode}, ` +
+          `stdout=${this.stdout}, stderr=${this.stderr}`
+        );
+      }
+      await new Promise<void>((resolve, reject) => {
+        const wake = (): void => {
+          clearTimeout(timer);
+          this.waiters.delete(wake);
+          resolve();
+        };
+        const timer = setTimeout(() => {
+          this.waiters.delete(wake);
+          reject(new Error(`Timed out waiting for CLI output ${JSON.stringify(text)}`));
+        }, remaining);
+        this.waiters.add(wake);
+      });
+    }
+  }
+
+  async expectStillRunningFor(ms: number): Promise<void> {
+    const exited = await Promise.race([
+      this.exit.then(() => true),
+      new Promise<false>(resolve => setTimeout(() => resolve(false), ms)),
+    ]);
+    if (exited) {
+      throw new Error(`CLI exited before reaching the held lock; stdout=${this.stdout}, stderr=${this.stderr}`);
+    }
+  }
+
+  kill(): void {
+    if (this.process.exitCode === null && this.process.signalCode === null) {
+      this.process.kill('SIGKILL');
+    }
+  }
+}
+
+describe.sequential('cross-process ownership file lock', () => {
+  let tempDir: string;
+  let lockPath: string;
+  const workers: LockWorker[] = [];
+  const clis: BuiltCli[] = [];
+  const vaults: string[] = [];
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'bwrb-lock-cross-process-'));
+    lockPath = join(tempDir, '.bwrb', 'locks', 'shared.lock');
+  });
+
+  afterEach(async () => {
+    for (const worker of workers) worker.kill();
+    for (const cli of clis) cli.kill();
+    await Promise.allSettled(workers.map(worker => worker.exit));
+    await Promise.allSettled(clis.map(cli => cli.exit));
+    workers.length = 0;
+    clis.length = 0;
+    await Promise.all(vaults.map(vault => cleanupTestVault(vault)));
+    vaults.length = 0;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('protects a live open-handle holder and closes before artifact cleanup', async () => {
+    const holder = startWorker({
+      mode: 'hold',
+      lockPath,
+      options: { retryMs: 5, attempts: 200, staleMs: 60, heartbeatMs: 10 },
+    });
+    await holder.waitFor('ready');
+    holder.send('start');
+    const acquired = await holder.waitFor('acquired');
+
+    const contender = startWorker({
+      mode: 'hold',
+      lockPath,
+      options: { retryMs: 5, attempts: 15, staleMs: 60, heartbeatMs: 10 },
+    });
+    await contender.waitFor('ready');
+    contender.send('start');
+    const fatal = await contender.waitFor('fatal');
+    expect(fatal.message).toBe('worker lock timeout');
+    expect(await contender.exit).toBe(1);
+
+    const metadata = JSON.parse(await readFile(lockPath, 'utf8')) as { pid: number };
+    expect(metadata.pid).toBe(acquired.pid);
+
+    holder.send('release');
+    await holder.waitFor('released');
+    expect(await holder.exit).toBe(0);
+    await expectNoArtifacts(lockPath);
+  });
+
+  it('recovers a dead holder, protects its successor, and cleans recovery artifacts', async () => {
+    const crashed = startWorker({
+      mode: 'hold',
+      lockPath,
+      options: { retryMs: 5, attempts: 200, staleMs: 60, heartbeatMs: 10 },
+    });
+    await crashed.waitFor('ready');
+    crashed.send('start');
+    await crashed.waitFor('acquired');
+    crashed.send('crash');
+    expect(await crashed.exit).toBe(70);
+
+    const successor = startWorker({
+      mode: 'hold',
+      lockPath,
+      options: { retryMs: 5, attempts: 400, staleMs: 60, heartbeatMs: 10 },
+    });
+    await successor.waitFor('ready');
+    successor.send('start');
+    const acquired = await successor.waitFor('acquired');
+    expect((JSON.parse(await readFile(lockPath, 'utf8')) as { pid: number }).pid).toBe(acquired.pid);
+
+    const contender = startWorker({
+      mode: 'hold',
+      lockPath,
+      options: { retryMs: 5, attempts: 15, staleMs: 60, heartbeatMs: 10 },
+    });
+    await contender.waitFor('ready');
+    contender.send('start');
+    expect((await contender.waitFor('fatal')).message).toBe('worker lock timeout');
+    expect(await contender.exit).toBe(1);
+    expect((JSON.parse(await readFile(lockPath, 'utf8')) as { pid: number }).pid).toBe(acquired.pid);
+
+    successor.send('release');
+    await successor.waitFor('released');
+    expect(await successor.exit).toBe(0);
+    await expectNoArtifacts(lockPath);
+  });
+
+  it('serializes a deterministic multi-process critical-section stress run', async () => {
+    const journalPath = join(tempDir, 'journal.ndjson');
+    const sentinelPath = join(tempDir, 'critical-section.active');
+    const options = { retryMs: 2, attempts: 2_000, staleMs: 1_000, heartbeatMs: 50 };
+    const contenders = Array.from({ length: 4 }, () => startWorker({
+      mode: 'stress',
+      lockPath,
+      options,
+      sentinelPath,
+      journalPath,
+      iterations: 12,
+    }));
+
+    await Promise.all(contenders.map(worker => worker.waitFor('ready')));
+    for (const worker of contenders) worker.send('start');
+    await Promise.all(contenders.map(worker => worker.waitFor('done')));
+    expect(await Promise.all(contenders.map(worker => worker.exit))).toEqual([0, 0, 0, 0]);
+    expect(contenders.flatMap(worker => worker.events).find(event => event.event === 'overlap')).toBeUndefined();
+
+    const journal = (await readFile(journalPath, 'utf8')).trim().split('\n')
+      .map(line => JSON.parse(line) as { event: 'enter' | 'exit'; pid: number; iteration: number });
+    expect(journal).toHaveLength(4 * 12 * 2);
+    for (let index = 0; index < journal.length; index += 2) {
+      const enter = journal[index]!;
+      const exit = journal[index + 1]!;
+      expect(enter.event).toBe('enter');
+      expect(exit).toEqual({ event: 'exit', pid: enter.pid, iteration: enter.iteration });
+    }
+    expect(existsSync(sentinelPath)).toBe(false);
+    await expectNoArtifacts(lockPath);
+  });
+
+  it('classifies under-lock delete disappearance in the actual built CLI text and JSON contracts', async () => {
+    const vaultDir = await createTestVault();
+    vaults.push(vaultDir);
+
+    const textTarget = join(vaultDir, 'Ideas', 'Sample Idea.md');
+    const textLock = startWorker({
+      mode: 'hold',
+      lockPath: getLineageMutationLockPath(vaultDir, textTarget),
+      options: { retryMs: 5, attempts: 400, staleMs: 1_000, heartbeatMs: 50 },
+    });
+    await textLock.waitFor('ready');
+    textLock.send('start');
+    await textLock.waitFor('acquired');
+
+    const textCli = startCli(vaultDir, ['delete', 'Sample Idea']);
+    textCli.process.stdin.end('y\n');
+    await textCli.waitForOutput('File to delete: Ideas/Sample Idea.md');
+    await unlink(textTarget);
+    textLock.send('release');
+    await textLock.waitFor('released');
+
+    expect(await textCli.exit).toBe(2);
+    expect(textCli.stderr).toContain(
+      'Delete target disappeared while waiting for the lineage lock; retry the command: Ideas/Sample Idea.md'
+    );
+    expect(textCli.stderr).not.toContain('File not found or already deleted');
+    await expectNoArtifacts(getLineageMutationLockPath(vaultDir, textTarget));
+
+    const jsonTarget = join(vaultDir, 'Ideas', 'Another Idea.md');
+    const jsonLock = startWorker({
+      mode: 'hold',
+      lockPath: getLineageMutationLockPath(vaultDir, jsonTarget),
+      options: { retryMs: 5, attempts: 400, staleMs: 1_000, heartbeatMs: 50 },
+    });
+    await jsonLock.waitFor('ready');
+    jsonLock.send('start');
+    await jsonLock.waitFor('acquired');
+
+    const jsonCli = startCli(vaultDir, [
+      'delete', '--path', 'Ideas/Another Idea.md', '--execute', '--output', 'json',
+    ]);
+    jsonCli.process.stdin.end();
+    // The held lock has no observer hook. A bounded alive check is the one
+    // timing allowance in this test: built dist startup/selection is complete
+    // well before this on both local and focused Windows CI, and an early exit
+    // fails with its captured output instead of being silently retried.
+    await jsonCli.expectStillRunningFor(process.platform === 'win32' ? 2_000 : 750);
+    await unlink(jsonTarget);
+    jsonLock.send('release');
+    await jsonLock.waitFor('released');
+
+    expect(await jsonCli.exit).toBe(2);
+    expect(JSON.parse(jsonCli.stdout)).toEqual({
+      success: false,
+      error: 'Delete target disappeared while waiting for the lineage lock; retry the command: Ideas/Another Idea.md',
+      data: {
+        reason: 'target-disappeared',
+        retryable: true,
+        paths: ['Ideas/Another Idea.md'],
+      },
+      code: 2,
+    });
+    await expectNoArtifacts(getLineageMutationLockPath(vaultDir, jsonTarget));
+  });
+
+  function startWorker(config: WorkerConfig): LockWorker {
+    const worker = new LockWorker(config);
+    workers.push(worker);
+    return worker;
+  }
+
+  function startCli(vaultDir: string, args: string[]): BuiltCli {
+    const cli = new BuiltCli(vaultDir, args);
+    clis.push(cli);
+    return cli;
+  }
+});
+
+async function expectNoArtifacts(lockPath: string): Promise<void> {
+  const entries = await readdir(join(lockPath, '..')).catch(() => []);
+  expect(entries.filter(entry => entry.startsWith(basename(lockPath)))).toEqual([]);
+}

--- a/tests/ts/lib/lineage-lock.test.ts
+++ b/tests/ts/lib/lineage-lock.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { existsSync } from 'fs';
-import { mkdtemp, mkdir, readFile, readdir, rm, stat, unlink, utimes, writeFile } from 'fs/promises';
+import { chmod, mkdtemp, mkdir, readFile, readdir, rm, stat, unlink, utimes, writeFile } from 'fs/promises';
 import { basename, join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -148,6 +148,26 @@ describe('lineage mutation lock', () => {
       { attempts: 8, retryMs: 2, staleMs: 100 }
     )).rejects.toThrow('Timed out waiting for a fork-lineage mutation lock');
     expect(await readFile(lockPath, 'utf-8')).toBe('not-json\n');
+  });
+
+  it.skipIf(process.platform === 'win32')('fails closed when an existing lock cannot be read', async () => {
+    const source = join(vaultDir, 'Source.md');
+    const lockPath = getLineageMutationLockPath(vaultDir, source);
+    await mkdir(join(vaultDir, '.bwrb', 'locks'), { recursive: true });
+    await writeFile(lockPath, lockMetadata(lockPath, deadPid(), 'unreadable-owner'));
+    await chmod(lockPath, 0o000);
+
+    try {
+      await expect(withLineageMutationLocks(
+        vaultDir,
+        [source],
+        async () => undefined,
+        { attempts: 8, retryMs: 2, staleMs: 1 }
+      )).rejects.toThrow('Timed out waiting for a fork-lineage mutation lock');
+      expect(existsSync(lockPath)).toBe(true);
+    } finally {
+      await chmod(lockPath, 0o600);
+    }
   });
 
   it('does not let an old holder release a replacement lock with another token', async () => {


### PR DESCRIPTION
## Summary

- make ownership-lock snapshot reads distinguish missing paths from Windows sharing/permission contention, preserving fail-closed retry/timeout behavior during recovery and release
- add a real child-process lock harness covering live-holder protection, crashed-holder recovery, successor ownership, mutual exclusion under stress, and recovery/quarantine cleanup
- add an additive Node 22 `windows-latest` job for the lineage, note-ID, delete-lineage, and cross-process lock suites
- classify a selected non-force delete target that disappears before the authoritative under-lock recheck with stable text and numeric JSON output
- normalize logical vault-relative discovery paths to forward slashes on every OS while retaining native absolute filesystem paths
- document the retry contract and preserve the required Fable planning/review packets under `.task-sweep/logs/`

## Delete disappearance contract

Text exits `2` with:

```text
Delete target disappeared while waiting for the lineage lock; retry the command: <path>
```

JSON retains the numeric exit code and includes:

```json
{
  "data": {
    "reason": "target-disappeared",
    "retryable": true,
    "paths": ["<path>"]
  },
  "code": 2
}
```

Ordinary initial not-found handling is unchanged.

## Verification

- exact final Node 22 / pnpm 10.11.0 parity: build, verify:pack, typecheck, lint, knip, then 114 files / 3,030 passed / 3 skipped
- independent tester: PASS; 29 focused tests, 22 delete regressions, six cross-process executions totaling 288 serialized critical sections, built-CLI single/bulk disappearance, unchanged initial no-match, docs and static gates
- Fable: early plan plus final full review and both CI-remediation follow-ups used exact `anthropic/claude-fable-5`; valid final verdicts were `NO BLOCKERS` with `finish_reason: stop`
- docs: `docs:check`, `docs:lint`, `docs:doctor`, and Astro build (42 pages)
- GitHub: Docs Relevance, Docs Site CI, Test, PTY Tests, Vercel, Vercel Preview Comments, and Windows Lock Tests all green
- Windows Server 2025 job proves open-handle protection, crash recovery, successor safety, cleanup, portable CLI spawning, and stable forward-slash output paths

The Windows job is additive and does not rename or weaken existing required checks.

Closes #807

