### PR TITLE
Prevent edits from overwriting lineage identity writes

### DIFF
--- a/.task-sweep/logs/claude-fable-5-plan-20260710-121000-issue-820.log
+++ b/.task-sweep/logs/claude-fable-5-plan-20260710-121000-issue-820.log
@@ -1,0 +1,6 @@
+model_requested: anthropic/claude-fable-5
+model_returned: anthropic/claude-5-fable-20260609
+finish_reason: stop
+output: /Users/alicemoore/Developer/bwrb-worktrees/issue-820-edit-concurrency/.task-sweep/logs/claude-fable-5-plan-output-20260710-121000-issue-820.md
+chars: 9356 words: 1335
+preview: # Plan — #820 edit-vs-lineage write race\n\n## 1. Architecture choice\n\n| Option | Verdict |\n|---|---|\n| Wrap whole JSON/interactive edit in the lineage path lock | ❌ Interactive edit holds a cross-process lock through human prompts; JSON edit holds it through vault-wide scans (context validation, cycle check, snapshot builds). Long holds + 30s acquisition timeout = spurious failures. |\n| Commit-phase lock + exact raw-byte stale detection | ✅ Core of the fix. Smallest surface, honest guarantee. |\n| Bounded auto-retry (JSON) / stable retryable error (interactive) | ✅ Layer on top of the above for behavior on staleness. |\n\n**Recommended shape** (all in `src/lib/edit.ts`):\n\n1. `parseNote` already returns `raw` — keep the snapshot's `raw` bytes from the initial read.\n2. At commit time, wrap the f

