### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,21 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-07-10
+
+Patch release for guarded existing-note lineage adoption, safer concurrent
+lineage mutations, and CLI parity across creation, search, configuration, and
+shell completion.
+
 ### Added
 
-- **Existing-note lineage adoption** — `bwrb lineage adopt <child> --from <parent>` previews by default and requires `--execute` to attach one exact, same-type existing note under another. It safely backfills missing IDs, refuses ambiguous, duplicate, malformed, dishonest, or cyclic edges, coordinates with fork/delete lineage locks, preserves bodies and ordinary metadata byte-for-byte, and returns agent-friendly change and body-hash evidence in JSON.
+- **Existing-note lineage adoption** — `bwrb lineage adopt <child> --from <parent>` previews by default and requires `--execute` to attach one exact, same-type existing note under another. It safely backfills missing IDs, refuses ambiguous, duplicate, malformed, dishonest, or cyclic edges, coordinates with fork/delete lineage locks, preserves bodies and ordinary metadata byte-for-byte, and returns agent-friendly change and body-hash evidence in JSON (#817).
+
+### Changed
+
+- **Creation placement and identity parity** — interactive and JSON creation now share canonical output-directory resolution and persist the supplied note identity consistently while preserving explicit, owned, template, fork, and filename-pattern precedence (#811, #813).
+- **Completion parity** — generated shell completion now tracks the visible Commander surface, including real schema/template subcommands and the complete `recent` workflow, while hidden compatibility commands stay hidden (#810).
+- **Date settings in config** — `config list/edit` now exposes validated `date_format` and `date_granularity`, and explicitly configured full-date formats normalize deterministically to canonical ISO storage (#809).
 
 ### Fixed
 

--- a/docs-site/src/content/docs/changelog.md
+++ b/docs-site/src/content/docs/changelog.md
@@ -11,9 +11,15 @@ For the complete changelog with all details, see [CHANGELOG.md](https://github.c
 
 ### Unreleased
 
+### 0.2.4
+
 - **Existing-note lineage adoption** — `bwrb lineage adopt <child> --from <parent>` adds a dry-run-first, lock-coordinated path for recording known derivation between existing same-type notes without rewriting their bodies or ordinary metadata
 - **Portable lineage mutation locking** — fork, adopt, delete, and note-ID coordination now have real cross-process stress coverage, a focused Windows CI lane, and stable retryable output when a non-force delete target disappears while waiting for its lock
 - **Edit/lineage concurrency** — edit commits now share fork/adopt path locks, replay stale JSON patches from fresh bytes, and return stable retryable output without overwriting newer identity or provenance writes
+- **Creation placement and identity parity** — interactive and JSON creation share canonical output-directory resolution and persist the supplied identity consistently
+- **Body-only content targeting** — `--body` excludes YAML frontmatter while preserving original file line numbers and body-only match context
+- **Date settings in config** — `config list/edit` exposes validated date format and granularity settings with deterministic canonical ISO storage
+- **Completion parity** — shell completion tracks the visible command surface, real schema/template subcommands, and the full `recent` workflow
 
 ### 0.2.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bwrb",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Schema-driven note management for markdown vaults",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- bump the packaged Bowerbird version from 0.2.3 to 0.2.4
- promote the complete post-v0.2.3 change set from Unreleased into a dated 0.2.4 changelog section
- publish matching 0.2.4 highlights in the documentation changelog

## Included changes

- guarded existing-note lineage adoption (#817)
- portable lineage locking and edit/lineage race protection (#821, #822)
- creation placement and identity parity (#819)
- body-only content targeting (#818)
- date settings through config (#816)
- shell-completion parity (#815)

## Verification

- `pnpm build`
- `pnpm verify:pack`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm test -- --exclude='**/*.pty.test.ts'` — 115 files; 3,037 passed; 3 skipped
- focused version contract — 2 passed
- built `dist/index.js --version` — `0.2.4`
- `pnpm schema:check`
- `pnpm docs:check`
- `pnpm docs:lint`
- `pnpm docs:doctor`
- `pnpm docs:build` — 42 pages

After this PR merges, create GitHub release `v0.2.4` from the merge commit. npm publication remains a separate manual step.
