### PR TITLE
Evaluate date expressions in schema defaults

### DIFF
--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -683,7 +683,7 @@ Complete list of field properties:
 | `label` | string | prompted | Custom label shown during prompting (the imperative prompt text) |
 | `description` | string | any | What this field is for and when to use it. Surfaced by `bwrb schema list`; distinct from `label` |
 | `required` | boolean | prompted | Whether field must have a value (default: `false`) |
-| `default` | string | prompted | Default value if user skips prompt |
+| `default` | string | prompted | Default value if user skips prompt. Date fields also accept creation-time expressions such as `@today` and `@today+7d` |
 | `granularity` | string | `date` | Coarsest precision allowed: `day` (default), `month`, or `year`. Overrides `date_granularity` |
 | `calendar` | string | `date` | Calendar id from `config.calendars`. Overrides the type's `calendar_default`; invalid on non-date fields |
 | `options` | array | `select` | Allowed values: bare strings or `{ value, description }` objects |
@@ -716,6 +716,16 @@ The rule is deliberately mechanical: fork-aware copying omits the stored field,
 then normal schema defaults may populate it. BWRB does not infer meaning from
 names such as `status`, `published`, or `approved`. Ordinary note creation and
 editing are unchanged by this marker.
+
+For fields with `prompt: "date"`, schema defaults accept the same creation-time
+date expressions as template defaults, including `@today`, `@today+7d`, and
+`today() + '7d'`. They evaluate when the default is materialized by ordinary
+creation, scoped blank-value restoration during `edit`, or `new --fork` after a
+`reset_on_fork` field is omitted. Non-date fields keep these strings literally,
+and malformed expressions fail before a note is written. Gregorian expressions
+are not supported for custom-calendar fields because custom calendars do not
+define a mapping from the current Gregorian date; use a literal date in that
+calendar instead.
 
 ### Built-in lineage metadata
 

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -290,6 +290,14 @@ bwrb list --body "search term" --output json
 frontmatter field predicate. Detailed `--matches` line numbers still refer to
 the original file, and displayed context never crosses into YAML frontmatter.
 
+### Schema Date Defaults
+
+Schema fields with `prompt: "date"` may use creation-time expressions such as
+`@today` or `@today+7d` as schema defaults. BWRB evaluates them for ordinary
+creation, scoped default restoration during edit, and reset-on-fork defaults.
+Non-date defaults remain literal. Custom-calendar date fields require literal
+dates in their configured calendar rather than Gregorian `@today` expressions.
+
 ### Relative-Date Fields
 
 Schema fields with `prompt: "relative-date"` store structured constraints, not

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -21,6 +21,7 @@ import {
 } from './local-date.js';
 import { validateRelativeDateValue } from './relative-date.js';
 import { parseCalendarDate } from './calendar-date.js';
+import { evaluateTemplateDefault } from './date-expression.js';
 
 export type NormalizedDateResult =
   | { valid: true; value: string }
