### PR TITLE
Fix audit filesChecked summary

### DIFF
--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -37,6 +37,7 @@ import {
 } from '../lib/audit/types.js';
 import {
   runAudit,
+  runAuditDetailed,
   discoverManagedFiles,
   auditFile,
 } from '../lib/audit/detection.js';
@@ -379,7 +380,7 @@ Examples:
         : undefined;
 
       // Run audit with unified targeting options
-      const results = await runAudit(schema, vaultDir, {
+      const { results, filesChecked } = await runAuditDetailed(schema, vaultDir, {
         typePath,
         strict: options.strict ?? false,
         pathFilter: pathGlob,
@@ -437,7 +438,7 @@ Examples:
       }
 
       // Output results (report mode)
-      const summary = calculateSummary(results);
+      const summary = calculateSummary(results, filesChecked);
 
       // Optional schema documentation coverage check (opt-in).
       const undocumented = options.checkSchemaDocs
@@ -497,6 +498,7 @@ export {
   
   // Detection functions
   runAudit,
+  runAuditDetailed,
   discoverManagedFiles,
   auditFile,
   

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -47,6 +47,7 @@ import { applyWhereExpressions } from '../where-targeting.js';
 import { type LoadedSchema, type Field, getOptionValues } from '../../types/schema.js';
 import {
   type AuditIssue,
+  type AuditRunResult,
   type FileAuditResult,
   type ManagedFile,
   type AuditRunOptions,
@@ -122,11 +123,11 @@ const VAULT_GLOBAL_RESULT_PATH = '(vault-wide)';
 /**
  * Run audit on all managed files.
  */
-export async function runAudit(
+export async function runAuditDetailed(
   schema: LoadedSchema,
   vaultDir: string,
   options: AuditRunOptions
-): Promise<FileAuditResult[]> {
+): Promise<AuditRunResult> {
   // Discover all managed files
   const files = await discoverManagedFiles(schema, vaultDir, options.typePath);
 
@@ -318,7 +319,22 @@ export async function runAudit(
     }
   }
 
-  return results;
+  return { results, filesChecked: filteredFiles.length };
+}
+
+/**
+ * Run audit detection and return only files with findings.
+ *
+ * This compatibility surface intentionally omits clean files. Command output
+ * uses {@link runAuditDetailed} so summary accounting can still report every
+ * targeted file that was inspected.
+ */
+export async function runAudit(
+  schema: LoadedSchema,
+  vaultDir: string,
+  options: AuditRunOptions
+): Promise<FileAuditResult[]> {
+  return (await runAuditDetailed(schema, vaultDir, options)).results;
 }
 
 // ============================================================================

--- a/src/lib/audit/output.ts
+++ b/src/lib/audit/output.ts
@@ -22,7 +22,10 @@ import {
 /**
  * Calculate summary statistics from results.
  */
-export function calculateSummary(results: FileAuditResult[]): AuditSummary {
+export function calculateSummary(
+  results: FileAuditResult[],
+  filesChecked: number = results.length
+): AuditSummary {
   let filesWithErrors = 0;
   let filesWithWarnings = 0;
   let totalErrors = 0;
@@ -40,7 +43,7 @@ export function calculateSummary(results: FileAuditResult[]): AuditSummary {
   }
 
   return {
-    filesChecked: results.length > 0 ? results.length : 0,
+    filesChecked,
     filesWithErrors,
     filesWithWarnings,
     totalErrors,

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -171,6 +171,12 @@ export interface FileAuditResult {
   issues: AuditIssue[];
 }
 
+/** Audit findings plus the number of targeted files actually inspected. */
+export interface AuditRunResult {
+  results: FileAuditResult[];
+  filesChecked: number;
+}
+
 /**
  * Overall audit summary.
  */

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -669,11 +669,16 @@ priority: medium
 `
       );
 
-      const result = await runCLI(['audit', 'idea', '--output', 'json'], tempVaultDir);
+      const result = await runCLI(
+        ['audit', '--path', 'Ideas/Good File.md', '--output', 'json'],
+        tempVaultDir
+      );
 
       const json = JSON.parse(result.stdout);
       expect(json.success).toBe(true);
       expect(json.files).toBeInstanceOf(Array);
+      expect(json.files).toHaveLength(0);
+      expect(json.summary.filesChecked).toBe(1);
       expect(json.summary.totalErrors).toBe(0);
     });
 
@@ -793,6 +798,14 @@ priority: medium
       expect(result.stdout).toContain('Summary:');
       expect(result.stdout).toContain('Files with issues: 2');
       expect(result.stdout).toContain('Total errors: 2');
+
+      const jsonResult = await runCLI(['audit', 'idea', '--output', 'json'], tempVaultDir);
+      const output = JSON.parse(jsonResult.stdout);
+      expect(output.summary).toMatchObject({
+        filesChecked: 3,
+        filesWithErrors: 2,
+        totalErrors: 2,
+      });
     });
   });
 


### PR DESCRIPTION
Closes #826

## Summary
- preserve the issue-only `runAudit` compatibility API
- add a detailed audit result carrying the post-targeting file count
- use that count for command summary output
- cover clean exact-path audits and mixed clean/error runs

## Verification
- `pnpm test -- tests/ts/commands/audit.test.ts` (224 passed)
- focused regression tests (clean path and mixed summary)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm build`
- built CLI reproduction: clean exact-path audit returns `filesChecked: 1`, empty `files`, and zero issues