### PR TITLE
Revitalize the documentation site design

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -26,6 +26,10 @@ export default defineConfig({
 			title: 'Bowerbird',
 			tagline: 'The type system for your notes',
 			description: 'Schema-driven note management for markdown vaults',
+			components: {
+				PageTitle: './src/components/PageTitle.astro',
+				SiteTitle: './src/components/SiteTitle.astro',
+			},
 			social: [
 				{ icon: 'github', label: 'GitHub', href: 'https://github.com/3mdistal/bwrb' },
 			],

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.37.6",
+    "@fontsource-variable/instrument-sans": "^5.2.8",
+    "@fontsource/ibm-plex-mono": "^5.2.7",
     "astro": "^5.17.1",
     "sharp": "^0.34.5"
   },

--- a/docs-site/pnpm-lock.yaml
+++ b/docs-site/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.37.6
         version: 0.37.6(astro@5.17.1(rollup@4.57.1)(typescript@5.9.3))
+      '@fontsource-variable/instrument-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.2.7
+        version: 5.2.7
       astro:
         specifier: ^5.17.1
         version: 5.17.1(rollup@4.57.1)(typescript@5.9.3)
@@ -250,6 +256,12 @@ packages:
 
   '@expressive-code/plugin-text-markers@0.41.6':
     resolution: {integrity: sha512-PBFa1wGyYzRExMDzBmAWC6/kdfG1oLn4pLpBeTfIRrALPjcGA/59HP3e7q9J0Smk4pC7U+lWkA2LHR8FYV8U7Q==}
+
+  '@fontsource-variable/instrument-sans@5.2.8':
+    resolution: {integrity: sha512-mTCaukbdIjjoipj2E3Q5XoZM3ZxJWdzyHevf/LG/0PHlfF9Q85pxOM7B7A9MerFyxmRzz5kVlumgIvgDSG4CPg==}
+
+  '@fontsource/ibm-plex-mono@5.2.7':
+    resolution: {integrity: sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==}
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -2042,6 +2054,10 @@ snapshots:
   '@expressive-code/plugin-text-markers@0.41.6':
     dependencies:
       '@expressive-code/core': 0.41.6
+
+  '@fontsource-variable/instrument-sans@5.2.8': {}
+
+  '@fontsource/ibm-plex-mono@5.2.7': {}
 
   '@img/colour@1.0.0': {}
 

--- a/docs-site/src/components/BowerbirdMark.astro
+++ b/docs-site/src/components/BowerbirdMark.astro
@@ -1,0 +1,26 @@
+---
+interface Props {
+	class?: string;
+}
+
+const { class: className } = Astro.props;
+---
+
+<svg class={className} viewBox="0 0 48 48" aria-hidden="true">
+	<path d="M9 4v40M18 4v40M30 4v40M39 4v40M4 9h40M4 18h40M4 30h40M4 39h40" />
+	<path class="mark-accent" d="M18 18h12v12H18z" />
+</svg>
+
+<style>
+	svg {
+		fill: none;
+		stroke: currentColor;
+		stroke-linecap: square;
+		stroke-width: 1.5;
+	}
+
+	.mark-accent {
+		stroke: var(--bb-accent, #315ee8);
+		stroke-width: 2.5;
+	}
+</style>

--- a/docs-site/src/components/Homepage.astro
+++ b/docs-site/src/components/Homepage.astro
@@ -1,0 +1,127 @@
+---
+import BowerbirdMark from './BowerbirdMark.astro';
+
+const capabilities = [
+	{ label: 'Plain Markdown', detail: 'Your vault stays yours.', mark: 'file' },
+	{ label: 'Local-first', detail: 'No account. No cloud.', mark: 'folder' },
+	{ label: 'Automation-ready', detail: 'JSON in. JSON out.', mark: 'bolt' },
+];
+---
+
+<div class="bb-home">
+	<section class="bb-hero" aria-labelledby="bb-hero-title">
+		<div class="bb-hero-copy">
+			<div class="bb-kicker"><BowerbirdMark /> <span>The type system for your notes</span></div>
+			<h1 id="bb-hero-title">Your notes,<br />with a type system.</h1>
+			<p class="bb-hero-dek">
+				Bring structure to Markdown vaults with schemas, validation, and tooling that stays out of your way.
+			</p>
+			<div class="bb-actions">
+				<a class="bb-button bb-button-primary" href="/getting-started/quick-start/">
+					<span aria-hidden="true">›_</span> Start with a schema
+				</a>
+				<a class="bb-button bb-button-quiet" href="https://github.com/3mdistal/bwrb">
+					View on GitHub <span aria-hidden="true">↗</span>
+				</a>
+			</div>
+		</div>
+
+		<div class="bb-system" aria-label="A Markdown note passing through a schema to become a validated note">
+			<div class="bb-system-labels" aria-hidden="true">
+				<span>Raw Markdown</span><span>Schema</span><span>Validated note</span>
+			</div>
+			<div class="bb-system-grid">
+				<div class="bb-code-panel bb-raw-panel">
+					<div class="bb-panel-bar"><span>task.md</span><i></i></div>
+					<pre><code><span>---</span>
+<b>title:</b> Ship CLI v1
+<b>status:</b> in-progress
+<b>due:</b> 2026-07-18
+<span>---</span>
+
+## Overview
+Build, test, and ship.</code></pre>
+				</div>
+
+				<div class="bb-schema-panel">
+					<div class="bb-node bb-node-root"><i></i><strong>task</strong><small>type</small></div>
+					<div class="bb-node"><i></i><span>title</span><small>string</small></div>
+					<div class="bb-node"><i></i><span>status</span><small>select</small></div>
+					<div class="bb-node"><i></i><span>due</span><small>date</small></div>
+				</div>
+
+				<div class="bb-note-panel">
+					<div class="bb-valid"><i></i> Valid</div>
+					<div><small>title <em>string</em></small><strong>Ship CLI v1</strong></div>
+					<div><small>status <em>select</em></small><span class="bb-chip">in-progress</span></div>
+					<div><small>due <em>date</em></small><strong>July 18, 2026</strong></div>
+				</div>
+			</div>
+		</div>
+	</section>
+
+	<section class="bb-proof" aria-label="Product principles">
+		{capabilities.map((capability) => (
+			<div>
+				<span class={`bb-proof-icon bb-proof-${capability.mark}`} aria-hidden="true"></span>
+				<strong>{capability.label}</strong>
+				<small>{capability.detail}</small>
+			</div>
+		))}
+	</section>
+
+	<section class="bb-story" aria-labelledby="bb-story-title">
+		<div class="bb-section-heading">
+			<p>From an idea to a trustworthy vault</p>
+			<h2 id="bb-story-title">Structure that grows<br />with your thinking.</h2>
+		</div>
+
+		<div class="bb-story-grid">
+			<article class="bb-story-card bb-story-schema">
+				<header><span>Schema / 01</span><strong>Define the shape.</strong><p>Describe fields once. Let every note follow.</p></header>
+				<div class="bb-card-stage">
+					<pre><code><b>task</b>: &#123;
+  <b>status</b>: <span>select</span>
+  <b>due</b>: <span>date</span>
+  <b>priority</b>: <span>number</span>
+&#125;</code></pre>
+					<div class="bb-mini-tree" aria-hidden="true">
+						<i></i><p><b>task</b><small>object</small></p>
+						<p><b>status</b><small>select</small></p>
+						<p><b>due</b><small>date</small></p>
+						<p><b>priority</b><small>number</small></p>
+					</div>
+				</div>
+			</article>
+
+			<article class="bb-story-card bb-story-create">
+				<header><span>Create / 02</span><strong>Write in Markdown.</strong><p>Keep the format you trust. Add structure as you need it.</p></header>
+				<div class="bb-card-stage bb-terminal-stage">
+					<div class="bb-terminal-bar"><i></i><i></i><i></i><span>Terminal</span></div>
+					<pre><code><b>$</b> bwrb new task --json
+
+<span>?</span> title    Ship CLI v1
+<span>?</span> status   in-progress
+<span>?</span> due      2026-07-18
+
+<em>✓ Created tasks/Ship CLI v1.md</em></code></pre>
+				</div>
+			</article>
+
+			<article class="bb-story-card bb-story-audit">
+				<header><span>Audit / 03</span><strong>Trust the whole vault.</strong><p>Find drift early. Migrate deliberately.</p></header>
+				<div class="bb-card-stage bb-audit-stage">
+					<div class="bb-audit-summary"><span><i></i>42 valid</span><span><i></i>2 warnings</span></div>
+					<div class="bb-audit-row"><code>tasks/ship-cli-v1.md</code><span>valid</span></div>
+					<div class="bb-audit-row"><code>tasks/old-idea.md</code><span class="is-warning">2 issues</span></div>
+					<div class="bb-audit-row"><code>notes/untitled.md</code><span class="is-muted">ignored</span></div>
+				</div>
+			</article>
+		</div>
+	</section>
+
+	<section class="bb-cta" aria-labelledby="bb-cta-title">
+		<div><span>Ready when your notes are.</span><h2 id="bb-cta-title">Give your vault a backbone.</h2></div>
+		<a class="bb-button bb-button-primary" href="/getting-started/quick-start/">Read the Quick Start <span aria-hidden="true">→</span></a>
+	</section>
+</div>

--- a/docs-site/src/components/PageTitle.astro
+++ b/docs-site/src/components/PageTitle.astro
@@ -1,0 +1,8 @@
+---
+import Default from '@astrojs/starlight/components/PageTitle.astro';
+
+const route = Astro.locals.starlightRoute;
+const isHomepage = route.id === '' || route.entry.slug === 'index';
+---
+
+{!isHomepage && <Default />}

--- a/docs-site/src/components/SiteTitle.astro
+++ b/docs-site/src/components/SiteTitle.astro
@@ -1,0 +1,30 @@
+---
+import BowerbirdMark from './BowerbirdMark.astro';
+---
+
+<a class="bb-site-title" href="/" aria-label="Bowerbird home">
+	<BowerbirdMark />
+	<span>Bowerbird</span>
+</a>
+
+<style>
+	.bb-site-title {
+		align-items: center;
+		color: var(--bb-ink);
+		display: inline-flex;
+		font-size: 1.06rem;
+		font-weight: 660;
+		gap: 0.62rem;
+		letter-spacing: -0.025em;
+		text-decoration: none;
+	}
+
+	.bb-site-title:hover {
+		color: var(--bb-accent);
+	}
+
+	.bb-site-title :global(svg) {
+		height: 1.85rem;
+		width: 1.85rem;
+	}
+</style>

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -2,51 +2,8 @@
 title: Bowerbird
 description: Schema-driven note management for markdown vaults
 template: splash
-hero:
-  tagline: The type system for your notes
-  image:
-    file: ../../assets/hero.jpeg
-    alt: Abstract structure representing connected notes
-  actions:
-    - text: Get Started
-      link: /getting-started/introduction/
-      icon: right-arrow
-    - text: View on GitHub
-      link: https://github.com/3mdistal/bwrb
-      icon: external
-      variant: minimal
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+import Homepage from '../../components/Homepage.astro';
 
-## What is Bowerbird?
-
-Bowerbird is a CLI tool that enforces strict schemas on Markdown/YAML files. It brings TypeScript-style type safety to personal knowledge management—your notes can't violate the schema, your queries always return valid data, and migrations are explicit.
-
-<CardGrid stagger>
-	<Card title="Schema Enforcement" icon="approve-check">
-		Define types, fields, and constraints. Bowerbird ensures every note conforms.
-	</Card>
-	<Card title="CLI-First" icon="seti:shell">
-		Works in your terminal. JSON mode for scripting and AI integration.
-	</Card>
-	<Card title="Portable & Offline" icon="laptop">
-		No accounts, no cloud. Just Markdown files and Git.
-	</Card>
-	<Card title="Incrementally Adoptable" icon="puzzle">
-		Start minimal. Add types as patterns emerge. Migrate when ready.
-	</Card>
-</CardGrid>
-
-## Quick Example
-
-```bash
-# Create a new task with schema-driven prompts
-bwrb new task
-
-# List all tasks filtered by status
-bwrb list task --where "status = 'active'"
-
-# Audit your vault for schema violations
-bwrb audit
-```
+<Homepage />

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -1,51 +1,693 @@
+@import '@fontsource-variable/instrument-sans';
+@import '@fontsource/ibm-plex-mono/400.css';
+@import '@fontsource/ibm-plex-mono/500.css';
+
 :root {
-	/* Bowerbird Blue Theme */
-	--sl-hue-accent: 215;
-	--sl-saturation-accent: 90%;
-	--sl-lightness-accent: 60%;
+	--bb-paper: #f7f7f3;
+	--bb-paper-raised: #fcfcf9;
+	--bb-ink: #15171a;
+	--bb-ink-soft: #555b62;
+	--bb-line: #d9d9d2;
+	--bb-line-soft: #e8e7e0;
+	--bb-accent: #315ee8;
+	--bb-accent-soft: #e9edff;
+	--bb-valid: #5e9e22;
+	--bb-valid-soft: #edf6e6;
+	--bb-warning: #b37a08;
+	--bb-radius: 8px;
+	--bb-shadow: 0 1px 1px rgb(21 23 26 / 4%), 0 12px 28px rgb(21 23 26 / 5%);
+	--sl-font: 'Instrument Sans Variable', sans-serif;
+	--sl-font-mono: 'IBM Plex Mono', monospace;
+	--sl-color-accent-low: var(--bb-accent-soft);
+	--sl-color-accent: var(--bb-accent);
+	--sl-color-accent-high: #1f46bd;
+	--sl-color-white: var(--bb-ink);
+	--sl-color-gray-1: #2a2d31;
+	--sl-color-gray-2: #44484e;
+	--sl-color-gray-3: #696e75;
+	--sl-color-gray-4: #9da1a5;
+	--sl-color-gray-5: var(--bb-line);
+	--sl-color-gray-6: var(--bb-line-soft);
+	--sl-color-black: var(--bb-paper);
+	--sl-color-bg: var(--bb-paper);
+	--sl-color-bg-nav: color-mix(in srgb, var(--bb-paper) 94%, transparent);
+	--sl-color-bg-sidebar: var(--bb-paper);
+	--sl-content-width: 47rem;
+	--sl-text-5xl: clamp(2.65rem, 5vw, 4.9rem);
 }
 
-/* Dark mode tweaks */
 :root[data-theme='dark'] {
-	--sl-color-accent-high: hsl(215, 90%, 75%);
-	--sl-color-accent: hsl(215, 90%, 60%);
-	--sl-color-accent-low: hsl(215, 90%, 25%);
+	--bb-paper: #0b0d10;
+	--bb-paper-raised: #111419;
+	--bb-ink: #f0f1ed;
+	--bb-ink-soft: #9ca2aa;
+	--bb-line: #2b2f35;
+	--bb-line-soft: #1d2126;
+	--bb-accent: #7292ff;
+	--bb-accent-soft: #17234c;
+	--bb-valid: #8fca55;
+	--bb-valid-soft: #1b2a16;
+	--bb-warning: #e3b752;
+	--bb-shadow: 0 1px 1px rgb(0 0 0 / 18%), 0 16px 40px rgb(0 0 0 / 16%);
+	--sl-color-accent-high: #aabfff;
+	--sl-color-white: var(--bb-ink);
+	--sl-color-gray-1: #d9dce0;
+	--sl-color-gray-2: #b8bdc3;
+	--sl-color-gray-3: #9298a0;
+	--sl-color-gray-4: #6f757d;
+	--sl-color-gray-5: var(--bb-line);
+	--sl-color-gray-6: var(--bb-line-soft);
+	--sl-color-black: var(--bb-paper);
 }
 
-/* Light mode tweaks */
-:root[data-theme='light'] {
-	--sl-color-accent-high: hsl(215, 90%, 40%);
-	--sl-color-accent: hsl(215, 90%, 50%);
-	--sl-color-accent-low: hsl(215, 90%, 85%);
+html {
+	background: var(--bb-paper);
 }
 
-/* Enhance Hero Section */
-.hero {
-	position: relative;
-	overflow: hidden;
+body {
+	background:
+		linear-gradient(90deg, transparent calc(100% - 1px), color-mix(in srgb, var(--bb-line-soft) 38%, transparent) 1px) 0 0 / 5rem 5rem,
+		var(--bb-paper);
+	color: var(--bb-ink);
+	font-family: var(--sl-font);
+	font-feature-settings: 'ss01', 'ss03';
 }
 
-/* Make the tagline pop */
-.hero .tagline {
-	font-size: 1.5rem;
-	background: -webkit-linear-gradient(315deg, var(--sl-color-accent-high) 25%, var(--sl-color-accent));
-	-webkit-background-clip: text;
-	-webkit-text-fill-color: transparent;
+::selection {
+	background: color-mix(in srgb, var(--bb-accent) 22%, transparent);
+}
+
+a,
+button,
+input {
+	transition: color 150ms ease, border-color 150ms ease, background-color 150ms ease, transform 150ms ease;
+}
+
+:focus-visible {
+	outline: 2px solid var(--bb-accent) !important;
+	outline-offset: 3px;
+}
+
+/* Documentation shell */
+
+header.header {
+	backdrop-filter: blur(18px);
+	border-bottom-color: var(--bb-line);
+	box-shadow: none;
+}
+
+.site-title {
+	color: var(--bb-ink);
+	font-size: 1.15rem;
+	font-weight: 650;
+	letter-spacing: -0.025em;
+}
+
+.site-title:hover {
+	color: var(--bb-accent);
+}
+
+.search-input,
+button[data-open-modal] {
+	background: color-mix(in srgb, var(--bb-paper-raised) 88%, transparent) !important;
+	border-color: var(--bb-line) !important;
+	border-radius: 7px !important;
+	box-shadow: 0 1px 0 rgb(255 255 255 / 28%) inset;
+}
+
+.sidebar-pane {
+	border-inline-end: 1px solid var(--bb-line);
+}
+
+.sidebar-content {
+	padding-block: 1.4rem 2rem;
+}
+
+.sidebar-content summary,
+.sidebar-content .top-level > li > a {
+	color: var(--bb-ink);
+	font-size: 0.72rem;
+	font-weight: 650;
+	letter-spacing: 0.095em;
+	text-transform: uppercase;
+}
+
+.sidebar-content a {
+	border-radius: 4px;
+	color: var(--bb-ink-soft);
+	font-size: 0.88rem;
+	padding-block: 0.37rem;
+}
+
+.sidebar-content a[aria-current='page'] {
+	background: linear-gradient(90deg, var(--bb-accent-soft), color-mix(in srgb, var(--bb-accent-soft) 15%, transparent));
+	box-shadow: -2px 0 0 var(--bb-accent);
+	color: var(--bb-ink);
+	font-weight: 620;
+}
+
+.sidebar-content a:not([aria-current='page']):hover {
+	background: color-mix(in srgb, var(--bb-ink) 4%, transparent);
+	color: var(--bb-ink);
+}
+
+.right-sidebar {
+	border-inline-start-color: var(--bb-line);
+}
+
+starlight-toc a {
+	color: var(--bb-ink-soft);
+	font-size: 0.79rem;
+	line-height: 1.45;
+}
+
+starlight-toc a[aria-current='true'] {
+	color: var(--bb-accent);
 	font-weight: 600;
 }
 
-/* Card hover effects */
-.card-grid .card {
-	transition: transform 0.2s ease-in-out, border-color 0.2s ease-in-out;
+.content-panel + .content-panel {
+	border-top-color: var(--bb-line-soft);
 }
 
-.card-grid .card:hover {
-	transform: translateY(-2px);
-	border-color: var(--sl-color-accent);
+.sl-markdown-content {
+	font-size: 1.03rem;
+	line-height: 1.76;
 }
 
-/* Make code blocks look sharper */
+.sl-markdown-content h1,
+.sl-markdown-content h2,
+.sl-markdown-content h3 {
+	color: var(--bb-ink);
+	font-weight: 570;
+	letter-spacing: -0.035em;
+}
+
+.sl-markdown-content h1 {
+	font-size: clamp(2.55rem, 4vw, 3.8rem);
+	line-height: 1.02;
+}
+
+.sl-markdown-content h2 {
+	border-top: 1px solid var(--bb-line);
+	font-size: 2rem;
+	line-height: 1.15;
+	padding-top: 2rem;
+}
+
+.sl-markdown-content h3 {
+	font-size: 1.35rem;
+}
+
+.sl-markdown-content :not(h1, h2, h3, h4, h5, h6) + :is(h2, h3) {
+	margin-top: 3.5rem;
+}
+
+.sl-markdown-content a:not([class]) {
+	text-decoration-color: color-mix(in srgb, var(--bb-accent) 45%, transparent);
+	text-decoration-thickness: 1px;
+	text-underline-offset: 0.2em;
+}
+
+.sl-markdown-content code:not(:where(.not-content *)) {
+	background: color-mix(in srgb, var(--bb-accent) 7%, var(--bb-paper-raised));
+	border: 1px solid var(--bb-line);
+	border-radius: 4px;
+	color: var(--bb-ink);
+	font-size: 0.86em;
+}
+
 .expressive-code .frame {
-	border: 1px solid var(--sl-color-gray-5);
-	box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+	border: 1px solid var(--bb-line);
+	border-radius: var(--bb-radius);
+	box-shadow: var(--bb-shadow);
+	overflow: hidden;
+}
+
+.expressive-code .frame.has-title .header,
+.expressive-code .frame.is-terminal .header {
+	border-bottom: 1px solid var(--bb-line);
+}
+
+.sl-markdown-content table {
+	border: 1px solid var(--bb-line);
+	border-radius: var(--bb-radius);
+	display: table;
+	overflow: hidden;
+	width: 100%;
+}
+
+.sl-markdown-content th {
+	background: color-mix(in srgb, var(--bb-ink) 4%, var(--bb-paper));
+	font-family: var(--sl-font-mono);
+	font-size: 0.73rem;
+	letter-spacing: 0.055em;
+	text-transform: uppercase;
+}
+
+.sl-markdown-content td,
+.sl-markdown-content th {
+	border-color: var(--bb-line);
+}
+
+.starlight-aside {
+	background: color-mix(in srgb, var(--sl-color-asides-text-accent) 4%, var(--bb-paper-raised));
+	border: 1px solid color-mix(in srgb, var(--sl-color-asides-text-accent) 32%, var(--bb-line));
+	border-radius: var(--bb-radius);
+	box-shadow: none;
+}
+
+/* Homepage */
+
+body:has(.bb-home) main,
+body:has(.bb-home) .content-panel,
+body:has(.bb-home) .sl-container,
+body:has(.bb-home) .sl-markdown-content {
+	max-width: none;
+	padding: 0;
+	width: 100%;
+}
+
+body:has(.bb-home) .main-frame {
+	padding: 0;
+}
+
+body:has(.bb-home) .content-panel {
+	border: 0;
+}
+
+.bb-home {
+	--home-pad: clamp(1.25rem, 4.5vw, 4.75rem);
+	background: var(--bb-paper);
+	color: var(--bb-ink);
+	margin-inline: auto;
+	max-width: 96rem;
+	overflow: hidden;
+}
+
+.bb-home :where(h1, h2, h3, p, pre) {
+	margin: 0;
+}
+
+.bb-hero {
+	display: grid;
+	grid-template-columns: minmax(20rem, 0.82fr) minmax(36rem, 1.18fr);
+	min-height: min(47rem, calc(100vh - var(--sl-nav-height)));
+}
+
+.bb-hero-copy {
+	align-items: flex-start;
+	border-inline-end: 1px solid var(--bb-line);
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding: clamp(5rem, 9vw, 9rem) var(--home-pad) 5rem;
+}
+
+.bb-kicker {
+	align-items: center;
+	color: var(--bb-ink-soft);
+	display: flex;
+	font-family: var(--sl-font-mono);
+	font-size: 0.68rem;
+	gap: 0.65rem;
+	letter-spacing: 0.075em;
+	margin-bottom: 2.2rem;
+	text-transform: uppercase;
+}
+
+.bb-kicker svg {
+	height: 1.5rem;
+	width: 1.5rem;
+}
+
+.bb-hero h1 {
+	font-size: clamp(3.65rem, 6vw, 6.4rem);
+	font-weight: 470;
+	letter-spacing: -0.065em;
+	line-height: 0.94;
+	max-width: 8ch;
+}
+
+.bb-hero-dek {
+	color: var(--bb-ink-soft);
+	font-size: clamp(1.05rem, 1.6vw, 1.3rem);
+	line-height: 1.55;
+	margin-top: 2.4rem !important;
+	max-width: 35rem;
+}
+
+.bb-actions {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+	margin-top: 2rem;
+}
+
+.bb-button {
+	align-items: center;
+	border-radius: 6px;
+	display: inline-flex;
+	font-size: 0.93rem;
+	font-weight: 580;
+	gap: 0.7rem;
+	justify-content: center;
+	min-height: 3rem;
+	padding-inline: 1.15rem;
+	text-decoration: none;
+}
+
+.bb-button:hover {
+	transform: translateY(-1px);
+}
+
+.bb-button-primary {
+	background: var(--bb-accent);
+	box-shadow: 0 8px 24px color-mix(in srgb, var(--bb-accent) 22%, transparent);
+	color: white;
+}
+
+.bb-button-primary:hover {
+	background: color-mix(in srgb, var(--bb-accent) 87%, black);
+	color: white;
+}
+
+.bb-button-primary > span {
+	font-family: var(--sl-font-mono);
+}
+
+.bb-button-quiet {
+	border: 1px solid transparent;
+	color: var(--bb-ink);
+}
+
+.bb-button-quiet:hover {
+	border-color: var(--bb-line);
+	background: var(--bb-paper-raised);
+}
+
+.bb-system {
+	align-items: center;
+	background:
+		linear-gradient(var(--bb-line-soft) 1px, transparent 1px) 0 0 / 100% 5rem,
+		linear-gradient(90deg, var(--bb-line-soft) 1px, transparent 1px) 0 0 / 5rem 100%;
+	display: flex;
+	justify-content: center;
+	min-width: 0;
+	padding: 5rem clamp(1.25rem, 3vw, 3.5rem) 3rem;
+	position: relative;
+}
+
+.bb-system::before {
+	background: radial-gradient(circle, color-mix(in srgb, var(--bb-accent) 14%, transparent), transparent 68%);
+	content: '';
+	inset: 12% 6%;
+	pointer-events: none;
+	position: absolute;
+}
+
+.bb-system-labels {
+	display: grid;
+	font-family: var(--sl-font-mono);
+	font-size: 0.62rem;
+	grid-template-columns: 1.06fr 0.84fr 1.1fr;
+	inset: auto clamp(1.25rem, 3vw, 3.5rem) calc(50% + 15rem);
+	letter-spacing: 0.07em;
+	position: absolute;
+	text-transform: uppercase;
+}
+
+.bb-system-labels span {
+	text-align: center;
+}
+
+.bb-system-grid {
+	align-items: center;
+	display: grid;
+	grid-template-columns: 1.06fr 0.84fr 1.1fr;
+	position: relative;
+	width: 100%;
+	z-index: 1;
+}
+
+.bb-code-panel,
+.bb-note-panel,
+.bb-schema-panel {
+	background: color-mix(in srgb, var(--bb-paper-raised) 96%, transparent);
+	border: 1px solid var(--bb-line);
+	box-shadow: var(--bb-shadow);
+}
+
+.bb-code-panel {
+	border-radius: var(--bb-radius) 0 0 var(--bb-radius);
+	overflow: hidden;
+}
+
+.bb-panel-bar {
+	align-items: center;
+	border-bottom: 1px solid var(--bb-line);
+	color: var(--bb-ink-soft);
+	display: flex;
+	font-family: var(--sl-font-mono);
+	font-size: 0.62rem;
+	justify-content: space-between;
+	padding: 0.65rem 0.8rem;
+}
+
+.bb-panel-bar i {
+	background: var(--bb-valid);
+	border-radius: 50%;
+	height: 0.4rem;
+	width: 0.4rem;
+}
+
+.bb-code-panel pre {
+	background: transparent;
+	font-size: clamp(0.62rem, 0.8vw, 0.75rem);
+	line-height: 1.7;
+	padding: 1rem;
+}
+
+.bb-code-panel pre span {
+	color: var(--bb-ink-soft);
+}
+
+.bb-code-panel pre b {
+	color: var(--bb-accent);
+	font-weight: 540;
+}
+
+.bb-schema-panel {
+	border-inline: 0;
+	padding: 1.2rem 1rem;
+	position: relative;
+}
+
+.bb-schema-panel::before,
+.bb-schema-panel::after {
+	background: var(--bb-accent);
+	content: '';
+	height: 1px;
+	position: absolute;
+	top: 50%;
+	width: 1.15rem;
+}
+
+.bb-schema-panel::before { left: -1.15rem; }
+.bb-schema-panel::after { right: -1.15rem; }
+
+.bb-node {
+	align-items: center;
+	border-top: 1px solid var(--bb-line-soft);
+	display: grid;
+	font-family: var(--sl-font-mono);
+	font-size: clamp(0.56rem, 0.8vw, 0.68rem);
+	grid-template-columns: auto 1fr auto;
+	gap: 0.42rem;
+	padding: 0.62rem 0;
+}
+
+.bb-node:first-child { border-top: 0; }
+.bb-node i { border: 1px solid var(--bb-accent); border-radius: 50%; height: 0.42rem; width: 0.42rem; }
+.bb-node small { color: var(--bb-ink-soft); }
+.bb-node-root { color: var(--bb-accent); }
+
+.bb-note-panel {
+	border-radius: 0 var(--bb-radius) var(--bb-radius) 0;
+	padding: 0.85rem;
+	position: relative;
+}
+
+.bb-valid {
+	align-items: center;
+	color: var(--bb-valid);
+	display: flex;
+	font-family: var(--sl-font-mono);
+	font-size: 0.62rem;
+	gap: 0.35rem;
+	justify-content: flex-end;
+	margin-bottom: 0.35rem;
+}
+
+.bb-valid i,
+.bb-audit-summary i {
+	background: var(--bb-valid);
+	border-radius: 50%;
+	height: 0.45rem;
+	box-shadow: 0 0 0 4px var(--bb-valid-soft);
+	width: 0.45rem;
+}
+
+.bb-note-panel > div:not(.bb-valid) {
+	border-top: 1px solid var(--bb-line-soft);
+	display: flex;
+	flex-direction: column;
+	gap: 0.28rem;
+	padding: 0.7rem 0.3rem;
+}
+
+.bb-note-panel small {
+	font-family: var(--sl-font-mono);
+	font-size: clamp(0.54rem, 0.7vw, 0.62rem);
+}
+
+.bb-note-panel small em {
+	color: var(--bb-ink-soft);
+	float: right;
+	font-style: normal;
+	font-weight: 400;
+}
+
+.bb-note-panel strong {
+	font-size: clamp(0.63rem, 0.9vw, 0.78rem);
+	font-weight: 550;
+}
+
+.bb-chip {
+	align-self: flex-start;
+	background: var(--bb-accent-soft);
+	border: 1px solid color-mix(in srgb, var(--bb-accent) 25%, transparent);
+	border-radius: 999px;
+	color: var(--bb-accent);
+	font-family: var(--sl-font-mono);
+	font-size: 0.58rem;
+	padding: 0.1rem 0.35rem;
+}
+
+.bb-proof {
+	border-block: 1px solid var(--bb-line);
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+}
+
+.bb-proof > div {
+	align-items: center;
+	display: grid;
+	grid-template-columns: auto 1fr;
+	grid-template-rows: auto auto;
+	column-gap: 0.8rem;
+	padding: 1.2rem var(--home-pad);
+}
+
+.bb-proof > div + div { border-inline-start: 1px solid var(--bb-line); }
+.bb-proof strong { font-family: var(--sl-font-mono); font-size: 0.7rem; font-weight: 550; letter-spacing: 0.02em; }
+.bb-proof small { color: var(--bb-ink-soft); font-size: 0.72rem; }
+.bb-proof-icon { grid-row: 1 / 3; height: 1.25rem; position: relative; width: 1.25rem; }
+.bb-proof-icon::before, .bb-proof-icon::after { border: 1px solid var(--bb-ink-soft); content: ''; position: absolute; }
+.bb-proof-file::before { border-radius: 2px; inset: 0.05rem 0.15rem; }
+.bb-proof-file::after { border-width: 0 0 1px 1px; height: 0.35rem; right: 0.15rem; top: 0.05rem; width: 0.35rem; }
+.bb-proof-folder::before { border-radius: 2px; inset: 0.32rem 0.05rem 0.1rem; }
+.bb-proof-folder::after { border-bottom: 0; border-radius: 2px 2px 0 0; height: 0.28rem; left: 0.12rem; top: 0.08rem; width: 0.55rem; }
+.bb-proof-bolt::before { border: 0; border-bottom: 1px solid; border-right: 1px solid; height: 0.75rem; left: 0.27rem; top: 0.05rem; transform: skew(-22deg) rotate(18deg); width: 0.55rem; }
+.bb-proof-bolt::after { display: none; }
+
+.bb-story { padding: clamp(5rem, 9vw, 9rem) var(--home-pad); }
+.bb-section-heading { align-items: end; display: flex; justify-content: space-between; margin-bottom: 3rem; }
+.bb-section-heading p { color: var(--bb-accent); font-family: var(--sl-font-mono); font-size: 0.68rem; letter-spacing: 0.08em; text-transform: uppercase; }
+.bb-section-heading h2 { font-size: clamp(2.5rem, 4.5vw, 4.7rem); font-weight: 470; letter-spacing: -0.055em; line-height: 0.98; text-align: right; }
+.bb-story-grid { display: grid; grid-template-columns: repeat(3, 1fr); }
+.bb-story-card { border: 1px solid var(--bb-line); display: flex; flex-direction: column; min-width: 0; }
+.bb-story-card + .bb-story-card { border-inline-start: 0; }
+.bb-story-card:first-child { border-radius: var(--bb-radius) 0 0 var(--bb-radius); }
+.bb-story-card:last-child { border-radius: 0 var(--bb-radius) var(--bb-radius) 0; }
+.bb-story-card header { border-bottom: 1px solid var(--bb-line); min-height: 10rem; padding: 1.4rem; }
+.bb-story-card header span { color: var(--bb-accent); display: block; font-family: var(--sl-font-mono); font-size: 0.65rem; letter-spacing: 0.06em; margin-bottom: 1rem; text-transform: uppercase; }
+.bb-story-card header strong { display: block; font-size: 1.4rem; font-weight: 570; letter-spacing: -0.03em; }
+.bb-story-card header p { color: var(--bb-ink-soft); font-size: 0.84rem; line-height: 1.5; margin-top: 0.35rem; }
+.bb-card-stage { background: var(--bb-paper-raised); flex: 1; min-height: 20rem; padding: 1.35rem; }
+.bb-card-stage pre { background: #101318; border-radius: 6px; color: #d7dce3; font-size: clamp(0.62rem, 0.8vw, 0.75rem); line-height: 1.7; padding: 1rem; }
+.bb-card-stage pre b { color: #88a3ff; font-weight: 500; }
+.bb-card-stage pre span { color: #a5d76f; }
+.bb-mini-tree { margin: 1.3rem 0 0 1rem; position: relative; }
+.bb-mini-tree > i { background: var(--bb-line); bottom: 1rem; left: 0.18rem; position: absolute; top: 0.8rem; width: 1px; }
+.bb-mini-tree p { align-items: center; display: flex; font-family: var(--sl-font-mono); font-size: 0.66rem; gap: 0.5rem; padding: 0.35rem 0 0.35rem 1rem; position: relative; }
+.bb-mini-tree p::before { background: var(--bb-paper-raised); border: 1px solid var(--bb-accent); border-radius: 50%; content: ''; height: 0.4rem; left: 0; position: absolute; width: 0.4rem; }
+.bb-mini-tree p small { color: var(--bb-ink-soft); margin-left: auto; }
+.bb-terminal-stage { padding: 0; }
+.bb-terminal-bar { align-items: center; border-bottom: 1px solid #2d323a; display: flex; gap: 0.35rem; padding: 0.75rem 1rem; }
+.bb-terminal-bar i { background: #454b54; border-radius: 50%; height: 0.45rem; width: 0.45rem; }
+.bb-terminal-bar span { color: #8e949d; font-family: var(--sl-font-mono); font-size: 0.58rem; margin-left: auto; }
+.bb-terminal-stage { background: #101318; border-radius: 0; }
+.bb-terminal-stage pre { border-radius: 0; padding: 1.5rem; }
+.bb-terminal-stage pre em { color: #a5d76f; font-style: normal; }
+.bb-audit-stage { padding: 1.1rem; }
+.bb-audit-summary { display: flex; font-family: var(--sl-font-mono); font-size: 0.68rem; gap: 1.2rem; padding: 1rem 0.4rem 1.4rem; }
+.bb-audit-summary span { align-items: center; display: flex; gap: 0.6rem; }
+.bb-audit-summary span:nth-child(2) i { background: var(--bb-warning); box-shadow: 0 0 0 4px color-mix(in srgb, var(--bb-warning) 12%, transparent); }
+.bb-audit-row { align-items: center; border-top: 1px solid var(--bb-line); display: flex; font-size: 0.68rem; justify-content: space-between; padding: 0.85rem 0.35rem; }
+.bb-audit-row code { color: var(--bb-ink); font-size: 0.64rem; }
+.bb-audit-row span { color: var(--bb-valid); font-family: var(--sl-font-mono); }
+.bb-audit-row .is-warning { color: var(--bb-warning); }
+.bb-audit-row .is-muted { color: var(--bb-ink-soft); }
+
+.bb-cta { align-items: center; border-top: 1px solid var(--bb-line); display: flex; justify-content: space-between; padding: clamp(3.5rem, 7vw, 6rem) var(--home-pad); }
+.bb-cta span { color: var(--bb-ink-soft); font-family: var(--sl-font-mono); font-size: 0.68rem; letter-spacing: 0.05em; text-transform: uppercase; }
+.bb-cta h2 { font-size: clamp(2rem, 4vw, 3.8rem); font-weight: 480; letter-spacing: -0.05em; line-height: 1; margin-top: 0.5rem !important; }
+
+@media (max-width: 72rem) {
+	.bb-hero { grid-template-columns: 1fr; }
+	.bb-hero-copy { border-bottom: 1px solid var(--bb-line); border-inline-end: 0; min-height: 38rem; }
+	.bb-system { min-height: 38rem; }
+	.bb-story-grid { grid-template-columns: 1fr; }
+	.bb-story-card + .bb-story-card { border-inline-start: 1px solid var(--bb-line); border-top: 0; }
+	.bb-story-card:first-child { border-radius: var(--bb-radius) var(--bb-radius) 0 0; }
+	.bb-story-card:last-child { border-radius: 0 0 var(--bb-radius) var(--bb-radius); }
+	.bb-story-card header { min-height: auto; }
+}
+
+@media (max-width: 50rem) {
+	.bb-home { --home-pad: 1.2rem; }
+	.bb-hero-copy { min-height: auto; padding-block: 5rem 4rem; }
+	.bb-hero h1 { font-size: clamp(3.35rem, 16vw, 5rem); }
+	.bb-system { align-items: stretch; min-height: auto; padding-block: 4rem 2rem; }
+	.bb-system-labels { display: none; }
+	.bb-system-grid { grid-template-columns: 1fr; }
+	.bb-code-panel { border-radius: var(--bb-radius) var(--bb-radius) 0 0; }
+	.bb-schema-panel { border: 1px solid var(--bb-line); border-block: 0; }
+	.bb-schema-panel::before, .bb-schema-panel::after { display: none; }
+	.bb-note-panel { border-radius: 0 0 var(--bb-radius) var(--bb-radius); }
+	.bb-proof { grid-template-columns: 1fr; }
+	.bb-proof > div + div { border-inline-start: 0; border-top: 1px solid var(--bb-line); }
+	.bb-section-heading { align-items: start; flex-direction: column; gap: 1.2rem; }
+	.bb-section-heading h2 { text-align: left; }
+	.bb-cta { align-items: flex-start; flex-direction: column; gap: 2rem; }
+	.sl-markdown-content h1 { font-size: 2.5rem; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.bb-hero-copy > *,
+	.bb-system-grid {
+		animation: bb-rise 520ms both cubic-bezier(0.2, 0.7, 0.2, 1);
+	}
+
+	.bb-hero-copy > :nth-child(2) { animation-delay: 70ms; }
+	.bb-hero-copy > :nth-child(3) { animation-delay: 130ms; }
+	.bb-hero-copy > :nth-child(4) { animation-delay: 190ms; }
+	.bb-system-grid { animation-delay: 130ms; }
+}
+
+@keyframes bb-rise {
+	from { opacity: 0; transform: translateY(12px); }
+	to { opacity: 1; transform: translateY(0); }
 }

--- a/docs/product/docs-visual-design-audit.md
+++ b/docs/product/docs-visual-design-audit.md
@@ -1,0 +1,189 @@
+# How should the Bowerbird docs become more modern and attractive?
+
+## Answer
+
+Bowerbird does not need a prettier Starlight theme. It needs a small visual system that makes the product's
+central idea visible: **structure emerging from plain text**.
+
+The current site is clear and usable, but visually generic. Its identity is mostly a blue accent, a gradient
+tagline, hover motion, and a stock-like abstract hero image. The homepage explains the product, but it does
+not yet *demonstrate* it. Interior documentation pages inherit sensible Starlight defaults, though their
+hierarchy, navigation density, and code surfaces feel utilitarian rather than crafted.
+
+The recommended direction is **The Living Schema**: a calm, editorial documentation system built around
+fine structural lines, YAML-to-typed-note transformations, monospace metadata, and a restrained mineral
+palette. Borrow Vercel's confidence and Linear's atmosphere, not either company's costume.
+
+## Evidence
+
+### Current Bowerbird site
+
+The homepage currently consists of a standard Starlight splash hero, four stock cards, and one code block
+(`docs-site/src/content/docs/index.mdx`). The only substantial visual customization is a blue accent palette,
+a gradient tagline, card hover movement, and code-block shadow (`docs-site/src/styles/custom.css`).
+
+Live inspection on 2026-07-12 found:
+
+- a generic system sans-serif stack;
+- a 64px/600-weight homepage title paired with a 1.5rem blue gradient tagline;
+- one decorative image that does not explain the product;
+- almost no visual texture beyond the tagline gradient;
+- interior pages using a readable 652px article measure and 16px/28px body type, but with default-feeling
+  headings, navigation, active states, and code frames;
+- a dense right-hand table of contents on longer pages, such as Quick Start, that competes with the article.
+
+This is a strong information foundation. The problem is not polish in isolated controls; it is that the site
+has no recurring visual grammar connecting the homepage, navigation, examples, and product idea.
+
+### What the reference sites do well
+
+Vercel's homepage uses a neutral canvas, unusually generous negative space, a restrained black-and-white
+core, large regular-weight type, geometric brand imagery, and product/customer evidence as composition.
+The visible hero is not crowded, and its 64px headline has room to breathe. The result feels confident
+because very few elements are asked to carry a great deal of hierarchy.
+
+Linear's homepage uses a dark near-black ground, subtle borders and glows, muted secondary text, controlled
+gradients, and large product-interface compositions. Its visual identity repeats through every layer: header,
+hero, figures, captions, and screenshots. The atmosphere comes from consistency and depth, not ornamental
+noise.
+
+The transferable lesson is not “make it monochrome” or “add glows.” Both sites:
+
+1. establish one unmistakable art direction;
+2. use type and space as primary visual material;
+3. show the product instead of substituting feature cards for evidence;
+4. repeat a small set of motifs across the whole page;
+5. keep color rare enough that action and meaning remain legible.
+
+### Feasibility in the current stack
+
+The site uses Astro 5 and Starlight 0.37. Starlight supports custom CSS for broad visual changes and targeted
+component overrides when markup must change. Overrides can also render conditionally for the homepage,
+which means Bowerbird can preserve Starlight's durable documentation shell while giving the landing page a
+distinct composition. A rewrite or framework migration is unnecessary.
+
+## Inferences
+
+### Design principles
+
+1. **Make structure the decoration.** Use schema lines, field labels, validation marks, hierarchy, and
+   transformations as the visual motif. Bowerbird's subject is already graphical.
+2. **Show the before and after.** The most persuasive hero artifact is an animated or stepped transformation:
+   loose Markdown/YAML becomes a validated typed note, then a queryable collection.
+3. **Prefer quiet confidence.** Use one cool accent and one warm signal color against ink/stone neutrals.
+   Avoid a rainbow SaaS gradient; the internet has met several already.
+4. **Separate marketing rhythm from reading rhythm.** The homepage can be expressive. Documentation pages
+   should remain calm, compact, and extremely legible.
+5. **Build identity from reusable tokens.** Typography, borders, radii, shadows, spacing, and motion should
+   be defined once and repeated rather than tuned page by page.
+
+### Proposed visual direction: The Living Schema
+
+**Palette**
+
+- Light canvas: warm paper (`#F7F7F4`) rather than pure white.
+- Dark canvas: blue-black ink (`#090B10`) rather than neutral black.
+- Primary text: ink (`#15171A`) / frost (`#F3F5F7`).
+- Structural lines: low-contrast slate with two opacity levels.
+- Accent: electric cobalt, slightly less saturated than the current blue.
+- Semantic spark: a restrained chartreuse or amber used only for valid/changed states.
+
+**Typography**
+
+- Use a modern variable grotesk for interface and display text (Geist is a natural open choice), paired with
+  a characterful monospace for commands, field labels, figure captions, and schema metadata.
+- Reduce homepage headline weight from 600 to roughly 450–520 and let scale plus spacing provide authority.
+- Tighten heading tracking slightly; loosen body leading and increase body text contrast.
+- Introduce small monospace eyebrow labels such as `SCHEMA / 01`, `VALIDATE / 02`, and `MIGRATE / 03`.
+
+**Visual grammar**
+
+- Hairline grids that subtly align hero copy, terminal output, and section boundaries.
+- Thin connectors between schema fields and rendered note values.
+- Small validation pulses/checks, with motion disabled under `prefers-reduced-motion`.
+- Square-to-soft (6–10px) radii rather than fully pill-shaped everything.
+- Very restrained shadows; use borders, inner highlights, and background planes for depth.
+- Product diagrams rendered from real Bowerbird examples, not abstract stock imagery.
+
+## Recommendation
+
+### Priority 0 — establish the system
+
+Create a compact token layer in `custom.css` for color, type, spacing, borders, radii, shadows, and motion.
+Add the chosen font assets with good fallbacks. Restyle the global header, search, sidebar, table of contents,
+article typography, links, focus states, code blocks, tables, callouts, and active navigation.
+
+This pass should make every page feel intentional even before the homepage is rebuilt.
+
+### Priority 1 — rebuild the homepage around product evidence
+
+Replace the stock splash composition and `hero.jpeg` with a custom homepage component or MDX composition:
+
+1. **Hero:** “Your notes, with a type system.” Pair the statement with a live schema-to-note transformation.
+2. **Proof strip:** three concise truths—plain Markdown, local-first, automation-ready—rather than logo theater.
+3. **Product story:** a three-part visual sequence: define → create → audit/migrate.
+4. **Real terminal moment:** a polished but authentic command interaction with output, not commands alone.
+5. **Capabilities:** replace four generic cards with editorial feature rows tied to real product surfaces.
+6. **Closing invitation:** one strong next step into Quick Start and one quieter GitHub link.
+
+Keep the homepage concise. Its job is to create desire and orientation, not reproduce the entire sidebar in
+evening wear.
+
+### Priority 2 — improve the documentation reading surface
+
+- Give article titles a clearer title/dek/metadata hierarchy.
+- Make the left navigation quieter and the active item more distinctive without using a full saturated bar.
+- Reduce right-rail competition: stronger section grouping, softer inactive links, sticky position with sane
+  maximum height.
+- Give code blocks a consistent terminal/editor frame only when context benefits from it; keep inline and
+  reference snippets simpler.
+- Style tables, steps, tabs, callouts, and command signatures as a coherent component family.
+- Add subtle previous/next navigation with section context.
+- Verify light and dark themes as equal designs rather than treating dark mode as recoloring.
+
+### Priority 3 — add signature details
+
+- A small custom Bowerbird mark derived from nested schema brackets or a woven field grid.
+- Lightweight diagrams for inheritance, migrations, ownership, and lineage.
+- Syntax-aware highlights that distinguish fields, values, types, and validation outcomes.
+- One purposeful entrance sequence on the homepage, under 500ms and reduced-motion safe.
+
+### What not to do
+
+- Do not copy Vercel's triangle/minimal black-and-white system or Linear's purple-blue glow language.
+- Do not solve the homepage with a larger gradient headline and more cards.
+- Do not put animation on ordinary documentation navigation.
+- Do not trade article contrast, keyboard focus, or scanability for atmosphere.
+- Do not override Starlight's entire layout when CSS and a homepage-only component override will suffice.
+
+### Suggested implementation slices
+
+1. **Visual-system prototype:** tokens plus one homepage hero and one representative long documentation page.
+2. **Homepage build:** custom composition and real product diagrams.
+3. **Documentation shell:** navigation, article typography, code, tables, and callouts.
+4. **Responsive/accessibility pass:** mobile hierarchy, keyboard navigation, reduced motion, contrast, and
+   layout-shift checks.
+5. **Visual regression pass:** light/dark screenshots at desktop and mobile widths.
+
+The first slice is the right next step because it tests the art direction on both kinds of page before the
+system spreads. A good prototype should answer one question: **does The Living Schema feel like Bowerbird,
+or merely like tasteful developer tooling?**
+
+## Uncertainties
+
+- The wordmark and hero image may have history or meaning not visible in the repository.
+- The preferred personality could tilt warmer/editorial or darker/technical; both fit the concept, but the
+  choice is taste rather than discoverable fact.
+- The audit did not include user analytics, so navigation-density recommendations are based on visual and
+  content inspection rather than observed reading behavior.
+- Before production, font licensing, performance budgets, and the exact Starlight override boundaries should
+  be confirmed in a small prototype.
+
+## Sources
+
+- Current site: <https://bwrb.dev/>
+- Current Quick Start: <https://bwrb.dev/getting-started/quick-start/>
+- Vercel homepage: <https://vercel.com/>
+- Linear homepage: <https://linear.app/>
+- Starlight component overrides: <https://starlight.astro.build/guides/overriding-components/>
+- Starlight overrides reference: <https://starlight.astro.build/reference/overrides/>


### PR DESCRIPTION
## Summary

- replace the stock Starlight splash page with a bespoke Bowerbird homepage built around real schema, note, and audit flows
- introduce the Living Schema visual system: custom mark, typography, color tokens, grid structure, and responsive composition
- refine the shared documentation shell across navigation, article typography, code blocks, tables, callouts, light mode, and dark mode
- preserve Starlight search, theme, sidebar, table-of-contents, and mobile behavior through targeted overrides
- add the visual design audit that informed the direction

## Verification

- `pnpm docs:lint`
- `pnpm docs:doctor`
- `pnpm docs:check`
- `pnpm -C docs-site build`
- browser verification at desktop and mobile widths
- light and dark theme verification
- primary CTA navigation to Quick Start
- no browser errors, framework overlays, or horizontal overflow

## Notes

The generated concepts were used as a north star rather than copied literally; product examples and commands were reconciled with the real Bowerbird surface.