@@ -441,7 +442,9 @@ export function validateFrontmatter(
 }
 
 /**
- * Apply defaults to frontmatter for missing fields.
+ * Apply defaults to frontmatter for missing fields. Date-typed schema defaults
+ * use the same creation-time expression evaluator as template defaults;
+ * non-date defaults remain literal.
  * Also injects the 'type' field with the type name.
  *
  * When `keyScope` is provided, ONLY those field names are considered for default
@@ -481,7 +484,18 @@ export function applyDefaults(
     const hasValue = !isBlankScalar(value);
 
     if (!hasValue && field.default !== undefined) {
-      result[fieldName] = field.default;
+      const evaluatedDefault = evaluateTemplateDefault(
+        field.default,
+        schema.config.dateFormat,
+        field.prompt
+      );
+      const calendarId = resolveDateCalendar(schema, typeName, fieldName, field);
+      if (calendarId && evaluatedDefault !== field.default) {
+        throw new Error(
+          `Date expressions are not supported for custom-calendar field '${fieldName}' (${calendarId}); use a literal ${calendarId} date instead.`
+        );
+      }
+      result[fieldName] = evaluatedDefault;
     }
 
     // Handle static values

--- a/tests/ts/commands/new-fork.test.ts
+++ b/tests/ts/commands/new-fork.test.ts
@@ -7,6 +7,7 @@ import {
   runCLI,
 } from '../fixtures/setup.js';
 import { parseNote } from '../../../src/lib/frontmatter.js';
+import { formatLocalDate } from '../../../src/lib/local-date.js';
 
 const SOURCE_ID = 'ABCDEF12-3456-4789-ABCD-EF1234567890';
 
@@ -82,10 +83,10 @@ Words worth keeping.
     expect(fork.body).toBe('## Draft\n\nWords worth keeping.\n');
   });
 
-  it('normalizes reset date defaults exactly like ordinary new and stays audit-clean', async () => {
+  it('evaluates dynamic schema date defaults for new, edit restoration, and fork, and stays audit-clean', async () => {
     const schemaPath = join(vaultDir, '.bwrb/schema.json');
     const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as any;
-    schema.types.task.fields.deadline.default = '12/25/2026';
+    schema.types.task.fields.deadline.default = '@today';
     schema.types.task.fields.deadline.reset_on_fork = true;
     await writeFile(schemaPath, JSON.stringify(schema, null, 2));
 
@@ -105,8 +106,16 @@ Words worth keeping.
     const forkOutput = JSON.parse(forked.stdout);
     const ordinaryNote = await parseNote(join(vaultDir, ordinaryOutput.path));
     const forkNote = await parseNote(join(vaultDir, forkOutput.path));
-    expect(ordinaryNote.frontmatter.deadline).toBe('2026-12-25');
+    const expected = formatLocalDate(new Date());
+    expect(ordinaryNote.frontmatter.deadline).toBe(expected);
     expect(forkNote.frontmatter.deadline).toBe(ordinaryNote.frontmatter.deadline);
+
+    const edited = await runCLI([
+      'edit', ordinaryOutput.path, '--json', '{"deadline":"   "}',
+    ], vaultDir);
+    expect(edited.exitCode, edited.stderr || edited.stdout).toBe(0);
+    const editedNote = await parseNote(join(vaultDir, ordinaryOutput.path));
+    expect(editedNote.frontmatter.deadline).toBe(expected);
 
     for (const notePath of [ordinaryOutput.path, forkOutput.path]) {
       const audit = await runCLI(['audit', '--path', notePath, '--output', 'json'], vaultDir);

--- a/tests/ts/lib/validation.test.ts
+++ b/tests/ts/lib/validation.test.ts
@@ -615,6 +615,57 @@ describe('validation', () => {
       expect(result.priority).toBe('high');
     });
 
+    it('evaluates schema defaults only for date-typed fields, including scoped restoration', () => {
+      const dateSchema = resolveSchema({
+        version: 2,
+        types: {
+          note: {
+            fields: {
+              due: { prompt: 'date', default: '@today' },
+              caption: { prompt: 'text', default: '@today' },
+            },
+          },
+        },
+      });
+
+      const result = applyDefaults(dateSchema, 'note', { due: '   ' }, new Set(['due']));
+      expect(result.due).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(result).not.toHaveProperty('caption');
+      expect(applyDefaults(dateSchema, 'note', {}).caption).toBe('@today');
+    });
+
+    it('rejects malformed schema date expressions before they can be persisted', () => {
+      const dateSchema = resolveSchema({
+        version: 2,
+        types: {
+          note: { fields: { due: { prompt: 'date', default: '@today+3x' } } },
+        },
+      });
+
+      expect(() => applyDefaults(dateSchema, 'note', {})).toThrow(/Invalid date expression/);
+    });
+
+    it('rejects Gregorian date expressions for custom-calendar schema defaults', () => {
+      const dateSchema = resolveSchema({
+        version: 2,
+        config: {
+          calendars: {
+            tmi: {
+              months: [{ name: 'First', days: 10 }],
+              eras: [{ name: 'After', shortName: 'AR' }],
+            },
+          },
+        },
+        types: {
+          note: { fields: { due: { prompt: 'date', calendar: 'tmi', default: '@today' } } },
+        },
+      });
+
+      expect(() => applyDefaults(dateSchema, 'note', {})).toThrow(
+        /not supported for custom-calendar field 'due'.*literal tmi date/
+      );
+    });
+
     it('should not override existing values', () => {
       const result = applyDefaults(schema, 'idea', {
         status: 'in-flight',


### PR DESCRIPTION
## Summary
- evaluate schema-level defaults with the existing type-aware date-expression evaluator
- apply the behavior consistently to ordinary creation, scoped edit restoration, and reset-on-fork defaults
- keep non-date defaults literal and fail clearly for malformed expressions or unsupported custom-calendar expressions
- document the public schema and automation contract

## Verification
- `pnpm test -- tests/ts/lib/validation.test.ts tests/ts/commands/new-fork.test.ts` (106 passed)
- `pnpm test -- --exclude='**/*.pty.test.ts'` (3,040 passed, 3 skipped)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm verify:pack`
- built-CLI scratch-vault reproduction: reset-on-fork `@today` persisted as `2026-07-12`; audit returned success with zero issues

## Custom calendars
Custom calendars define no mapping from the current Gregorian date. Schema date expressions on those fields now fail before writing and direct users to provide a literal date in the configured calendar.