--- a/.task-sweep/logs/claude-fable-5-plan-output-20260710-121000-issue-820.md
+++ b/.task-sweep/logs/claude-fable-5-plan-output-20260710-121000-issue-820.md
@@ -1,0 +1,86 @@
+# Plan — #820 edit-vs-lineage write race
+
+## 1. Architecture choice
+
+| Option | Verdict |
+|---|---|
+| Wrap whole JSON/interactive edit in the lineage path lock | ❌ Interactive edit holds a cross-process lock through human prompts; JSON edit holds it through vault-wide scans (context validation, cycle check, snapshot builds). Long holds + 30s acquisition timeout = spurious failures. |
+| Commit-phase lock + exact raw-byte stale detection | ✅ Core of the fix. Smallest surface, honest guarantee. |
+| Bounded auto-retry (JSON) / stable retryable error (interactive) | ✅ Layer on top of the above for behavior on staleness. |
+
+**Recommended shape** (all in `src/lib/edit.ts`):
+
+1. `parseNote` already returns `raw` — keep the snapshot's `raw` bytes from the initial read.
+2. At commit time, wrap the final phase in `withLineageMutationLocks(vaultDir, [filePath], ...)`:
+   - Re-read the file, compare **exact raw bytes** to the snapshot.
+   - If equal: `prepareRecurrenceFastPath` → `writeNote` → `commitRecurrenceFastPath`, all inside the lock (see Q3).
+   - If stale:
+     - **JSON edit**: release the lock (or loop inside a fresh acquisition), re-run the full pipeline (parse → merge → defaults → normalize → validate → recurrence prepare) against the *latest* bytes, bounded to **3 attempts**. Safe because the patch is declarative merge semantics — replaying it against the new state is exactly what a user retry would do. After 3 attempts, emit the retryable error.
+     - **Interactive edit**: do **not** silently replay (the user's answers were shown against stale current-values). Emit the stable retryable error; nothing written.
+3. This means recurrence prepare moves *inside* the lock for the JSON path (it must be re-run per retry attempt anyway since old-frontmatter changes). Interactive edit: run prompts fully unlocked, then do prepare + stale-check + write inside the lock.
+
+Honest guarantee to document: this serializes **BWRB edit vs. BWRB fork/adopt** on the same note. It does not (and cannot, without O_EXCL-rename CAS the filesystem doesn't offer) exclude an unrelated external editor between check and rename — say so explicitly in docs; do not claim general CAS.
+
+## 2. Error ownership and output mapping
+
+- New exported error class in `src/lib/edit.ts` (or a tiny `src/lib/concurrency-error.ts` if fork/adopt share it per Q4): `ConcurrentNoteModificationError { path: string; attempts?: number }`.
+- The **command layer** (`src/commands/edit.ts` catch block, alongside `UserCancelledError` handling) owns output mapping — consistent with existing conventions.
+- Text: `Error: Note changed on disk while editing; no changes were written. Retry the command.` — exit with the same generic failure code the lineage-lock timeout path uses today (keep exit-code surface unchanged; the *machine* signal lives in JSON).
+- JSON (via existing `jsonError` extras):
+
+```json
+{
+  "success": false,
+  "error": "Note changed on disk while editing; no changes were written. Retry the command.",
+  "code": "note-modified-concurrently",
+  "retryable": true,
+  "data": { "path": "<vault-relative>", "attempts": 3 }
+}
+```
+
+Also map the lock-acquisition timeout inside edit to the same `retryable: true` shape (`code: "lock-timeout"`) so automation has one contract.
+
+## 3. Recurrence interaction
+
+- **Prepare inside the lock, per attempt.** `prepareRecurrenceFastPath` takes old + new frontmatter; on a retry the "old" state changed, so a cached plan is invalid. Re-prepare against the freshly read snapshot inside the lock each attempt. Prepare failing still aborts before `writeNote` — atomicity invariant preserved.
+- **Commit inside the same lock.** `commitRecurrenceFastPath` back-links `next` onto the predecessor; that second predecessor write must not race a lineage mutation either, so keep it within the held lock.
+- **Reentrancy trap:** `withLineageMutationLocks` is not reentrant. Verify `commitRecurrenceFastPath` (and successor ID registration) never acquires a *path* lock for the predecessor — if it takes the global note-ID assignment lock, that's fine and matches the established order (path locks → ID lock, same as fork/adopt). Never the reverse.
+
+## 4. Fork/adopt pre-write assertions
+
+Making edit lock-aware closes the stated race by itself (lineage writers already hold the lock across read→write). But acceptance #1 asks identity writes to *detect* staleness, and it's cheap defense-in-depth against non-BWRB writers:
+
+- `ensureSourceId` (fork): it re-parses inside the lock and writes almost immediately — add a re-read + byte-compare against `parsed.raw` immediately before `writeFileAtomic`; on mismatch throw the retryable error. **Rollback guard:** the registry-failure rollback (`writeFileAtomic(sourcePath, parsed.raw)`) must first read current bytes and only restore if they equal `nextRaw` we just wrote; otherwise report incomplete rollback without clobbering.
+- `applyPreparedAdoption`: before each of the two writes, re-read and compare with `parentOriginal.raw` / `childOriginal.raw`. **Rollback guard (data-loss risk):** current rollback blindly restores originals — if a newer write landed, rollback destroys it. Change each rollback to CAS-style: restore only if current bytes == the `nextRaw` this process wrote; else append to `rollbackErrors` with a "left as-is" note.
+
+Map these to the same `note-modified-concurrently` retryable output in the fork/adopt command handlers (fork could safely auto-retry once since it holds the lock; a single bounded retry inside the lock is acceptable, but failing retryable is also fine — keep it simple: fail retryable).
+
+## 5. Deterministic tests
+
+Use real CLI child processes with **file-based handshakes** (matches the PR #821 fixture style), no sleeps:
+
+- **Seam:** a tiny test-only barrier in edit's commit path: if `BWRB_TEST_BARRIER_DIR` is set, after the initial `parseNote` write `<dir>/edit-read.ready`, then poll (short interval, generous deadline) for `<dir>/edit-commit.go` before entering the lock. No-op when unset; keep it one guarded function so knip/lint stay clean.
+- **Test A (edit-vs-fork, JSON retry):** start `bwrb edit --json '{"status":"done"}'` with barrier dir → wait for `edit-read.ready` → run `bwrb new --fork <source>` to completion → touch `edit-commit.go` → assert edit exits 0, final file contains **both** the backfilled `id` (byte-exact insertion preserved) and the patch, registry consistent.
+- **Test B (edit-vs-adopt, same shape):** adopt inserts `forked-from` (+ maybe `id`) during the pause; assert JSON edit retry preserves both system fields; assert `forked-from` value untouched by the edit.
+- **Test C (interactive stale):** same handshake but interactive edit driven via scripted stdin (existing non-PTY interactive harness); assert stable retryable error, exit code, and **file bytes unchanged** from the lineage result.
+- **Test D (lock blocking):** fixture child holds the path lock (existing #821 fixture) while `bwrb edit --json` runs → assert edit blocks then succeeds after release; and a never-released hold → assert `lock-timeout` retryable JSON (use small `retryMs/attempts` override if the fixture exposes it, or accept the env-tunable override if one exists — don't add new prod knobs beyond what #821 established).
+- **Test E (adopt rollback guard):** unit-level — inject failing `dependencies.registerIds`, mutate child bytes between write and rollback via the dependency hook, assert rollback does not restore stale originals.
+- Byte-invariant assertions everywhere: compare full file contents, not parsed frontmatter, to protect EOL/quote/comment preservation.
+
+## 6. Docs, gates, scope traps
+
+**Docs:** docs-site edit page (concurrent-modification behavior, retryable JSON contract, honest external-editor caveat), fork + lineage adopt pages (new conflict error), `docs/skill/SKILL.md` (new `code`/`retryable` fields = automation contract change), changelog entry.
+
+**Focused commands:** targeted vitest runs for the new concurrency specs, then existing edit, fork, adoption, lineage-lock, audit, recurrence suites.
+
+**Full gates, exact order:** `build`, `verify:pack`, `typecheck`, `lint`, `knip`, non-PTY tests. Draft PR → full TaskSweep → ready → normal merge after every gate; no early merge.
+
+**Scope traps:** don't convert `writeNote`/`writeFileAtomic` into a general CAS primitive; don't touch bulk/audit/template/migration writers; don't add locks around interactive prompts; don't extend to multi-note edit coordination; don't change exit-code numbering.
+
+## 7. Deadlock / data-loss callouts
+
+1. **Lock order invariant:** path lineage locks (sorted) → global note-ID lock, always. Edit's new lock nests recurrence commit's ID registration correctly; audit the recurrence engine to confirm it never takes a path lock.
+2. **Non-reentrant locks:** edit must own the lock scope and never call anything that re-acquires the same path lock (recurrence back-link is the risk point).
+3. **Adopt rollback clobber:** fixed via CAS-guarded rollback (Q4) — this is the single real data-loss bug beyond the headline race; fix it in the same PR since it's in-scope for "rollback cannot clobber a newer edit."
+4. **Retry livelock:** bounded at 3 attempts with the retryable error as the floor — deterministic output either way.
+5. **Fork's `ensureSourceId` rollback** has the same clobber shape; guard identically.

--- a/.task-sweep/logs/claude-fable-5-plan-prompt-20260710-121000-issue-820.md
+++ b/.task-sweep/logs/claude-fable-5-plan-prompt-20260710-121000-issue-820.md
@@ -1,0 +1,1367 @@
+# TaskSweep early planning packet — BWRB issue #820
+
+You are advising before implementation. You have no tools. Give a concise, concrete plan; do not mutate anything or broaden beyond this issue.
+
+## Normalized task
+
+- ID/source: GitHub issue #820, https://github.com/3mdistal/bwrb/issues/820
+- Title: Prevent concurrent edits from being overwritten by lineage identity writes
+- Repo/base: 3mdistal/bwrb, origin/main at merge commit 7093f233ffc0e43c5086e184ed19e518148211c8 (PR #821)
+- Branch/lane: codex/820-lineage-edit-concurrency in an isolated worktree
+- Problem: new --fork source ID backfill and lineage adopt atomically rewrite raw note bytes while holding path-keyed lineage locks. Ordinary edit reads a note without those locks and later rewrites serialized frontmatter/body. A stale edit can overwrite an id or forked-from inserted after its read. PR #821 hardened the lock cross-platform; this issue now closes the remaining edit-vs-lineage race.
+- Acceptance:
+  1. Identity/provenance writes detect when note bytes changed after their authoritative read and fail or safely retry without overwriting the concurrent ordinary edit.
+  2. Text and JSON behavior is deterministic, with stable retryable output when automatic retry is unsafe.
+  3. Focused deterministic edit-vs-new --fork and edit-vs-lineage-adopt races.
+  4. Preserve byte-sensitive YAML/body invariants and keep forked-from immutable outside sanctioned lineage workflows.
+  5. Existing fork, adoption, audit, lineage-lock, edit, recurrence, and full suites remain green.
+- User authorized draft PR, full TaskSweep, ready transition, and normal merge after every gate. Do not merge early.
+- Scope: solve one-note ordinary edit coordination with fork/adopt identity writes. Do not redesign all bulk/audit/template/migration writers unless a tiny shared primitive is strictly required by this issue.
+
+## Repo facts and constraints
+
+- TypeScript ESM Commander CLI; Node 22; pnpm 10.11.0.
+- Full parity exact order: build, verify:pack, typecheck, lint, knip, non-PTY tests.
+- User behavior docs are canonical in docs-site/src/content/docs/; update docs/skill/SKILL.md for automation contract changes and changelogs when behavior changes.
+- System fields id and forked-from are already rejected from JSON patch input and omitted from interactive edit prompts.
+- withLineageMutationLocks sorts path locks and fails closed. Fork/adopt take path locks; adopt then takes the global note-ID assignment lock. PR #821 adds real child-process lock fixtures and Windows CI.
+- writeFileAtomic uses temp + fsync + rename but has no compare-and-swap. writeNote is a direct write.
+- JSON edit and interactive edit both parse near the beginning, validate/prepare recurrence work, then write much later.
+- Recurrence edit planning/commit must not regress atomicity.
+- Holding a cross-process lock throughout human prompts is likely undesirable; evaluate commit-phase locking plus stale detection/retry.
+- A read/check/rename CAS cannot exclude an unrelated external editor between check and rename. The acceptance is specifically ordinary BWRB edit versus sanctioned lineage mutations; clarify the honest guarantee rather than claiming general filesystem CAS.
+
+## Questions for the plan
+
+1. What is the smallest safe architecture? Compare:
+   - wrapping the entire JSON/interactive edit in the lineage path lock;
+   - commit-phase lock with exact raw-byte stale detection;
+   - bounded automatic retry for JSON patches against the latest note while interactive edits return a stable retryable error.
+2. Which code should own the retryable error and output mapping? Propose exact text, exit code, and JSON data shape consistent with current BWRB conventions.
+3. How should recurrence preparation/commit interact with the lock and possible retry so no predecessor/successor inconsistency is introduced?
+4. Do fork/adopt need their own pre-write raw-byte assertions after this change, or does making ordinary edit lock-aware satisfy the stated race? If assertions are added, ensure rollback cannot clobber a newer edit.
+5. Give a deterministic test design for edit-vs-fork and edit-vs-adopt, preferably exercising actual CLI processes with explicit handshakes rather than sleeps. Identify any minimal dependency seam/test-only fixture needed.
+6. List docs/changelog/agent-skill updates, focused commands, full gates, and scope traps.
+7. Call out lock-order or rollback deadlocks/data-loss risks.
+
+## Relevant current code
+
+### src/lib/edit.ts
+```ts
+
+export interface EditResult {
+  updatedFields: string[];
+  path: string;
+}
+
+export interface EditFromJsonOptions {
+  /** Whether to output errors as JSON */
+  jsonMode?: boolean;
+}
+
+export interface EditInteractiveOptions {
+  /** Whether to check for missing body sections */
+  checkSections?: boolean;
+}
+
+// ============================================================================
+// JSON Edit Mode (Non-Interactive)
+// ============================================================================
+
+/**
+ * Edit a note from JSON input (non-interactive mode with merge semantics).
+ *
+ * @param schema - Loaded schema
+ * @param vaultDir - Vault directory path
+ * @param filePath - Absolute path to the note file
+ * @param jsonInput - JSON string with patch data
+ * @param options - Edit options
+ * @returns Result with updated field names
+ */
+export async function editNoteFromJson(
+  schema: LoadedSchema,
+  vaultDir: string,
+  filePath: string,
+  jsonInput: string,
+  options: EditFromJsonOptions = {}
+): Promise<EditResult> {
+  const { jsonMode = true } = options;
+
+  // Parse JSON input
+  let patchData: Record<string, unknown>;
+  try {
+    patchData = JSON.parse(jsonInput) as Record<string, unknown>;
+  } catch (e) {
+    const error = `Invalid JSON: ${(e as Error).message}`;
+    if (jsonMode) {
+      printJson(jsonError(error));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(error);
+  }
+
+  // Disallow editing system-managed fields
+  const reservedField = Object.keys(patchData).find(isBwrbReservedFrontmatterField);
+  if (reservedField) {
+    const error = `Field '${reservedField}' is system-managed and cannot be modified`;
+    if (jsonMode) {
+      printJson(jsonError(error, {
+        errors: [{ field: reservedField, value: patchData[reservedField], message: error }],
+      }));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(error);
+  }
+
+  // Parse existing note
+  const { frontmatter, body } = await parseNote(filePath);
+
+  // Resolve type path from existing frontmatter
+  const typePath = resolveTypePathFromFrontmatter(schema, frontmatter);
+  if (!typePath) {
+    const error = 'Could not determine note type from frontmatter';
+    if (jsonMode) {
+      printJson(jsonError(error));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(error);
+  }
+
+  const typeDef = getTypeDefByPath(schema, typePath);
+  if (!typeDef) {
+    const error = `Unknown type path: ${typePath}`;
+    if (jsonMode) {
+      printJson(jsonError(error));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(error);
+  }
+
+  const patchValidation = validateFrontmatter(schema, typePath, patchData, { strictFields: true });
+  const unknownPatchErrors = patchValidation.errors.filter(error => error.type === 'unknown_field');
+  if (unknownPatchErrors.length > 0) {
+    if (jsonMode) {
+      printJson({
+        success: false,
+        error: 'Validation failed',
+        errors: unknownPatchErrors.map(e => ({
+          field: e.field,
+          message: e.message,
+          ...(e.value !== undefined && { value: e.value }),
+          ...(e.suggestion !== undefined && { suggestion: e.suggestion }),
+        })),
+      });
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(`Validation failed: ${unknownPatchErrors.map(e => e.message).join(', ')}`);
+  }
+
+  // Merge patch data into existing frontmatter
+  const mergedFrontmatter = mergeFrontmatter(frontmatter, patchData);
+  const updatedFields = Object.keys(patchData).filter(k => patchData[k] !== undefined);
+
+  // Materialize defaults BEFORE validating/writing — but ONLY for the parity
+  // case, SURGICALLY scoped to the keys the user blanked in THIS patch.
+  //
+  // The write↔audit parity bug (#707): a blank (incl. whitespace-only) value for
+  // a key whose field HAS a `default`/`value` passes validation —
+  // `validateFrontmatter` treats it as "unset → satisfied by the default" — but
+  // the blank would be PERSISTED, so `audit` then flags `empty-string-required`:
+  // write says OK, audit says broken. Materializing the default for that key makes
+  // write and audit agree.
+  //
+  // A BLANKET `applyDefaults` over the whole merged frontmatter over-corrects in
+  // two ways, so we scope instead:
+  //   1. Explicit removal (`{"field": null}`) is the documented way to delete a
+  //      field. `mergeFrontmatter` deletes it; a blanket default would write it
+  //      straight back. We EXCLUDE null (isBlankScalar is true for null, so we
+  //      filter on a blank STRING specifically) → removal is preserved.
+  //   2. An edit must not materialize defaults for fields the user never touched.
+  //      Scoping to user-patch keys leaves untouched fields alone.
+  //
+  // Keys the user blanked but whose field has NO default stay blank: optional →
+  // unset (trim-everywhere preserved), required → still rejected at validation.
+  const fields = getFieldsForType(schema, typePath);
+  const blankPatchKeys = new Set(
+    Object.keys(patchData).filter((key) => {
+      if (typeof patchData[key] !== 'string' || !isBlankScalar(patchData[key])) return false;
+      // Plain prompt:list fields must validate as arrays on write (#742). Do
+      // not let a default such as [] hide a user-supplied scalar patch before
+      // validation gets to enforce the same shape audit expects.
+      return fields[key]?.prompt !== 'list';
+    })
+  );
+  const defaultedFrontmatter = applyDefaults(
+    schema,
+    typePath,
+    mergedFrontmatter,
+    blankPatchKeys
+  );
+
+  // Normalize date-like fields to canonical YYYY-MM-DD strings — AFTER defaults
+  // are materialized (#707). A materialized date default can be non-canonical
+  // (e.g. `default: "12/25/2026"`); `validateFrontmatter` accepts the slash form,
+  // so without normalizing it here the raw default would be PERSISTED and `audit`
+  // would then flag `invalid-date-format`. Running the single date-normalization
+  // pass after `applyDefaults` canonicalizes BOTH user-supplied date values and
+  // any date default we just filled in, so write and audit agree on the stored
+  // form. (Mirrors `new`/json-mode, which materializes defaults before building
+  // the note.)
+  const resolvedFrontmatter = normalizeDateFields(schema, typePath, defaultedFrontmatter);
+
+  // Validate merged result
+  const validation = validateFrontmatter(schema, typePath, resolvedFrontmatter);
+  if (!validation.valid) {
+    if (jsonMode) {
+      printJson({
+        success: false,
+        error: 'Validation failed',
+        errors: validation.errors.map(e => ({
+          field: e.field,
+          message: e.message,
+          currentValue: frontmatter[e.field],
+          ...(e.value !== undefined && { value: e.value }),
+          ...(e.expected !== undefined && { expected: e.expected }),
+          ...(e.suggestion !== undefined && { suggestion: e.suggestion }),
+        })),
+      });
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(`Validation failed: ${validation.errors.map(e => e.message).join(', ')}`);
+  }
+
+  // Validate context fields (source type constraints)
+  const contextValidation = await validateContextFields(schema, vaultDir, typePath, resolvedFrontmatter);
+  if (!contextValidation.valid) {
+    if (jsonMode) {
+      printJson({
+        success: false,
+        error: 'Context field validation failed',
+        errors: contextValidation.errors.map(e => ({
+          type: e.type,
+          field: e.field,
+          message: e.message,
+          currentValue: frontmatter[e.field],
+          ...(e.value !== undefined && { value: e.value }),
+          ...(e.expected !== undefined && { expected: e.expected }),
+        })),
+      });
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(`Context validation failed: ${contextValidation.errors.map(e => e.message).join(', ')}`);
+  }
+
+  const relativeDateDiagnostics = await validateRelativeDateCalendarOffsetsForWrite(
+    schema,
+    vaultDir,
+    typePath,
+    resolvedFrontmatter,
+    relative(vaultDir, filePath)
+  );
+  if (relativeDateDiagnostics.length > 0) {
+    if (jsonMode) {
+      printJson({
+        success: false,
+        error: 'Validation failed',
+        errors: relativeDateDiagnostics.map(diagnostic => ({
+          field: diagnostic.field,
+          message: diagnostic.message,
+          currentValue: frontmatter[diagnostic.field],
+          value: resolvedFrontmatter[diagnostic.field],
+        })),
+      });
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(`Validation failed: ${relativeDateDiagnostics.map(diagnostic => diagnostic.message).join(', ')}`);
+  }
+
+  // Validate parent field doesn't create a cycle (for recursive types)
+  if (typeDef.recursive && resolvedFrontmatter['parent']) {
+    const noteName = filePath.split('/').pop()?.replace(/\.md$/, '') ?? '';
+    const cycleError = await validateParentNoCycle(
+      schema,
+      vaultDir,
+      noteName,
+      resolvedFrontmatter['parent'] as string
+    );
+    if (cycleError) {
+      if (jsonMode) {
+        printJson({
+          success: false,
+          error: cycleError.message,
+          errors: [{
+            field: cycleError.field,
+            message: cycleError.message,
+          }],
+        });
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+      throw new Error(cycleError.message);
+    }
+  }
+
+  // Get field order
+  const fieldOrder = getFrontmatterOrder(typeDef);
+  const orderedFields = fieldOrder.length > 0 ? fieldOrder : Object.keys(resolvedFrontmatter);
+
+  // Recurrence fast path (atomicity, #107): VALIDATE + COMPUTE the successor
+  // BEFORE mutating the predecessor. If this completion would spawn a successor
+  // but the spawn can't succeed (missing template, partial/unparseable offset
+  // base), prepare throws here and we abort WITHOUT writing the predecessor —
+  // never leaving it `done` with no successor.
+  const fastPathPlan = await prepareRecurrenceFastPath(
+    schema,
+    vaultDir,
+    typeDef.name,
+    filePath,
+    frontmatter,
+    resolvedFrontmatter,
+    body
+  );
+
+  // Write updated note (predecessor status change is now safe to commit).
+  await writeNote(filePath, resolvedFrontmatter, body, orderedFields);
+
+  // Commit the prepared spawn (create successor + back-link `next`). Identical
+  // result to the audit backstop, which shares the same engine.
+  await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+
+  return { updatedFields, path: filePath };
+}
+
+// ============================================================================
+// Interactive Edit Mode
+// ============================================================================
+
+/**
+ * Edit an existing note's frontmatter interactively.
+ *
+ * @param schema - Loaded schema
+ * @param vaultDir - Vault directory path
+ * @param filePath - Absolute path to the note file
+  vaultDir: string,
+  filePath: string,
+  options: EditInteractiveOptions = {}
+): Promise<void> {
+  const { checkSections = true } = options;
+
+  const { frontmatter, body } = await parseNote(filePath);
+  const fileName = filePath.split('/').pop() ?? filePath;
+
+  printInfo(`\n=== Editing: ${fileName} ===`);
+
+  // Resolve type path from frontmatter
+  const typePath = resolveTypePathFromFrontmatter(schema, frontmatter);
+  if (!typePath) {
+    printWarning('Warning: Unknown type, showing raw frontmatter edit');
+    console.log('Current frontmatter:');
+    console.log(JSON.stringify(frontmatter, null, 2));
+    return;
+  }
+
+  const typeDef = getTypeDefByPath(schema, typePath);
+  if (!typeDef) {
+    printWarning(`Warning: Unknown type path: ${typePath}`);
+    return;
+  }
+
+  printInfo(`Type path: ${typePath}\n`);
+
+  // Edit frontmatter fields
+  // Preserve system-managed fields without offering them as editable schema
+  // input, even if a vault schema happens to declare a same-named field.
+  const newFrontmatter: Record<string, unknown> = Object.fromEntries(
+    Object.entries(frontmatter).filter(([fieldName]) =>
+      isBwrbReservedFrontmatterField(fieldName)
+    )
+  );
+  const fields = getFieldsForType(schema, typePath);
+  const fieldOrder = getFrontmatterOrder(typeDef);
+
+  // Determine actual field order
+  const orderedFields = fieldOrder.length > 0 ? fieldOrder : Object.keys(fields);
+
+  for (const fieldName of orderedFields) {
+    if (isBwrbReservedFrontmatterField(fieldName)) continue;
+    const field = fields[fieldName];
+    if (!field) continue;
+
+    const currentValue = frontmatter[fieldName];
+    const newValue = await promptFieldEdit(
+      schema,
+      vaultDir,
+      fieldName,
+      field,
+      currentValue
+    );
+
+    if (newValue !== undefined) {
+      newFrontmatter[fieldName] = newValue;
+    }
+  }
+
+  // Check for missing body sections
+  let updatedBody = body;
+  const bodySections = typeDef.bodySections;
+  if (checkSections && bodySections && bodySections.length > 0) {
+    const addSections = await promptConfirm('\nCheck for missing sections?');
+    if (addSections === null) {
+      throw new UserCancelledError();
+    }
+    if (addSections) {
+      updatedBody = await addMissingSections(body, bodySections);
+    }
+  }
+
+  // Recurrence fast path (atomicity, #107): VALIDATE + COMPUTE before mutating
+  // the predecessor (see editNoteFromJson). Interactive edit reconstructs the
+  // full frontmatter, so `frontmatter` (read at the top) is the old state.
+  const fastPathPlan = await prepareRecurrenceFastPath(
+    schema,
+    vaultDir,
+    typeDef.name,
+    filePath,
+    frontmatter,
+    newFrontmatter,
+    updatedBody
+  );
+
+  // Write updated file (predecessor change is now safe to commit).
+  await writeNote(filePath, newFrontmatter, updatedBody, orderedFields);
+  printSuccess(`\n✓ Updated: ${filePath}`);
+
+  // Commit the prepared spawn.
+  const fastPath = await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+  if (fastPath.successorPath) {
+    printSuccess(`✓ Spawned recurrence successor: ${fastPath.successorPath}`);
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function mergeFrontmatter(
+  existing: Record<string, unknown>,
+  patch: Record<string, unknown>
+): Record<string, unknown> {
+
+```
+
+### src/commands/new/fork.ts
+```ts
+  vaultDir: string,
+  options: ForkNoteOptions
+): Promise<ForkNoteResult> {
+  const source = await resolveForkSource(schema, vaultDir, options.target);
+  if (isValidNoteId(source.frontmatter.id)) {
+    await assertSourceIdUnique(schema, vaultDir, source.file.path, source.frontmatter.id);
+  }
+  assertOwnedForkAllowed(schema, source.file);
+
+  const sourceName = resolveSourceName(source);
+  const childName = await resolveChildName(sourceName, options);
+
+  return withLineageMutationLocks(vaultDir, [source.file.path], async () => {
+    // The path-keyed lock begins before legacy ID backfill and remains held
+    // through the child registry append. A concurrent non-force delete either
+    // removes the source first or observes this completed child.
+    const sourceId = await ensureSourceId(schema, vaultDir, source.file.path);
+
+    // Re-read after a possible ID backfill so the child copies the source's
+    // current frontmatter rather than a stale pre-lock snapshot.
+    const current = await parseNote(source.file.path);
+    const currentType = resolveTypeFromFrontmatter(schema, current.frontmatter);
+    if (!currentType) {
+      throw new Error(`Fork source no longer has a valid schema type: ${source.file.relativePath}`);
+    }
+
+    const warnings = collectSchemaDriftWarnings(schema, currentType, current.frontmatter);
+    const frontmatter = normalizeDateFields(
+      schema,
+      currentType,
+      buildForkFrontmatter(
+        schema,
+        currentType,
+        current.frontmatter,
+        childName,
+        sourceId
+      )
+    );
+    const childId = await generateUniqueNoteId(vaultDir);
+    frontmatter.id = childId;
+
+    const pathResult = buildNotePath(dirname(source.file.path), childName, 'interactive');
+    const relativePath = relative(vaultDir, pathResult.path);
+    if (relativePath.length > PORTABLE_PATH_MAX_LENGTH) {
+      throw new Error(
+        `Note path is ${relativePath.length} characters, exceeding the portable limit of ${PORTABLE_PATH_MAX_LENGTH}: ${relativePath}`
+      );
+    }
+
+    const pathLengthWarning = relativePath.length > PORTABLE_PATH_WARNING_LENGTH
+      ? {
+          path: relativePath,
+          length: relativePath.length,
+          threshold: PORTABLE_PATH_WARNING_LENGTH,
+          max: PORTABLE_PATH_MAX_LENGTH,
+        }
+      : undefined;
+
+    const orderedFields = buildForkFieldOrder(current.frontmatter, frontmatter);
+    try {
+      await writeNoteExclusive(pathResult.path, frontmatter, current.body, orderedFields);
+    } catch (error) {
+      if (isFileExistsError(error)) {
+        throw new Error(`File already exists: ${relativePath}`);
+      }
+      throw error;
+    }
+
+    try {
+      await registerIssuedNoteId(vaultDir, childId, pathResult.path);
+    } catch (error) {
+      // A note without a registry row is not a completed creation. Roll it
+      // back; the source ID backfill intentionally remains durable.
+      await unlink(pathResult.path).catch(() => undefined);
+      throw error;
+    }
+  if (selected === null) throw new UserCancelledError();
+  if (!selected.trim()) throw new Error('Fork name cannot be empty.');
+  return selected.trim();
+}
+
+async function ensureSourceId(
+  schema: LoadedSchema,
+  vaultDir: string,
+  sourcePath: string
+): Promise<string> {
+  return withNoteIdAssignmentLock(vaultDir, async () => {
+    const parsed = await parseNote(sourcePath);
+    const existing = parsed.frontmatter.id;
+    if (existing !== undefined) {
+      if (!isValidNoteId(existing)) {
+        throw new Error(`Fork source has an invalid id and was not modified: ${relative(vaultDir, sourcePath)}`);
+      }
+      await assertSourceIdUnique(schema, vaultDir, sourcePath, existing);
+      return existing;
+    }
+
+    const id = await generateUniqueNoteId(vaultDir);
+    const collisions = await findNotesWithId(schema, vaultDir, id);
+    if (collisions.length > 0) {
+      throw new Error('Generated source ID collides with an existing note; retry the command.');
+    }
+    const nextRaw = insertFrontmatterScalarPreservingBytes(parsed.raw, 'id', id);
+    await writeFileAtomic(sourcePath, nextRaw);
+    try {
+      await registerIssuedNoteId(vaultDir, id, sourcePath);
+    } catch (error) {
+      await writeFileAtomic(sourcePath, parsed.raw);
+      throw error;
+    }
+    return id;
+  });
+}
+
+async function assertSourceIdUnique(
+  schema: LoadedSchema,
+  vaultDir: string,
+  sourcePath: string,
+  id: string
+): Promise<void> {
+  const matches = await findNotesWithId(schema, vaultDir, id);
+  const otherMatches = matches.filter(file => resolve(file.path) !== resolve(sourcePath));
+
+```
+
+### src/commands/lineage/adopt.ts
+```ts
+  registrations: Array<{ id: string; notePath: string }>;
+}
+
+/** Preview or apply one guarded immediate-source edge between existing notes. */
+export async function adoptLineage(
+  schema: LoadedSchema,
+  vaultDir: string,
+  options: LineageAdoptOptions,
+  dependencies: LineageAdoptDependencies = {}
+): Promise<LineageAdoptResult> {
+  const initial = await resolveTargets(schema, vaultDir, options.child, options.parent);
+  assertDifferentNotes(vaultDir, initial.child, initial.parent);
+
+  if (!options.execute) {
+    return (await prepareAdoption(schema, vaultDir, initial.child, initial.parent, 'dry-run')).result;
+  }
+
+  const lockedPaths = [initial.child.file.path, initial.parent.file.path];
+  return withLineageMutationLocks(vaultDir, lockedPaths, async () =>
+    withNoteIdAssignmentLock(vaultDir, async () => {
+      const current = await resolveTargets(schema, vaultDir, options.child, options.parent);
+      assertTargetsStayedLocked(vaultDir, initial, current);
+      const prepared = await prepareAdoption(
+        schema,
+        vaultDir,
+        current.child,
+        current.parent,
+        'execute'
+      );
+      await applyPreparedAdoption(
+        vaultDir,
+        prepared,
+        dependencies.registerIds ?? registerIssuedNoteIds
+      );
+      return prepared.result;
+    })
+  );
+}
+
+async function resolveTargets(
+  schema: LoadedSchema,
+  vaultDir: string,
+  childTarget: string,
+  parentTarget: string
+): Promise<{ child: ResolvedExactNoteTarget; parent: ResolvedExactNoteTarget }> {
+  const child = await resolveExactNoteTarget(schema, vaultDir, childTarget, {
+    purpose: 'adoption child',
+  });
+  const parent = await resolveExactNoteTarget(schema, vaultDir, parentTarget, {
+    purpose: 'adoption parent',
+  });
+      `parent ${parent.file.relativePath} is ${parent.typeName}.`
+    );
+  }
+
+  assertNoExistingProvenance(child);
+  assertValidExistingId(child, 'child');
+  assertValidExistingId(parent, 'parent');
+
+  const snapshot = await buildVaultNoteSnapshot(schema, vaultDir);
+  assertGraphSafe(snapshot);
+
+  const usedIds = new Set<string>();
+  for (const note of snapshot.notes) {
+    const id = note.frontmatter?.id;
+    if (isValidNoteId(id)) usedIds.add(normalizeNoteId(id));
+  }
+
+  const parentExistingId = parent.frontmatter.id;
+  const parentId = isValidNoteId(parentExistingId)
+    ? parentExistingId
+    : await generateProspectiveId(vaultDir, usedIds);
+  usedIds.add(normalizeNoteId(parentId));
+
+  const childExistingId = child.frontmatter.id;
+  const childId = isValidNoteId(childExistingId)
+    ? childExistingId
+    : await generateProspectiveId(vaultDir, usedIds);
+  usedIds.add(normalizeNoteId(childId));
+
+  if (normalizeNoteId(childId) === normalizeNoteId(parentId)) {
+    throw new Error('Cannot adopt a note under itself: child and parent have the same stable id.');
+  }
+
+  const prospective = withProspectiveEdge(
+    snapshot,
+    child.file.path,
+    parent.file.path,
+    childId,
+    parentId
+  );
+  assertGraphSafe(prospective, true);
+
+  const parentRaw = await readFile(parent.file.path, 'utf-8');
+  const childRaw = await readFile(child.file.path, 'utf-8');
+  const parentNextRaw = isValidNoteId(parentExistingId)
+    ? parentRaw
+    : insertFrontmatterScalarPreservingBytes(parentRaw, 'id', parentId);
+  let childNextRaw = childRaw;
+  if (!isValidNoteId(childExistingId)) {
+    childNextRaw = insertFrontmatterScalarPreservingBytes(childNextRaw, 'id', childId);
+  }
+  childNextRaw = insertFrontmatterScalarPreservingBytes(childNextRaw, 'forked-from', parentId);
+
+  const childOriginal = parseNoteContent(childRaw);
+  const parentOriginal = parseNoteContent(parentRaw);
+  const childNext = parseNoteContent(childNextRaw);
+  const parentNext = parseNoteContent(parentNextRaw);
+  assertOnlySystemFieldsChanged(child.file.relativePath, childOriginal, childNext);
+  assertOnlySystemFieldsChanged(parent.file.relativePath, parentOriginal, parentNext);
+
+  const status = mode === 'execute' ? 'applied' : 'planned';
+  const changes: LineageAdoptChange[] = [];
+  if (!isValidNoteId(parentExistingId)) {
+    changes.push({ path: parent.file.relativePath, field: 'id', value: parentId, status });
+  }
+  if (!isValidNoteId(childExistingId)) {
+    changes.push({ path: child.file.relativePath, field: 'id', value: childId, status });
+  }
+  changes.push({
+    path: child.file.relativePath,
+    field: 'forked-from',
+    value: parentId,
+    status,
+  });
+
+  const registrations: Array<{ id: string; notePath: string }> = [];
+  if (!isValidNoteId(parentExistingId)) {
+    registrations.push({ id: parentId, notePath: parent.file.path });
+  }
+  if (!isValidNoteId(childExistingId)) {
+    registrations.push({ id: childId, notePath: child.file.path });
+  }
+
+  return {
+    child,
+    parent,
+    childOriginal,
+    parentOriginal,
+    childNextRaw,
+    parentNextRaw,
+    registrations,
+    result: {
+      mode,
+      child: {
+        path: child.file.relativePath,
+        id: childId,
+        id_generated: !isValidNoteId(childExistingId),
+      },
+      parent: {
+        path: parent.file.relativePath,
+        id: parentId,
+        id_generated: !isValidNoteId(parentExistingId),
+      },
+      changes,
+      warnings: mode === 'dry-run' && registrations.length > 0
+        ? ['Generated IDs in a dry run are provisional; execute revalidates and assigns fresh UUIDs.']
+        : [],
+      body_invariance: {
+        child: buildBodyEvidence(childOriginal.body, childNext.body),
+        parent: buildBodyEvidence(parentOriginal.body, parentNext.body),
+      },
+    },
+  };
+}
+
+async function applyPreparedAdoption(
+  vaultDir: string,
+  prepared: PreparedAdoption,
+  registerIds: typeof registerIssuedNoteIds
+): Promise<void> {
+  let parentWritten = false;
+  let childWritten = false;
+  try {
+    if (prepared.parentNextRaw !== prepared.parentOriginal.raw) {
+      await writeFileAtomic(prepared.parent.file.path, prepared.parentNextRaw);
+      parentWritten = true;
+    }
+    await writeFileAtomic(prepared.child.file.path, prepared.childNextRaw);
+    childWritten = true;
+    await registerIds(vaultDir, prepared.registrations);
+  } catch (error) {
+    const rollbackErrors: string[] = [];
+    if (childWritten) {
+      await writeFileAtomic(prepared.child.file.path, prepared.childOriginal.raw)
+        .catch(rollbackError => rollbackErrors.push(formatError(rollbackError)));
+    }
+    if (parentWritten) {
+      await writeFileAtomic(prepared.parent.file.path, prepared.parentOriginal.raw)
+        .catch(rollbackError => rollbackErrors.push(formatError(rollbackError)));
+    }
+    if (rollbackErrors.length > 0) {
+      throw new Error(
+        `Lineage adoption failed (${formatError(error)}) and rollback was incomplete: ${rollbackErrors.join('; ')}`
+      );
+    }
+    throw error;
+
+```
+
+### src/lib/frontmatter.ts
+```ts
+  }
+
+  return value;
+}
+
+export interface ParsedNote {
+  frontmatter: Record<string, unknown>;
+  body: string;
+  raw: string;
+}
+
+/** Parse an in-memory markdown note using the same normalization as parseNote. */
+export function parseNoteContent(content: string): ParsedNote {
+  const { data, content: body } = matter(content);
+  return {
+    frontmatter: normalizeMatterValue(data) as Record<string, unknown>,
+    body,
+    raw: content,
+  };
+}
+
+/**
+ * Parse a markdown file's frontmatter and body.
+ */
+export async function parseNote(filePath: string): Promise<ParsedNote> {
+  const content = await readFile(filePath, 'utf-8');
+  return parseNoteContent(content);
+}
+
+/**
+ * Parse frontmatter from a string.
+ */
+export function parseFrontmatter(content: string): Record<string, unknown> {
+  const { data } = matter(content);
+  return normalizeMatterValue(data) as Record<string, unknown>;
+}
+
+/**
+ * Insert a plain scalar into a note's top-level frontmatter without
+ * reserializing any existing YAML.
+ *
+ * This is intentionally narrow: callers must supply a plain-safe key and
+ * value. The original bytes (including BOM, EOL style, comments, anchors,
+ * quote style, block scalars, and body) are otherwise left untouched.
+ */
+export function insertFrontmatterScalarPreservingBytes(
+  content: string,
+  key: string,
+  value: string
+): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(key)) {
+    throw new Error(`Cannot insert unsafe frontmatter key: ${key}`);
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(value)) {
+    throw new Error(`Cannot insert non-plain frontmatter value for ${key}`);
+  }
+
+  const structural = readStructuralFrontmatterFromRaw(content);
+  const block = structural.primaryBlock;
+  const doc = structural.doc;
+  if (
+    !block ||
+    !structural.atTop ||
+    !doc ||
+    structural.yamlErrors.length > 0 ||
+    !isMap(doc.contents)
+  ) {
+    throw new Error('Cannot insert field: note does not have valid top-level mapping frontmatter');
+  }
+
+  const map = doc.contents as YAMLMap;
+  const pairs = map.items as Pair[];
+  if (pairs.some(pair => String((pair.key as Scalar | null | undefined)?.value ?? '') === key)) {
+    throw new Error(`Cannot insert field: frontmatter already contains '${key}'`);
+  }
+
+  const yaml = structural.yaml ?? '';
+  const typePair = pairs.find(
+    pair => String((pair.key as Scalar | null | undefined)?.value ?? '') === 'type'
+  );
+  const typeEnd = (typePair?.value as { range?: [number, number, number] } | null | undefined)
+    ?.range?.[2];
+  const insertionOffset = typeof typeEnd === 'number' ? typeEnd : yaml.length;
+  const insertionPoint = block.yamlStart + insertionOffset;
+  const eol = detectEol(content);
+  const before = content.slice(0, insertionPoint);
+  const separator = before.endsWith('\n') ? '' : eol;
+  return `${before}${separator}${key}: ${value}${eol}${content.slice(insertionPoint)}`;
+}
+
+/** Replace a UTF-8 file atomically via a same-directory temporary file. */
+export async function writeFileAtomic(filePath: string, content: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  const mode = await stat(filePath).then(info => info.mode).catch(() => undefined);
+  const tempPath = join(
+    dirname(filePath),
+    `.${basename(filePath)}.bwrb-${process.pid}-${randomUUID()}.tmp`
+  );
+  const handle = await open(tempPath, 'wx', mode);
+  let renamed = false;
+
+  try {
+    await handle.writeFile(content, 'utf-8');
+    await handle.sync();
+    await handle.close();
+    await rename(tempPath, filePath);
+    renamed = true;
+  } finally {
+    await handle.close().catch(() => undefined);
+    if (!renamed) await unlink(tempPath).catch(() => undefined);
+  }
+}
+
+/**
+ * Serialize frontmatter to YAML string (without delimiters).
+ * Always puts 'type' first if present.
+ */
+export function serializeFrontmatter(
+  data: Record<string, unknown>,
+  order?: string[]
+): string {
+export function buildNoteContent(
+  frontmatter: Record<string, unknown>,
+  body: string,
+  frontmatterOrder?: string[]
+): string {
+  const yaml = serializeFrontmatter(frontmatter, frontmatterOrder);
+  return `---\n${yaml}\n---\n${body}`;
+}
+
+/**
+ * Write a note to disk, creating directories as needed.
+ */
+export async function writeNote(
+  filePath: string,
+  frontmatter: Record<string, unknown>,
+  body: string,
+  frontmatterOrder?: string[]
+): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  const content = buildNoteContent(frontmatter, body, frontmatterOrder);
+  await writeFile(filePath, content, 'utf-8');
+}
+
+/**
+ * Create a note without ever replacing an existing path.
+ *
+ * The exclusive `wx` open is the filesystem-level reservation: concurrent
+ * callers for the same path cannot both succeed. If writing fails after the
+ * reservation is created, the partial file is removed before the error is
+ * rethrown. Existing write paths keep their current overwrite semantics by
+ * continuing to use {@link writeNote}.
+ */
+export async function writeNoteExclusive(
+  filePath: string,
+  frontmatter: Record<string, unknown>,
+  body: string,
+  frontmatterOrder?: string[]
+): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  const content = buildNoteContent(frontmatter, body, frontmatterOrder);
+  const handle = await open(filePath, 'wx');
+
+```
+
+### src/lib/lineage-lock.ts
+```ts
+import { createHash, randomUUID } from 'crypto';
+import { mkdir, open, readFile, readdir, rename, stat, unlink } from 'fs/promises';
+import { basename, dirname, relative, resolve } from 'path';
+
+const LOCK_RETRY_MS = 20;
+const LOCK_ATTEMPTS = 1_500;
+const STALE_LOCK_MS = 30_000;
+const HEARTBEAT_MS = 10_000;
+const LOCK_VERSION = 1;
+
+export interface OwnershipFileLockOptions {
+  retryMs: number;
+  attempts: number;
+  staleMs: number;
+  heartbeatMs: number;
+}
+
+interface LockMetadata {
+  version: number;
+  pid: number;
+  token: string;
+  createdAt: number;
+  heartbeatAt: number;
+  pathKey: string;
+}
+
+interface LockSnapshot {
+  raw: string;
+  metadata: LockMetadata | null;
+  device: number;
+  inode: number;
+  modifiedAt: number;
+  size: number;
+}
+
+type LockSnapshotRead =
+  | { kind: 'present'; snapshot: LockSnapshot }
+  | { kind: 'missing' }
+  | { kind: 'busy' };
+
+const DEFAULT_OPTIONS: OwnershipFileLockOptions = {
+  retryMs: LOCK_RETRY_MS,
+  attempts: LOCK_ATTEMPTS,
+  staleMs: STALE_LOCK_MS,
+  heartbeatMs: HEARTBEAT_MS,
+};
+
+/**
+ * Serialize mutations that can create or remove fork edges for a source file.
+ *
+ * The key is the source's canonical vault-relative path rather than its UUID:
+ * legacy notes without IDs must participate in the same critical section as
+ * the fork that may assign their first ID.
+ */
+export async function withLineageMutationLocks<T>(
+  vaultDir: string,
+  sourcePaths: string[],
+  task: () => Promise<T>,
+  optionOverrides: Partial<OwnershipFileLockOptions> = {}
+): Promise<T> {
+  const options = { ...DEFAULT_OPTIONS, ...optionOverrides };
+  const lockPaths = Array.from(new Set(
+    sourcePaths.map(sourcePath => getLineageMutationLockPath(vaultDir, sourcePath))
+  )).sort((a, b) => a.localeCompare(b, 'en'));
+
+  const releases: Array<() => Promise<void>> = [];
+  try {
+    for (const lockPath of lockPaths) {
+      releases.push(await acquireLock(
+        lockPath,
+        options,
+        'Timed out waiting for a fork-lineage mutation lock; retry the command.'
+      ));
+    }
+    return await task();
+  } finally {
+    for (let index = releases.length - 1; index >= 0; index--) {
+      await releases[index]!();
+    }
+  }
+}
+
+/**
+ * Run one task while holding an ownership-safe lock at an existing lock path.
+ *
+ * This is shared by lineage-edge locks and the fixed note-ID coordination
+ * locks. Recovery and release are token/inode aware, so an old holder cannot
+ * remove a successor that has taken over the same pathname.
+ */
+export async function withOwnershipFileLock<T>(
+  lockPath: string,
+  task: () => Promise<T>,
+  optionOverrides: Partial<OwnershipFileLockOptions> = {},
+  timeoutMessage = 'Timed out waiting for a file lock; retry the command.'
+): Promise<T> {
+  const options = { ...DEFAULT_OPTIONS, ...optionOverrides };
+  const release = await acquireLock(resolve(lockPath), options, timeoutMessage);
+  try {
+    return await task();
+  } finally {
+    await release();
+  }
+}
+
+export function getLineageMutationLockPath(vaultDir: string, sourcePath: string): string {
+  const vaultRoot = resolve(vaultDir);
+  const absoluteSource = resolve(sourcePath);
+  const relativeSource = relative(vaultRoot, absoluteSource).replace(/\\/g, '/');
+  if (
+    relativeSource === '' ||
+    relativeSource === '..' ||
+    relativeSource.startsWith('../') ||
+    relativeSource.startsWith('/')
+  ) {
+    throw new Error(`Lineage lock source must be a file inside the vault: ${sourcePath}`);
+  }
+
+  // Lower-casing intentionally over-serializes case-only path variants. That
+  // is safer on case-insensitive filesystems and the digest remains portable.
+  const key = createHash('sha256').update(relativeSource.normalize('NFC').toLowerCase()).digest('hex');
+
+```
+
+### src/commands/edit.ts
+```ts
+
+interface EditOptions {
+  picker?: string;
+  type?: string;
+  path?: string;
+  where?: string[];
+  id?: string;
+  body?: string;
+  json?: string;
+  output?: string;
+  open?: boolean;
+  app?: string;
+}
+
+function resolveEditJsonMode(options: EditOptions, globalOutput?: string): boolean {
+  const requested = options.output ?? globalOutput;
+  if (requested === undefined) {
+    return options.json !== undefined;
+  }
+  return requested === 'json';
+}
+
+interface EditOpenJsonData {
+  open: OpenResultData;
+}
+
+async function openAfterEdit(
+  vaultDir: string,
+  notePath: string,
+  appMode: AppMode,
+  config: ResolvedConfig,
+  jsonMode: boolean
+): Promise<EditOpenJsonData | undefined> {
+  if (jsonMode) {
+    const openData = getOpenResultData(vaultDir, notePath, appMode, config);
+    if (appMode !== 'print') {
+      await openNote(vaultDir, notePath, appMode, config, false);
+    }
+    return { open: openData };
+  }
+
+  await openNote(vaultDir, notePath, appMode, config, false);
+  return undefined;
+}
+
+function printEditSuccess(
+  path: string,
+  updatedFields: string[],
+  jsonMode: boolean,
+  data?: EditOpenJsonData
+): void {
+  if (jsonMode) {
+    printJson(jsonSuccess({ path, updated: updatedFields, ...(data ? { data } : {}) }));
+    return;
+  }
+
+  const updatedText = updatedFields.length > 0
+    ? ` (${updatedFields.join(', ')})`
+    : '';
+  printSuccess(`Updated: ${path}${updatedText}`);
+}
+
+// ============================================================================
+// Command Definition
+// ============================================================================
+
+export const editCommand = new Command('edit')
+  .description('Edit an existing note')
+  .argument('[query]', 'Note name or path to edit')
+  .argument('[mode]', 'App mode for --open: system, editor, visual, obsidian, print')
+  .option('--picker <mode>', 'Picker mode: fzf, numbered, none', 'fzf')
+  .option('-t, --type <type>', 'Filter by note type')
+  .option('-p, --path <glob>', 'Filter by path pattern')
+  .option('-w, --where <expr...>', 'Filter by frontmatter expression')
+  .option('--id <uuid>', 'Filter by stable note id')
+  .option('-b, --body <pattern>', 'Filter by body content')
+  .option('--json <patch>', 'Non-interactive patch/merge mode')
+  .option('--output <format>', 'Output format: text or json (default: json with --json)')
+  .option('-o, --open', 'Open the note in Obsidian after editing')
+  .option('--app <mode>', 'App mode for --open: system (default), editor, visual, obsidian, print')
+  .addHelpText('after', `
+      if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
+      const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
+      const schema = await loadSchema(vaultDir);
+
+      if (globalOpts.nonInteractive && !patchMode) {
+        printError('bwrb edit requires --json <patch> when --non-interactive is set.');
+        process.exit(1);
+      }
+
+      // Validate the app mode eagerly (mirrors `open`): an invalid value from
+      // either --app or the positional [mode] errors loudly here rather than
+      // being silently ignored when --open isn't requested. Surface it as a
+      // VALIDATION_ERROR (exit 1) with a clear message, consistent with `open`.
+      if (appModeInput !== undefined) {
+        try {
+          parseAppMode(appModeInput);
+        } catch (modeErr) {
+          const message = modeErr instanceof Error ? modeErr.message : String(modeErr);
+          if (jsonMode) {
+            printJson(jsonError(message));
+            process.exit(ExitCodes.VALIDATION_ERROR);
+          }
+          printError(message);
+          process.exit(1);
+        }
+      }
+
+      // Validate type if provided
+      if (options.type) {
+        const typeDef = getTypeDefByPath(schema, options.type);
+        if (!typeDef) {
+          const error = formatUnknownTypeError(schema, options.type);
+          if (jsonMode) {
+            printJson(jsonError(error));
+            process.exit(ExitCodes.VALIDATION_ERROR);
+          }
+          printError(error);
+          process.exit(1);
+        }
+      }
+
+      // Check if query is an absolute path to an existing file
+      if (query && isAbsolute(query)) {
+        // Only the existence check may fall through to name resolution. Once we
+        // know the file exists, edit errors (e.g. a recurrence spawn failure:
+        // "Recurrence template 'X' was not found", "Cannot compute recurrence
+        // offset: ...") MUST propagate to the outer catch so the user sees the
+        // real message — never swallowed into a misleading "No matching notes".
+        let fileExists = false;
+        try {
+          await fs.access(query);
+          fileExists = true;
+        } catch {
+          // File doesn't exist or isn't accessible - fall through to normal resolution.
+        }
+
+        if (fileExists) {
+          // It's a valid absolute path - use it directly.
+          if (patchMode) {
+            const editResult = await editNoteFromJson(schema, vaultDir, query, options.json!, { jsonMode });
+            let openData: EditOpenJsonData | undefined;
+            if (options.open) {
+              const appMode = resolveAppMode(appModeInput, schema.config);
+              if (!jsonMode) {
+                printEditSuccess(relative(vaultDir, query), editResult.updatedFields, jsonMode);
+                await openAfterEdit(vaultDir, query, appMode, schema.config, jsonMode);
+                return;
+              }
+              openData = await openAfterEdit(vaultDir, query, appMode, schema.config, jsonMode);
+            }
+            printEditSuccess(relative(vaultDir, query), editResult.updatedFields, jsonMode, openData);
+          } else {
+            await editNoteInteractive(schema, vaultDir, query, {});
+            printSuccess(`Updated ${basename(query, '.md')}`);
+            if (options.open) {
+              const appMode = resolveAppMode(appModeInput, schema.config);
+              await openNote(vaultDir, query, appMode, schema.config, false);
+            }
+          }
+          return;
+        }
+      }
+
+      // Build targeting options
+      const targeting: TargetingOptions = {};
+      if (options.type) targeting.type = options.type;
+      if (options.path) targeting.path = options.path;
+      if (options.where) targeting.where = options.where;
+      if (options.id) targeting.id = options.id;
+      if (options.body) targeting.body = options.body;
+
+      // Determine if we have targeting constraints
+      const hasTargeting = hasAnyTargeting(targeting);
+
+      // Determine picker mode
+      const pickerMode = parsePickerMode(resolveGlobalPickerMode(options.picker, globalOpts, 'fzf'));
+      const effectivePickerMode: PickerMode = patchMode ? 'none' : pickerMode;
+
+      // In JSON mode without interactive picker, require a query or targeting
+      if (patchMode && !query && !hasTargeting) {
+        const error = 'Query required when using --json without targeting options';
+        if (jsonMode) {
+          printJson(jsonError(error));
+        } else {
+          printError(error);
+        }
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+
+      // Build candidates based on targeting
+      let candidates: ManagedFile[];
+      const index = await buildNoteIndex(schema, vaultDir);
+
+      if (hasTargeting) {
+        // Use resolveTargets for proper filtering
+        const targetingResult = await resolveTargets(targeting, schema, vaultDir);
+        if (targetingResult.error) {
+          exitWithResolutionError(targetingResult.error, targetingResult.files, jsonMode);
+        }
+        candidates = targetingResult.files;
+      } else {
+        candidates = index.allFiles;
+      }
+
+      // Create a filtered index for resolution
+      const candidatePaths = new Set(candidates.map((candidate) => candidate.relativePath));
+      const filteredIndex = {
+        ...index,
+        allFiles: candidates,
+        byPath: new Map(
+          [...index.byPath].filter(([path]) => candidatePaths.has(path))
+        ),
+        byBasename: new Map<string, ManagedFile[]>(),
+        byAlias: new Map(
+          [...index.byAlias]
+            .map(([alias, files]): [string, ManagedFile[]] => [
+              alias,
+              files.filter((file) => candidatePaths.has(file.relativePath)),
+            ])
+            .filter(([, files]) => files.length > 0)
+        ),
+      };
+      // Rebuild byBasename for filtered candidates
+      for (const file of candidates) {
+        const fileBasename = basename(file.relativePath, '.md');
+        const existing = filteredIndex.byBasename.get(fileBasename) ?? [];
+        existing.push(file);
+        filteredIndex.byBasename.set(fileBasename, existing);
+      }
+
+      const result = await resolveAndPick(filteredIndex, query, {
+        pickerMode: effectivePickerMode,
+        prompt: 'Select note to edit',
+        preview: false,
+        vaultDir,
+      });
+
+      if (!result.ok) {
+        if (result.cancelled) {
+          process.exit(0);
+        }
+        exitWithResolutionError(result.error, result.candidates, jsonMode);
+      }
+
+      const targetFile = result.file;
+
+      // Perform the edit
+      if (patchMode) {
+        // JSON patch mode: non-interactive patch with selectable output format
+        const editResult = await editNoteFromJson(schema, vaultDir, targetFile.path, options.json!, { jsonMode });
+        let openData: EditOpenJsonData | undefined;
+
+        // Open after edit if requested
+        if (options.open) {
+          const appMode = resolveAppMode(appModeInput, schema.config);
+          if (!jsonMode) {
+            printEditSuccess(targetFile.relativePath, editResult.updatedFields, jsonMode);
+            await openAfterEdit(vaultDir, targetFile.path, appMode, schema.config, jsonMode);
+            return;
+          }
+          openData = await openAfterEdit(vaultDir, targetFile.path, appMode, schema.config, jsonMode);
+        }
+        printEditSuccess(targetFile.relativePath, editResult.updatedFields, jsonMode, openData);
+        return;
+      } else {
+        // Interactive mode
+        await editNoteInteractive(schema, vaultDir, targetFile.path);
+        printSuccess(`Updated: ${targetFile.relativePath}`);
+
+        // Open after edit if requested
+        if (options.open) {
+          const appMode = resolveAppMode(appModeInput, schema.config);
+          await openNote(vaultDir, targetFile.path, appMode, schema.config, false);
+        }
+        return;
+      }
+    } catch (err) {
+      if (err instanceof UserCancelledError) {
+        if (jsonMode) {
+          printJson(jsonError('Cancelled', { code: ExitCodes.VALIDATION_ERROR }));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+        console.log('Cancelled.');
+        process.exit(1);
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      if (err instanceof OpenConfigurationError) {
+        if (jsonMode) {
+          printJson(jsonError(message));
+          process.exit(ExitCodes.VALIDATION_ERROR);
+        }
+
+```

--- a/.task-sweep/logs/claude-fable-5-review-20260710-123500-issue-820.log
+++ b/.task-sweep/logs/claude-fable-5-review-20260710-123500-issue-820.log
@@ -1,0 +1,7 @@
+model_requested: anthropic/claude-fable-5
+model_returned: anthropic/claude-5-fable-20260609
+finish_reason: length
+output: /Users/alicemoore/Developer/bwrb-worktrees/issue-820-edit-concurrency/.task-sweep/logs/claude-fable-5-review-output-20260710-123500-issue-820.md
+chars: 0 words: 0
+warning: response content was empty/null; inspect finish_reason and increase --max-tokens if needed.
+preview: 

--- a/.task-sweep/logs/claude-fable-5-review-attempt2-20260710-123500-issue-820.log
+++ b/.task-sweep/logs/claude-fable-5-review-attempt2-20260710-123500-issue-820.log
@@ -1,0 +1,6 @@
+model_requested: anthropic/claude-fable-5
+model_returned: anthropic/claude-5-fable-20260609
+finish_reason: length
+output: /Users/alicemoore/Developer/bwrb-worktrees/issue-820-edit-concurrency/.task-sweep/logs/claude-fable-5-review-output-attempt2-20260710-123500-issue-820.md
+chars: 2702 words: 343
+preview: NO BLOCKERS\n\n## SPEC FIDELITY\n\nAll five acceptance criteria are substantively met by the embedded diff:\n\n1. **Conflict detection** — `src/lib/note-write-concurrency.ts` provides `assertNoteBytesUnchanged`, wired into edit's guarded commit (`src/lib/edit.ts:351-368, 462-474`), fork source-ID backfill (`src/new/fork.ts:216`), and adopt's pre-write phase (`src/commands/lineage/adopt.ts:273-282`). Edit's barrier/lock ordering is correct: the read/validation is unlocked, the lock is taken only for the commit phase, and interactive prompts (and the test barrier) occur *before* lock acquisition — consistent with "do not hold lineage locks across human prompts."\n2. **Stable typed output** — `ConcurrentNoteModificationError` maps to numeric `code: 2` + `data.{reason,retryable,path,attempts}` in edi

--- a/.task-sweep/logs/claude-fable-5-review-context-20260710-124500-issue-820.log
+++ b/.task-sweep/logs/claude-fable-5-review-context-20260710-124500-issue-820.log
@@ -1,0 +1,6 @@
+model_requested: anthropic/claude-fable-5
+model_returned: anthropic/claude-5-fable-20260609
+finish_reason: stop
+output: /Users/alicemoore/Developer/bwrb-worktrees/issue-820-edit-concurrency/.task-sweep/logs/claude-fable-5-review-context-output-20260710-124500-issue-820.md
+chars: 3252 words: 434
+preview: NO BLOCKERS\n\n## SPEC FIDELITY\n\nThe prior review's spec conclusions hold, and the follow-up delta resolves both open items:\n\n1. **Docs ambiguity fixed** — all three surfaces now state "up to three total attempts (the initial attempt plus at most two retries)": `json-mode.md`, `edit.md`, and `SKILL.md`. This matches `JSON_EDIT_ATTEMPTS = 3` and `data.attempts: 3` exactly. No remaining drift.\n2. **Test barrier gate fixed** — `waitForEditCommitBarrier` now requires both `BWRB_TEST_EDIT_BARRIER_ENABLED === '1'` and `BWRB_TEST_EDIT_BARRIER_DIR`, and the test spawner sets both. The prior risk (a leaked dir var hanging every JSON edit 20s/attempt) is closed; accidental activation now requires two deliberate env settings. Barrier placement remains correct: before lock acquisition, so no lock is hel

--- a/.task-sweep/logs/claude-fable-5-review-context-output-20260710-124500-issue-820.md
+++ b/.task-sweep/logs/claude-fable-5-review-context-output-20260710-124500-issue-820.md
@@ -1,0 +1,23 @@
+NO BLOCKERS
+
+## SPEC FIDELITY
+
+The prior review's spec conclusions hold, and the follow-up delta resolves both open items:
+
+1. **Docs ambiguity fixed** — all three surfaces now state "up to three total attempts (the initial attempt plus at most two retries)": `json-mode.md`, `edit.md`, and `SKILL.md`. This matches `JSON_EDIT_ATTEMPTS = 3` and `data.attempts: 3` exactly. No remaining drift.
+2. **Test barrier gate fixed** — `waitForEditCommitBarrier` now requires both `BWRB_TEST_EDIT_BARRIER_ENABLED === '1'` and `BWRB_TEST_EDIT_BARRIER_DIR`, and the test spawner sets both. The prior risk (a leaked dir var hanging every JSON edit 20s/attempt) is closed; accidental activation now requires two deliberate env settings. Barrier placement remains correct: before lock acquisition, so no lock is held during the handshake.
+3. **Output mapping** — all four handlers (edit, new, search, lineage adopt) emit numeric `code: 2` with `reason/retryable/path/attempts`; the retry-exhaustion tests assert the full JSON shape with `toEqual`, and text mode asserts stderr + empty stdout. Path normalization (`replace(/\\/g, '/')`) is Windows-safe.
+4. **Rollback clobber safety** — `rollbackNoteIfUnchanged` compares current bytes to *this command's own write* before restoring; fork's registry-failure path and adopt's `applyPreparedAdoption` both use it, child-then-parent, aggregating rollback errors without masking the original. The "newer bytes left as-is" test proves a post-write external writer survives rollback.
+5. **Interactive stale** — no replay; `ConcurrentNoteModificationError` propagates and the newer bytes are preserved (asserted in test).
+
+## STANDARDS AND RISK
+
+Non-blocking, in priority order:
+
+1. **Completing prior item 2 (byte comparison is UTF-8-string comparison)**: `readFile(path, 'utf-8')` decodes before comparing. Two files with *different* invalid-UTF-8 byte sequences can decode to identical replacement-character strings and pass the guard. For UTF-8 markdown vaults this is theoretical; BOM/CRLF are preserved in the decoded string and tests confirm parity. Consider `Buffer.compare` if binary-adjacent notes ever become in-scope.
+2. **Fork backfill lock nesting not visible in packet**: the excerpt shows `withNoteIdAssignmentLock` wrapping assert→write, but not the per-note lineage mutation lock docs claim is shared. Prior review and the independent race tests (fork-vs-edit, 5x source + dist) confirm correct behavior; merge gate should just confirm the lineage lock wraps or contains this path so the assert→write window is closed against edit, not merely narrowed.
+3. **Recurrence commit scope**: `commitRecurrenceFastPath` runs under only the edited note's lock; successor creation and back-links to other notes aren't guarded. Acceptable given the spec excludes other writers, but worth a code comment.
+4. **`resolvedVaultDir ?? process.cwd()` fallback** can yield odd relative paths; unreachable in practice since the error requires vault resolution.
+5. Minor: `lineage adopt` uses `process.exitCode`/return while the other handlers `process.exit` — behaviorally equivalent, slightly inconsistent style; the post-loop `throw` in `editNoteFromJson` is unreachable (TS-satisfying) dead code.
+
+Gate decision: **merge**.

--- a/.task-sweep/logs/claude-fable-5-review-context-prompt-20260710-124500-issue-820.md
+++ b/.task-sweep/logs/claude-fable-5-review-context-prompt-20260710-124500-issue-820.md
@@ -1,0 +1,1160 @@
+You are completing a PR readiness review after the same exact-model full-diff review was truncated. The prior review content is embedded below. It started NO BLOCKERS, completed SPEC FIDELITY, and identified one docs ambiguity plus remaining non-blocking risk analysis before truncation. That docs ambiguity is now fixed. Review the bounded high-risk code/tests and follow-up delta below, especially concurrency windows, rollback clobber risk, recurrence lock scope, output mapping, and the explicit test barrier gate.
+
+Constraints:
+- No tools or edits.
+- Start with exactly one of BLOCKERS, NON-BLOCKING, or NO BLOCKERS.
+- Separate SPEC FIDELITY and STANDARDS AND RISK.
+- Treat this as the final PR gate.
+- Block only concrete correctness/data-loss/spec/repo-policy defects.
+- Do not re-flag the user-required .task-sweep artifacts.
+- Maximum 450 words. Finish the answer.
+
+Task: BWRB #820 prevents ordinary edit from overwriting concurrent new --fork ID backfill or lineage-adopt ID/forked-from writes. JSON has 3 total attempts (initial plus at most 2 retries); interactive stale answers are not replayed. Unsafe conflict returns numeric code 2 with reason/retryable/path/attempts. Exact bytes, system immutability, recurrence, rollback safety, docs, and deterministic edit-vs-fork/adopt coverage are required. Scope excludes other writers.
+
+Verified evidence:
+- Node22 exact parity 3037 pass/3 skip, build/package/typecheck/lint/knip.
+- independent tester PASS: 593 focused/repeated assertions; concurrency suite 5x source + 5x built dist; real built edit/adopt race; audit/lineage clean; exact bodies and reserved field rejection; docs gates/build.
+- Windows Lock Tests green on the draft implementation commit.
+- follow-up docs/test-hook commit passed Node22 typecheck/lint/knip, concurrency 6/6, all docs gates/build.
+- External unrelated editors cannot take BWRB locks; docs state the remaining tiny check-to-rename window honestly.
+
+PRIOR TRUNCATED REVIEW:
+NO BLOCKERS
+
+## SPEC FIDELITY
+
+All five acceptance criteria are substantively met by the embedded diff:
+
+1. **Conflict detection** — `src/lib/note-write-concurrency.ts` provides `assertNoteBytesUnchanged`, wired into edit's guarded commit (`src/lib/edit.ts:351-368, 462-474`), fork source-ID backfill (`src/new/fork.ts:216`), and adopt's pre-write phase (`src/commands/lineage/adopt.ts:273-282`). Edit's barrier/lock ordering is correct: the read/validation is unlocked, the lock is taken only for the commit phase, and interactive prompts (and the test barrier) occur *before* lock acquisition — consistent with "do not hold lineage locks across human prompts."
+2. **Stable typed output** — `ConcurrentNoteModificationError` maps to numeric `code: 2` + `data.{reason,retryable,path,attempts}` in edit, new, search, and lineage adopt handlers.
+3. **Race coverage** — `tests/ts/commands/edit-lineage-concurrency.test.ts` covers edit-vs-fork replay, edit-vs-adopt replay, JSON/text retry exhaustion, search --edit mapping, and interactive stale; `lineage-adopt.test.ts:268` covers the newer-writer rollback guard.
+4. **Byte invariants** — replay tests verify BOM/CRLF/comment/provider preservation via sequential-edit byte equality; adopt rollback only restores over its own bytes.
+5. Suite green claims are evidence-only; consistent with the diff.
+
+Spec-fidelity notes (non-blocking):
+- **Doc drift on retry count**: implementation is 3 total attempts (`JSON_EDIT_ATTEMPTS = 3`, loop at `src/lib/edit.ts:127`), i.e. 2 replays after the first attempt. `docs-site/.../json-mode.md` ("retries internally up to three times"), `edit.md` ("replayed ... up to three times"), and `SKILL.md` ("replay from fresh bytes up to three times") all imply 3 replays. `data.attempts: 3` is accurate; the prose is not. Suggest "up to three attempts."
+- `.task-sweep/logs` plan artifacts are asserted committed but excluded from the packet; unverifiable here — accept per spec statement, but the merge gate should confirm they exist at the manifest paths.
+
+## STANDARDS AND RISK
+
+Non-blocking items, roughly in priority order:
+
+1. **Test seam in production code** (`src/lib/edit.ts:487-506`): `waitForEditCommitBarrier` is env-activated (`BWRB_TEST_EDIT_BARRIER_DIR`) in the shipped JSON edit path with a 20s poll loop, plus the `beforeCommit` hook in the public `EditInteractiveOptions` interface (`src/lib/edit.ts:72`). If the env var leaks into a real environment, every JSON edit hangs up to 20s per attempt and then fails. Consider prefix-validating the dir or gating on an explicit test marker; at minimum document it as test-only.
+2. **"Exact raw-byte" is actually UTF-8-string comparison** (`note-write-concurrency.
+
+BOUND HIGH-RISK PACKET:
+## errors/concurrency
+```
+    super('User cancelled');
+    this.name = 'UserCancelledError';
+  }
+}
+
+/**
+ * A note changed after a command's authoritative read but before its guarded
+ * write. Callers must retry from a fresh snapshot rather than overwriting the
+ * newer bytes.
+ */
+export class ConcurrentNoteModificationError extends Error {
+  readonly path: string;
+  readonly attempts: number;
+
+  constructor(path: string, attempts = 1) {
+    super('Note changed on disk during a guarded write; newer bytes were preserved. Retry the command.');
+    this.name = 'ConcurrentNoteModificationError';
+    this.path = path;
+    this.attempts = attempts;
+  }
+}
+import { readFile } from 'fs/promises';
+import { relative } from 'path';
+import { ConcurrentNoteModificationError } from './errors.js';
+import { writeFileAtomic } from './frontmatter.js';
+
+/** Assert that a note still has the exact bytes used to prepare a mutation. */
+export async function assertNoteBytesUnchanged(
+  filePath: string,
+  expectedRaw: string,
+  attempts = 1
+): Promise<void> {
+  const currentRaw = await readFile(filePath, 'utf-8');
+  if (currentRaw !== expectedRaw) {
+    throw new ConcurrentNoteModificationError(filePath, attempts);
+  }
+}
+
+/**
+ * Restore a prior snapshot only when the file still contains this command's
+ * own write. A newer writer always wins; rollback must never erase it.
+ */
+export async function rollbackNoteIfUnchanged(
+  filePath: string,
+  writtenRaw: string,
+  originalRaw: string
+): Promise<boolean> {
+  const currentRaw = await readFile(filePath, 'utf-8');
+  if (currentRaw !== writtenRaw) return false;
+  await writeFileAtomic(filePath, originalRaw);
+  return true;
+}
+
+/** Stable agent-facing details shared by every guarded note writer. */
+export function concurrentModificationData(
+  vaultDir: string,
+  error: ConcurrentNoteModificationError
+): { reason: string; retryable: true; path: string; attempts: number } {
+  return {
+    reason: 'note-modified-concurrently',
+    retryable: true,
+    path: relative(vaultDir, error.path).replace(/\\/g, '/'),
+    attempts: error.attempts,
+  };
+}
+
+```
+
+## edit core
+```
+  updatedFields: string[];
+  path: string;
+}
+
+export interface EditFromJsonOptions {
+  /** Whether to output errors as JSON */
+  jsonMode?: boolean;
+}
+
+export interface EditInteractiveOptions {
+  /** Whether to check for missing body sections */
+  checkSections?: boolean;
+  /** Internal dependency hook for deterministic commit-race tests. */
+  beforeCommit?: () => Promise<void>;
+}
+
+const JSON_EDIT_ATTEMPTS = 3;
+
+// ============================================================================
+// JSON Edit Mode (Non-Interactive)
+// ============================================================================
+
+/**
+ * Edit a note from JSON input (non-interactive mode with merge semantics).
+ * 
+ * @param schema - Loaded schema
+ * @param vaultDir - Vault directory path
+ * @param filePath - Absolute path to the note file
+ * @param jsonInput - JSON string with patch data
+ * @param options - Edit options
+ * @returns Result with updated field names
+ */
+export async function editNoteFromJson(
+  schema: LoadedSchema,
+  vaultDir: string,
+  filePath: string,
+  jsonInput: string,
+  options: EditFromJsonOptions = {}
+): Promise<EditResult> {
+  const { jsonMode = true } = options;
+
+  // Parse JSON input
+  let patchData: Record<string, unknown>;
+  try {
+    patchData = JSON.parse(jsonInput) as Record<string, unknown>;
+  } catch (e) {
+    const error = `Invalid JSON: ${(e as Error).message}`;
+    if (jsonMode) {
+      printJson(jsonError(error));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(error);
+  }
+
+  // Disallow editing system-managed fields
+  const reservedField = Object.keys(patchData).find(isBwrbReservedFrontmatterField);
+  if (reservedField) {
+    const error = `Field '${reservedField}' is system-managed and cannot be modified`;
+    if (jsonMode) {
+      printJson(jsonError(error, {
+        errors: [{ field: reservedField, value: patchData[reservedField], message: error }],
+      }));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(error);
+  }
+
+  for (let attempt = 1; attempt <= JSON_EDIT_ATTEMPTS; attempt++) {
+    try {
+      return await editNoteFromJsonAttempt(
+        schema,
+        vaultDir,
+        filePath,
+        patchData,
+        jsonMode,
+        attempt
+      );
+    } catch (error) {
+      if (
+        error instanceof ConcurrentNoteModificationError &&
+        attempt < JSON_EDIT_ATTEMPTS
+      ) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new ConcurrentNoteModificationError(filePath, JSON_EDIT_ATTEMPTS);
+}
+
+async function editNoteFromJsonAttempt(
+  schema: LoadedSchema,
+  vaultDir: string,
+  filePath: string,
+  patchData: Record<string, unknown>,
+  jsonMode: boolean,
+  attempt: number
+): Promise<EditResult> {
+
+  // Parse existing note
+  const { frontmatter, body, raw } = await parseNote(filePath);
+
+  // Resolve type path from existing frontmatter
+  const typePath = resolveTypePathFromFrontmatter(schema, frontmatter);
+  if (!typePath) {
+    const error = 'Could not determine note type from frontmatter';
+    if (jsonMode) {
+      printJson(jsonError(error));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(error);
+  }
+
+  const typeDef = getTypeDefByPath(schema, typePath);
+  if (!typeDef) {
+    );
+    if (cycleError) {
+      if (jsonMode) {
+        printJson({
+          success: false,
+          error: cycleError.message,
+          errors: [{
+            field: cycleError.field,
+            message: cycleError.message,
+          }],
+        });
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+      throw new Error(cycleError.message);
+    }
+  }
+
+  // Get field order
+  const fieldOrder = getFrontmatterOrder(typeDef);
+  const orderedFields = fieldOrder.length > 0 ? fieldOrder : Object.keys(resolvedFrontmatter);
+
+  await waitForEditCommitBarrier(attempt, filePath);
+
+  await withLineageMutationLocks(vaultDir, [filePath], async () => {
+    await assertNoteBytesUnchanged(filePath, raw, attempt);
+
+    // Recurrence prepare, predecessor write, and successor/back-link commit are
+    // one guarded commit phase. A retry always re-prepares from fresh bytes.
+    const fastPathPlan = await prepareRecurrenceFastPath(
+      schema,
+      vaultDir,
+      typeDef.name,
+      filePath,
+      frontmatter,
+      resolvedFrontmatter,
+      body
+    );
+    await writeNote(filePath, resolvedFrontmatter, body, orderedFields);
+    await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+  });
+
+  return { updatedFields, path: filePath };
+}
+
+// ============================================================================
+// Interactive Edit Mode
+// ============================================================================
+
+/**
+ * Edit an existing note's frontmatter interactively.
+ * 
+ * @param schema - Loaded schema
+ * @param vaultDir - Vault directory path
+ * @param filePath - Absolute path to the note file
+ * @param options - Edit options
+ */
+ */
+export async function editNoteInteractive(
+  schema: LoadedSchema,
+  vaultDir: string,
+  filePath: string,
+  options: EditInteractiveOptions = {}
+): Promise<void> {
+  const { checkSections = true, beforeCommit } = options;
+  
+  const { frontmatter, body, raw } = await parseNote(filePath);
+  const fileName = filePath.split('/').pop() ?? filePath;
+
+  printInfo(`\n=== Editing: ${fileName} ===`);
+
+  // Resolve type path from frontmatter
+  const typePath = resolveTypePathFromFrontmatter(schema, frontmatter);
+  if (!typePath) {
+    printWarning('Warning: Unknown type, showing raw frontmatter edit');
+    console.log('Current frontmatter:');
+    console.log(JSON.stringify(frontmatter, null, 2));
+    return;
+  }
+
+  const typeDef = getTypeDefByPath(schema, typePath);
+  if (!typeDef) {
+    printWarning(`Warning: Unknown type path: ${typePath}`);
+    return;
+  }
+
+  printInfo(`Type path: ${typePath}\n`);
+
+  // Edit frontmatter fields
+  // Preserve system-managed fields without offering them as editable schema
+  // input, even if a vault schema happens to declare a same-named field.
+  const newFrontmatter: Record<string, unknown> = Object.fromEntries(
+    Object.entries(frontmatter).filter(([fieldName]) =>
+      isBwrbReservedFrontmatterField(fieldName)
+    )
+  );
+  const fields = getFieldsForType(schema, typePath);
+  const fieldOrder = getFrontmatterOrder(typeDef);
+
+  // Determine actual field order
+  const orderedFields = fieldOrder.length > 0 ? fieldOrder : Object.keys(fields);
+
+  for (const fieldName of orderedFields) {
+    if (isBwrbReservedFrontmatterField(fieldName)) continue;
+    const field = fields[fieldName];
+    if (!field) continue;
+
+    const currentValue = frontmatter[fieldName];
+    const newValue = await promptFieldEdit(
+      schema,
+      vaultDir,
+      fieldName,
+      field,
+      currentValue
+    );
+
+    if (newValue !== undefined) {
+      newFrontmatter[fieldName] = newValue;
+    }
+  }
+
+  // Check for missing body sections
+  let updatedBody = body;
+  const bodySections = typeDef.bodySections;
+  if (checkSections && bodySections && bodySections.length > 0) {
+    const addSections = await promptConfirm('\nCheck for missing sections?');
+    if (addSections === null) {
+      throw new UserCancelledError();
+    }
+    if (addSections) {
+      updatedBody = await addMissingSections(body, bodySections);
+    }
+  }
+
+  await beforeCommit?.();
+  const fastPath = await withLineageMutationLocks(vaultDir, [filePath], async () => {
+    await assertNoteBytesUnchanged(filePath, raw);
+    const fastPathPlan = await prepareRecurrenceFastPath(
+      schema,
+      vaultDir,
+      typeDef.name,
+      filePath,
+      frontmatter,
+      newFrontmatter,
+      updatedBody
+    );
+    await writeNote(filePath, newFrontmatter, updatedBody, orderedFields);
+    return commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+  });
+  printSuccess(`\n✓ Updated: ${filePath}`);
+  if (fastPath.successorPath) {
+    printSuccess(`✓ Spawned recurrence successor: ${fastPath.successorPath}`);
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** File handshake used only by cross-process race tests. */
+async function waitForEditCommitBarrier(attempt: number, filePath: string): Promise<void> {
+  if (process.env.BWRB_TEST_EDIT_BARRIER_ENABLED !== '1') return;
+  const barrierDir = process.env.BWRB_TEST_EDIT_BARRIER_DIR;
+  if (!barrierDir) return;
+
+  await mkdir(barrierDir, { recursive: true });
+  const readyPath = join(barrierDir, `edit-read-${attempt}.ready`);
+  const commitPath = join(barrierDir, `edit-commit-${attempt}.go`);
+  await writeFile(readyPath, `${filePath}\n`, 'utf-8');
+
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    try {
+      await access(commitPath);
+      return;
+    } catch {
+      await new Promise(resolve => setTimeout(resolve, 5));
+    }
+  }
+  throw new Error(`Timed out waiting for edit test barrier: ${commitPath}`);
+}
+
+function mergeFrontmatter(
+  existing: Record<string, unknown>,
+  patch: Record<string, unknown>
+): Record<string, unknown> {
+  const result = { ...existing };
+
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) {
+      // Remove field
+      delete result[key];
+    } else {
+
+```
+
+## fork/adopt
+```
+  schema: LoadedSchema,
+  vaultDir: string,
+  sourcePath: string
+): Promise<string> {
+  return withNoteIdAssignmentLock(vaultDir, async () => {
+    const parsed = await parseNote(sourcePath);
+    const existing = parsed.frontmatter.id;
+    if (existing !== undefined) {
+      if (!isValidNoteId(existing)) {
+        throw new Error(`Fork source has an invalid id and was not modified: ${relative(vaultDir, sourcePath)}`);
+      }
+      await assertSourceIdUnique(schema, vaultDir, sourcePath, existing);
+      return existing;
+    }
+
+    const id = await generateUniqueNoteId(vaultDir);
+    const collisions = await findNotesWithId(schema, vaultDir, id);
+    if (collisions.length > 0) {
+      throw new Error('Generated source ID collides with an existing note; retry the command.');
+    }
+    const nextRaw = insertFrontmatterScalarPreservingBytes(parsed.raw, 'id', id);
+    await assertNoteBytesUnchanged(sourcePath, parsed.raw);
+    await writeFileAtomic(sourcePath, nextRaw);
+    try {
+      await registerIssuedNoteId(vaultDir, id, sourcePath);
+    } catch (error) {
+      const rolledBack = await rollbackNoteIfUnchanged(sourcePath, nextRaw, parsed.raw);
+      if (!rolledBack) {
+        throw new Error(
+          `Source ID registration failed (${formatError(error)}) and rollback was skipped because ` +
+          'the source changed again; newer bytes were preserved.'
+        );
+      }
+      throw error;
+    }
+    return id;
+  });
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function assertSourceIdUnique(
+  schema: LoadedSchema,
+  vaultDir: string,
+  sourcePath: string,
+  id: string
+): Promise<void> {
+  const matches = await findNotesWithId(schema, vaultDir, id);
+  const otherMatches = matches.filter(file => resolve(file.path) !== resolve(sourcePath));
+    },
+  };
+}
+
+async function applyPreparedAdoption(
+  vaultDir: string,
+  prepared: PreparedAdoption,
+  registerIds: typeof registerIssuedNoteIds
+): Promise<void> {
+  let parentWritten = false;
+  let childWritten = false;
+  try {
+    if (prepared.parentNextRaw !== prepared.parentOriginal.raw) {
+      await assertNoteBytesUnchanged(
+        prepared.parent.file.path,
+        prepared.parentOriginal.raw
+      );
+      await writeFileAtomic(prepared.parent.file.path, prepared.parentNextRaw);
+      parentWritten = true;
+    }
+    await assertNoteBytesUnchanged(
+      prepared.child.file.path,
+      prepared.childOriginal.raw
+    );
+    await writeFileAtomic(prepared.child.file.path, prepared.childNextRaw);
+    childWritten = true;
+    await registerIds(vaultDir, prepared.registrations);
+  } catch (error) {
+    const rollbackErrors: string[] = [];
+    if (childWritten) {
+      await rollbackNoteIfUnchanged(
+        prepared.child.file.path,
+        prepared.childNextRaw,
+        prepared.childOriginal.raw
+      ).then(rolledBack => {
+        if (!rolledBack) {
+          rollbackErrors.push(`${prepared.child.file.relativePath} changed again; newer bytes left as-is`);
+        }
+      }).catch(rollbackError => rollbackErrors.push(formatError(rollbackError)));
+    }
+    if (parentWritten) {
+      await rollbackNoteIfUnchanged(
+        prepared.parent.file.path,
+        prepared.parentNextRaw,
+        prepared.parentOriginal.raw
+      ).then(rolledBack => {
+        if (!rolledBack) {
+          rollbackErrors.push(`${prepared.parent.file.relativePath} changed again; newer bytes left as-is`);
+        }
+      }).catch(rollbackError => rollbackErrors.push(formatError(rollbackError)));
+    }
+    if (rollbackErrors.length > 0) {
+      throw new Error(
+        `Lineage adoption failed (${formatError(error)}) and rollback was incomplete: ${rollbackErrors.join('; ')}`
+      );
+    }
+    throw error;
+  }
+}
+
+function assertDifferentNotes(
+  vaultDir: string,
+  child: ResolvedExactNoteTarget,
+  parent: ResolvedExactNoteTarget
+): void {
+  const childLock = getLineageMutationLockPath(vaultDir, child.file.path);
+  const parentLock = getLineageMutationLockPath(vaultDir, parent.file.path);
+  if (childLock === parentLock) {
+    throw new Error(`Cannot adopt a note under itself: ${child.file.relativePath}.`);
+  }
+}
+
+```
+
+## handlers
+```
+diff --git a/src/commands/edit.ts b/src/commands/edit.ts
+index 4ebd46e..b1be2bd 100644
+--- a/src/commands/edit.ts
++++ b/src/commands/edit.ts
+@@ -26,7 +26,8 @@ import {
+   type OpenResultData,
+ } from './open.js';
+ import { resolveTargets, hasAnyTargeting, type TargetingOptions } from '../lib/targeting.js';
+-import { UserCancelledError } from '../lib/errors.js';
++import { ConcurrentNoteModificationError, UserCancelledError } from '../lib/errors.js';
++import { concurrentModificationData } from '../lib/note-write-concurrency.js';
+ import type { ResolvedConfig } from '../types/schema.js';
+ 
+ // ============================================================================
+@@ -163,6 +164,7 @@ Precedence (for --open app mode):
+     // rather than silently falling back to the default app.
+     const appModeInput = options.app ?? mode;
+     let jsonMode = patchMode;
++    let resolvedVaultDir: string | undefined;
+     try {
+       const globalOpts = getGlobalOpts(cmd);
+       jsonMode = resolveEditJsonMode(options, globalOpts.output);
+@@ -179,6 +181,7 @@ Precedence (for --open app mode):
+       const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
+       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
+       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
++      resolvedVaultDir = vaultDir;
+       const schema = await loadSchema(vaultDir);
+ 
+       if (globalOpts.nonInteractive && !patchMode) {
+@@ -374,6 +377,17 @@ Precedence (for --open app mode):
+         return;
+       }
+     } catch (err) {
++      if (err instanceof ConcurrentNoteModificationError) {
++        if (jsonMode) {
++          printJson(jsonError(err.message, {
++            code: ExitCodes.IO_ERROR,
++            data: concurrentModificationData(resolvedVaultDir ?? process.cwd(), err),
++          }));
++          process.exit(ExitCodes.IO_ERROR);
++        }
++        printError(err.message);
++        process.exit(ExitCodes.IO_ERROR);
++      }
+       if (err instanceof UserCancelledError) {
+         if (jsonMode) {
+           printJson(jsonError('Cancelled', { code: ExitCodes.VALIDATION_ERROR }));
+diff --git a/src/commands/lineage/index.ts b/src/commands/lineage/index.ts
+index 470b501..d6b1450 100644
+--- a/src/commands/lineage/index.ts
++++ b/src/commands/lineage/index.ts
+@@ -5,6 +5,8 @@ import { getGlobalOpts } from '../../lib/command.js';
+ import { ExitCodes, jsonError, printJson } from '../../lib/output.js';
+ import { printError, printInfo, printSuccess } from '../../lib/prompt.js';
+ import { adoptLineage } from './adopt.js';
++import { ConcurrentNoteModificationError } from '../../lib/errors.js';
++import { concurrentModificationData } from '../../lib/note-write-concurrency.js';
+ 
+ interface AdoptCommandOptions {
+   from?: string;
+@@ -27,6 +29,7 @@ Examples:
+ `)
+   .action(async (child: string, options: AdoptCommandOptions, command: Command) => {
+     const jsonMode = options.output === 'json';
++    let resolvedVaultDir: string | undefined;
+     try {
+       if (options.output !== 'text' && options.output !== 'json') {
+         throw new Error('--output must be text or json.');
+@@ -44,6 +47,7 @@ Examples:
+         allowFindDown: true,
+         jsonMode,
+       });
++      resolvedVaultDir = vaultDir;
+       const schema = await loadSchema(vaultDir);
+       const result = await adoptLineage(schema, vaultDir, {
+         child,
+@@ -73,6 +77,18 @@ Examples:
+       );
+     } catch (error) {
+       const message = error instanceof Error ? error.message : String(error);
++      if (error instanceof ConcurrentNoteModificationError) {
++        if (jsonMode) {
++          printJson(jsonError(message, {
++            code: ExitCodes.IO_ERROR,
++            data: concurrentModificationData(resolvedVaultDir ?? process.cwd(), error),
++          }));
++        } else {
++          printError(message);
++        }
++        process.exitCode = ExitCodes.IO_ERROR;
++        return;
++      }
+       if (jsonMode) {
+         printJson(jsonError(message, { code: ExitCodes.VALIDATION_ERROR }));
+       } else {
+diff --git a/src/commands/new.ts b/src/commands/new.ts
+index 6eae656..b8d188f 100644
+--- a/src/commands/new.ts
++++ b/src/commands/new.ts
+@@ -23,7 +23,8 @@ import {
+   type InheritedTemplateResolution,
+ } from '../lib/template.js';
+ import type { LoadedSchema, Template } from '../types/schema.js';
+-import { UserCancelledError } from '../lib/errors.js';
++import { ConcurrentNoteModificationError, UserCancelledError } from '../lib/errors.js';
++import { concurrentModificationData } from '../lib/note-write-concurrency.js';
+ import { createNoteFromJson } from './new/json-mode.js';
+ import { resolveTypePath } from './new/type-selection.js';
+ import { createNoteInteractive } from './new/interactive.js';
+@@ -93,6 +94,7 @@ Template management:
+     const forkJsonMode = forkMode && options.output === 'json';
+     const jsonMode = options.json !== undefined || forkJsonMode;
+     const typePath = options.type ?? positionalType;
++    let resolvedVaultDir: string | undefined;
+ 
+     try {
+       const globalOpts = getGlobalOpts(cmd);
+@@ -103,6 +105,7 @@ Template management:
+       const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
+       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
+       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
++      resolvedVaultDir = vaultDir;
+       const schema = await loadSchema(vaultDir);
+ 
+       validateForkOptions(positionalType, options);
+@@ -240,6 +243,17 @@ Template management:
+         await openNote(vaultDir, filePath, resolveAppMode(undefined, schema.config), schema.config, false);
+       }
+     } catch (err) {
++      if (err instanceof ConcurrentNoteModificationError) {
++        if (jsonMode) {
++          printJson(jsonError(err.message, {
++            code: ExitCodes.IO_ERROR,
++            data: concurrentModificationData(resolvedVaultDir ?? process.cwd(), err),
++          }));
++          process.exit(ExitCodes.IO_ERROR);
++        }
++        printError(err.message);
++        process.exit(ExitCodes.IO_ERROR);
++      }
+       if (err instanceof JsonCommandError) {
+         if (!err.result.success) {
+           err.result.code = err.exitCode;
+diff --git a/src/commands/search.ts b/src/commands/search.ts
+index 4754725..c7a3fa4 100644
+--- a/src/commands/search.ts
++++ b/src/commands/search.ts
+@@ -47,7 +47,8 @@ import {
+ } from '../lib/fuzzy-search.js';
+ import { parseNote } from '../lib/frontmatter.js';
+ import { applyWhereExpressions } from '../lib/where-targeting.js';
+-import { UserCancelledError } from '../lib/errors.js';
++import { ConcurrentNoteModificationError, UserCancelledError } from '../lib/errors.js';
++import { concurrentModificationData } from '../lib/note-write-concurrency.js';
+ import { resolveTargets, type TargetingOptions } from '../lib/targeting.js';
+ 
+ // ============================================================================
+@@ -311,6 +312,7 @@ export async function runSearchCommand(
+     // Resolve output format from deprecated flags and new --output option
+     const outputFormat = resolveSearchOutputFormat(options);
+     const jsonMode = outputFormat === 'json';
++    let resolvedVaultDir: string | undefined;
+ 
+     // App-mode precedence: an explicit --app flag wins over the positional
+     // [mode] (the convenience form). Fold the resolved value back into
+@@ -387,6 +389,7 @@ export async function runSearchCommand(
+       const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
+       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
+       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
++      resolvedVaultDir = vaultDir;
+       const schema = await loadSchema(vaultDir);
+ 
+       if (globalOpts.nonInteractive && options.edit && !options.json) {
+@@ -408,6 +411,17 @@ export async function runSearchCommand(
+         await handleNameSearch(query, effectiveOptions, vaultDir, schema, jsonMode, outputFormat);
+       }
+     } catch (err) {
++      if (err instanceof ConcurrentNoteModificationError) {
++        if (jsonMode) {
++          printJson(jsonError(err.message, {
++            code: ExitCodes.IO_ERROR,
++            data: concurrentModificationData(resolvedVaultDir ?? process.cwd(), err),
++          }));
++          process.exit(ExitCodes.IO_ERROR);
++        }
++        printError(err.message);
++        process.exit(ExitCodes.IO_ERROR);
++      }
+       if (err instanceof UserCancelledError) {
+         if (jsonMode) {
+           printJson(jsonError('Cancelled', { code: ExitCodes.VALIDATION_ERROR }));
+
+```
+
+## docs fix delta
+```
+diff --git a/docs-site/src/content/docs/automation/json-mode.md b/docs-site/src/content/docs/automation/json-mode.md
+index 126157c..9e98bfc 100644
+--- a/docs-site/src/content/docs/automation/json-mode.md
++++ b/docs-site/src/content/docs/automation/json-mode.md
+@@ -35,8 +35,9 @@ complete JSON value, but success shapes differ by workflow:
+ Guarded note writers use numeric top-level error codes. If edit, fork, or
+ adoption observes newer note bytes, exit code `2` includes
+ `data.reason: "note-modified-concurrently"`, `data.retryable: true`, the
+-vault-relative `data.path`, and `data.attempts`. JSON edit retries internally up
+-to three times before returning that error.
++vault-relative `data.path`, and `data.attempts`. JSON edit makes up to three
++total attempts (the initial attempt plus at most two retries) before returning
++that error.
+ 
+ Normal list output is intentionally a raw array:
+ 
+diff --git a/docs-site/src/content/docs/reference/commands/edit.md b/docs-site/src/content/docs/reference/commands/edit.md
+index cdbc77f..0a7f294 100644
+--- a/docs-site/src/content/docs/reference/commands/edit.md
++++ b/docs-site/src/content/docs/reference/commands/edit.md
+@@ -65,13 +65,14 @@ bwrb edit -t task --where "status == 'active'" "Deploy" --json '{"priority":"hig
+ 
+ The final edit commit shares the note's lineage mutation lock with `new --fork`
+ and `lineage adopt`. Bowerbird compares the note's exact raw bytes after taking
+-the lock. A JSON patch that became stale is replayed against the latest note up
+-to three times, so a concurrent `id` backfill or `forked-from` edge is preserved.
++the lock. A JSON patch that became stale is retried against the latest note for
++up to three total attempts, so a concurrent `id` backfill or `forked-from` edge
++is preserved.
+ Interactive answers are never replayed against unseen values; the command asks
+ you to retry instead.
+ 
+-If all JSON retries become stale, JSON output uses numeric exit code `2` and
+-stable retry context:
++If all three JSON attempts become stale, JSON output uses numeric exit code `2`
++and stable retry context:
+ 
+ ```json
+ {
+diff --git a/docs/skill/SKILL.md b/docs/skill/SKILL.md
+index 29e19c4..e1565d0 100644
+--- a/docs/skill/SKILL.md
++++ b/docs/skill/SKILL.md
+@@ -399,7 +399,7 @@ bwrb edit --type task --where "status == 'active'" "Deploy" --json '{"status": "
+ Notes:
+ - If multiple notes share the same name, `bwrb edit` errors and lists candidates. Disambiguate with `--type`, `--path`, or a vault-relative path.
+ - `bwrb new --json` rejects unknown frontmatter fields after merging template defaults. `bwrb edit --json` rejects unknown fields in the patch.
+-- Edit commits coordinate with fork/adopt lineage writes. JSON patches replay from fresh bytes up to three times; on exhaustion, retry only when JSON has numeric `code: 2`, `data.reason: "note-modified-concurrently"`, and `data.retryable: true`. Interactive edits do not replay answers gathered from stale values.
++- Edit commits coordinate with fork/adopt lineage writes. JSON patches make up to three total attempts (the initial attempt plus at most two retries) from fresh bytes; on exhaustion, retry only when JSON has numeric `code: 2`, `data.reason: "note-modified-concurrently"`, and `data.retryable: true`. Interactive edits do not replay answers gathered from stale values.
+ 
+ ### Deleting Notes
+ 
+diff --git a/src/lib/edit.ts b/src/lib/edit.ts
+index 9c9ebb4..eea71fb 100644
+--- a/src/lib/edit.ts
++++ b/src/lib/edit.ts
+@@ -486,6 +486,7 @@ export async function editNoteInteractive(
+ 
+ /** File handshake used only by cross-process race tests. */
+ async function waitForEditCommitBarrier(attempt: number, filePath: string): Promise<void> {
++  if (process.env.BWRB_TEST_EDIT_BARRIER_ENABLED !== '1') return;
+   const barrierDir = process.env.BWRB_TEST_EDIT_BARRIER_DIR;
+   if (!barrierDir) return;
+ 
+diff --git a/tests/ts/commands/edit-lineage-concurrency.test.ts b/tests/ts/commands/edit-lineage-concurrency.test.ts
+index dd793b3..c3f6310 100644
+--- a/tests/ts/commands/edit-lineage-concurrency.test.ts
++++ b/tests/ts/commands/edit-lineage-concurrency.test.ts
+@@ -37,6 +37,7 @@ function spawnCli(args: string[], cwd: string, barrierDir: string): RunningCli {
+     env: withTestCliNodeOptions({
+       ...process.env,
+       NO_COLOR: '1',
++      BWRB_TEST_EDIT_BARRIER_ENABLED: '1',
+       BWRB_TEST_EDIT_BARRIER_DIR: barrierDir,
+     }, { useDist: USE_DIST }),
+     stdio: ['ignore', 'pipe', 'pipe'],
+
+```
+
+## key tests
+```
+import { spawn } from 'child_process';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  CLI_PATH,
+  PROJECT_ROOT,
+  cleanupTestVault,
+  createTestVault,
+  runCLI,
+  waitForFile,
+  withTestCliNodeOptions,
+} from '../fixtures/setup.js';
+import { insertFrontmatterScalarPreservingBytes, parseNote } from '../../../src/lib/frontmatter.js';
+import { loadSchema } from '../../../src/lib/schema.js';
+import { editNoteInteractive } from '../../../src/lib/edit.js';
+import { ConcurrentNoteModificationError } from '../../../src/lib/errors.js';
+
+const CLI_SRC_PATH = join(PROJECT_ROOT, 'src/index.ts');
+const TSX_CLI = join(PROJECT_ROOT, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+const USE_DIST = process.env.BWRB_TEST_DIST === '1';
+const CHILD_ID = '11111111-1111-4111-8111-111111111111';
+const PARENT_ID = '22222222-2222-4222-8222-222222222222';
+
+interface RunningCli {
+  completion: Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  kill: () => void;
+}
+
+function spawnCli(args: string[], cwd: string, barrierDir: string): RunningCli {
+  const command = process.execPath;
+  const cliArgs = USE_DIST
+    ? [CLI_PATH, '--vault', cwd, ...args]
+    : [TSX_CLI, CLI_SRC_PATH, '--vault', cwd, ...args];
+  const child = spawn(command, cliArgs, {
+    cwd,
+    env: withTestCliNodeOptions({
+      ...process.env,
+      NO_COLOR: '1',
+      BWRB_TEST_EDIT_BARRIER_ENABLED: '1',
+      BWRB_TEST_EDIT_BARRIER_DIR: barrierDir,
+    }, { useDist: USE_DIST }),
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const completion = new Promise<{ stdout: string; stderr: string; exitCode: number }>(
+    (resolve, reject) => {
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', chunk => { stdout += chunk.toString(); });
+      child.stderr.on('data', chunk => { stderr += chunk.toString(); });
+      child.on('error', reject);
+      child.on('close', code => resolve({
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        exitCode: code ?? 0,
+      }));
+    }
+  );
+  return { completion, kill: () => child.kill('SIGKILL') };
+}
+
+async function releaseAttempt(barrierDir: string, attempt: number): Promise<void> {
+  await waitForFile(join(barrierDir, `edit-read-${attempt}.ready`), { timeoutMs: 10_000 });
+  await writeFile(join(barrierDir, `edit-commit-${attempt}.go`), 'go\n');
+}
+
+describe('edit versus lineage identity writes', () => {
+  let vaultDir: string;
+  const running: RunningCli[] = [];
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    for (const process of running) process.kill();
+    await cleanupTestVault(vaultDir);
+  });
+
+  it('replays a JSON edit after new --fork backfills the source ID', async () => {
+    const sourcePath = join(vaultDir, 'Ideas/Fork Race Source.md');
+    const sourceRaw = '\uFEFF---\r\ntype: "idea" # quoted\r\nstatus: raw\r\npriority: medium\r\nprovider: { remote: keep-me }\r\n---\r\nBody bytes.\r\n';
+    await writeFile(sourcePath, sourceRaw);
+    const barrierDir = join(vaultDir, '.barrier-fork');
+    const edit = spawnCli([
+      'edit', sourcePath, '--json', '{"priority":"high"}', '--output', 'json',
+    ], vaultDir, barrierDir);
+    running.push(edit);
+
+    await waitForFile(join(barrierDir, 'edit-read-1.ready'), { timeoutMs: 10_000 });
+    const fork = await runCLI([
+      'new', '--fork', sourcePath, '--name', 'Fork Race Child', '--output', 'json',
+    ], vaultDir);
+    expect(fork.exitCode, fork.stderr || fork.stdout).toBe(0);
+    const forkJson = JSON.parse(fork.stdout) as { id: string; forked_from: string; path: string };
+    await writeFile(join(barrierDir, 'edit-commit-1.go'), 'go\n');
+    await releaseAttempt(barrierDir, 2);
+
+    const edited = await edit.completion;
+    expect(edited.exitCode, edited.stderr || edited.stdout).toBe(0);
+    expect(JSON.parse(edited.stdout)).toMatchObject({ success: true, updated: ['priority'] });
+    const source = await parseNote(sourcePath);
+    expect(source.frontmatter).toMatchObject({
+      id: forkJson.forked_from,
+      priority: 'high',
+      provider: { remote: 'keep-me' },
+    });
+    expect(source.body).toBe('Body bytes.\r\n');
+    expect((await parseNote(join(vaultDir, forkJson.path))).frontmatter['forked-from'])
+      .toBe(forkJson.forked_from);
+
+    const expectedPath = join(vaultDir, 'Ideas/Fork Race Expected.md');
+    await writeFile(
+      expectedPath,
+      insertFrontmatterScalarPreservingBytes(sourceRaw, 'id', forkJson.forked_from)
+    );
+    const sequential = await runCLI([
+      'edit', expectedPath, '--json', '{"priority":"high"}', '--output', 'json',
+    ], vaultDir);
+    expect(sequential.exitCode, sequential.stderr || sequential.stdout).toBe(0);
+    expect(await readFile(sourcePath, 'utf-8')).toBe(await readFile(expectedPath, 'utf-8'));
+  });
+
+  it('replays a JSON edit after lineage adopt writes immutable provenance', async () => {
+    const childPath = join(vaultDir, 'Ideas/Adopt Race Child.md');
+    const parentPath = join(vaultDir, 'Ideas/Adopt Race Parent.md');
+    const childRaw = `---\ntype: idea\nid: ${CHILD_ID}\nstatus: raw\npriority: medium\nprovider: { remote: child }\n---\nChild body.\n`;
+    const parentRaw = `---\ntype: idea\nid: ${PARENT_ID}\nstatus: raw\npriority: medium\n---\nParent body.\n`;
+    await writeFile(childPath, childRaw);
+    await writeFile(parentPath, parentRaw);
+    const barrierDir = join(vaultDir, '.barrier-adopt');
+    const edit = spawnCli([
+      'edit', childPath, '--json', '{"priority":"high"}', '--output', 'json',
+    ], vaultDir, barrierDir);
+    running.push(edit);
+
+    await waitForFile(join(barrierDir, 'edit-read-1.ready'), { timeoutMs: 10_000 });
+    const adopted = await runCLI([
+      'lineage', 'adopt', childPath, '--from', parentPath, '--execute', '--output', 'json',
+    ], vaultDir);
+    expect(adopted.exitCode, adopted.stderr || adopted.stdout).toBe(0);
+    await writeFile(join(barrierDir, 'edit-commit-1.go'), 'go\n');
+    await releaseAttempt(barrierDir, 2);
+
+    const edited = await edit.completion;
+    expect(edited.exitCode, edited.stderr || edited.stdout).toBe(0);
+    const child = await parseNote(childPath);
+    expect(child.frontmatter).toMatchObject({
+      id: CHILD_ID,
+      'forked-from': PARENT_ID,
+      priority: 'high',
+      provider: { remote: 'child' },
+    });
+    expect(child.body).toBe('Child body.\n');
+
+    const expectedPath = join(vaultDir, 'Ideas/Adopt Race Expected.md');
+    await writeFile(
+      expectedPath,
+      insertFrontmatterScalarPreservingBytes(childRaw, 'forked-from', PARENT_ID)
+    );
+    const sequential = await runCLI([
+      'edit', expectedPath, '--json', '{"priority":"high"}', '--output', 'json',
+    ], vaultDir);
+    expect(sequential.exitCode, sequential.stderr || sequential.stdout).toBe(0);
+    expect(await readFile(childPath, 'utf-8')).toBe(await readFile(expectedPath, 'utf-8'));
+  });
+
+  it.each(['json', 'text'] as const)(
+    'preserves the newest bytes and emits a stable retryable %s error after retry exhaustion',
+    async (output) => {
+      const notePath = join(vaultDir, `Ideas/Retry Exhaustion ${output}.md`);
+      let currentRaw = '---\ntype: idea\nstatus: raw\npriority: medium\n---\nOriginal body.\n';
+      await writeFile(notePath, currentRaw);
+      const barrierDir = join(vaultDir, `.barrier-${output}`);
+      const edit = spawnCli([
+        'edit', notePath, '--json', '{"priority":"high"}', '--output', output,
+      ], vaultDir, barrierDir);
+      running.push(edit);
+
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        await waitForFile(join(barrierDir, `edit-read-${attempt}.ready`), { timeoutMs: 10_000 });
+        currentRaw = currentRaw.replace('Original body.', `Original body. external-${attempt}`);
+        await writeFile(notePath, currentRaw);
+        await writeFile(join(barrierDir, `edit-commit-${attempt}.go`), 'go\n');
+      }
+
+      const result = await edit.completion;
+      expect(result.exitCode).toBe(2);
+      expect(await readFile(notePath, 'utf-8')).toBe(currentRaw);
+      if (output === 'json') {
+        expect(JSON.parse(result.stdout)).toEqual({
+          success: false,
+          error: 'Note changed on disk during a guarded write; newer bytes were preserved. Retry the command.',
+          code: 2,
+          data: {
+            reason: 'note-modified-concurrently',
+            retryable: true,
+            path: `Ideas/Retry Exhaustion ${output}.md`,
+            attempts: 3,
+          },
+        });
+      } else {
+        expect(result.stdout).toBe('');
+        expect(result.stderr).toContain(
+          'Note changed on disk during a guarded write; newer bytes were preserved. Retry the command.'
+        );
+      }
+    }
+  );
+
+  it('does not replay interactive answers or write when its snapshot is stale', async () => {
+    const notePath = join(vaultDir, 'Ideas/Interactive Stale.md');
+    const originalRaw = '---\ntype: idea\nstatus: raw\n---\nOriginal body.\n';
+    const newerRaw = '---\ntype: idea\nid: 33333333-3333-4333-8333-333333333333\nstatus: raw\n---\nOriginal body.\n';
+    await writeFile(notePath, originalRaw);
+    const schema = await loadSchema(vaultDir);
+    const idea = schema.types.get('idea')!;
+    idea.fields = { type: { value: 'idea' } };
+    idea.fieldOrder = ['type'];
+
+    await expect(editNoteInteractive(schema, vaultDir, notePath, {
+      checkSections: false,
+      beforeCommit: async () => { await writeFile(notePath, newerRaw); },
+    })).rejects.toBeInstanceOf(ConcurrentNoteModificationError);
+    expect(await readFile(notePath, 'utf-8')).toBe(newerRaw);
+  });
+
+  it('maps stale search --edit JSON through the same numeric retryable contract', async () => {
+    const notePath = join(vaultDir, 'Ideas/Search Retry Exhaustion.md');
+    let currentRaw = '---\ntype: idea\nstatus: raw\npriority: medium\n---\nSearch body.\n';
+    await writeFile(notePath, currentRaw);
+    const barrierDir = join(vaultDir, '.barrier-search');
+    const edit = spawnCli([
+      'search', 'Search Retry Exhaustion', '--edit', '--json', '{"priority":"high"}',
+      '--output', 'json', '--picker', 'none',
+    ], vaultDir, barrierDir);
+    running.push(edit);
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      await waitForFile(join(barrierDir, `edit-read-${attempt}.ready`), { timeoutMs: 10_000 });
+      currentRaw = currentRaw.replace('Search body.', `Search body. external-${attempt}`);
+      await writeFile(notePath, currentRaw);
+      await writeFile(join(barrierDir, `edit-commit-${attempt}.go`), 'go\n');
+    }
+
+    const result = await edit.completion;
+    expect(result.exitCode).toBe(2);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      success: false,
+      code: 2,
+      data: {
+        reason: 'note-modified-concurrently',
+        retryable: true,
+        path: 'Ideas/Search Retry Exhaustion.md',
+        attempts: 3,
+      },
+    });
+    expect(await readFile(notePath, 'utf-8')).toBe(currentRaw);
+  });
+});
+    await writeFile(childPath, childRaw);
+    await writeFile(parentPath, parentRaw);
+    const registryPath = join(vaultDir, '.bwrb/ids.jsonl');
+    const registryBefore = await readFile(registryPath, 'utf-8').catch(() => null);
+    const schema = await loadSchema(vaultDir);
+
+    await expect(adoptLineage(
+      schema,
+      vaultDir,
+      { child: 'Rollback Child', parent: 'Rollback Parent', execute: true },
+      { registerIds: async () => { throw new Error('injected registry failure'); } }
+    )).rejects.toThrow('injected registry failure');
+
+    expect(await readFile(childPath, 'utf-8')).toBe(childRaw);
+    expect(await readFile(parentPath, 'utf-8')).toBe(parentRaw);
+    expect(await readFile(registryPath, 'utf-8').catch(() => null)).toBe(registryBefore);
+  });
+
+  it('never rolls adoption back over bytes written after its own child write', async () => {
+    const childPath = join(vaultDir, 'Ideas/Rollback Race Child.md');
+    const parentPath = join(vaultDir, 'Ideas/Rollback Race Parent.md');
+    const childRaw = noteRaw({ body: 'Original child bytes\n' });
+    const parentRaw = noteRaw({ body: 'Original parent bytes\n' });
+    const newerChildRaw = noteRaw({
+      id: C,
+      extra: 'provider: { newer: true }\n',
+      body: 'Newer child bytes\n',
+    });
+    await writeFile(childPath, childRaw);
+    await writeFile(parentPath, parentRaw);
+    const schema = await loadSchema(vaultDir);
+
+    await expect(adoptLineage(
+      schema,
+      vaultDir,
+      { child: 'Rollback Race Child', parent: 'Rollback Race Parent', execute: true },
+      {
+        registerIds: async () => {
+          await writeFile(childPath, newerChildRaw);
+          throw new Error('injected registry failure after a newer writer');
+        },
+      }
+    )).rejects.toThrow('newer bytes left as-is');
+
+    expect(await readFile(childPath, 'utf-8')).toBe(newerChildRaw);
+    expect(await readFile(parentPath, 'utf-8')).toBe(parentRaw);
+  });
+
+  it('refuses cycles and ambiguous or missing exact targets', async () => {
+    await writeFile(join(vaultDir, 'Ideas/Cycle Root.md'), noteRaw({ id: A }));
+    await writeFile(join(vaultDir, 'Ideas/Cycle Child.md'), noteRaw({ id: B, parent: A }));
+    const cycle = await runCLI([
+      'lineage', 'adopt', 'Cycle Root', '--from', 'Cycle Child', '--execute', '--output', 'json',
+    ], vaultDir);
+    expect(cycle.exitCode).toBe(1);
+    expect(JSON.parse(cycle.stdout).error).toContain('would create a cycle');
+
+    await mkdir(join(vaultDir, 'Ideas/Nested'), { recursive: true });
+    await writeFile(join(vaultDir, 'Ideas/Ambiguous.md'), noteRaw());
+    await writeFile(join(vaultDir, 'Ideas/Nested/Ambiguous.md'), noteRaw());
+    for (const [child, parent, noun] of [
+
+```
+

--- a/.task-sweep/logs/claude-fable-5-review-output-attempt2-20260710-123500-issue-820.md
+++ b/.task-sweep/logs/claude-fable-5-review-output-attempt2-20260710-123500-issue-820.md
@@ -1,0 +1,22 @@
+NO BLOCKERS
+
+## SPEC FIDELITY
+
+All five acceptance criteria are substantively met by the embedded diff:
+
+1. **Conflict detection** — `src/lib/note-write-concurrency.ts` provides `assertNoteBytesUnchanged`, wired into edit's guarded commit (`src/lib/edit.ts:351-368, 462-474`), fork source-ID backfill (`src/new/fork.ts:216`), and adopt's pre-write phase (`src/commands/lineage/adopt.ts:273-282`). Edit's barrier/lock ordering is correct: the read/validation is unlocked, the lock is taken only for the commit phase, and interactive prompts (and the test barrier) occur *before* lock acquisition — consistent with "do not hold lineage locks across human prompts."
+2. **Stable typed output** — `ConcurrentNoteModificationError` maps to numeric `code: 2` + `data.{reason,retryable,path,attempts}` in edit, new, search, and lineage adopt handlers.
+3. **Race coverage** — `tests/ts/commands/edit-lineage-concurrency.test.ts` covers edit-vs-fork replay, edit-vs-adopt replay, JSON/text retry exhaustion, search --edit mapping, and interactive stale; `lineage-adopt.test.ts:268` covers the newer-writer rollback guard.
+4. **Byte invariants** — replay tests verify BOM/CRLF/comment/provider preservation via sequential-edit byte equality; adopt rollback only restores over its own bytes.
+5. Suite green claims are evidence-only; consistent with the diff.
+
+Spec-fidelity notes (non-blocking):
+- **Doc drift on retry count**: implementation is 3 total attempts (`JSON_EDIT_ATTEMPTS = 3`, loop at `src/lib/edit.ts:127`), i.e. 2 replays after the first attempt. `docs-site/.../json-mode.md` ("retries internally up to three times"), `edit.md` ("replayed ... up to three times"), and `SKILL.md` ("replay from fresh bytes up to three times") all imply 3 replays. `data.attempts: 3` is accurate; the prose is not. Suggest "up to three attempts."
+- `.task-sweep/logs` plan artifacts are asserted committed but excluded from the packet; unverifiable here — accept per spec statement, but the merge gate should confirm they exist at the manifest paths.
+
+## STANDARDS AND RISK
+
+Non-blocking items, roughly in priority order:
+
+1. **Test seam in production code** (`src/lib/edit.ts:487-506`): `waitForEditCommitBarrier` is env-activated (`BWRB_TEST_EDIT_BARRIER_DIR`) in the shipped JSON edit path with a 20s poll loop, plus the `beforeCommit` hook in the public `EditInteractiveOptions` interface (`src/lib/edit.ts:72`). If the env var leaks into a real environment, every JSON edit hangs up to 20s per attempt and then fails. Consider prefix-validating the dir or gating on an explicit test marker; at minimum document it as test-only.
+2. **"Exact raw-byte" is actually UTF-8-string comparison** (`note-write-concurrency.

--- a/.task-sweep/logs/claude-fable-5-review-prompt-20260710-123500-issue-820.md
+++ b/.task-sweep/logs/claude-fable-5-review-prompt-20260710-123500-issue-820.md
@@ -1,0 +1,1130 @@
+You are reviewing an embedded pull request diff for correctness bugs, missed edge cases, security/data-loss issues, test gaps, documentation drift, runtime risk, and release risk.
+
+Review on separate axes:
+- SPEC FIDELITY: missing/partial requirements, wrong behavior, unrequested scope.
+- STANDARDS AND RISK: repo conventions plus correctness, data safety, tests, runtime, maintainability.
+
+Constraints:
+- Review only the embedded spec, standards, and diff.
+- No tools, edits, GitHub actions, or repository mutations.
+- Treat this as a PR readiness gate.
+- Cite paths and line numbers where possible.
+- First line exactly one of: BLOCKERS, NON-BLOCKING, NO BLOCKERS.
+- Separate blockers from non-blocking suggestions. Block only concrete defects.
+- Review docs against implementation.
+- Keep concise but inspect concurrency and rollback carefully.
+
+BEGIN TASK / SPEC
+GitHub issue #820: Prevent concurrent edits from being overwritten by lineage identity writes.
+Base: BWRB origin/main@7093f233 (merged PR #821).
+Problem: new --fork and lineage adopt hold path-keyed lineage locks while inserting id/forked-from with byte-preserving atomic writes. Ordinary edit previously read without those locks and later serialized stale bytes, so it could erase identity/provenance.
+Acceptance:
+1. Identity/provenance writes detect note-byte changes after authoritative reads and fail or safely retry without overwriting concurrent ordinary edit.
+2. Deterministic text and JSON behavior with stable retryable error when automatic retry is unsafe.
+3. Focused deterministic edit-vs-new --fork and edit-vs-lineage adopt race coverage.
+4. Preserve byte-sensitive YAML/body invariants and forked-from immutability outside sanctioned workflows.
+5. Existing fork, adoption, audit, lineage-lock, edit, recurrence, and full suites stay green.
+Scope: narrowly edit/fork/adopt coordination; no general bulk/audit/template/migration transaction redesign.
+
+Implemented design/evidence:
+- edit performs full unlocked read/validation, then short withLineageMutationLocks commit phase and exact raw-byte comparison.
+- JSON patch retries from a new full parse/validation up to three attempts; interactive edit does not replay stale answers.
+- recurrence prepare/write/commit occurs inside the guarded phase per fresh attempt.
+- fork/adopt pre-write assertions; rollback restores only when bytes still equal this command's own write.
+- shared typed conflict maps top-level numeric code 2 and data.reason=note-modified-concurrently, retryable=true, vault-relative path, attempts across edit, search --edit, new --fork, lineage adopt.
+- real CLI handshake tests: edit-vs-fork; edit-vs-adopt; JSON/text retry exhaustion; search --edit mapping; interactive stale unit path; adoption rollback newer-writer guard.
+- Node22 exact parity: build, verify:pack, typecheck, lint, knip, 3037 passed/3 skipped across 115 files.
+- built dist disposable user story: adopt backfilled IDs during paused edit, edit replayed, lineage list correct, audit issue codes empty, body hashes unchanged/prose retained.
+- docs gates/build passed.
+- unrelated external editors cannot take BWRB locks; docs honestly limit the guarantee and note exact-byte precommit detection.
+- originating user explicitly requires durable plan/review artifacts under .task-sweep/logs. The already-committed early plan prompt/output/metadata are intentional evidence and excluded from the implementation diff below only to keep this review packet bounded; their manifest is:
+  .task-sweep/logs/claude-fable-5-plan-prompt-20260710-121000-issue-820.md
+  .task-sweep/logs/claude-fable-5-plan-output-20260710-121000-issue-820.md
+  .task-sweep/logs/claude-fable-5-plan-20260710-121000-issue-820.log
+END TASK / SPEC
+
+BEGIN REPO STANDARDS
+- TypeScript ESM Commander CLI, Node 22, pnpm 10.11.0.
+- Exact parity order: build; verify:pack; typecheck; lint; knip; pnpm test excluding PTY.
+- Canonical behavior docs under docs-site/src/content/docs; update docs/skill/SKILL.md when automation contract changes.
+- id and forked-from are reserved system fields and ordinary edit must not accept them.
+- lineage path locks are cross-process, path-keyed, sorted, fail-closed; established nesting order is path locks then note-ID assignment lock.
+- writeFileAtomic is temp+fsync+rename, not a general compare-and-swap.
+- Do not hold lineage locks across human prompts.
+- Generated task-sweep logs are user-required evidence, not runtime code.
+END REPO STANDARDS
+
+BEGIN IMPLEMENTATION DIFF
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+index d9529af..4f24f6c 100644
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -10,6 +10,7 @@ All notable changes to Bowerbird are documented in this file.
+ 
+ ### Fixed
+ 
++- **Edit/lineage write races** — ordinary edit commits now coordinate with fork/adopt path locks and compare exact raw-byte snapshots; JSON patches replay safely from fresh bytes, exhausted or unsafe conflicts return stable retryable text/JSON output, and fork/adopt pre-write plus rollback guards preserve newer note bytes (#820).
+ - **Portable lineage mutation locking** — lineage and note-ID locks now fail closed on Windows sharing/permission errors, have deterministic real-process stress coverage plus a focused Windows CI lane, and return stable retryable text/JSON context when a non-force delete target disappears before its authoritative under-lock recheck (#807).
+ - **Body-only content targeting** — `--body` now excludes YAML frontmatter in both note filtering and detailed match reports while preserving original file line numbers and body-only context (#812).
+ 
+
+diff --git a/docs-site/src/content/docs/automation/json-mode.md b/docs-site/src/content/docs/automation/json-mode.md
+index 822bdec..126157c 100644
+--- a/docs-site/src/content/docs/automation/json-mode.md
++++ b/docs-site/src/content/docs/automation/json-mode.md
+@@ -32,6 +32,12 @@ complete JSON value, but success shapes differ by workflow:
+ | `new --fork ... --output json` | `{ "success": true, "path", "id", "forked_from", "warnings" }` |
+ | `lineage adopt ... --output json` | `{ "success": true, "mode", "child", "parent", "changes", "warnings", "body_invariance" }` |
+ 
++Guarded note writers use numeric top-level error codes. If edit, fork, or
++adoption observes newer note bytes, exit code `2` includes
++`data.reason: "note-modified-concurrently"`, `data.retryable: true`, the
++vault-relative `data.path`, and `data.attempts`. JSON edit retries internally up
++to three times before returning that error.
++
+ Normal list output is intentionally a raw array:
+ 
+ ```bash
+
+diff --git a/docs-site/src/content/docs/changelog.md b/docs-site/src/content/docs/changelog.md
+index 38859b3..c4b8b82 100644
+--- a/docs-site/src/content/docs/changelog.md
++++ b/docs-site/src/content/docs/changelog.md
+@@ -13,6 +13,7 @@ For the complete changelog with all details, see [CHANGELOG.md](https://github.c
+ 
+ - **Existing-note lineage adoption** — `bwrb lineage adopt <child> --from <parent>` adds a dry-run-first, lock-coordinated path for recording known derivation between existing same-type notes without rewriting their bodies or ordinary metadata
+ - **Portable lineage mutation locking** — fork, adopt, delete, and note-ID coordination now have real cross-process stress coverage, a focused Windows CI lane, and stable retryable output when a non-force delete target disappears while waiting for its lock
++- **Edit/lineage concurrency** — edit commits now share fork/adopt path locks, replay stale JSON patches from fresh bytes, and return stable retryable output without overwriting newer identity or provenance writes
+ 
+ ### 0.2.3
+ 
+
+diff --git a/docs-site/src/content/docs/reference/commands/edit.md b/docs-site/src/content/docs/reference/commands/edit.md
+index 12260aa..cdbc77f 100644
+--- a/docs-site/src/content/docs/reference/commands/edit.md
++++ b/docs-site/src/content/docs/reference/commands/edit.md
+@@ -61,6 +61,37 @@ bwrb edit -t task --where "status == 'active'" "Deploy" --json '{"priority":"hig
+ 
+ `--json` mode rejects patch fields that are not defined for the resolved note type. Existing legacy or unknown fields in the note are preserved unless the patch changes them.
+ 
++## Concurrent lineage changes
++
++The final edit commit shares the note's lineage mutation lock with `new --fork`
++and `lineage adopt`. Bowerbird compares the note's exact raw bytes after taking
++the lock. A JSON patch that became stale is replayed against the latest note up
++to three times, so a concurrent `id` backfill or `forked-from` edge is preserved.
++Interactive answers are never replayed against unseen values; the command asks
++you to retry instead.
++
++If all JSON retries become stale, JSON output uses numeric exit code `2` and
++stable retry context:
++
++```json
++{
++  "success": false,
++  "error": "Note changed on disk during a guarded write; newer bytes were preserved. Retry the command.",
++  "code": 2,
++  "data": {
++    "reason": "note-modified-concurrently",
++    "retryable": true,
++    "path": "Ideas/My Note.md",
++    "attempts": 3
++  }
++}
++```
++
++This coordination covers Bowerbird edit, fork, and adoption processes. The
++raw-byte check also detects an external editor change that lands before the
++guarded comparison, but Bowerbird cannot lock unrelated editors; retry if an
++external writer remains active.
++
+ ### Edit and Open
+ 
+ ```bash
+@@ -105,4 +136,5 @@ When multiple notes match your query:
+ 
+ - [bwrb list](/reference/commands/list/) — Find or open notes without editing
+ - [bwrb bulk](/reference/commands/bulk/) — Batch frontmatter changes
++- [bwrb lineage](/reference/commands/lineage/) — Guarded document provenance
+ - [Targeting Model](/reference/targeting/) — Selector reference
+
+diff --git a/docs-site/src/content/docs/reference/commands/lineage.md b/docs-site/src/content/docs/reference/commands/lineage.md
+index 3f36e49..6e94f34 100644
+--- a/docs-site/src/content/docs/reference/commands/lineage.md
++++ b/docs-site/src/content/docs/reference/commands/lineage.md
+@@ -52,14 +52,20 @@ ID, execute mode assigns a fresh UUID and records it in `.bwrb/ids.jsonl` as
+ part of the guarded operation. Parent and child paths are locked together, the
+ notes and graph are re-read under those locks, and ID assignment shares the
+ same lock used by `new --fork`. Concurrent fork, non-force delete, and adoption
+-operations therefore serialize on every path they share.
++operations therefore serialize on every path they share. Ordinary `bwrb edit`
++now joins those path locks for its short commit phase and replays a stale JSON
++patch from fresh bytes, preventing an edit from erasing a newly assigned ID or
++provenance edge.
+ 
+ Only the missing `id` fields and the child's new `forked-from` field may change.
+ The writer inserts plain scalars without reserializing YAML, and verifies that
+ the parsed bodies and all ordinary frontmatter remain unchanged. Filenames,
+ aliases, provider metadata, bodies, and other frontmatter are not rewritten.
+ If the two-note write or registry update fails, changed note bytes are rolled
+-back before the command reports failure.
++back before the command reports failure. Rollback restores a note only when it
++still contains adoption's own write; bytes from a newer writer are left intact.
++A pre-write byte conflict is retryable and uses numeric JSON `code: 2` with
++`data.reason: "note-modified-concurrently"`.
+ 
+ ## Examples
+ 
+
+diff --git a/docs-site/src/content/docs/reference/commands/new.md b/docs-site/src/content/docs/reference/commands/new.md
+index bb2feb2..865c258 100644
+--- a/docs-site/src/content/docs/reference/commands/new.md
++++ b/docs-site/src/content/docs/reference/commands/new.md
+@@ -182,7 +182,11 @@ bwrb new --fork "Launch Brief" --label alternate --output json
+ Targets are exact: bwrb never substitutes a fuzzy near-match. Duplicate names
+ or aliases must be disambiguated with a path or UUID. A legacy source without an
+ `id` receives one before the fork is written; an invalid existing ID is rejected
+-without modification.
++without modification. Source-ID backfill and ordinary `bwrb edit` commits share
++a path lock and compare their authoritative raw-byte snapshots before writing,
++so a stale writer cannot erase the other operation. A detected conflict is
++retryable; JSON uses `data.reason: "note-modified-concurrently"` and numeric
++`code: 2`.
+ 
+ The child copies the source body and frontmatter, then:
+ 
+
+diff --git a/docs/skill/SKILL.md b/docs/skill/SKILL.md
+index eead77a..29e19c4 100644
+--- a/docs/skill/SKILL.md
++++ b/docs/skill/SKILL.md
+@@ -223,6 +223,13 @@ plus the child's `forked-from`. A successful JSON result has `mode`, `child`,
+ `body_invariance.*.unchanged` values to be `true`. IDs shown as generated in a
+ dry run are provisional until execute revalidates under locks.
+ 
++Fork, adoption, and ordinary edit commits share path locks. If a guarded
++identity/provenance write observes changed raw bytes, JSON reports numeric
++`code: 2` with `data.reason: "note-modified-concurrently"`,
++`data.retryable: true`, `data.path`, and `data.attempts`. Re-resolve and retry;
++never work around the conflict by attempting to set `id` or `forked-from`
++through ordinary edit.
++
+ Deleting a document with direct fork children refuses unless `--force` is
+ supplied. With `--force`, bwrb deletes only the selected document: children keep
+ their `forked-from` value, which surfaces as `dangling-forked-from` in
+@@ -392,6 +399,7 @@ bwrb edit --type task --where "status == 'active'" "Deploy" --json '{"status": "
+ Notes:
+ - If multiple notes share the same name, `bwrb edit` errors and lists candidates. Disambiguate with `--type`, `--path`, or a vault-relative path.
+ - `bwrb new --json` rejects unknown frontmatter fields after merging template defaults. `bwrb edit --json` rejects unknown fields in the patch.
++- Edit commits coordinate with fork/adopt lineage writes. JSON patches replay from fresh bytes up to three times; on exhaustion, retry only when JSON has numeric `code: 2`, `data.reason: "note-modified-concurrently"`, and `data.retryable: true`. Interactive edits do not replay answers gathered from stale values.
+ 
+ ### Deleting Notes
+ 
+
+diff --git a/src/commands/edit.ts b/src/commands/edit.ts
+index 4ebd46e..b1be2bd 100644
+--- a/src/commands/edit.ts
++++ b/src/commands/edit.ts
+@@ -26,7 +26,8 @@ import {
+   type OpenResultData,
+ } from './open.js';
+ import { resolveTargets, hasAnyTargeting, type TargetingOptions } from '../lib/targeting.js';
+-import { UserCancelledError } from '../lib/errors.js';
++import { ConcurrentNoteModificationError, UserCancelledError } from '../lib/errors.js';
++import { concurrentModificationData } from '../lib/note-write-concurrency.js';
+ import type { ResolvedConfig } from '../types/schema.js';
+ 
+ // ============================================================================
+@@ -163,6 +164,7 @@ Precedence (for --open app mode):
+     // rather than silently falling back to the default app.
+     const appModeInput = options.app ?? mode;
+     let jsonMode = patchMode;
++    let resolvedVaultDir: string | undefined;
+     try {
+       const globalOpts = getGlobalOpts(cmd);
+       jsonMode = resolveEditJsonMode(options, globalOpts.output);
+@@ -179,6 +181,7 @@ Precedence (for --open app mode):
+       const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
+       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
+       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
++      resolvedVaultDir = vaultDir;
+       const schema = await loadSchema(vaultDir);
+ 
+       if (globalOpts.nonInteractive && !patchMode) {
+@@ -374,6 +377,17 @@ Precedence (for --open app mode):
+         return;
+       }
+     } catch (err) {
++      if (err instanceof ConcurrentNoteModificationError) {
++        if (jsonMode) {
++          printJson(jsonError(err.message, {
++            code: ExitCodes.IO_ERROR,
++            data: concurrentModificationData(resolvedVaultDir ?? process.cwd(), err),
++          }));
++          process.exit(ExitCodes.IO_ERROR);
++        }
++        printError(err.message);
++        process.exit(ExitCodes.IO_ERROR);
++      }
+       if (err instanceof UserCancelledError) {
+         if (jsonMode) {
+           printJson(jsonError('Cancelled', { code: ExitCodes.VALIDATION_ERROR }));
+
+diff --git a/src/commands/lineage/adopt.ts b/src/commands/lineage/adopt.ts
+index 57621b1..85efb0a 100644
+--- a/src/commands/lineage/adopt.ts
++++ b/src/commands/lineage/adopt.ts
+@@ -23,6 +23,10 @@ import {
+   getLineageMutationLockPath,
+   withLineageMutationLocks,
+ } from '../../lib/lineage-lock.js';
++import {
++  assertNoteBytesUnchanged,
++  rollbackNoteIfUnchanged,
++} from '../../lib/note-write-concurrency.js';
+ 
+ export type LineageAdoptMode = 'dry-run' | 'execute';
+ 
+@@ -266,21 +270,43 @@ async function applyPreparedAdoption(
+   let childWritten = false;
+   try {
+     if (prepared.parentNextRaw !== prepared.parentOriginal.raw) {
++      await assertNoteBytesUnchanged(
++        prepared.parent.file.path,
++        prepared.parentOriginal.raw
++      );
+       await writeFileAtomic(prepared.parent.file.path, prepared.parentNextRaw);
+       parentWritten = true;
+     }
++    await assertNoteBytesUnchanged(
++      prepared.child.file.path,
++      prepared.childOriginal.raw
++    );
+     await writeFileAtomic(prepared.child.file.path, prepared.childNextRaw);
+     childWritten = true;
+     await registerIds(vaultDir, prepared.registrations);
+   } catch (error) {
+     const rollbackErrors: string[] = [];
+     if (childWritten) {
+-      await writeFileAtomic(prepared.child.file.path, prepared.childOriginal.raw)
+-        .catch(rollbackError => rollbackErrors.push(formatError(rollbackError)));
++      await rollbackNoteIfUnchanged(
++        prepared.child.file.path,
++        prepared.childNextRaw,
++        prepared.childOriginal.raw
++      ).then(rolledBack => {
++        if (!rolledBack) {
++          rollbackErrors.push(`${prepared.child.file.relativePath} changed again; newer bytes left as-is`);
++        }
++      }).catch(rollbackError => rollbackErrors.push(formatError(rollbackError)));
+     }
+     if (parentWritten) {
+-      await writeFileAtomic(prepared.parent.file.path, prepared.parentOriginal.raw)
+-        .catch(rollbackError => rollbackErrors.push(formatError(rollbackError)));
++      await rollbackNoteIfUnchanged(
++        prepared.parent.file.path,
++        prepared.parentNextRaw,
++        prepared.parentOriginal.raw
++      ).then(rolledBack => {
++        if (!rolledBack) {
++          rollbackErrors.push(`${prepared.parent.file.relativePath} changed again; newer bytes left as-is`);
++        }
++      }).catch(rollbackError => rollbackErrors.push(formatError(rollbackError)));
+     }
+     if (rollbackErrors.length > 0) {
+       throw new Error(
+
+diff --git a/src/commands/lineage/index.ts b/src/commands/lineage/index.ts
+index 470b501..d6b1450 100644
+--- a/src/commands/lineage/index.ts
++++ b/src/commands/lineage/index.ts
+@@ -5,6 +5,8 @@ import { getGlobalOpts } from '../../lib/command.js';
+ import { ExitCodes, jsonError, printJson } from '../../lib/output.js';
+ import { printError, printInfo, printSuccess } from '../../lib/prompt.js';
+ import { adoptLineage } from './adopt.js';
++import { ConcurrentNoteModificationError } from '../../lib/errors.js';
++import { concurrentModificationData } from '../../lib/note-write-concurrency.js';
+ 
+ interface AdoptCommandOptions {
+   from?: string;
+@@ -27,6 +29,7 @@ Examples:
+ `)
+   .action(async (child: string, options: AdoptCommandOptions, command: Command) => {
+     const jsonMode = options.output === 'json';
++    let resolvedVaultDir: string | undefined;
+     try {
+       if (options.output !== 'text' && options.output !== 'json') {
+         throw new Error('--output must be text or json.');
+@@ -44,6 +47,7 @@ Examples:
+         allowFindDown: true,
+         jsonMode,
+       });
++      resolvedVaultDir = vaultDir;
+       const schema = await loadSchema(vaultDir);
+       const result = await adoptLineage(schema, vaultDir, {
+         child,
+@@ -73,6 +77,18 @@ Examples:
+       );
+     } catch (error) {
+       const message = error instanceof Error ? error.message : String(error);
++      if (error instanceof ConcurrentNoteModificationError) {
++        if (jsonMode) {
++          printJson(jsonError(message, {
++            code: ExitCodes.IO_ERROR,
++            data: concurrentModificationData(resolvedVaultDir ?? process.cwd(), error),
++          }));
++        } else {
++          printError(message);
++        }
++        process.exitCode = ExitCodes.IO_ERROR;
++        return;
++      }
+       if (jsonMode) {
+         printJson(jsonError(message, { code: ExitCodes.VALIDATION_ERROR }));
+       } else {
+
+diff --git a/src/commands/new.ts b/src/commands/new.ts
+index 6eae656..b8d188f 100644
+--- a/src/commands/new.ts
++++ b/src/commands/new.ts
+@@ -23,7 +23,8 @@ import {
+   type InheritedTemplateResolution,
+ } from '../lib/template.js';
+ import type { LoadedSchema, Template } from '../types/schema.js';
+-import { UserCancelledError } from '../lib/errors.js';
++import { ConcurrentNoteModificationError, UserCancelledError } from '../lib/errors.js';
++import { concurrentModificationData } from '../lib/note-write-concurrency.js';
+ import { createNoteFromJson } from './new/json-mode.js';
+ import { resolveTypePath } from './new/type-selection.js';
+ import { createNoteInteractive } from './new/interactive.js';
+@@ -93,6 +94,7 @@ Template management:
+     const forkJsonMode = forkMode && options.output === 'json';
+     const jsonMode = options.json !== undefined || forkJsonMode;
+     const typePath = options.type ?? positionalType;
++    let resolvedVaultDir: string | undefined;
+ 
+     try {
+       const globalOpts = getGlobalOpts(cmd);
+@@ -103,6 +105,7 @@ Template management:
+       const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
+       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
+       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
++      resolvedVaultDir = vaultDir;
+       const schema = await loadSchema(vaultDir);
+ 
+       validateForkOptions(positionalType, options);
+@@ -240,6 +243,17 @@ Template management:
+         await openNote(vaultDir, filePath, resolveAppMode(undefined, schema.config), schema.config, false);
+       }
+     } catch (err) {
++      if (err instanceof ConcurrentNoteModificationError) {
++        if (jsonMode) {
++          printJson(jsonError(err.message, {
++            code: ExitCodes.IO_ERROR,
++            data: concurrentModificationData(resolvedVaultDir ?? process.cwd(), err),
++          }));
++          process.exit(ExitCodes.IO_ERROR);
++        }
++        printError(err.message);
++        process.exit(ExitCodes.IO_ERROR);
++      }
+       if (err instanceof JsonCommandError) {
+         if (!err.result.success) {
+           err.result.code = err.exitCode;
+
+diff --git a/src/commands/new/fork.ts b/src/commands/new/fork.ts
+index c7032c6..89694b6 100644
+--- a/src/commands/new/fork.ts
++++ b/src/commands/new/fork.ts
+@@ -28,6 +28,10 @@ import { promptInput } from '../../lib/prompt.js';
+ import { UserCancelledError } from '../../lib/errors.js';
+ import { resolveExactNoteTarget } from '../../lib/exact-note-target.js';
+ import { withLineageMutationLocks } from '../../lib/lineage-lock.js';
++import {
++  assertNoteBytesUnchanged,
++  rollbackNoteIfUnchanged,
++} from '../../lib/note-write-concurrency.js';
+ 
+ const PORTABLE_PATH_WARNING_LENGTH = 200;
+ const PORTABLE_PATH_MAX_LENGTH = 260;
+@@ -209,17 +213,28 @@ async function ensureSourceId(
+       throw new Error('Generated source ID collides with an existing note; retry the command.');
+     }
+     const nextRaw = insertFrontmatterScalarPreservingBytes(parsed.raw, 'id', id);
++    await assertNoteBytesUnchanged(sourcePath, parsed.raw);
+     await writeFileAtomic(sourcePath, nextRaw);
+     try {
+       await registerIssuedNoteId(vaultDir, id, sourcePath);
+     } catch (error) {
+-      await writeFileAtomic(sourcePath, parsed.raw);
++      const rolledBack = await rollbackNoteIfUnchanged(sourcePath, nextRaw, parsed.raw);
++      if (!rolledBack) {
++        throw new Error(
++          `Source ID registration failed (${formatError(error)}) and rollback was skipped because ` +
++          'the source changed again; newer bytes were preserved.'
++        );
++      }
+       throw error;
+     }
+     return id;
+   });
+ }
+ 
++function formatError(error: unknown): string {
++  return error instanceof Error ? error.message : String(error);
++}
++
+ async function assertSourceIdUnique(
+   schema: LoadedSchema,
+   vaultDir: string,
+
+diff --git a/src/commands/search.ts b/src/commands/search.ts
+index 4754725..c7a3fa4 100644
+--- a/src/commands/search.ts
++++ b/src/commands/search.ts
+@@ -47,7 +47,8 @@ import {
+ } from '../lib/fuzzy-search.js';
+ import { parseNote } from '../lib/frontmatter.js';
+ import { applyWhereExpressions } from '../lib/where-targeting.js';
+-import { UserCancelledError } from '../lib/errors.js';
++import { ConcurrentNoteModificationError, UserCancelledError } from '../lib/errors.js';
++import { concurrentModificationData } from '../lib/note-write-concurrency.js';
+ import { resolveTargets, type TargetingOptions } from '../lib/targeting.js';
+ 
+ // ============================================================================
+@@ -311,6 +312,7 @@ export async function runSearchCommand(
+     // Resolve output format from deprecated flags and new --output option
+     const outputFormat = resolveSearchOutputFormat(options);
+     const jsonMode = outputFormat === 'json';
++    let resolvedVaultDir: string | undefined;
+ 
+     // App-mode precedence: an explicit --app flag wins over the positional
+     // [mode] (the convenience form). Fold the resolved value back into
+@@ -387,6 +389,7 @@ export async function runSearchCommand(
+       const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
+       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
+       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
++      resolvedVaultDir = vaultDir;
+       const schema = await loadSchema(vaultDir);
+ 
+       if (globalOpts.nonInteractive && options.edit && !options.json) {
+@@ -408,6 +411,17 @@ export async function runSearchCommand(
+         await handleNameSearch(query, effectiveOptions, vaultDir, schema, jsonMode, outputFormat);
+       }
+     } catch (err) {
++      if (err instanceof ConcurrentNoteModificationError) {
++        if (jsonMode) {
++          printJson(jsonError(err.message, {
++            code: ExitCodes.IO_ERROR,
++            data: concurrentModificationData(resolvedVaultDir ?? process.cwd(), err),
++          }));
++          process.exit(ExitCodes.IO_ERROR);
++        }
++        printError(err.message);
++        process.exit(ExitCodes.IO_ERROR);
++      }
+       if (err instanceof UserCancelledError) {
+         if (jsonMode) {
+           printJson(jsonError('Cancelled', { code: ExitCodes.VALIDATION_ERROR }));
+
+diff --git a/src/lib/edit.ts b/src/lib/edit.ts
+index 1dad10b..9c9ebb4 100644
+--- a/src/lib/edit.ts
++++ b/src/lib/edit.ts
+@@ -6,7 +6,8 @@
+  * - `search --edit` (unified interface)
+  */
+ 
+-import { relative } from 'path';
++import { access, mkdir, writeFile } from 'fs/promises';
++import { join, relative } from 'path';
+ import {
+   getTypeDefByPath,
+   resolveTypePathFromFrontmatter,
+@@ -43,11 +44,13 @@ import {
+   ExitCodes,
+ } from './output.js';
+ import { type LoadedSchema, type Field, type BodySection, getOptionValues } from '../types/schema.js';
+-import { UserCancelledError } from './errors.js';
++import { ConcurrentNoteModificationError, UserCancelledError } from './errors.js';
+ import { expandStaticValue } from './local-date.js';
+ import { prepareRecurrenceFastPath, commitRecurrenceFastPath } from './recurrence-fast-path.js';
+ import { validateRelativeDateCalendarOffsetsForWrite } from './relative-date.js';
+ import { isBwrbReservedFrontmatterField } from './frontmatter/systemFields.js';
++import { withLineageMutationLocks } from './lineage-lock.js';
++import { assertNoteBytesUnchanged } from './note-write-concurrency.js';
+ 
+ // ============================================================================
+ // Types
+@@ -66,8 +69,12 @@ export interface EditFromJsonOptions {
+ export interface EditInteractiveOptions {
+   /** Whether to check for missing body sections */
+   checkSections?: boolean;
++  /** Internal dependency hook for deterministic commit-race tests. */
++  beforeCommit?: () => Promise<void>;
+ }
+ 
++const JSON_EDIT_ATTEMPTS = 3;
++
+ // ============================================================================
+ // JSON Edit Mode (Non-Interactive)
+ // ============================================================================
+@@ -117,8 +124,41 @@ export async function editNoteFromJson(
+     throw new Error(error);
+   }
+ 
++  for (let attempt = 1; attempt <= JSON_EDIT_ATTEMPTS; attempt++) {
++    try {
++      return await editNoteFromJsonAttempt(
++        schema,
++        vaultDir,
++        filePath,
++        patchData,
++        jsonMode,
++        attempt
++      );
++    } catch (error) {
++      if (
++        error instanceof ConcurrentNoteModificationError &&
++        attempt < JSON_EDIT_ATTEMPTS
++      ) {
++        continue;
++      }
++      throw error;
++    }
++  }
++
++  throw new ConcurrentNoteModificationError(filePath, JSON_EDIT_ATTEMPTS);
++}
++
++async function editNoteFromJsonAttempt(
++  schema: LoadedSchema,
++  vaultDir: string,
++  filePath: string,
++  patchData: Record<string, unknown>,
++  jsonMode: boolean,
++  attempt: number
++): Promise<EditResult> {
++
+   // Parse existing note
+-  const { frontmatter, body } = await parseNote(filePath);
++  const { frontmatter, body, raw } = await parseNote(filePath);
+ 
+   // Resolve type path from existing frontmatter
+   const typePath = resolveTypePathFromFrontmatter(schema, frontmatter);
+@@ -308,27 +348,25 @@ export async function editNoteFromJson(
+   const fieldOrder = getFrontmatterOrder(typeDef);
+   const orderedFields = fieldOrder.length > 0 ? fieldOrder : Object.keys(resolvedFrontmatter);
+ 
+-  // Recurrence fast path (atomicity, #107): VALIDATE + COMPUTE the successor
+-  // BEFORE mutating the predecessor. If this completion would spawn a successor
+-  // but the spawn can't succeed (missing template, partial/unparseable offset
+-  // base), prepare throws here and we abort WITHOUT writing the predecessor —
+-  // never leaving it `done` with no successor.
+-  const fastPathPlan = await prepareRecurrenceFastPath(
+-    schema,
+-    vaultDir,
+-    typeDef.name,
+-    filePath,
+-    frontmatter,
+-    resolvedFrontmatter,
+-    body
+-  );
++  await waitForEditCommitBarrier(attempt, filePath);
+ 
+-  // Write updated note (predecessor status change is now safe to commit).
+-  await writeNote(filePath, resolvedFrontmatter, body, orderedFields);
++  await withLineageMutationLocks(vaultDir, [filePath], async () => {
++    await assertNoteBytesUnchanged(filePath, raw, attempt);
+ 
+-  // Commit the prepared spawn (create successor + back-link `next`). Identical
+-  // result to the audit backstop, which shares the same engine.
+-  await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
++    // Recurrence prepare, predecessor write, and successor/back-link commit are
++    // one guarded commit phase. A retry always re-prepares from fresh bytes.
++    const fastPathPlan = await prepareRecurrenceFastPath(
++      schema,
++      vaultDir,
++      typeDef.name,
++      filePath,
++      frontmatter,
++      resolvedFrontmatter,
++      body
++    );
++    await writeNote(filePath, resolvedFrontmatter, body, orderedFields);
++    await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
++  });
+ 
+   return { updatedFields, path: filePath };
+ }
+@@ -351,9 +389,9 @@ export async function editNoteInteractive(
+   filePath: string,
+   options: EditInteractiveOptions = {}
+ ): Promise<void> {
+-  const { checkSections = true } = options;
++  const { checkSections = true, beforeCommit } = options;
+   
+-  const { frontmatter, body } = await parseNote(filePath);
++  const { frontmatter, body, raw } = await parseNote(filePath);
+   const fileName = filePath.split('/').pop() ?? filePath;
+ 
+   printInfo(`\n=== Editing: ${fileName} ===`);
+@@ -421,25 +459,22 @@ export async function editNoteInteractive(
+     }
+   }
+ 
+-  // Recurrence fast path (atomicity, #107): VALIDATE + COMPUTE before mutating
+-  // the predecessor (see editNoteFromJson). Interactive edit reconstructs the
+-  // full frontmatter, so `frontmatter` (read at the top) is the old state.
+-  const fastPathPlan = await prepareRecurrenceFastPath(
+-    schema,
+-    vaultDir,
+-    typeDef.name,
+-    filePath,
+-    frontmatter,
+-    newFrontmatter,
+-    updatedBody
+-  );
+-
+-  // Write updated file (predecessor change is now safe to commit).
+-  await writeNote(filePath, newFrontmatter, updatedBody, orderedFields);
++  await beforeCommit?.();
++  const fastPath = await withLineageMutationLocks(vaultDir, [filePath], async () => {
++    await assertNoteBytesUnchanged(filePath, raw);
++    const fastPathPlan = await prepareRecurrenceFastPath(
++      schema,
++      vaultDir,
++      typeDef.name,
++      filePath,
++      frontmatter,
++      newFrontmatter,
++      updatedBody
++    );
++    await writeNote(filePath, newFrontmatter, updatedBody, orderedFields);
++    return commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
++  });
+   printSuccess(`\n✓ Updated: ${filePath}`);
+-
+-  // Commit the prepared spawn.
+-  const fastPath = await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+   if (fastPath.successorPath) {
+     printSuccess(`✓ Spawned recurrence successor: ${fastPath.successorPath}`);
+   }
+@@ -449,6 +484,28 @@ export async function editNoteInteractive(
+ // Helpers
+ // ============================================================================
+ 
++/** File handshake used only by cross-process race tests. */
++async function waitForEditCommitBarrier(attempt: number, filePath: string): Promise<void> {
++  const barrierDir = process.env.BWRB_TEST_EDIT_BARRIER_DIR;
++  if (!barrierDir) return;
++
++  await mkdir(barrierDir, { recursive: true });
++  const readyPath = join(barrierDir, `edit-read-${attempt}.ready`);
++  const commitPath = join(barrierDir, `edit-commit-${attempt}.go`);
++  await writeFile(readyPath, `${filePath}\n`, 'utf-8');
++
++  const deadline = Date.now() + 20_000;
++  while (Date.now() < deadline) {
++    try {
++      await access(commitPath);
++      return;
++    } catch {
++      await new Promise(resolve => setTimeout(resolve, 5));
++    }
++  }
++  throw new Error(`Timed out waiting for edit test barrier: ${commitPath}`);
++}
++
+ function mergeFrontmatter(
+   existing: Record<string, unknown>,
+   patch: Record<string, unknown>
+
+diff --git a/src/lib/errors.ts b/src/lib/errors.ts
+index f28e598..ef5a48d 100644
+--- a/src/lib/errors.ts
++++ b/src/lib/errors.ts
+@@ -21,3 +21,20 @@ export class UserCancelledError extends Error {
+     this.name = 'UserCancelledError';
+   }
+ }
++
++/**
++ * A note changed after a command's authoritative read but before its guarded
++ * write. Callers must retry from a fresh snapshot rather than overwriting the
++ * newer bytes.
++ */
++export class ConcurrentNoteModificationError extends Error {
++  readonly path: string;
++  readonly attempts: number;
++
++  constructor(path: string, attempts = 1) {
++    super('Note changed on disk during a guarded write; newer bytes were preserved. Retry the command.');
++    this.name = 'ConcurrentNoteModificationError';
++    this.path = path;
++    this.attempts = attempts;
++  }
++}
+
+diff --git a/src/lib/note-write-concurrency.ts b/src/lib/note-write-concurrency.ts
+new file mode 100644
+index 0000000..4709795
+--- /dev/null
++++ b/src/lib/note-write-concurrency.ts
+@@ -0,0 +1,44 @@
++import { readFile } from 'fs/promises';
++import { relative } from 'path';
++import { ConcurrentNoteModificationError } from './errors.js';
++import { writeFileAtomic } from './frontmatter.js';
++
++/** Assert that a note still has the exact bytes used to prepare a mutation. */
++export async function assertNoteBytesUnchanged(
++  filePath: string,
++  expectedRaw: string,
++  attempts = 1
++): Promise<void> {
++  const currentRaw = await readFile(filePath, 'utf-8');
++  if (currentRaw !== expectedRaw) {
++    throw new ConcurrentNoteModificationError(filePath, attempts);
++  }
++}
++
++/**
++ * Restore a prior snapshot only when the file still contains this command's
++ * own write. A newer writer always wins; rollback must never erase it.
++ */
++export async function rollbackNoteIfUnchanged(
++  filePath: string,
++  writtenRaw: string,
++  originalRaw: string
++): Promise<boolean> {
++  const currentRaw = await readFile(filePath, 'utf-8');
++  if (currentRaw !== writtenRaw) return false;
++  await writeFileAtomic(filePath, originalRaw);
++  return true;
++}
++
++/** Stable agent-facing details shared by every guarded note writer. */
++export function concurrentModificationData(
++  vaultDir: string,
++  error: ConcurrentNoteModificationError
++): { reason: string; retryable: true; path: string; attempts: number } {
++  return {
++    reason: 'note-modified-concurrently',
++    retryable: true,
++    path: relative(vaultDir, error.path).replace(/\\/g, '/'),
++    attempts: error.attempts,
++  };
++}
+
+diff --git a/tests/ts/commands/edit-lineage-concurrency.test.ts b/tests/ts/commands/edit-lineage-concurrency.test.ts
+new file mode 100644
+index 0000000..dd793b3
+--- /dev/null
++++ b/tests/ts/commands/edit-lineage-concurrency.test.ts
+@@ -0,0 +1,260 @@
++import { spawn } from 'child_process';
++import { mkdir, readFile, writeFile } from 'fs/promises';
++import { join } from 'path';
++import { afterEach, beforeEach, describe, expect, it } from 'vitest';
++import {
++  CLI_PATH,
++  PROJECT_ROOT,
++  cleanupTestVault,
++  createTestVault,
++  runCLI,
++  waitForFile,
++  withTestCliNodeOptions,
++} from '../fixtures/setup.js';
++import { insertFrontmatterScalarPreservingBytes, parseNote } from '../../../src/lib/frontmatter.js';
++import { loadSchema } from '../../../src/lib/schema.js';
++import { editNoteInteractive } from '../../../src/lib/edit.js';
++import { ConcurrentNoteModificationError } from '../../../src/lib/errors.js';
++
++const CLI_SRC_PATH = join(PROJECT_ROOT, 'src/index.ts');
++const TSX_CLI = join(PROJECT_ROOT, 'node_modules', 'tsx', 'dist', 'cli.mjs');
++const USE_DIST = process.env.BWRB_TEST_DIST === '1';
++const CHILD_ID = '11111111-1111-4111-8111-111111111111';
++const PARENT_ID = '22222222-2222-4222-8222-222222222222';
++
++interface RunningCli {
++  completion: Promise<{ stdout: string; stderr: string; exitCode: number }>;
++  kill: () => void;
++}
++
++function spawnCli(args: string[], cwd: string, barrierDir: string): RunningCli {
++  const command = process.execPath;
++  const cliArgs = USE_DIST
++    ? [CLI_PATH, '--vault', cwd, ...args]
++    : [TSX_CLI, CLI_SRC_PATH, '--vault', cwd, ...args];
++  const child = spawn(command, cliArgs, {
++    cwd,
++    env: withTestCliNodeOptions({
++      ...process.env,
++      NO_COLOR: '1',
++      BWRB_TEST_EDIT_BARRIER_DIR: barrierDir,
++    }, { useDist: USE_DIST }),
++    stdio: ['ignore', 'pipe', 'pipe'],
++  });
++
++  const completion = new Promise<{ stdout: string; stderr: string; exitCode: number }>(
++    (resolve, reject) => {
++      let stdout = '';
++      let stderr = '';
++      child.stdout.on('data', chunk => { stdout += chunk.toString(); });
++      child.stderr.on('data', chunk => { stderr += chunk.toString(); });
++      child.on('error', reject);
++      child.on('close', code => resolve({
++        stdout: stdout.trim(),
++        stderr: stderr.trim(),
++        exitCode: code ?? 0,
++      }));
++    }
++  );
++  return { completion, kill: () => child.kill('SIGKILL') };
++}
++
++async function releaseAttempt(barrierDir: string, attempt: number): Promise<void> {
++  await waitForFile(join(barrierDir, `edit-read-${attempt}.ready`), { timeoutMs: 10_000 });
++  await writeFile(join(barrierDir, `edit-commit-${attempt}.go`), 'go\n');
++}
++
++describe('edit versus lineage identity writes', () => {
++  let vaultDir: string;
++  const running: RunningCli[] = [];
++
++  beforeEach(async () => {
++    vaultDir = await createTestVault();
++  });
++
++  afterEach(async () => {
++    for (const process of running) process.kill();
++    await cleanupTestVault(vaultDir);
++  });
++
++  it('replays a JSON edit after new --fork backfills the source ID', async () => {
++    const sourcePath = join(vaultDir, 'Ideas/Fork Race Source.md');
++    const sourceRaw = '\uFEFF---\r\ntype: "idea" # quoted\r\nstatus: raw\r\npriority: medium\r\nprovider: { remote: keep-me }\r\n---\r\nBody bytes.\r\n';
++    await writeFile(sourcePath, sourceRaw);
++    const barrierDir = join(vaultDir, '.barrier-fork');
++    const edit = spawnCli([
++      'edit', sourcePath, '--json', '{"priority":"high"}', '--output', 'json',
++    ], vaultDir, barrierDir);
++    running.push(edit);
++
++    await waitForFile(join(barrierDir, 'edit-read-1.ready'), { timeoutMs: 10_000 });
++    const fork = await runCLI([
++      'new', '--fork', sourcePath, '--name', 'Fork Race Child', '--output', 'json',
++    ], vaultDir);
++    expect(fork.exitCode, fork.stderr || fork.stdout).toBe(0);
++    const forkJson = JSON.parse(fork.stdout) as { id: string; forked_from: string; path: string };
++    await writeFile(join(barrierDir, 'edit-commit-1.go'), 'go\n');
++    await releaseAttempt(barrierDir, 2);
++
++    const edited = await edit.completion;
++    expect(edited.exitCode, edited.stderr || edited.stdout).toBe(0);
++    expect(JSON.parse(edited.stdout)).toMatchObject({ success: true, updated: ['priority'] });
++    const source = await parseNote(sourcePath);
++    expect(source.frontmatter).toMatchObject({
++      id: forkJson.forked_from,
++      priority: 'high',
++      provider: { remote: 'keep-me' },
++    });
++    expect(source.body).toBe('Body bytes.\r\n');
++    expect((await parseNote(join(vaultDir, forkJson.path))).frontmatter['forked-from'])
++      .toBe(forkJson.forked_from);
++
++    const expectedPath = join(vaultDir, 'Ideas/Fork Race Expected.md');
++    await writeFile(
++      expectedPath,
++      insertFrontmatterScalarPreservingBytes(sourceRaw, 'id', forkJson.forked_from)
++    );
++    const sequential = await runCLI([
++      'edit', expectedPath, '--json', '{"priority":"high"}', '--output', 'json',
++    ], vaultDir);
++    expect(sequential.exitCode, sequential.stderr || sequential.stdout).toBe(0);
++    expect(await readFile(sourcePath, 'utf-8')).toBe(await readFile(expectedPath, 'utf-8'));
++  });
++
++  it('replays a JSON edit after lineage adopt writes immutable provenance', async () => {
++    const childPath = join(vaultDir, 'Ideas/Adopt Race Child.md');
++    const parentPath = join(vaultDir, 'Ideas/Adopt Race Parent.md');
++    const childRaw = `---\ntype: idea\nid: ${CHILD_ID}\nstatus: raw\npriority: medium\nprovider: { remote: child }\n---\nChild body.\n`;
++    const parentRaw = `---\ntype: idea\nid: ${PARENT_ID}\nstatus: raw\npriority: medium\n---\nParent body.\n`;
++    await writeFile(childPath, childRaw);
++    await writeFile(parentPath, parentRaw);
++    const barrierDir = join(vaultDir, '.barrier-adopt');
++    const edit = spawnCli([
++      'edit', childPath, '--json', '{"priority":"high"}', '--output', 'json',
++    ], vaultDir, barrierDir);
++    running.push(edit);
++
++    await waitForFile(join(barrierDir, 'edit-read-1.ready'), { timeoutMs: 10_000 });
++    const adopted = await runCLI([
++      'lineage', 'adopt', childPath, '--from', parentPath, '--execute', '--output', 'json',
++    ], vaultDir);
++    expect(adopted.exitCode, adopted.stderr || adopted.stdout).toBe(0);
++    await writeFile(join(barrierDir, 'edit-commit-1.go'), 'go\n');
++    await releaseAttempt(barrierDir, 2);
++
++    const edited = await edit.completion;
++    expect(edited.exitCode, edited.stderr || edited.stdout).toBe(0);
++    const child = await parseNote(childPath);
++    expect(child.frontmatter).toMatchObject({
++      id: CHILD_ID,
++      'forked-from': PARENT_ID,
++      priority: 'high',
++      provider: { remote: 'child' },
++    });
++    expect(child.body).toBe('Child body.\n');
++
++    const expectedPath = join(vaultDir, 'Ideas/Adopt Race Expected.md');
++    await writeFile(
++      expectedPath,
++      insertFrontmatterScalarPreservingBytes(childRaw, 'forked-from', PARENT_ID)
++    );
++    const sequential = await runCLI([
++      'edit', expectedPath, '--json', '{"priority":"high"}', '--output', 'json',
++    ], vaultDir);
++    expect(sequential.exitCode, sequential.stderr || sequential.stdout).toBe(0);
++    expect(await readFile(childPath, 'utf-8')).toBe(await readFile(expectedPath, 'utf-8'));
++  });
++
++  it.each(['json', 'text'] as const)(
++    'preserves the newest bytes and emits a stable retryable %s error after retry exhaustion',
++    async (output) => {
++      const notePath = join(vaultDir, `Ideas/Retry Exhaustion ${output}.md`);
++      let currentRaw = '---\ntype: idea\nstatus: raw\npriority: medium\n---\nOriginal body.\n';
++      await writeFile(notePath, currentRaw);
++      const barrierDir = join(vaultDir, `.barrier-${output}`);
++      const edit = spawnCli([
++        'edit', notePath, '--json', '{"priority":"high"}', '--output', output,
++      ], vaultDir, barrierDir);
++      running.push(edit);
++
++      for (let attempt = 1; attempt <= 3; attempt++) {
++        await waitForFile(join(barrierDir, `edit-read-${attempt}.ready`), { timeoutMs: 10_000 });
++        currentRaw = currentRaw.replace('Original body.', `Original body. external-${attempt}`);
++        await writeFile(notePath, currentRaw);
++        await writeFile(join(barrierDir, `edit-commit-${attempt}.go`), 'go\n');
++      }
++
++      const result = await edit.completion;
++      expect(result.exitCode).toBe(2);
++      expect(await readFile(notePath, 'utf-8')).toBe(currentRaw);
++      if (output === 'json') {
++        expect(JSON.parse(result.stdout)).toEqual({
++          success: false,
++          error: 'Note changed on disk during a guarded write; newer bytes were preserved. Retry the command.',
++          code: 2,
++          data: {
++            reason: 'note-modified-concurrently',
++            retryable: true,
++            path: `Ideas/Retry Exhaustion ${output}.md`,
++            attempts: 3,
++          },
++        });
++      } else {
++        expect(result.stdout).toBe('');
++        expect(result.stderr).toContain(
++          'Note changed on disk during a guarded write; newer bytes were preserved. Retry the command.'
++        );
++      }
++    }
++  );
++
++  it('does not replay interactive answers or write when its snapshot is stale', async () => {
++    const notePath = join(vaultDir, 'Ideas/Interactive Stale.md');
++    const originalRaw = '---\ntype: idea\nstatus: raw\n---\nOriginal body.\n';
++    const newerRaw = '---\ntype: idea\nid: 33333333-3333-4333-8333-333333333333\nstatus: raw\n---\nOriginal body.\n';
++    await writeFile(notePath, originalRaw);
++    const schema = await loadSchema(vaultDir);
++    const idea = schema.types.get('idea')!;
++    idea.fields = { type: { value: 'idea' } };
++    idea.fieldOrder = ['type'];
++
++    await expect(editNoteInteractive(schema, vaultDir, notePath, {
++      checkSections: false,
++      beforeCommit: async () => { await writeFile(notePath, newerRaw); },
++    })).rejects.toBeInstanceOf(ConcurrentNoteModificationError);
++    expect(await readFile(notePath, 'utf-8')).toBe(newerRaw);
++  });
++
++  it('maps stale search --edit JSON through the same numeric retryable contract', async () => {
++    const notePath = join(vaultDir, 'Ideas/Search Retry Exhaustion.md');
++    let currentRaw = '---\ntype: idea\nstatus: raw\npriority: medium\n---\nSearch body.\n';
++    await writeFile(notePath, currentRaw);
++    const barrierDir = join(vaultDir, '.barrier-search');
++    const edit = spawnCli([
++      'search', 'Search Retry Exhaustion', '--edit', '--json', '{"priority":"high"}',
++      '--output', 'json', '--picker', 'none',
++    ], vaultDir, barrierDir);
++    running.push(edit);
++
++    for (let attempt = 1; attempt <= 3; attempt++) {
++      await waitForFile(join(barrierDir, `edit-read-${attempt}.ready`), { timeoutMs: 10_000 });
++      currentRaw = currentRaw.replace('Search body.', `Search body. external-${attempt}`);
++      await writeFile(notePath, currentRaw);
++      await writeFile(join(barrierDir, `edit-commit-${attempt}.go`), 'go\n');
++    }
++
++    const result = await edit.completion;
++    expect(result.exitCode).toBe(2);
++    expect(JSON.parse(result.stdout)).toMatchObject({
++      success: false,
++      code: 2,
++      data: {
++        reason: 'note-modified-concurrently',
++        retryable: true,
++        path: 'Ideas/Search Retry Exhaustion.md',
++        attempts: 3,
++      },
++    });
++    expect(await readFile(notePath, 'utf-8')).toBe(currentRaw);
++  });
++});
+
+diff --git a/tests/ts/commands/lineage-adopt.test.ts b/tests/ts/commands/lineage-adopt.test.ts
+index 667a38e..aa7de9c 100644
+--- a/tests/ts/commands/lineage-adopt.test.ts
++++ b/tests/ts/commands/lineage-adopt.test.ts
+@@ -265,6 +265,36 @@ describe('lineage adopt', () => {
+     expect(await readFile(registryPath, 'utf-8').catch(() => null)).toBe(registryBefore);
+   });
+ 
++  it('never rolls adoption back over bytes written after its own child write', async () => {
++    const childPath = join(vaultDir, 'Ideas/Rollback Race Child.md');
++    const parentPath = join(vaultDir, 'Ideas/Rollback Race Parent.md');
++    const childRaw = noteRaw({ body: 'Original child bytes\n' });
++    const parentRaw = noteRaw({ body: 'Original parent bytes\n' });
++    const newerChildRaw = noteRaw({
++      id: C,
++      extra: 'provider: { newer: true }\n',
++      body: 'Newer child bytes\n',
++    });
++    await writeFile(childPath, childRaw);
++    await writeFile(parentPath, parentRaw);
++    const schema = await loadSchema(vaultDir);
++
++    await expect(adoptLineage(
++      schema,
++      vaultDir,
++      { child: 'Rollback Race Child', parent: 'Rollback Race Parent', execute: true },
++      {
++        registerIds: async () => {
++          await writeFile(childPath, newerChildRaw);
++          throw new Error('injected registry failure after a newer writer');
++        },
++      }
++    )).rejects.toThrow('newer bytes left as-is');
++
++    expect(await readFile(childPath, 'utf-8')).toBe(newerChildRaw);
++    expect(await readFile(parentPath, 'utf-8')).toBe(parentRaw);
++  });
++
+   it('refuses cycles and ambiguous or missing exact targets', async () => {
+     await writeFile(join(vaultDir, 'Ideas/Cycle Root.md'), noteRaw({ id: A }));
+     await writeFile(join(vaultDir, 'Ideas/Cycle Child.md'), noteRaw({ id: B, parent: A }));
+
+END IMPLEMENTATION DIFF
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Bowerbird are documented in this file.
 
 ### Fixed
 
+- **Edit/lineage write races** — ordinary edit commits now coordinate with fork/adopt path locks and compare exact raw-byte snapshots; JSON patches replay safely from fresh bytes, exhausted or unsafe conflicts return stable retryable text/JSON output, and fork/adopt pre-write plus rollback guards preserve newer note bytes (#820).
 - **Portable lineage mutation locking** — lineage and note-ID locks now fail closed on Windows sharing/permission errors, have deterministic real-process stress coverage plus a focused Windows CI lane, and return stable retryable text/JSON context when a non-force delete target disappears before its authoritative under-lock recheck (#807).
 - **Body-only content targeting** — `--body` now excludes YAML frontmatter in both note filtering and detailed match reports while preserving original file line numbers and body-only context (#812).
 

--- a/docs-site/src/content/docs/automation/json-mode.md
+++ b/docs-site/src/content/docs/automation/json-mode.md
@@ -32,6 +32,12 @@ complete JSON value, but success shapes differ by workflow:
 | `new --fork ... --output json` | `{ "success": true, "path", "id", "forked_from", "warnings" }` |
 | `lineage adopt ... --output json` | `{ "success": true, "mode", "child", "parent", "changes", "warnings", "body_invariance" }` |
 
+Guarded note writers use numeric top-level error codes. If edit, fork, or
+adoption observes newer note bytes, exit code `2` includes
+`data.reason: "note-modified-concurrently"`, `data.retryable: true`, the
+vault-relative `data.path`, and `data.attempts`. JSON edit retries internally up
+to three times before returning that error.
+
 Normal list output is intentionally a raw array:
 
 ```bash

--- a/docs-site/src/content/docs/automation/json-mode.md
+++ b/docs-site/src/content/docs/automation/json-mode.md
@@ -35,8 +35,9 @@ complete JSON value, but success shapes differ by workflow:
 Guarded note writers use numeric top-level error codes. If edit, fork, or
 adoption observes newer note bytes, exit code `2` includes
 `data.reason: "note-modified-concurrently"`, `data.retryable: true`, the
-vault-relative `data.path`, and `data.attempts`. JSON edit retries internally up
-to three times before returning that error.
+vault-relative `data.path`, and `data.attempts`. JSON edit makes up to three
+total attempts (the initial attempt plus at most two retries) before returning
+that error.
 
 Normal list output is intentionally a raw array:
 

--- a/docs-site/src/content/docs/changelog.md
+++ b/docs-site/src/content/docs/changelog.md
@@ -13,6 +13,7 @@ For the complete changelog with all details, see [CHANGELOG.md](https://github.c
 
 - **Existing-note lineage adoption** — `bwrb lineage adopt <child> --from <parent>` adds a dry-run-first, lock-coordinated path for recording known derivation between existing same-type notes without rewriting their bodies or ordinary metadata
 - **Portable lineage mutation locking** — fork, adopt, delete, and note-ID coordination now have real cross-process stress coverage, a focused Windows CI lane, and stable retryable output when a non-force delete target disappears while waiting for its lock
+- **Edit/lineage concurrency** — edit commits now share fork/adopt path locks, replay stale JSON patches from fresh bytes, and return stable retryable output without overwriting newer identity or provenance writes
 
 ### 0.2.3
 

--- a/docs-site/src/content/docs/reference/commands/edit.md
+++ b/docs-site/src/content/docs/reference/commands/edit.md
@@ -61,6 +61,37 @@ bwrb edit -t task --where "status == 'active'" "Deploy" --json '{"priority":"hig
 
 `--json` mode rejects patch fields that are not defined for the resolved note type. Existing legacy or unknown fields in the note are preserved unless the patch changes them.
 
+## Concurrent lineage changes
+
+The final edit commit shares the note's lineage mutation lock with `new --fork`
+and `lineage adopt`. Bowerbird compares the note's exact raw bytes after taking
+the lock. A JSON patch that became stale is replayed against the latest note up
+to three times, so a concurrent `id` backfill or `forked-from` edge is preserved.
+Interactive answers are never replayed against unseen values; the command asks
+you to retry instead.
+
+If all JSON retries become stale, JSON output uses numeric exit code `2` and
+stable retry context:
+
+```json
+{
+  "success": false,
+  "error": "Note changed on disk during a guarded write; newer bytes were preserved. Retry the command.",
+  "code": 2,
+  "data": {
+    "reason": "note-modified-concurrently",
+    "retryable": true,
+    "path": "Ideas/My Note.md",
+    "attempts": 3
+  }
+}
+```
+
+This coordination covers Bowerbird edit, fork, and adoption processes. The
+raw-byte check also detects an external editor change that lands before the
+guarded comparison, but Bowerbird cannot lock unrelated editors; retry if an
+external writer remains active.
+
 ### Edit and Open
 
 ```bash
@@ -105,4 +136,5 @@ When multiple notes match your query:
 
 - [bwrb list](/reference/commands/list/) — Find or open notes without editing
 - [bwrb bulk](/reference/commands/bulk/) — Batch frontmatter changes
+- [bwrb lineage](/reference/commands/lineage/) — Guarded document provenance
 - [Targeting Model](/reference/targeting/) — Selector reference

--- a/docs-site/src/content/docs/reference/commands/edit.md
+++ b/docs-site/src/content/docs/reference/commands/edit.md
@@ -65,13 +65,14 @@ bwrb edit -t task --where "status == 'active'" "Deploy" --json '{"priority":"hig
 
 The final edit commit shares the note's lineage mutation lock with `new --fork`
 and `lineage adopt`. Bowerbird compares the note's exact raw bytes after taking
-the lock. A JSON patch that became stale is replayed against the latest note up
-to three times, so a concurrent `id` backfill or `forked-from` edge is preserved.
+the lock. A JSON patch that became stale is retried against the latest note for
+up to three total attempts, so a concurrent `id` backfill or `forked-from` edge
+is preserved.
 Interactive answers are never replayed against unseen values; the command asks
 you to retry instead.
 
-If all JSON retries become stale, JSON output uses numeric exit code `2` and
-stable retry context:
+If all three JSON attempts become stale, JSON output uses numeric exit code `2`
+and stable retry context:
 
 ```json
 {

--- a/docs-site/src/content/docs/reference/commands/lineage.md
+++ b/docs-site/src/content/docs/reference/commands/lineage.md
@@ -52,14 +52,20 @@ ID, execute mode assigns a fresh UUID and records it in `.bwrb/ids.jsonl` as
 part of the guarded operation. Parent and child paths are locked together, the
 notes and graph are re-read under those locks, and ID assignment shares the
 same lock used by `new --fork`. Concurrent fork, non-force delete, and adoption
-operations therefore serialize on every path they share.
+operations therefore serialize on every path they share. Ordinary `bwrb edit`
+now joins those path locks for its short commit phase and replays a stale JSON
+patch from fresh bytes, preventing an edit from erasing a newly assigned ID or
+provenance edge.
 
 Only the missing `id` fields and the child's new `forked-from` field may change.
 The writer inserts plain scalars without reserializing YAML, and verifies that
 the parsed bodies and all ordinary frontmatter remain unchanged. Filenames,
 aliases, provider metadata, bodies, and other frontmatter are not rewritten.
 If the two-note write or registry update fails, changed note bytes are rolled
-back before the command reports failure.
+back before the command reports failure. Rollback restores a note only when it
+still contains adoption's own write; bytes from a newer writer are left intact.
+A pre-write byte conflict is retryable and uses numeric JSON `code: 2` with
+`data.reason: "note-modified-concurrently"`.
 
 ## Examples
 

--- a/docs-site/src/content/docs/reference/commands/new.md
+++ b/docs-site/src/content/docs/reference/commands/new.md
@@ -182,7 +182,11 @@ bwrb new --fork "Launch Brief" --label alternate --output json
 Targets are exact: bwrb never substitutes a fuzzy near-match. Duplicate names
 or aliases must be disambiguated with a path or UUID. A legacy source without an
 `id` receives one before the fork is written; an invalid existing ID is rejected
-without modification.
+without modification. Source-ID backfill and ordinary `bwrb edit` commits share
+a path lock and compare their authoritative raw-byte snapshots before writing,
+so a stale writer cannot erase the other operation. A detected conflict is
+retryable; JSON uses `data.reason: "note-modified-concurrently"` and numeric
+`code: 2`.
 
 The child copies the source body and frontmatter, then:
 

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -223,6 +223,13 @@ plus the child's `forked-from`. A successful JSON result has `mode`, `child`,
 `body_invariance.*.unchanged` values to be `true`. IDs shown as generated in a
 dry run are provisional until execute revalidates under locks.
 
+Fork, adoption, and ordinary edit commits share path locks. If a guarded
+identity/provenance write observes changed raw bytes, JSON reports numeric
+`code: 2` with `data.reason: "note-modified-concurrently"`,
+`data.retryable: true`, `data.path`, and `data.attempts`. Re-resolve and retry;
+never work around the conflict by attempting to set `id` or `forked-from`
+through ordinary edit.
+
 Deleting a document with direct fork children refuses unless `--force` is
 supplied. With `--force`, bwrb deletes only the selected document: children keep
 their `forked-from` value, which surfaces as `dangling-forked-from` in
@@ -392,6 +399,7 @@ bwrb edit --type task --where "status == 'active'" "Deploy" --json '{"status": "
 Notes:
 - If multiple notes share the same name, `bwrb edit` errors and lists candidates. Disambiguate with `--type`, `--path`, or a vault-relative path.
 - `bwrb new --json` rejects unknown frontmatter fields after merging template defaults. `bwrb edit --json` rejects unknown fields in the patch.
+- Edit commits coordinate with fork/adopt lineage writes. JSON patches replay from fresh bytes up to three times; on exhaustion, retry only when JSON has numeric `code: 2`, `data.reason: "note-modified-concurrently"`, and `data.retryable: true`. Interactive edits do not replay answers gathered from stale values.
 
 ### Deleting Notes
 

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -399,7 +399,7 @@ bwrb edit --type task --where "status == 'active'" "Deploy" --json '{"status": "
 Notes:
 - If multiple notes share the same name, `bwrb edit` errors and lists candidates. Disambiguate with `--type`, `--path`, or a vault-relative path.
 - `bwrb new --json` rejects unknown frontmatter fields after merging template defaults. `bwrb edit --json` rejects unknown fields in the patch.
-- Edit commits coordinate with fork/adopt lineage writes. JSON patches replay from fresh bytes up to three times; on exhaustion, retry only when JSON has numeric `code: 2`, `data.reason: "note-modified-concurrently"`, and `data.retryable: true`. Interactive edits do not replay answers gathered from stale values.
+- Edit commits coordinate with fork/adopt lineage writes. JSON patches make up to three total attempts (the initial attempt plus at most two retries) from fresh bytes; on exhaustion, retry only when JSON has numeric `code: 2`, `data.reason: "note-modified-concurrently"`, and `data.retryable: true`. Interactive edits do not replay answers gathered from stale values.
 
 ### Deleting Notes
 

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -26,7 +26,8 @@ import {
   type OpenResultData,
 } from './open.js';
 import { resolveTargets, hasAnyTargeting, type TargetingOptions } from '../lib/targeting.js';
-import { UserCancelledError } from '../lib/errors.js';
+import { ConcurrentNoteModificationError, UserCancelledError } from '../lib/errors.js';
+import { concurrentModificationData } from '../lib/note-write-concurrency.js';
 import type { ResolvedConfig } from '../types/schema.js';
 
 // ============================================================================
@@ -163,6 +164,7 @@ Precedence (for --open app mode):
     // rather than silently falling back to the default app.
     const appModeInput = options.app ?? mode;
     let jsonMode = patchMode;
+    let resolvedVaultDir: string | undefined;
     try {
       const globalOpts = getGlobalOpts(cmd);
       jsonMode = resolveEditJsonMode(options, globalOpts.output);
@@ -179,6 +181,7 @@ Precedence (for --open app mode):
       const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
+      resolvedVaultDir = vaultDir;
       const schema = await loadSchema(vaultDir);
 
       if (globalOpts.nonInteractive && !patchMode) {
@@ -374,6 +377,17 @@ Precedence (for --open app mode):
         return;
       }
     } catch (err) {
+      if (err instanceof ConcurrentNoteModificationError) {
+        if (jsonMode) {
+          printJson(jsonError(err.message, {
+            code: ExitCodes.IO_ERROR,
+            data: concurrentModificationData(resolvedVaultDir ?? process.cwd(), err),
+          }));
+          process.exit(ExitCodes.IO_ERROR);
+        }
+        printError(err.message);
+        process.exit(ExitCodes.IO_ERROR);
+      }
       if (err instanceof UserCancelledError) {
         if (jsonMode) {
           printJson(jsonError('Cancelled', { code: ExitCodes.VALIDATION_ERROR }));

--- a/src/commands/lineage/adopt.ts
+++ b/src/commands/lineage/adopt.ts
@@ -23,6 +23,10 @@ import {
   getLineageMutationLockPath,
   withLineageMutationLocks,
 } from '../../lib/lineage-lock.js';
+import {
+  assertNoteBytesUnchanged,
+  rollbackNoteIfUnchanged,
+} from '../../lib/note-write-concurrency.js';
 
 export type LineageAdoptMode = 'dry-run' | 'execute';
 
@@ -266,21 +270,43 @@ async function applyPreparedAdoption(
   let childWritten = false;
   try {
     if (prepared.parentNextRaw !== prepared.parentOriginal.raw) {
+      await assertNoteBytesUnchanged(
+        prepared.parent.file.path,
+        prepared.parentOriginal.raw
+      );
       await writeFileAtomic(prepared.parent.file.path, prepared.parentNextRaw);
       parentWritten = true;
     }
+    await assertNoteBytesUnchanged(
+      prepared.child.file.path,
+      prepared.childOriginal.raw
+    );
     await writeFileAtomic(prepared.child.file.path, prepared.childNextRaw);
     childWritten = true;
     await registerIds(vaultDir, prepared.registrations);
   } catch (error) {
     const rollbackErrors: string[] = [];
     if (childWritten) {
-      await writeFileAtomic(prepared.child.file.path, prepared.childOriginal.raw)
-        .catch(rollbackError => rollbackErrors.push(formatError(rollbackError)));
+      await rollbackNoteIfUnchanged(
+        prepared.child.file.path,
+        prepared.childNextRaw,
+        prepared.childOriginal.raw
+      ).then(rolledBack => {
+        if (!rolledBack) {
+          rollbackErrors.push(`${prepared.child.file.relativePath} changed again; newer bytes left as-is`);
+        }
+      }).catch(rollbackError => rollbackErrors.push(formatError(rollbackError)));
     }
     if (parentWritten) {
-      await writeFileAtomic(prepared.parent.file.path, prepared.parentOriginal.raw)
-        .catch(rollbackError => rollbackErrors.push(formatError(rollbackError)));
+      await rollbackNoteIfUnchanged(
+        prepared.parent.file.path,
+        prepared.parentNextRaw,
+        prepared.parentOriginal.raw
+      ).then(rolledBack => {
+        if (!rolledBack) {
+          rollbackErrors.push(`${prepared.parent.file.relativePath} changed again; newer bytes left as-is`);
+        }
+      }).catch(rollbackError => rollbackErrors.push(formatError(rollbackError)));
     }
     if (rollbackErrors.length > 0) {
       throw new Error(

--- a/src/commands/lineage/index.ts
+++ b/src/commands/lineage/index.ts
@@ -5,6 +5,8 @@ import { getGlobalOpts } from '../../lib/command.js';
 import { ExitCodes, jsonError, printJson } from '../../lib/output.js';
 import { printError, printInfo, printSuccess } from '../../lib/prompt.js';
 import { adoptLineage } from './adopt.js';
+import { ConcurrentNoteModificationError } from '../../lib/errors.js';
+import { concurrentModificationData } from '../../lib/note-write-concurrency.js';
 
 interface AdoptCommandOptions {
   from?: string;
@@ -27,6 +29,7 @@ Examples:
 `)
   .action(async (child: string, options: AdoptCommandOptions, command: Command) => {
     const jsonMode = options.output === 'json';
+    let resolvedVaultDir: string | undefined;
     try {
       if (options.output !== 'text' && options.output !== 'json') {
         throw new Error('--output must be text or json.');
@@ -44,6 +47,7 @@ Examples:
         allowFindDown: true,
         jsonMode,
       });
+      resolvedVaultDir = vaultDir;
       const schema = await loadSchema(vaultDir);
       const result = await adoptLineage(schema, vaultDir, {
         child,
@@ -73,6 +77,18 @@ Examples:
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      if (error instanceof ConcurrentNoteModificationError) {
+        if (jsonMode) {
+          printJson(jsonError(message, {
+            code: ExitCodes.IO_ERROR,
+            data: concurrentModificationData(resolvedVaultDir ?? process.cwd(), error),
+          }));
+        } else {
+          printError(message);
+        }
+        process.exitCode = ExitCodes.IO_ERROR;
+        return;
+      }
       if (jsonMode) {
         printJson(jsonError(message, { code: ExitCodes.VALIDATION_ERROR }));
       } else {

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -23,7 +23,8 @@ import {
   type InheritedTemplateResolution,
 } from '../lib/template.js';
 import type { LoadedSchema, Template } from '../types/schema.js';
-import { UserCancelledError } from '../lib/errors.js';
+import { ConcurrentNoteModificationError, UserCancelledError } from '../lib/errors.js';
+import { concurrentModificationData } from '../lib/note-write-concurrency.js';
 import { createNoteFromJson } from './new/json-mode.js';
 import { resolveTypePath } from './new/type-selection.js';
 import { createNoteInteractive } from './new/interactive.js';
@@ -93,6 +94,7 @@ Template management:
     const forkJsonMode = forkMode && options.output === 'json';
     const jsonMode = options.json !== undefined || forkJsonMode;
     const typePath = options.type ?? positionalType;
+    let resolvedVaultDir: string | undefined;
 
     try {
       const globalOpts = getGlobalOpts(cmd);
@@ -103,6 +105,7 @@ Template management:
       const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
+      resolvedVaultDir = vaultDir;
       const schema = await loadSchema(vaultDir);
 
       validateForkOptions(positionalType, options);
@@ -240,6 +243,17 @@ Template management:
         await openNote(vaultDir, filePath, resolveAppMode(undefined, schema.config), schema.config, false);
       }
     } catch (err) {
+      if (err instanceof ConcurrentNoteModificationError) {
+        if (jsonMode) {
+          printJson(jsonError(err.message, {
+            code: ExitCodes.IO_ERROR,
+            data: concurrentModificationData(resolvedVaultDir ?? process.cwd(), err),
+          }));
+          process.exit(ExitCodes.IO_ERROR);
+        }
+        printError(err.message);
+        process.exit(ExitCodes.IO_ERROR);
+      }
       if (err instanceof JsonCommandError) {
         if (!err.result.success) {
           err.result.code = err.exitCode;

--- a/src/commands/new/fork.ts
+++ b/src/commands/new/fork.ts
@@ -28,6 +28,10 @@ import { promptInput } from '../../lib/prompt.js';
 import { UserCancelledError } from '../../lib/errors.js';
 import { resolveExactNoteTarget } from '../../lib/exact-note-target.js';
 import { withLineageMutationLocks } from '../../lib/lineage-lock.js';
+import {
+  assertNoteBytesUnchanged,
+  rollbackNoteIfUnchanged,
+} from '../../lib/note-write-concurrency.js';
 
 const PORTABLE_PATH_WARNING_LENGTH = 200;
 const PORTABLE_PATH_MAX_LENGTH = 260;
@@ -209,15 +213,26 @@ async function ensureSourceId(
       throw new Error('Generated source ID collides with an existing note; retry the command.');
     }
     const nextRaw = insertFrontmatterScalarPreservingBytes(parsed.raw, 'id', id);
+    await assertNoteBytesUnchanged(sourcePath, parsed.raw);
     await writeFileAtomic(sourcePath, nextRaw);
     try {
       await registerIssuedNoteId(vaultDir, id, sourcePath);
     } catch (error) {
-      await writeFileAtomic(sourcePath, parsed.raw);
+      const rolledBack = await rollbackNoteIfUnchanged(sourcePath, nextRaw, parsed.raw);
+      if (!rolledBack) {
+        throw new Error(
+          `Source ID registration failed (${formatError(error)}) and rollback was skipped because ` +
+          'the source changed again; newer bytes were preserved.'
+        );
+      }
       throw error;
     }
     return id;
   });
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 async function assertSourceIdUnique(

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -47,7 +47,8 @@ import {
 } from '../lib/fuzzy-search.js';
 import { parseNote } from '../lib/frontmatter.js';
 import { applyWhereExpressions } from '../lib/where-targeting.js';
-import { UserCancelledError } from '../lib/errors.js';
+import { ConcurrentNoteModificationError, UserCancelledError } from '../lib/errors.js';
+import { concurrentModificationData } from '../lib/note-write-concurrency.js';
 import { resolveTargets, type TargetingOptions } from '../lib/targeting.js';
 
 // ============================================================================
@@ -311,6 +312,7 @@ export async function runSearchCommand(
     // Resolve output format from deprecated flags and new --output option
     const outputFormat = resolveSearchOutputFormat(options);
     const jsonMode = outputFormat === 'json';
+    let resolvedVaultDir: string | undefined;
 
     // App-mode precedence: an explicit --app flag wins over the positional
     // [mode] (the convenience form). Fold the resolved value back into
@@ -387,6 +389,7 @@ export async function runSearchCommand(
       const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode };
       if (globalOpts.vault) vaultOptions.vault = globalOpts.vault;
       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
+      resolvedVaultDir = vaultDir;
       const schema = await loadSchema(vaultDir);
 
       if (globalOpts.nonInteractive && options.edit && !options.json) {
@@ -408,6 +411,17 @@ export async function runSearchCommand(
         await handleNameSearch(query, effectiveOptions, vaultDir, schema, jsonMode, outputFormat);
       }
     } catch (err) {
+      if (err instanceof ConcurrentNoteModificationError) {
+        if (jsonMode) {
+          printJson(jsonError(err.message, {
+            code: ExitCodes.IO_ERROR,
+            data: concurrentModificationData(resolvedVaultDir ?? process.cwd(), err),
+          }));
+          process.exit(ExitCodes.IO_ERROR);
+        }
+        printError(err.message);
+        process.exit(ExitCodes.IO_ERROR);
+      }
       if (err instanceof UserCancelledError) {
         if (jsonMode) {
           printJson(jsonError('Cancelled', { code: ExitCodes.VALIDATION_ERROR }));

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -486,6 +486,7 @@ export async function editNoteInteractive(
 
 /** File handshake used only by cross-process race tests. */
 async function waitForEditCommitBarrier(attempt: number, filePath: string): Promise<void> {
+  if (process.env.BWRB_TEST_EDIT_BARRIER_ENABLED !== '1') return;
   const barrierDir = process.env.BWRB_TEST_EDIT_BARRIER_DIR;
   if (!barrierDir) return;
 

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -6,7 +6,8 @@
  * - `search --edit` (unified interface)
  */
 
-import { relative } from 'path';
+import { access, mkdir, writeFile } from 'fs/promises';
+import { join, relative } from 'path';
 import {
   getTypeDefByPath,
   resolveTypePathFromFrontmatter,
@@ -43,11 +44,13 @@ import {
   ExitCodes,
 } from './output.js';
 import { type LoadedSchema, type Field, type BodySection, getOptionValues } from '../types/schema.js';
-import { UserCancelledError } from './errors.js';
+import { ConcurrentNoteModificationError, UserCancelledError } from './errors.js';
 import { expandStaticValue } from './local-date.js';
 import { prepareRecurrenceFastPath, commitRecurrenceFastPath } from './recurrence-fast-path.js';
 import { validateRelativeDateCalendarOffsetsForWrite } from './relative-date.js';
 import { isBwrbReservedFrontmatterField } from './frontmatter/systemFields.js';
+import { withLineageMutationLocks } from './lineage-lock.js';
+import { assertNoteBytesUnchanged } from './note-write-concurrency.js';
 
 // ============================================================================
 // Types
@@ -66,7 +69,11 @@ export interface EditFromJsonOptions {
 export interface EditInteractiveOptions {
   /** Whether to check for missing body sections */
   checkSections?: boolean;
+  /** Internal dependency hook for deterministic commit-race tests. */
+  beforeCommit?: () => Promise<void>;
 }
+
+const JSON_EDIT_ATTEMPTS = 3;
 
 // ============================================================================
 // JSON Edit Mode (Non-Interactive)
@@ -117,8 +124,41 @@ export async function editNoteFromJson(
     throw new Error(error);
   }
 
+  for (let attempt = 1; attempt <= JSON_EDIT_ATTEMPTS; attempt++) {
+    try {
+      return await editNoteFromJsonAttempt(
+        schema,
+        vaultDir,
+        filePath,
+        patchData,
+        jsonMode,
+        attempt
+      );
+    } catch (error) {
+      if (
+        error instanceof ConcurrentNoteModificationError &&
+        attempt < JSON_EDIT_ATTEMPTS
+      ) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new ConcurrentNoteModificationError(filePath, JSON_EDIT_ATTEMPTS);
+}
+
+async function editNoteFromJsonAttempt(
+  schema: LoadedSchema,
+  vaultDir: string,
+  filePath: string,
+  patchData: Record<string, unknown>,
+  jsonMode: boolean,
+  attempt: number
+): Promise<EditResult> {
+
   // Parse existing note
-  const { frontmatter, body } = await parseNote(filePath);
+  const { frontmatter, body, raw } = await parseNote(filePath);
 
   // Resolve type path from existing frontmatter
   const typePath = resolveTypePathFromFrontmatter(schema, frontmatter);
@@ -308,27 +348,25 @@ export async function editNoteFromJson(
   const fieldOrder = getFrontmatterOrder(typeDef);
   const orderedFields = fieldOrder.length > 0 ? fieldOrder : Object.keys(resolvedFrontmatter);
 
-  // Recurrence fast path (atomicity, #107): VALIDATE + COMPUTE the successor
-  // BEFORE mutating the predecessor. If this completion would spawn a successor
-  // but the spawn can't succeed (missing template, partial/unparseable offset
-  // base), prepare throws here and we abort WITHOUT writing the predecessor —
-  // never leaving it `done` with no successor.
-  const fastPathPlan = await prepareRecurrenceFastPath(
-    schema,
-    vaultDir,
-    typeDef.name,
-    filePath,
-    frontmatter,
-    resolvedFrontmatter,
-    body
-  );
+  await waitForEditCommitBarrier(attempt, filePath);
 
-  // Write updated note (predecessor status change is now safe to commit).
-  await writeNote(filePath, resolvedFrontmatter, body, orderedFields);
+  await withLineageMutationLocks(vaultDir, [filePath], async () => {
+    await assertNoteBytesUnchanged(filePath, raw, attempt);
 
-  // Commit the prepared spawn (create successor + back-link `next`). Identical
-  // result to the audit backstop, which shares the same engine.
-  await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+    // Recurrence prepare, predecessor write, and successor/back-link commit are
+    // one guarded commit phase. A retry always re-prepares from fresh bytes.
+    const fastPathPlan = await prepareRecurrenceFastPath(
+      schema,
+      vaultDir,
+      typeDef.name,
+      filePath,
+      frontmatter,
+      resolvedFrontmatter,
+      body
+    );
+    await writeNote(filePath, resolvedFrontmatter, body, orderedFields);
+    await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+  });
 
   return { updatedFields, path: filePath };
 }
@@ -351,9 +389,9 @@ export async function editNoteInteractive(
   filePath: string,
   options: EditInteractiveOptions = {}
 ): Promise<void> {
-  const { checkSections = true } = options;
+  const { checkSections = true, beforeCommit } = options;
   
-  const { frontmatter, body } = await parseNote(filePath);
+  const { frontmatter, body, raw } = await parseNote(filePath);
   const fileName = filePath.split('/').pop() ?? filePath;
 
   printInfo(`\n=== Editing: ${fileName} ===`);
@@ -421,25 +459,22 @@ export async function editNoteInteractive(
     }
   }
 
-  // Recurrence fast path (atomicity, #107): VALIDATE + COMPUTE before mutating
-  // the predecessor (see editNoteFromJson). Interactive edit reconstructs the
-  // full frontmatter, so `frontmatter` (read at the top) is the old state.
-  const fastPathPlan = await prepareRecurrenceFastPath(
-    schema,
-    vaultDir,
-    typeDef.name,
-    filePath,
-    frontmatter,
-    newFrontmatter,
-    updatedBody
-  );
-
-  // Write updated file (predecessor change is now safe to commit).
-  await writeNote(filePath, newFrontmatter, updatedBody, orderedFields);
+  await beforeCommit?.();
+  const fastPath = await withLineageMutationLocks(vaultDir, [filePath], async () => {
+    await assertNoteBytesUnchanged(filePath, raw);
+    const fastPathPlan = await prepareRecurrenceFastPath(
+      schema,
+      vaultDir,
+      typeDef.name,
+      filePath,
+      frontmatter,
+      newFrontmatter,
+      updatedBody
+    );
+    await writeNote(filePath, newFrontmatter, updatedBody, orderedFields);
+    return commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+  });
   printSuccess(`\n✓ Updated: ${filePath}`);
-
-  // Commit the prepared spawn.
-  const fastPath = await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
   if (fastPath.successorPath) {
     printSuccess(`✓ Spawned recurrence successor: ${fastPath.successorPath}`);
   }
@@ -448,6 +483,28 @@ export async function editNoteInteractive(
 // ============================================================================
 // Helpers
 // ============================================================================
+
+/** File handshake used only by cross-process race tests. */
+async function waitForEditCommitBarrier(attempt: number, filePath: string): Promise<void> {
+  const barrierDir = process.env.BWRB_TEST_EDIT_BARRIER_DIR;
+  if (!barrierDir) return;
+
+  await mkdir(barrierDir, { recursive: true });
+  const readyPath = join(barrierDir, `edit-read-${attempt}.ready`);
+  const commitPath = join(barrierDir, `edit-commit-${attempt}.go`);
+  await writeFile(readyPath, `${filePath}\n`, 'utf-8');
+
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    try {
+      await access(commitPath);
+      return;
+    } catch {
+      await new Promise(resolve => setTimeout(resolve, 5));
+    }
+  }
+  throw new Error(`Timed out waiting for edit test barrier: ${commitPath}`);
+}
 
 function mergeFrontmatter(
   existing: Record<string, unknown>,

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -21,3 +21,20 @@ export class UserCancelledError extends Error {
     this.name = 'UserCancelledError';
   }
 }
+
+/**
+ * A note changed after a command's authoritative read but before its guarded
+ * write. Callers must retry from a fresh snapshot rather than overwriting the
+ * newer bytes.
+ */
+export class ConcurrentNoteModificationError extends Error {
+  readonly path: string;
+  readonly attempts: number;
+
+  constructor(path: string, attempts = 1) {
+    super('Note changed on disk during a guarded write; newer bytes were preserved. Retry the command.');
+    this.name = 'ConcurrentNoteModificationError';
+    this.path = path;
+    this.attempts = attempts;
+  }
+}

--- a/src/lib/note-write-concurrency.ts
+++ b/src/lib/note-write-concurrency.ts
@@ -1,0 +1,44 @@
+import { readFile } from 'fs/promises';
+import { relative } from 'path';
+import { ConcurrentNoteModificationError } from './errors.js';
+import { writeFileAtomic } from './frontmatter.js';
+
+/** Assert that a note still has the exact bytes used to prepare a mutation. */
+export async function assertNoteBytesUnchanged(
+  filePath: string,
+  expectedRaw: string,
+  attempts = 1
+): Promise<void> {
+  const currentRaw = await readFile(filePath, 'utf-8');
+  if (currentRaw !== expectedRaw) {
+    throw new ConcurrentNoteModificationError(filePath, attempts);
+  }
+}
+
+/**
+ * Restore a prior snapshot only when the file still contains this command's
+ * own write. A newer writer always wins; rollback must never erase it.
+ */
+export async function rollbackNoteIfUnchanged(
+  filePath: string,
+  writtenRaw: string,
+  originalRaw: string
+): Promise<boolean> {
+  const currentRaw = await readFile(filePath, 'utf-8');
+  if (currentRaw !== writtenRaw) return false;
+  await writeFileAtomic(filePath, originalRaw);
+  return true;
+}
+
+/** Stable agent-facing details shared by every guarded note writer. */
+export function concurrentModificationData(
+  vaultDir: string,
+  error: ConcurrentNoteModificationError
+): { reason: string; retryable: true; path: string; attempts: number } {
+  return {
+    reason: 'note-modified-concurrently',
+    retryable: true,
+    path: relative(vaultDir, error.path).replace(/\\/g, '/'),
+    attempts: error.attempts,
+  };
+}

--- a/tests/ts/commands/edit-lineage-concurrency.test.ts
+++ b/tests/ts/commands/edit-lineage-concurrency.test.ts
@@ -1,0 +1,260 @@
+import { spawn } from 'child_process';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  CLI_PATH,
+  PROJECT_ROOT,
+  cleanupTestVault,
+  createTestVault,
+  runCLI,
+  waitForFile,
+  withTestCliNodeOptions,
+} from '../fixtures/setup.js';
+import { insertFrontmatterScalarPreservingBytes, parseNote } from '../../../src/lib/frontmatter.js';
+import { loadSchema } from '../../../src/lib/schema.js';
+import { editNoteInteractive } from '../../../src/lib/edit.js';
+import { ConcurrentNoteModificationError } from '../../../src/lib/errors.js';
+
+const CLI_SRC_PATH = join(PROJECT_ROOT, 'src/index.ts');
+const TSX_CLI = join(PROJECT_ROOT, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+const USE_DIST = process.env.BWRB_TEST_DIST === '1';
+const CHILD_ID = '11111111-1111-4111-8111-111111111111';
+const PARENT_ID = '22222222-2222-4222-8222-222222222222';
+
+interface RunningCli {
+  completion: Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  kill: () => void;
+}
+
+function spawnCli(args: string[], cwd: string, barrierDir: string): RunningCli {
+  const command = process.execPath;
+  const cliArgs = USE_DIST
+    ? [CLI_PATH, '--vault', cwd, ...args]
+    : [TSX_CLI, CLI_SRC_PATH, '--vault', cwd, ...args];
+  const child = spawn(command, cliArgs, {
+    cwd,
+    env: withTestCliNodeOptions({
+      ...process.env,
+      NO_COLOR: '1',
+      BWRB_TEST_EDIT_BARRIER_DIR: barrierDir,
+    }, { useDist: USE_DIST }),
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const completion = new Promise<{ stdout: string; stderr: string; exitCode: number }>(
+    (resolve, reject) => {
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', chunk => { stdout += chunk.toString(); });
+      child.stderr.on('data', chunk => { stderr += chunk.toString(); });
+      child.on('error', reject);
+      child.on('close', code => resolve({
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        exitCode: code ?? 0,
+      }));
+    }
+  );
+  return { completion, kill: () => child.kill('SIGKILL') };
+}
+
+async function releaseAttempt(barrierDir: string, attempt: number): Promise<void> {
+  await waitForFile(join(barrierDir, `edit-read-${attempt}.ready`), { timeoutMs: 10_000 });
+  await writeFile(join(barrierDir, `edit-commit-${attempt}.go`), 'go\n');
+}
+
+describe('edit versus lineage identity writes', () => {
+  let vaultDir: string;
+  const running: RunningCli[] = [];
+
+  beforeEach(async () => {
+    vaultDir = await createTestVault();
+  });
+
+  afterEach(async () => {
+    for (const process of running) process.kill();
+    await cleanupTestVault(vaultDir);
+  });
+
+  it('replays a JSON edit after new --fork backfills the source ID', async () => {
+    const sourcePath = join(vaultDir, 'Ideas/Fork Race Source.md');
+    const sourceRaw = '\uFEFF---\r\ntype: "idea" # quoted\r\nstatus: raw\r\npriority: medium\r\nprovider: { remote: keep-me }\r\n---\r\nBody bytes.\r\n';
+    await writeFile(sourcePath, sourceRaw);
+    const barrierDir = join(vaultDir, '.barrier-fork');
+    const edit = spawnCli([
+      'edit', sourcePath, '--json', '{"priority":"high"}', '--output', 'json',
+    ], vaultDir, barrierDir);
+    running.push(edit);
+
+    await waitForFile(join(barrierDir, 'edit-read-1.ready'), { timeoutMs: 10_000 });
+    const fork = await runCLI([
+      'new', '--fork', sourcePath, '--name', 'Fork Race Child', '--output', 'json',
+    ], vaultDir);
+    expect(fork.exitCode, fork.stderr || fork.stdout).toBe(0);
+    const forkJson = JSON.parse(fork.stdout) as { id: string; forked_from: string; path: string };
+    await writeFile(join(barrierDir, 'edit-commit-1.go'), 'go\n');
+    await releaseAttempt(barrierDir, 2);
+
+    const edited = await edit.completion;
+    expect(edited.exitCode, edited.stderr || edited.stdout).toBe(0);
+    expect(JSON.parse(edited.stdout)).toMatchObject({ success: true, updated: ['priority'] });
+    const source = await parseNote(sourcePath);
+    expect(source.frontmatter).toMatchObject({
+      id: forkJson.forked_from,
+      priority: 'high',
+      provider: { remote: 'keep-me' },
+    });
+    expect(source.body).toBe('Body bytes.\r\n');
+    expect((await parseNote(join(vaultDir, forkJson.path))).frontmatter['forked-from'])
+      .toBe(forkJson.forked_from);
+
+    const expectedPath = join(vaultDir, 'Ideas/Fork Race Expected.md');
+    await writeFile(
+      expectedPath,
+      insertFrontmatterScalarPreservingBytes(sourceRaw, 'id', forkJson.forked_from)
+    );
+    const sequential = await runCLI([
+      'edit', expectedPath, '--json', '{"priority":"high"}', '--output', 'json',
+    ], vaultDir);
+    expect(sequential.exitCode, sequential.stderr || sequential.stdout).toBe(0);
+    expect(await readFile(sourcePath, 'utf-8')).toBe(await readFile(expectedPath, 'utf-8'));
+  });
+
+  it('replays a JSON edit after lineage adopt writes immutable provenance', async () => {
+    const childPath = join(vaultDir, 'Ideas/Adopt Race Child.md');
+    const parentPath = join(vaultDir, 'Ideas/Adopt Race Parent.md');
+    const childRaw = `---\ntype: idea\nid: ${CHILD_ID}\nstatus: raw\npriority: medium\nprovider: { remote: child }\n---\nChild body.\n`;
+    const parentRaw = `---\ntype: idea\nid: ${PARENT_ID}\nstatus: raw\npriority: medium\n---\nParent body.\n`;
+    await writeFile(childPath, childRaw);
+    await writeFile(parentPath, parentRaw);
+    const barrierDir = join(vaultDir, '.barrier-adopt');
+    const edit = spawnCli([
+      'edit', childPath, '--json', '{"priority":"high"}', '--output', 'json',
+    ], vaultDir, barrierDir);
+    running.push(edit);
+
+    await waitForFile(join(barrierDir, 'edit-read-1.ready'), { timeoutMs: 10_000 });
+    const adopted = await runCLI([
+      'lineage', 'adopt', childPath, '--from', parentPath, '--execute', '--output', 'json',
+    ], vaultDir);
+    expect(adopted.exitCode, adopted.stderr || adopted.stdout).toBe(0);
+    await writeFile(join(barrierDir, 'edit-commit-1.go'), 'go\n');
+    await releaseAttempt(barrierDir, 2);
+
+    const edited = await edit.completion;
+    expect(edited.exitCode, edited.stderr || edited.stdout).toBe(0);
+    const child = await parseNote(childPath);
+    expect(child.frontmatter).toMatchObject({
+      id: CHILD_ID,
+      'forked-from': PARENT_ID,
+      priority: 'high',
+      provider: { remote: 'child' },
+    });
+    expect(child.body).toBe('Child body.\n');
+
+    const expectedPath = join(vaultDir, 'Ideas/Adopt Race Expected.md');
+    await writeFile(
+      expectedPath,
+      insertFrontmatterScalarPreservingBytes(childRaw, 'forked-from', PARENT_ID)
+    );
+    const sequential = await runCLI([
+      'edit', expectedPath, '--json', '{"priority":"high"}', '--output', 'json',
+    ], vaultDir);
+    expect(sequential.exitCode, sequential.stderr || sequential.stdout).toBe(0);
+    expect(await readFile(childPath, 'utf-8')).toBe(await readFile(expectedPath, 'utf-8'));
+  });
+
+  it.each(['json', 'text'] as const)(
+    'preserves the newest bytes and emits a stable retryable %s error after retry exhaustion',
+    async (output) => {
+      const notePath = join(vaultDir, `Ideas/Retry Exhaustion ${output}.md`);
+      let currentRaw = '---\ntype: idea\nstatus: raw\npriority: medium\n---\nOriginal body.\n';
+      await writeFile(notePath, currentRaw);
+      const barrierDir = join(vaultDir, `.barrier-${output}`);
+      const edit = spawnCli([
+        'edit', notePath, '--json', '{"priority":"high"}', '--output', output,
+      ], vaultDir, barrierDir);
+      running.push(edit);
+
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        await waitForFile(join(barrierDir, `edit-read-${attempt}.ready`), { timeoutMs: 10_000 });
+        currentRaw = currentRaw.replace('Original body.', `Original body. external-${attempt}`);
+        await writeFile(notePath, currentRaw);
+        await writeFile(join(barrierDir, `edit-commit-${attempt}.go`), 'go\n');
+      }
+
+      const result = await edit.completion;
+      expect(result.exitCode).toBe(2);
+      expect(await readFile(notePath, 'utf-8')).toBe(currentRaw);
+      if (output === 'json') {
+        expect(JSON.parse(result.stdout)).toEqual({
+          success: false,
+          error: 'Note changed on disk during a guarded write; newer bytes were preserved. Retry the command.',
+          code: 2,
+          data: {
+            reason: 'note-modified-concurrently',
+            retryable: true,
+            path: `Ideas/Retry Exhaustion ${output}.md`,
+            attempts: 3,
+          },
+        });
+      } else {
+        expect(result.stdout).toBe('');
+        expect(result.stderr).toContain(
+          'Note changed on disk during a guarded write; newer bytes were preserved. Retry the command.'
+        );
+      }
+    }
+  );
+
+  it('does not replay interactive answers or write when its snapshot is stale', async () => {
+    const notePath = join(vaultDir, 'Ideas/Interactive Stale.md');
+    const originalRaw = '---\ntype: idea\nstatus: raw\n---\nOriginal body.\n';
+    const newerRaw = '---\ntype: idea\nid: 33333333-3333-4333-8333-333333333333\nstatus: raw\n---\nOriginal body.\n';
+    await writeFile(notePath, originalRaw);
+    const schema = await loadSchema(vaultDir);
+    const idea = schema.types.get('idea')!;
+    idea.fields = { type: { value: 'idea' } };
+    idea.fieldOrder = ['type'];
+
+    await expect(editNoteInteractive(schema, vaultDir, notePath, {
+      checkSections: false,
+      beforeCommit: async () => { await writeFile(notePath, newerRaw); },
+    })).rejects.toBeInstanceOf(ConcurrentNoteModificationError);
+    expect(await readFile(notePath, 'utf-8')).toBe(newerRaw);
+  });
+
+  it('maps stale search --edit JSON through the same numeric retryable contract', async () => {
+    const notePath = join(vaultDir, 'Ideas/Search Retry Exhaustion.md');
+    let currentRaw = '---\ntype: idea\nstatus: raw\npriority: medium\n---\nSearch body.\n';
+    await writeFile(notePath, currentRaw);
+    const barrierDir = join(vaultDir, '.barrier-search');
+    const edit = spawnCli([
+      'search', 'Search Retry Exhaustion', '--edit', '--json', '{"priority":"high"}',
+      '--output', 'json', '--picker', 'none',
+    ], vaultDir, barrierDir);
+    running.push(edit);
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      await waitForFile(join(barrierDir, `edit-read-${attempt}.ready`), { timeoutMs: 10_000 });
+      currentRaw = currentRaw.replace('Search body.', `Search body. external-${attempt}`);
+      await writeFile(notePath, currentRaw);
+      await writeFile(join(barrierDir, `edit-commit-${attempt}.go`), 'go\n');
+    }
+
+    const result = await edit.completion;
+    expect(result.exitCode).toBe(2);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      success: false,
+      code: 2,
+      data: {
+        reason: 'note-modified-concurrently',
+        retryable: true,
+        path: 'Ideas/Search Retry Exhaustion.md',
+        attempts: 3,
+      },
+    });
+    expect(await readFile(notePath, 'utf-8')).toBe(currentRaw);
+  });
+});

--- a/tests/ts/commands/edit-lineage-concurrency.test.ts
+++ b/tests/ts/commands/edit-lineage-concurrency.test.ts
@@ -37,6 +37,7 @@ function spawnCli(args: string[], cwd: string, barrierDir: string): RunningCli {
     env: withTestCliNodeOptions({
       ...process.env,
       NO_COLOR: '1',
+      BWRB_TEST_EDIT_BARRIER_ENABLED: '1',
       BWRB_TEST_EDIT_BARRIER_DIR: barrierDir,
     }, { useDist: USE_DIST }),
     stdio: ['ignore', 'pipe', 'pipe'],

--- a/tests/ts/commands/lineage-adopt.test.ts
+++ b/tests/ts/commands/lineage-adopt.test.ts
@@ -265,6 +265,36 @@ describe('lineage adopt', () => {
     expect(await readFile(registryPath, 'utf-8').catch(() => null)).toBe(registryBefore);
   });
 
+  it('never rolls adoption back over bytes written after its own child write', async () => {
+    const childPath = join(vaultDir, 'Ideas/Rollback Race Child.md');
+    const parentPath = join(vaultDir, 'Ideas/Rollback Race Parent.md');
+    const childRaw = noteRaw({ body: 'Original child bytes\n' });
+    const parentRaw = noteRaw({ body: 'Original parent bytes\n' });
+    const newerChildRaw = noteRaw({
+      id: C,
+      extra: 'provider: { newer: true }\n',
+      body: 'Newer child bytes\n',
+    });
+    await writeFile(childPath, childRaw);
+    await writeFile(parentPath, parentRaw);
+    const schema = await loadSchema(vaultDir);
+
+    await expect(adoptLineage(
+      schema,
+      vaultDir,
+      { child: 'Rollback Race Child', parent: 'Rollback Race Parent', execute: true },
+      {
+        registerIds: async () => {
+          await writeFile(childPath, newerChildRaw);
+          throw new Error('injected registry failure after a newer writer');
+        },
+      }
+    )).rejects.toThrow('newer bytes left as-is');
+
+    expect(await readFile(childPath, 'utf-8')).toBe(newerChildRaw);
+    expect(await readFile(parentPath, 'utf-8')).toBe(parentRaw);
+  });
+
   it('refuses cycles and ambiguous or missing exact targets', async () => {
     await writeFile(join(vaultDir, 'Ideas/Cycle Root.md'), noteRaw({ id: A }));
     await writeFile(join(vaultDir, 'Ideas/Cycle Child.md'), noteRaw({ id: B, parent: A }));


### PR DESCRIPTION
## Summary

- serialize the short edit commit phase with fork/adopt lineage path locks and compare exact raw bytes before writing
- replay stale JSON patches from fresh bytes for three total attempts (the initial attempt plus at most two retries); keep interactive answers fail-fast and retryable
- add identity/provenance pre-write assertions and compare-before-rollback guards so newer note bytes are never blindly restored over
- publish the stable numeric JSON error contract in reference docs, automation docs, the bundled agent skill, and changelogs

## Verification

- Node 22.21.1 / pnpm 10.11.0 full CI parity:
  - `pnpm build`
  - `pnpm verify:pack`
  - `pnpm typecheck`
  - `pnpm lint`
  - `pnpm knip`
  - `pnpm test -- --exclude='**/*.pty.test.ts'` (115 files; 3,037 passed; 3 skipped)
- Focused deterministic real-CLI races: edit vs missing-ID `new --fork`; edit vs `lineage adopt`; JSON/text retry exhaustion; search edit handler; interactive no-replay stale branch
- Existing focused suites: adoption 14/14, fork 22/22, edit/search 154/154
- Fresh independent tester (no implementation authorship): PASS across 593 focused/repeated assertions, including source and built-dist race repetitions
- Docs: `docs:check`, `schema:check`, `docs:lint`, `docs:doctor`, and `docs:build`
- Built `dist/index.js` disposable-vault race: adopt backfilled both IDs while edit was paused; edit replayed, lineage listed both notes, audit was clean, and both prose bodies remained present
- Final-head CI: Test (source and built dist), PTY Tests, Windows Lock Tests, Docs Relevance, Docs Site CI, Vercel, and Vercel Preview Comments all passed

## TaskSweep evidence

- Early plan, exact OpenRouter model `anthropic/claude-fable-5`:
  - `.task-sweep/logs/claude-fable-5-plan-prompt-20260710-121000-issue-820.md`
  - `.task-sweep/logs/claude-fable-5-plan-output-20260710-121000-issue-820.md`
  - `.task-sweep/logs/claude-fable-5-plan-20260710-121000-issue-820.log`
- Final review, same exact model, valid `finish_reason: stop`: **NO BLOCKERS**
  - `.task-sweep/logs/claude-fable-5-review-context-prompt-20260710-124500-issue-820.md`
  - `.task-sweep/logs/claude-fable-5-review-context-output-20260710-124500-issue-820.md`
  - `.task-sweep/logs/claude-fable-5-review-context-20260710-124500-issue-820.log`

Closes #820
