### PR TITLE
docs: refocus repository README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,20 @@
 
 Short for **Bowerbird**, pronounced "birb."
 
-**The type system for your notes.** Bowerbird is a CLI that creates, validates,
-queries, and migrates Markdown notes against a schema. Your files remain plain
-Markdown; Bowerbird supplies the guardrails.
+**The type system for your notes.** Bowerbird is a CLI that creates, validates, queries, and migrates Markdown notes against a schema. Your files remain plain Markdown; Bowerbird supplies the guardrails.
 
-It is especially useful beneath AI agents that write to a vault: the agent can
-work quickly while deterministic commands enforce structure, find notes, and
-catch drift. Bowerbird does not call an LLM or require an account, cloud, or
-database.
+It is especially useful beneath AI agents that write to a vault: the agent can work quickly while deterministic commands enforce structure, find notes, and catch drift. Bowerbird does not call an LLM or require an account, cloud, or database.
 
 > [!WARNING]
-> Bowerbird is pre-release software. The CLI is usable, but its schema format
-> and command surface may change before v1.0. Follow the
-> [roadmap](https://bwrb.dev/product/roadmap/)
-> for current direction.
+> Bowerbird is pre-release software. The CLI is usable, but its schema format and command surface may change before v1.0. Follow the [roadmap](https://bwrb.dev/product/roadmap/) for current direction.
 
 ## Why Bowerbird?
 
-- **Schema enforcement for Markdown.** Define types, inherited fields, relations,
-  templates, and body structure without surrendering your files to an app.
-- **Safe evolution.** Audit existing notes, preview repairs, and migrate schemas
-  explicitly as your vault changes.
-- **One deterministic CLI.** Create, edit, find, open, and batch-update notes
-  interactively or through machine-readable automation.
+- **Schema enforcement for Markdown.** Define types, inherited fields, relations, templates, and body structure without surrendering your files to an app.
+- **Safe evolution.** Audit existing notes, preview repairs, and migrate schemas explicitly as your vault changes.
+- **One deterministic CLI.** Create, edit, find, open, and batch-update notes interactively or through machine-readable automation.
 
-Bowerbird is not a note editor, sync service, database, CMS, or version-control
-system. Use the tools you already like for those jobs; Bowerbird keeps the notes
-they touch structurally sound.
+Bowerbird is not a note editor, sync service, database, CMS, or version-control system. Use the tools you already like for those jobs; Bowerbird keeps the notes they touch structurally sound.
 
 ## Install
 
@@ -45,8 +32,7 @@ Or install it with pnpm:
 pnpm add -g bwrb
 ```
 
-See the full [installation guide](https://bwrb.dev/getting-started/installation/)
-for shell completion, upgrades, and troubleshooting.
+See the full [installation guide](https://bwrb.dev/getting-started/installation/) for shell completion, upgrades, and troubleshooting.
 
 ## Create your first vault
 
@@ -59,12 +45,9 @@ bwrb --vault . --non-interactive new idea --json '{"name":"First idea"}'
 bwrb --vault . list --type idea --output json
 ```
 
-This creates `.bwrb/schema.json`, adds an `idea` type, writes
-`Ideas/First idea.md`, and lists the result as JSON. The schema is the source of
-truth for the vault's types and fields.
+This creates `.bwrb/schema.json`, adds an `idea` type, writes `Ideas/First idea.md`, and lists the result as JSON. The schema is the source of truth for the vault's types and fields.
 
-Continue with the [five-minute Quick Start](https://bwrb.dev/getting-started/quick-start/)
-to define prompted fields and audit your first notes.
+Continue with the [five-minute Quick Start](https://bwrb.dev/getting-started/quick-start/) to define prompted fields and audit your first notes.
 
 Once a vault has a schema, everyday commands look like this:
 
@@ -75,9 +58,7 @@ bwrb edit "My Idea"
 bwrb audit
 ```
 
-Run `bwrb --help` or `<command> --help` to inspect the installed command surface.
-Use `--vault /path/to/vault` from outside a vault, or let Bowerbird discover the
-nearest `.bwrb/schema.json` from your current directory.
+Run `bwrb --help` or `<command> --help` to inspect the installed command surface. Use `--vault /path/to/vault` from outside a vault, or let Bowerbird discover the nearest `.bwrb/schema.json` from your current directory.
 
 ## What you can do
 
@@ -92,20 +73,13 @@ nearest `.bwrb/schema.json` from your current directory.
 | Save repeatable queries | `dashboard` | [Dashboards](https://bwrb.dev/reference/commands/dashboard/) |
 | Configure and automate vaults | `config`, `--non-interactive`, JSON modes | [JSON automation](https://bwrb.dev/automation/json-mode/) |
 
-The complete user documentation lives at [bwrb.dev](https://bwrb.dev/). User-facing
-CLI behavior is canonical there; product rationale and plans live in
-[`docs/product`](https://github.com/3mdistal/bwrb/tree/main/docs/product).
+The complete user documentation lives at [bwrb.dev](https://bwrb.dev/). User-facing CLI behavior is canonical there; product rationale and plans live in [`docs/product`](https://github.com/3mdistal/bwrb/tree/main/docs/product).
 
 ## Core model
 
-Each vault contains a version 2 schema at `.bwrb/schema.json`. Types live in a
-flat map and can extend one parent type. Fields may be static, prompted, derived
-from vault relations, or constrained to select options. Templates add reusable
-defaults, bodies, and related-note scaffolding.
+Each vault contains a version 2 schema at `.bwrb/schema.json`. Types live in a flat map and can extend one parent type. Fields may be static, prompted, derived from vault relations, or constrained to select options. Templates add reusable defaults, bodies, and related-note scaffolding.
 
-Markdown remains the source of truth. Bowerbird refuses invalid writes through
-its CLI, while `bwrb audit` finds drift introduced by external editors or agents.
-Schema migrations make structural changes explicit and reviewable.
+Markdown remains the source of truth. Bowerbird refuses invalid writes through its CLI, while `bwrb audit` finds drift introduced by external editors or agents. Schema migrations make structural changes explicit and reviewable.
 
 For the complete contracts, use the canonical guides:
 
@@ -128,8 +102,7 @@ pnpm install
 pnpm build
 ```
 
-Run the CLI from source with `pnpm dev -- <command>`. Before pushing code, run
-the repository's CI-parity checks in this exact order:
+Run the CLI from source with `pnpm dev -- <command>`. Before pushing code, run the repository's CI-parity checks in this exact order:
 
 ```sh
 pnpm build
@@ -140,10 +113,7 @@ pnpm knip
 pnpm test -- --exclude='**/*.pty.test.ts'
 ```
 
-Contributor and architecture guidance lives in
-[`AGENTS.md`](https://github.com/3mdistal/bwrb/blob/main/AGENTS.md). Documentation
-work should also follow the
-[canonical documentation policy](https://github.com/3mdistal/bwrb/blob/main/docs/product/canonical-docs-policy.md).
+Contributor and architecture guidance lives in [`AGENTS.md`](https://github.com/3mdistal/bwrb/blob/main/AGENTS.md). Documentation work should also follow the [canonical documentation policy](https://github.com/3mdistal/bwrb/blob/main/docs/product/canonical-docs-policy.md).
 
 ## Project links
 

--- a/README.md
+++ b/README.md
@@ -1,641 +1,154 @@
-# bwrb
+# Bowerbird (`bwrb`)
 
-Short for **bowerbird**, pronounced "birb".
+Short for **Bowerbird**, pronounced "birb."
 
-Schema-driven note management for markdown vaults.
+**The type system for your notes.** Bowerbird is a CLI that creates, validates,
+queries, and migrates Markdown notes against a schema. Your files remain plain
+Markdown; Bowerbird supplies the guardrails.
 
-> **Pre-release software.** bwrb is under active development. The CLI works and is usable, but the schema format and command surface may change before v1.0. See the [roadmap](https://github.com/3mdistal/bwrb/blob/main/docs/product/roadmap.md) for current status.
+It is especially useful beneath AI agents that write to a vault: the agent can
+work quickly while deterministic commands enforce structure, find notes, and
+catch drift. Bowerbird does not call an LLM or require an account, cloud, or
+database.
 
-## Documentation policy
+> [!WARNING]
+> Bowerbird is pre-release software. The CLI is usable, but its schema format
+> and command surface may change before v1.0. Follow the
+> [roadmap](https://bwrb.dev/product/roadmap/)
+> for current direction.
 
-- User-facing CLI docs are canonical on the docs site: https://bwrb.dev
-- Product rationale/internal notes live in `docs/product/`
-- Canon policy and routing rules: [`docs/product/canonical-docs-policy.md`](docs/product/canonical-docs-policy.md)
+## Why Bowerbird?
 
-## Overview
+- **Schema enforcement for Markdown.** Define types, inherited fields, relations,
+  templates, and body structure without surrendering your files to an app.
+- **Safe evolution.** Audit existing notes, preview repairs, and migrate schemas
+  explicitly as your vault changes.
+- **One deterministic CLI.** Create, edit, find, open, and batch-update notes
+  interactively or through machine-readable automation.
 
-`bwrb` creates, queries, migrates, and audits markdown notes against a version 2
-type schema. It supports:
+Bowerbird is not a note editor, sync service, database, CMS, or version-control
+system. Use the tools you already like for those jobs; Bowerbird keeps the notes
+they touch structurally sound.
 
-- Flat types with inheritance, reusable traits, ownership, and templates
-- Dynamic frontmatter prompts, body sections, and instance scaffolding
-- Canonical `list` discovery by filters, exact name, fuzzy name, body matches,
-  stable ID, or document lineage
-- Schema migrations plus conservative audit and repair workflows
-- Partial and relative dates, including schema-defined custom calendars
-- Native document forks with immutable provenance, lineage inspection, and
-  fork-safe deletion
-- Command-specific JSON automation and explicit non-interactive safety
-- Any markdown vault selected through discovery or the global `--vault` flag
+## Install
 
-## Prerequisites
-
-- **Node.js** >= 22
-
-## Installation
-
-### From source (development)
+Bowerbird requires Node.js 22 or newer.
 
 ```sh
-cd ~/Developer/bwrb
-pnpm install
-pnpm build
-pnpm link --global  # Makes 'bwrb' available globally
+npm install -g bwrb
+bwrb --version
 ```
 
-### Development mode
+Or install it with pnpm:
 
 ```sh
-pnpm dev -- new idea  # Run without building
+pnpm add -g bwrb
 ```
 
-## Setup
+See the full [installation guide](https://bwrb.dev/getting-started/installation/)
+for shell completion, upgrades, and troubleshooting.
 
-Initialize each vault you want to use with bwrb:
+## Create your first vault
 
 ```sh
 mkdir my-vault
 cd my-vault
 bwrb init --yes
+bwrb --vault . --non-interactive schema new type idea --directory Ideas --output json
+bwrb --vault . --non-interactive new idea --json '{"name":"First idea"}'
+bwrb --vault . list --type idea --output json
 ```
 
-This creates a version 2 `.bwrb/schema.json`. See the
-[Quick Start](https://bwrb.dev/getting-started/quick-start/) for a runnable first
-schema.
+This creates `.bwrb/schema.json`, adds an `idea` type, writes
+`Ideas/First idea.md`, and lists the result as JSON. The schema is the source of
+truth for the vault's types and fields.
 
-## Usage
+Continue with the [five-minute Quick Start](https://bwrb.dev/getting-started/quick-start/)
+to define prompted fields and audit your first notes.
+
+Once a vault has a schema, everyday commands look like this:
 
 ```sh
-# Vault path resolution (in order of precedence):
-# 1. --vault=<path> or -v <path> argument
-# 2. Find-up: nearest ancestor with .bwrb/schema.json
-# 3. BWRB_VAULT environment variable
-# 4. Find-down under cwd if not in a vault:
-#    - 1 candidate => auto-select
-#    - multiple => numbered picker (TTY) or error requiring --vault
-#      (non-TTY or --output json)
-
-# Interactive mode - prompts for type selection
-bwrb new
-bwrb --vault=/path/to/vault new
-
-# Direct creation - specify type
-bwrb new objective    # Then select subtype (task/milestone/project/goal)
-bwrb new idea         # Creates idea directly (no child-type selection)
-
-# Templates
-bwrb new task --template bug-report  # Use specific template
-bwrb new task --template default     # Use default.md template explicitly
-bwrb new task --no-template          # Skip templates, use schema only
-
-# Edit existing file
-bwrb edit path/to/file.md
-bwrb edit Objectives/Tasks/My\ Task.md
-
-# List objects by type
-bwrb list idea                 # List all ideas (names only)
-bwrb list objective            # List all objectives (tasks, milestones, etc.)
-bwrb list objective/task       # List only tasks
-bwrb list objective/milestone  # List only milestones
-
-# List output options
-bwrb list --output paths idea                # Show vault-relative paths
-bwrb list --fields=status,priority idea      # Show selected frontmatter fields in a table
-bwrb list --output paths --fields=status objective  # Combine paths + fields
-
-# Resolve, search, and open through list
-bwrb list --name "My Note"                   # Resolve by name, path, or alias
-bwrb list --name "My Note" --output link     # Output: [[My Note]]
-bwrb list --fuzzy "My Nte" --output json      # Ranked matches with scores
-bwrb list --body "TODO" --matches             # Detailed Markdown body matches
-bwrb list --name "My Note" --open --app editor
-bwrb list --id "<uuid>" --open --app print
-
-# Preserve a revision as a native document fork, then inspect its family
-bwrb new --fork "Briefs/Launch Brief" --label concise --output json
-bwrb list --lineage "Briefs/Launch Brief" --output tree
-
-# Adopt two existing same-type notes after previewing the exact guarded change
-bwrb lineage adopt "Launch Brief v2" --from "Launch Brief" --dry-run --output json
-bwrb lineage adopt "Launch Brief v2" --from "Launch Brief" --execute --output json
-
-# Help
-bwrb --help
-bwrb list --help
+bwrb new idea
+bwrb list --type idea
+bwrb edit "My Idea"
+bwrb audit
 ```
 
-## Schema Structure
+Run `bwrb --help` or `<command> --help` to inspect the installed command surface.
+Use `--vault /path/to/vault` from outside a vault, or let Bowerbird discover the
+nearest `.bwrb/schema.json` from your current directory.
 
-The schema file is expected at `<vault>/.bwrb/schema.json`. It defines:
+## What you can do
 
-### Types
+| Goal | Commands | Documentation |
+| --- | --- | --- |
+| Create and edit typed notes | `new`, `edit`, `delete` | [Creating notes](https://bwrb.dev/reference/commands/new/) |
+| Find, inspect, and open notes | `list`, `recent` | [Finding notes](https://bwrb.dev/reference/commands/list/) |
+| Define and evolve types | `schema` | [Schema reference](https://bwrb.dev/reference/schema/) |
+| Detect and repair drift | `audit`, `bulk` | [Auditing](https://bwrb.dev/reference/commands/audit/) |
+| Reuse note structures | `template` | [Templates](https://bwrb.dev/templates/overview/) |
+| Preserve document ancestry | `lineage`, `new --fork` | [Lineage](https://github.com/3mdistal/bwrb/blob/main/docs-site/src/content/docs/reference/commands/lineage.md) |
+| Save repeatable queries | `dashboard` | [Dashboards](https://bwrb.dev/reference/commands/dashboard/) |
+| Configure and automate vaults | `config`, `--non-interactive`, JSON modes | [JSON automation](https://bwrb.dev/automation/json-mode/) |
 
-Version 2 schemas keep all types in one flat map. A child names its parent with
-`extends`:
+The complete user documentation lives at [bwrb.dev](https://bwrb.dev/). User-facing
+CLI behavior is canonical there; product rationale and plans live in
+[`docs/product`](https://github.com/3mdistal/bwrb/tree/main/docs/product).
 
-```json
-{
-  "version": 2,
-  "types": {
-    "objective": {
-      "output_dir": "Objectives",
-      "fields": {
-        "type": { "value": "objective" },
-        "status": {
-          "prompt": "select",
-          "options": ["planned", "active", "done"],
-          "default": "planned"
-        }
-      }
-    },
-    "task": {
-      "extends": "objective",
-      "output_dir": "Objectives/Tasks",
-      "fields": {
-        "type": { "value": "task" },
-        "priority": {
-          "prompt": "select",
-          "options": ["low", "medium", "high"],
-          "default": "medium"
-        }
-      },
-      "field_order": ["type", "status", "priority"]
-    }
-  }
-}
-```
+## Core model
 
-### Type Definition
+Each vault contains a version 2 schema at `.bwrb/schema.json`. Types live in a
+flat map and can extend one parent type. Fields may be static, prompted, derived
+from vault relations, or constrained to select options. Templates add reusable
+defaults, bodies, and related-note scaffolding.
 
-Type properties include:
+Markdown remains the source of truth. Bowerbird refuses invalid writes through
+its CLI, while `bwrb audit` finds drift introduced by external editors or agents.
+Schema migrations make structural changes explicit and reviewable.
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `extends` | No | Parent type name; defaults to the implicit `meta` root |
-| `output_dir` | No | Directory relative to vault root. If omitted, creation uses the computed pluralized type hierarchy reported by schema inspection; an explicit type or ancestor directory takes precedence |
-| `fields` | No | Field definitions, merged with inherited fields |
-| `field_order` | No | Array specifying effective field order |
-| `body_sections` | No | Array of section definitions |
+For the complete contracts, use the canonical guides:
 
-### Frontmatter Fields
+- [Types and inheritance](https://bwrb.dev/concepts/types-and-inheritance/)
+- [Schema concepts](https://bwrb.dev/concepts/schema/)
+- [Templates](https://bwrb.dev/templates/overview/)
+- [Schema migrations](https://bwrb.dev/concepts/migrations/)
+- [Targeting notes and vaults](https://bwrb.dev/reference/targeting/)
+- [Getting started](https://bwrb.dev/getting-started/introduction/)
 
-Fields can be static or prompted:
+## Contributing
 
-**Static value:**
-```json
-{
-  "type": { "value": "objective" },
-  "creation-date": { "value": "$NOW" }
-}
-```
-
-Special values: `$NOW` (local datetime, `YYYY-MM-DD HH:mm`), `$TODAY` (local date, `YYYY-MM-DD`)
-
-**Select from options:**
-```json
-{
-  "status": {
-    "prompt": "select",
-    "options": ["raw", "backlog", "planned", "in-flight", "settled"],
-    "default": "raw"
-  }
-}
-```
-
-**Text input:**
-```json
-{
-  "deadline": {
-    "prompt": "text",
-    "label": "Deadline (YYYY-MM-DD)",
-    "required": false
-  }
-}
-```
-
-**Dynamic (vault query):**
-
-Query notes of a specific type to populate field options:
-
-```json
-{
-  "milestone": {
-    "prompt": "relation",
-    "source": "milestone",
-    "filter": { "status": { "not_in": ["settled", "ghosted"] } },
-    "required": false
-  }
-}
-```
-
-- `source` - Type name to query (e.g., `"milestone"`)
-- `filter` - Optional per-field condition object for filtering candidates
-- Relation link formatting is vault-wide through `config.link_format`
-
-### Body Sections
-
-Define document structure after frontmatter:
-
-```json
-{
-  "body_sections": [
-    {
-      "title": "Steps",
-      "level": 2,
-      "content_type": "checkboxes",
-      "prompt": "list",
-      "prompt_label": "Steps (comma-separated)"
-    },
-    {
-      "title": "Notes",
-      "level": 2,
-      "content_type": "paragraphs",
-      "children": [
-        { "title": "Subsection", "level": 3, "content_type": "bullets" }
-      ]
-    }
-  ]
-}
-```
-
-Content types: `none`, `paragraphs`, `bullets`, `checkboxes`
-
-## Templates
-
-Templates provide reusable defaults and body structure for note creation. They're stored in `.bwrb/templates/`, organized by type path.
-
-### Template Location
-
-```
-my-vault/
-└── .bwrb/
-    ├── schema.json
-    └── templates/
-        ├── idea/
-        │   └── default.md           # Default template for ideas
-        └── objective/
-            └── task/
-                ├── default.md       # Default template for tasks
-                └── bug-report.md    # Bug report template
-```
-
-### Template Format
-
-Templates are markdown files with special frontmatter:
-
-```yaml
----
-type: template
-template-for: objective/task
-description: Bug report with reproduction steps
-defaults:
-  status: backlog
-  priority: high
-prompt-fields:
-  - deadline
----
-
-## Description
-
-[Describe the bug]
-
-## Steps to Reproduce
-
-1. 
-2. 
-3. 
-
-## Expected Behavior
-
-## Actual Behavior
-```
-
-### Template Properties
-
-| Property | Required | Description |
-|----------|----------|-------------|
-| `type` | Yes | Must be `template` |
-| `template-for` | Yes | Type path (e.g., `objective/task`) |
-| `description` | No | Human-readable description |
-| `defaults` | No | Default field values (skip prompting) |
-| `prompt-fields` | No | Fields to always prompt for, even with defaults |
-| `filename-pattern` | No | Override default filename |
-| `instances` | No | Related notes/tasks to scaffold with the parent |
-
-### Template Defaults and Dates
-
-Template defaults can use date expressions such as `@today+3d` or
-`today() + '7d'` for fields whose schema prompt is `date`. Those expressions are
-evaluated when the note is created and normalized to the schema's date format.
-Defaults on scaffolded `instances` use the same behavior, so child task fields
-like `scheduled` or `deadline` can be relative to the creation date.
-
-Non-date fields pass date-looking strings through literally. For example, a text
-field default of `@today+3d` is written as `@today+3d`, not evaluated.
-
-### Template Body
-
-The template body becomes the note body, with variable substitution:
-- `{fieldName}` - Replaced with frontmatter value
-- `{date}` - Today's date (YYYY-MM-DD)
-- `{date:FORMAT}` - Formatted date (e.g., `{date:YYYY-MM}`)
-
-### Instance Scaffolding
-
-Templates can define `instances` to create related notes when the parent is
-created. Instances may use any configured type, including the same type as the
-parent, so a `task` template can scaffold additional `task` notes.
-
-Each instance is filed into the child type's configured `output_dir`, not beside
-the parent unless both types use the same output directory. Existing instance
-files are skipped rather than overwritten.
-
-```yaml
----
-type: template
-template-for: task
-description: Builder article production checklist
-defaults:
-  status: planned
-  scheduled: "@today+1d"
-  deadline: "@today+7d"
-instances:
-  - type: task
-    defaults:
-      name: "Outline article"
-      scheduled: "@today+1d"
-  - type: task
-    defaults:
-      name: "Draft article"
-      scheduled: "@today+3d"
-  - type: task
-    defaults:
-      name: "Review and publish article"
-      scheduled: "@today+5d"
----
-```
-
-Instance `defaults` and explicit child `filename` values do not interpolate
-parent placeholders like `{name}`. Use literal child names/filenames, rely on
-the child type's own filename pattern, or generate article-specific child names
-with a wrapper script. Avoid braces in explicit child filenames unless you want
-the braces to be part of the actual filename.
-
-### CLI Usage
+Clone the repository and install the pinned pnpm version's dependencies:
 
 ```sh
-# Auto-use default.md if it exists
-bwrb new task
-
-# Use specific template
-bwrb new task --template bug-report
-
-# Require default template (error if not found)
-bwrb new task --template default
-
-# Skip template system
-bwrb new task --no-template
-
-# JSON mode with templates
-bwrb new task --json '{"name": "Fix bug"}' --template bug-report
+git clone https://github.com/3mdistal/bwrb.git
+cd bwrb
+corepack enable
+pnpm install
+pnpm build
 ```
 
-### Template Discovery
-
-Templates use **strict matching** - only templates in the exact type path directory are considered:
-- `objective/task` -> `.bwrb/templates/objective/task/*.md`
-- `idea` -> `.bwrb/templates/idea/*.md`
-
-There is no inheritance from parent types.
-
-### Template Management
-
-Use the `template` command to manage templates:
+Run the CLI from source with `pnpm dev -- <command>`. Before pushing code, run
+the repository's CI-parity checks in this exact order:
 
 ```sh
-# List all templates
-bwrb template list
-bwrb template list objective/task    # Filter by type
-bwrb template list idea default      # Show specific template details
-
-# Validate templates against schema
-bwrb template validate               # All templates
-bwrb template validate idea          # Templates for specific type
-
-# Create new template interactively
-bwrb template new idea
-bwrb template new objective/task --name bug-report
-
-# Create template from JSON
-bwrb template new idea --name quick --json '{"defaults": {"status": "raw"}}'
-
-# Edit template interactively
-bwrb template edit idea default
-
-# Edit template from JSON
-bwrb template edit idea default --json '{"defaults": {"priority": "high"}}'
-
-# Delete a template
-bwrb template delete idea quick
+pnpm build
+pnpm verify:pack
+pnpm typecheck
+pnpm lint
+pnpm knip
+pnpm test -- --exclude='**/*.pty.test.ts'
 ```
 
-## Adding a New Type
+Contributor and architecture guidance lives in
+[`AGENTS.md`](https://github.com/3mdistal/bwrb/blob/main/AGENTS.md). Documentation
+work should also follow the
+[canonical documentation policy](https://github.com/3mdistal/bwrb/blob/main/docs/product/canonical-docs-policy.md).
 
-1. Add type definition under `types`:
-   ```json
-   {
-     "types": {
-       "my-type": {
-         "output_dir": "My/Output/Dir",
-         "fields": {
-           "type": { "value": "my-type" },
-           "status": { "prompt": "select", "options": ["raw", "active", "done"] }
-         },
-         "field_order": ["type", "status"],
-         "body_sections": []
-       }
-     }
-   }
-   ```
+## Project links
 
-2. Validate schema (optional):
-   ```sh
-   ./validate_schema.sh
-   ```
-
-## Schema Validation
-
-The schema structure is defined by `schema.schema.json` (JSON Schema draft-07). To validate:
-
-```sh
-./validate_schema.sh
-```
-
-> **Contributors:** `schema.schema.json` and `docs-site/public/schema.json` are
-> **generated** from the Zod source of truth in `src/types/schema.ts` — do not
-> edit them by hand. After changing the Zod schema run `pnpm schema:gen` and
-> commit the result. CI (`pnpm schema:check`, part of `pnpm qa`) fails if the
-> committed files are stale.
-
-## File Structure
-
-**bwrb repo:**
-```
-bwrb/
-├── src/
-│   ├── index.ts              # CLI entry point
-│   ├── commands/
-│   │   ├── new.ts            # Create new notes
-│   │   ├── edit.ts           # Edit existing notes
-│   │   └── list.ts           # List and filter notes
-│   ├── lib/
-│   │   ├── schema.ts         # Schema loading & validation
-│   │   ├── frontmatter.ts    # Frontmatter parsing & writing
-│   │   ├── query.ts          # Filter parsing & evaluation
-│   │   ├── vault.ts          # Vault operations
-│   │   └── prompt.ts         # Interactive prompts
-│   ├── types/
-│   │   └── schema.ts         # Zod schema definitions (source of truth)
-│   └── tools/
-│       └── schema/
-│           └── generate-json-schema.ts  # Generates the JSON Schema from Zod
-├── tests/
-│   └── ts/                   # TypeScript test suite
-├── package.json
-├── tsconfig.json
-├── vitest.config.ts
-├── schema.schema.json        # GENERATED JSON Schema (run `pnpm schema:gen`)
-└── README.md
-```
-
-**Each vault:**
-```
-my-vault/
-└── .bwrb/
-    └── schema.json     # Vault-specific type definitions
-```
-
-## Finding and Opening Notes
-
-### `bwrb list`
-
-`list` is the canonical query, search, and opening surface. Resolve by name,
-path, alias, or stable ID; run fuzzy or body searches; and optionally open the
-selected result.
-
-```sh
-bwrb list --name "My Note"                             # Case-insensitive resolution
-bwrb list --name "Ideas/My Note.md" --output link      # [[My Note]]
-bwrb list --fuzzy "My Nte" --output json               # Ranked candidates
-bwrb list --body "TODO" --matches --context 0          # Detailed file matches
-bwrb list --name "My Note" --open --app editor         # Open in editor
-bwrb list --id "<uuid>" --open --app print             # Stable-id path lookup
-```
-
-**App modes:**
-- `obsidian` - Open in Obsidian via URI scheme
-- `editor` - Open in `$VISUAL` or `$EDITOR`
-- `system` - Open with system default handler (default)
-- `print` - Just print the resolved path
-
-**Environment variable:** Set `BWRB_DEFAULT_APP` to change the default app mode:
-```sh
-export BWRB_DEFAULT_APP=editor  # Always open in $EDITOR by default
-```
-
-**Picker modes** (when query matches multiple files or no query):
-- `--picker auto` - Use fzf if available, else numbered select (default)
-- `--picker fzf` - Force fzf
-- `--picker numbered` - Force numbered select
-- `--picker none` - Error on ambiguity (for scripting)
-
-**JSON output** (implies `--picker none`):
-```sh
-bwrb list --name "My Note" --open --app print --output json
-```
-
-Name resolution uses the shortest unambiguous wikilink form:
-- Basename if unique across vault: `[[My Note]]`
-- Full path if ambiguous: `[[Ideas/My Note]]`
-
-```sh
-bwrb list --name "My Note" --output link --picker none
-bwrb list --name "Amb" --picker none --output json
-```
-
-**Neovim/scripting example:**
-```sh
-# Copy wikilink to clipboard (macOS)
-bwrb list --name "My Note" --output link --picker none | pbcopy
-
-# Use in a Lua script
-local link = vim.fn.system("bwrb list --name 'My Note' --output link --picker none")
-```
-
-The older `bwrb search` and `bwrb open` commands remain callable for script
-compatibility, but are hidden from the canonical top-level help and completion
-lists.
-
-## Shell Completion
-
-Enable tab completion for commands, types, and paths.
-
-### Bash
-
-Add to `~/.bashrc`:
-
-```bash
-eval "$(bwrb completion bash)"
-```
-
-### Zsh
-
-Add to `~/.zshrc`:
-
-```zsh
-eval "$(bwrb completion zsh)"
-```
-
-### Fish
-
-Run once to install:
-
-```fish
-bwrb completion fish > ~/.config/fish/completions/bwrb.fish
-```
-
-### What Gets Completed
-
-- **Commands**: `bwrb <TAB>` shows every visible top-level command: `new`,
-  `edit`, `delete`, `list`, `recent`, `schema`, `audit`, `bulk`, `template`,
-  `lineage`, `dashboard`, `init`, `config`, and `completion`.
-- **Options**: `bwrb list -<TAB>` shows `--type`, `--path`, `--where`, etc.
-- **Subcommands**: `bwrb schema <TAB>`, `bwrb template <TAB>`, and
-  `bwrb lineage <TAB>` follow the
-  commands shown in their current help output.
-- **Types**: `bwrb list --type <TAB>` shows types from your schema (task, idea, etc.)
-- **Paths**: `bwrb list --path <TAB>` shows vault directories (Ideas/, Objectives/, etc.)
-
-## Running Tests
-
-```sh
-pnpm test              # Run tests
-pnpm test:coverage     # Run with coverage report
-pnpm typecheck         # Type checking
-pnpm docs:lint         # Verify canonical docs concept links
-```
-
-## Docs Site
-
-Run docs-site workflows from the repository root:
-
-```sh
-pnpm docs:install      # Install docs-site dependencies
-pnpm docs:dev          # Start docs dev server
-pnpm docs:build        # Build docs site
-pnpm docs:preview      # Preview built docs site
-```
-
-For docs-site details and deployment notes, see `docs-site/README.md`.
-
-If you hit local docs contributor setup quirks (ignored build scripts or transient TS diagnostics), see `docs-site/README.md#contributor-troubleshooting`.
+- [Documentation](https://bwrb.dev/)
+- [Changelog](https://bwrb.dev/changelog/)
+- [Roadmap](https://bwrb.dev/product/roadmap/)
+- [Issues](https://github.com/3mdistal/bwrb/issues)
+- [MIT License](https://github.com/3mdistal/bwrb/blob/main/LICENSE)

--- a/plans/readme-audit-2026-07-12.md
+++ b/plans/readme-audit-2026-07-12.md
@@ -1,0 +1,173 @@
+# README audit
+
+## Question
+
+Does the repository README accurately orient a new user to Bowerbird's current
+value, installation path, command surface, and canonical documentation—and what
+should change, if anything?
+
+## Answer
+
+The README is mostly accurate, but it is not doing the README job cleanly. It
+opens with a generic category description, omits the normal package installation
+path, and then expands into a 641-line second user manual. That conflicts with
+the repository's own documentation policy and makes the product's strongest
+idea—type safety for Markdown notes—harder to see than its feature inventory.
+
+This should be a focused rewrite rather than a factual patch. The target is a
+short front door for prospective users and contributors, with detailed behavior
+routed to `bwrb.dev`.
+
+## Evidence
+
+### 1. Critical: the public installation path is missing
+
+The README's Installation section offers only a source checkout and development
+mode ([README](../README.md#installation)). The canonical installation guide
+leads with `npm install -g bwrb` and also documents `pnpm add -g bwrb`
+([installation guide](../docs-site/src/content/docs/getting-started/installation.md)).
+The package is currently published as `bwrb@0.2.4`, matching the repository
+version in [`package.json`](../package.json).
+
+**Recommendation:** make `npm install -g bwrb` the primary path, keep pnpm as an
+alternative, and move source installation into a contributor section.
+
+### 2. High: the opening undersells the product's distinct promise
+
+"Schema-driven note management for markdown vaults" is accurate, but broad
+([README](../README.md#bwrb)). The product vision supplies a clearer distinction:
+"the type system for your notes," with schema enforcement as the core and PKM
+features around it ([product vision](../docs/product/vision.md#what-is-bowerbird)).
+The README's first concrete explanation is an eight-item capability list, so a
+reader learns what it has before learning why it exists.
+
+**Recommendation:** lead with the type-safety promise and a two- or three-sentence
+boundary: Markdown stays the source of truth; Bowerbird creates, validates,
+queries, and migrates notes against a schema; it is not a note editor, database,
+sync service, or LLM.
+
+### 3. High: the README violates the repo's summary-and-link policy
+
+The README declares the docs site canonical near the top
+([README](../README.md#documentation-policy)), but then reproduces detailed
+behavior contracts for schema fields, body sections, templates, instance
+scaffolding, query resolution, picker modes, and shell completion. The
+authoritative policy explicitly says "summary + link, not full mirroring" and
+warns against parallel full behavior specs
+([canonical policy](../docs/product/canonical-docs-policy.md#link-vs-mirror-rules)).
+
+This duplication carries drift risk and obscures navigation. The 641-line README
+contains 31 Markdown headings, while the docs site already has dedicated getting
+started, schema, template, list, completion, and command-reference pages.
+
+**Recommendation:** retain only:
+
+- the product promise and boundaries;
+- prerequisites and package installation;
+- one five-minute path from `init` to creating and listing a note;
+- a compact capability/command map linking to canonical pages;
+- contributor setup and quality-check links;
+- pre-release status and roadmap link.
+
+Move or remove the detailed schema reference, template specification, instance
+edge cases, picker semantics, completion inventory, and duplicated `list`
+examples. Those belong on `bwrb.dev`.
+
+### 4. Medium: the quick path does not demonstrate the payoff
+
+Setup stops after `bwrb init --yes` and sends the reader elsewhere for a runnable
+schema ([README](../README.md#setup)). The following Usage block begins with eight
+lines about vault-resolution precedence, then ranges across templates, querying,
+forks, and lineage adoption ([README](../README.md#usage)). That is reference
+material, not a first-success narrative.
+
+**Recommendation:** show a tiny end-to-end sequence whose commands are guaranteed
+by the generated starter vault: install, `bwrb init --yes`, inspect or create a
+starter type, create one note, list it, and audit it. If `init --yes` does not
+currently create a schema that supports that exact flow, link directly to the
+canonical Quick Start rather than inventing a partial example.
+
+### 5. Medium: contributor material is mixed into user documentation
+
+Generated-schema warnings, the repository tree, test commands, and docs-site
+development are legitimate contributor information
+([README](../README.md#schema-validation), [README](../README.md#file-structure),
+[README](../README.md#running-tests)). They arrive after hundreds of lines of
+user reference material and do not form a clear contributor path.
+
+**Recommendation:** consolidate them under a short Contributing section that
+points to `AGENTS.md`, the exact CI workflow or documented parity commands, and
+the docs-site contributor README. Avoid maintaining a hand-curated partial source
+tree; it goes stale without helping a new contributor navigate the architecture.
+
+### 6. Low: naming and information hierarchy can be tightened
+
+The pronunciation note is personable and worth keeping. The separate
+Documentation policy section, however, is repository governance presented before
+the product overview. Readers need the product and first action before the rules
+for where maintainers write docs.
+
+**Recommendation:** keep a prominent Documentation link near the top, but move
+the policy link into Contributing. Use "Bowerbird" in prose and `bwrb` for the
+binary consistently.
+
+## Verified facts
+
+- Repository and npm package versions both report `0.2.4`.
+- The runtime prerequisite is Node.js 22 or newer.
+- Current root help exposes 14 top-level commands, including `recent` and
+  `lineage`; `search` and `open` remain hidden compatibility commands.
+- `validate_schema.sh` and the generated `schema.schema.json` both exist.
+- `pnpm docs:lint`, `pnpm docs:doctor`, and `pnpm docs:check` pass on the current
+  checkout.
+
+These checks support the conclusion that the dominant problem is scope and
+orientation, not widespread factual decay.
+
+## Inferences
+
+- The README grew by accreting release-specific documentation parity updates.
+  Its individual sections are often careful and current, but their combined
+  shape is no longer coherent.
+- A shorter README will reduce maintenance cost only if the rewrite replaces
+  removed contracts with direct canonical links. Deleting detail without routing
+  readers would merely exchange duplication for a scavenger hunt.
+- The most useful audience order is likely: prospective user, installing user,
+  returning user seeking docs, then contributor. This matches the repository's
+  package distribution and docs-site structure, but it is still a product choice.
+
+## Uncertainties
+
+- Whether the README should optimize primarily for the author/agent workflow or
+  for outside adopters. The recommended structure works for both, but the
+  examples and tone may differ.
+- Whether badges, screenshots, or a terminal recording are desired. None is
+  necessary to fix the current structural problem.
+- The exact minimal schema/example to embed should be verified against a fresh
+  `bwrb init --yes` vault during implementation.
+
+## Recommendation
+
+Rewrite the README around this structure:
+
+1. Name, pronunciation, one-line type-safety promise, and pre-release warning.
+2. Three short "why Bowerbird" bullets and explicit product boundaries.
+3. Install from npm, verify with `bwrb --version`.
+4. Five-minute quick start with one visible success.
+5. Compact capability map: create/edit, find/open, schema/audit/migrate,
+   templates, automation/lineage—each linked to canonical docs.
+6. Documentation and roadmap links.
+7. Short contributor section with source setup and CI-parity pointer.
+
+Aim for roughly 150–250 lines. Treat that as a design constraint, not a sacred
+number: enough room to sing, not enough to become the whole aviary.
+
+## Sources
+
+- [`README.md`](../README.md)
+- [`package.json`](../package.json)
+- [`src/index.ts`](../src/index.ts)
+- [Canonical documentation policy](../docs/product/canonical-docs-policy.md)
+- [Product vision](../docs/product/vision.md)
+- [Installation guide](../docs-site/src/content/docs/getting-started/installation.md)
+- [Quick Start](../docs-site/src/content/docs/getting-started/quick-start.md)

--- a/plans/readme-audit-2026-07-12.md
+++ b/plans/readme-audit-2026-07-12.md
@@ -16,7 +16,9 @@ idea—type safety for Markdown notes—harder to see than its feature inventory
 
 This should be a focused rewrite rather than a factual patch. The target is a
 short front door for prospective users and contributors, with detailed behavior
-routed to `bwrb.dev`.
+routed to `bwrb.dev`. Because `README.md` ships in the npm package, this is also
+the package's npm landing page; prospective and installing users are therefore
+the primary audience, not merely one possible audience.
 
 ## Evidence
 
@@ -44,21 +46,23 @@ reader learns what it has before learning why it exists.
 **Recommendation:** lead with the type-safety promise and a two- or three-sentence
 boundary: Markdown stays the source of truth; Bowerbird creates, validates,
 queries, and migrates notes against a schema; it is not a note editor, database,
-sync service, or LLM.
+sync service, or LLM. One sentence should surface its distinctive role as a set
+of deterministic guardrails beneath the agents that author a vault.
 
-### 3. High: the README violates the repo's summary-and-link policy
+### 3. High: the README contradicts its own declaration of canonical docs
 
 The README declares the docs site canonical near the top
 ([README](../README.md#documentation-policy)), but then reproduces detailed
 behavior contracts for schema fields, body sections, templates, instance
-scaffolding, query resolution, picker modes, and shell completion. The
-authoritative policy explicitly says "summary + link, not full mirroring" and
-warns against parallel full behavior specs
+scaffolding, query resolution, picker modes, and shell completion. Repository
+policy reinforces "summary + link, not full mirroring" and warns against parallel
+full behavior specs across the two documentation trees it governs
 ([canonical policy](../docs/product/canonical-docs-policy.md#link-vs-mirror-rules)).
 
 This duplication carries drift risk and obscures navigation. The 641-line README
-contains 31 Markdown headings, while the docs site already has dedicated getting
-started, schema, template, list, completion, and command-reference pages.
+contains 36 Markdown headings outside fenced examples, while the docs site has
+dedicated getting started, schema, template, list, completion, and
+command-reference pages.
 
 **Recommendation:** retain only:
 
@@ -72,6 +76,9 @@ started, schema, template, list, completion, and command-reference pages.
 Move or remove the detailed schema reference, template specification, instance
 edge cases, picker semantics, completion inventory, and duplicated `list`
 examples. Those belong on `bwrb.dev`.
+
+Public documentation links should be absolute `https://bwrb.dev` or GitHub URLs,
+not repository-relative links, so they resolve from both GitHub and npm.
 
 ### 4. Medium: the quick path does not demonstrate the payoff
 
@@ -99,6 +106,10 @@ user reference material and do not form a clear contributor path.
 points to `AGENTS.md`, the exact CI workflow or documented parity commands, and
 the docs-site contributor README. Avoid maintaining a hand-curated partial source
 tree; it goes stale without helping a new contributor navigate the architecture.
+
+The current source-install example also begins with the personal path
+`~/Developer/bwrb`, which is not a portable instruction. Contributor setup should
+show a clone command and repository-relative steps.
 
 ### 6. Low: naming and information hierarchy can be tightened
 
@@ -132,15 +143,12 @@ orientation, not widespread factual decay.
 - A shorter README will reduce maintenance cost only if the rewrite replaces
   removed contracts with direct canonical links. Deleting detail without routing
   readers would merely exchange duplication for a scavenger hunt.
-- The most useful audience order is likely: prospective user, installing user,
-  returning user seeking docs, then contributor. This matches the repository's
-  package distribution and docs-site structure, but it is still a product choice.
+- The useful audience order is: prospective user, installing user, returning
+  user seeking docs, then contributor. The npm rendering context settles this
+  more firmly than repository taste alone.
 
 ## Uncertainties
 
-- Whether the README should optimize primarily for the author/agent workflow or
-  for outside adopters. The recommended structure works for both, but the
-  examples and tone may differ.
 - Whether badges, screenshots, or a terminal recording are desired. None is
   necessary to fix the current structural problem.
 - The exact minimal schema/example to embed should be verified against a fresh
@@ -158,6 +166,27 @@ Rewrite the README around this structure:
    templates, automation/lineage—each linked to canonical docs.
 6. Documentation and roadmap links.
 7. Short contributor section with source setup and CI-parity pointer.
+
+## Acceptance criteria
+
+- `npm install -g bwrb` is the first installation command shown.
+- Source installation appears only under Contributing and uses a portable clone
+  path, not `~/Developer/bwrb`.
+- Public links are absolute and resolve from the npm README context.
+- Every shown command is verified copy-paste runnable. If a fresh
+  `bwrb init --yes` vault cannot support the complete embedded example, link to
+  the canonical Quick Start rather than duplicating its schema.
+- Detailed behavior-contract tables and specs for schemas, templates, picker and
+  app modes, and completion are replaced with summaries plus canonical links.
+- The hand-curated repository tree is removed.
+- The capability map covers the full command surface directly or via a full
+  command-reference link, including `recent`, `bulk`, `dashboard`, and `config`.
+- The opening states the type-safety promise, clear product boundaries, and the
+  deterministic agent-guardrail use case.
+- No current package version is hardcoded in prose.
+- The contributor section points to `AGENTS.md` and the repository's exact local
+  CI-parity sequence.
+- `pnpm docs:lint`, `pnpm docs:doctor`, and `pnpm docs:check` pass.
 
 Aim for roughly 150–250 lines. Treat that as a design constraint, not a sacred
 number: enough room to sing, not enough to become the whole aviary.

--- a/plans/readme-audit-fable-review-2026-07-12.md
+++ b/plans/readme-audit-fable-review-2026-07-12.md
@@ -1,0 +1,63 @@
+# Fable review of the README audit
+
+Model requested: `claude-fable-5` via local Claude Code  
+Finish state: completed successfully  
+Source reviewed: `plans/readme-audit-2026-07-12.md` and its repository evidence
+
+## Verdict
+
+Fable agreed with the central diagnosis: the README's main problem is scope and
+orientation rather than widespread factual drift. It approved the recommended
+audience order and information architecture, with four material amendments.
+
+## Must incorporate
+
+1. **Treat the README as the npm landing page.** `package.json` includes
+   `README.md` in the published package. This largely resolves the audience
+   question in favor of prospective and installing users.
+2. **Use absolute public links.** Public documentation links in the rewrite
+   should point to `https://bwrb.dev` or absolute GitHub URLs so they work from
+   npm as well as GitHub.
+3. **Name the source-install bug.** `cd ~/Developer/bwrb` is a personal path,
+   not a runnable contributor instruction. Source setup should begin with a
+   portable clone instruction.
+4. **Reframe the duplication claim.** The canonical-docs policy explicitly
+   scopes its boundary to `docs-site/` and `docs/product/`; the more exact claim
+   is that the README contradicts its own declaration of the docs site as canon
+   by mirroring extensive behavior contracts.
+
+## Additional recommendations
+
+- Surface deterministic guardrails for agent-authored vaults in the opening;
+  this is a distinctive part of the product vision, while Bowerbird itself does
+  not call an LLM.
+- Make the capability map account for `dashboard`, `recent`, `bulk`, and
+  `config`, with a full-command-reference escape hatch.
+- Prefer linking to the canonical Quick Start over embedding another schema,
+  because the generated `init --yes` schema must currently be replaced before
+  the documented example flow.
+- Remove the hand-maintained repository tree rather than shortening it.
+- Avoid hardcoded release versions in README prose, and consider linking to the
+  changelog.
+
+## Proposed acceptance criteria
+
+- `npm install -g bwrb` is the first installation command.
+- Source setup appears only under Contributing and uses a portable clone path.
+- All public links are absolute and resolve from the npm rendering context.
+- Every shown command is verified copy-paste runnable, or the README links to
+  the canonical Quick Start instead of duplicating its schema.
+- Detailed schema, template, picker, app-mode, and completion contracts are
+  replaced by short summaries and canonical links.
+- The hand-curated source tree is removed.
+- The contributor section links `AGENTS.md` and the exact CI-parity workflow.
+- The opening states the type-safety promise, product boundaries, and the
+  deterministic agent-guardrail use case.
+- No hardcoded current package version appears in prose.
+- `pnpm docs:lint`, `pnpm docs:doctor`, and `pnpm docs:check` pass.
+
+## Verification note
+
+Fable reported 36 Markdown headings rather than the audit's original 31.
+Independent counting outside fenced code blocks confirmed 36, so the audit was
+corrected.


### PR DESCRIPTION
## Summary

- rewrite the README as a concise npm/GitHub front door
- lead with Bowerbird's type-safety and agent-guardrail purpose
- add npm-first installation and a verified fresh-vault flow
- replace duplicated behavior contracts with canonical documentation links
- preserve the audit and independent Fable review as planning artifacts
- remove unintended hard line breaks from rendered prose

## Verification

- exact README quick-start flow in a disposable vault
- all public README links return HTTP 200
- `pnpm docs:lint`
- `pnpm docs:doctor`
- `pnpm docs:check`
- `pnpm verify:pack`
- rendered GFM contains no unintended `<br>` tags
- `git diff --check`