### PR TITLE
Add agent change-candidate and review workflow primitives

### DIFF
--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -242,6 +242,80 @@
         },
         "recurrence": {
           "$ref": "#/definitions/recurrence"
+        },
+        "transition_guards": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "on": {
+                "type": "string",
+                "minLength": 1
+              },
+              "requires": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "relation": {
+                      "type": "string",
+                      "pattern": "^(?!forked-from$).*$",
+                      "description": "Schema field name; \"forked-from\" is reserved for system-managed lineage"
+                    },
+                    "min": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "all": {
+                      "type": "object",
+                      "properties": {
+                        "field": {
+                          "$ref": "#/definitions/trait/properties/transition_guards/items/properties/requires/items/properties/relation"
+                        },
+                        "equals": {
+                          "type": "string"
+                        },
+                        "in": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1
+                        }
+                      },
+                      "required": [
+                        "field"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "failed_when": {
+                      "$ref": "#/definitions/trait/properties/transition_guards/items/properties/requires/items/properties/all"
+                    },
+                    "stale_when": {
+                      "$ref": "#/definitions/trait/properties/transition_guards/items/properties/requires/items/properties/all"
+                    }
+                  },
+                  "required": [
+                    "relation",
+                    "all"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1
+              }
+            },
+            "required": [
+              "on",
+              "requires"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "transition_effects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/transitionEffect"
+          }
         }
       },
       "additionalProperties": false
@@ -271,6 +345,30 @@
       },
       "required": [
         "on"
+      ],
+      "additionalProperties": false
+    },
+    "transitionEffect": {
+      "type": "object",
+      "properties": {
+        "on": {
+          "type": "string",
+          "minLength": 1
+        },
+        "relation": {
+          "$ref": "#/definitions/trait/properties/transition_guards/items/properties/requires/items/properties/relation"
+        },
+        "set": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "on",
+        "relation",
+        "set"
       ],
       "additionalProperties": false
     },

--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -433,6 +433,132 @@
         "plural": {
           "type": "string",
           "description": "Custom plural form for folder naming (e.g., 'research' instead of 'researches'). Auto-pluralized if not specified."
+        },
+        "retention": {
+          "type": "object",
+          "properties": {
+            "when": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "in": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  }
+                },
+                "required": [
+                  "in"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "clock": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "$ref": "#/definitions/trait/properties/transition_guards/items/properties/requires/items/properties/relation"
+                },
+                "after": {
+                  "type": "string",
+                  "pattern": "^([1-9]\\d*)d$"
+                }
+              },
+              "required": [
+                "field",
+                "after"
+              ],
+              "additionalProperties": false
+            },
+            "resolved_when": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "in": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  }
+                },
+                "required": [
+                  "in"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "archive"
+                      },
+                      "directory": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "directory"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "tombstone"
+                      },
+                      "set": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "set"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "delete"
+                      }
+                    },
+                    "required": [
+                      "kind"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              "minItems": 1
+            }
+          },
+          "required": [
+            "when",
+            "clock",
+            "actions"
+          ],
+          "additionalProperties": false,
+          "description": "Type-local retention policy evaluated by audit"
         }
       },
       "additionalProperties": false

--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -469,7 +469,7 @@
         },
         "value": {
           "type": "string",
-          "description": "Static value (use $NOW for current datetime, $TODAY for date)"
+          "description": "Static value (use $NOW for current datetime, $TODAY for date, or $ACTOR for logical runner provenance)"
         },
         "description": {
           "type": "string",

--- a/docs-site/src/content/docs/automation/json-mode.md
+++ b/docs-site/src/content/docs/automation/json-mode.md
@@ -16,6 +16,22 @@ bwrb --non-interactive new task --json '{"name":"Fix login","priority":"high"}'
 bwrb --non-interactive edit "My Task" --json '{"status":"settled"}'
 ```
 
+## Logical actor provenance
+
+Schemas opt into runner provenance with `{ "value": "$ACTOR" }`. Establish the
+identity once for the CLI process:
+
+```bash
+BWRB_ACTOR='codex:session-17' bwrb new attestation \
+  --json '{"name":"CI passed","outcome":"passed"}'
+bwrb --actor 'orchestrator:reviewer-2' new attestation \
+  --json '{"name":"Independent review","outcome":"passed"}'
+```
+
+The explicit root option wins over the environment. If neither exists,
+`$ACTOR` becomes `unknown`; Bowerbird never guesses Alice from an OS account,
+Git identity, or hostname. Actor values are provenance, not permission.
+
 ## JSON output shapes
 
 Check the command reference before choosing a parser. Bowerbird emits one

--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -47,9 +47,29 @@ The target argument is auto-detected as type, path (contains `/`), or where expr
 | `--auto` | With `--fix`: automatically apply unambiguous fixes |
 | `--dry-run` | With `--fix`: preview fixes without writing |
 | `--execute` | With `--fix --auto`: apply auto-fixes for execute-gated issues (for example `trailing-whitespace`) |
+| `--retention-action <kind>` | Explicitly preview or execute configured `archive`, `tombstone`, or `delete` retention action; requires `--fix --only retention-due` |
 
 Repair mode writes by default and requires explicit targeting (selectors or `--all`).
 Use `--dry-run` to preview fixes without writing.
+
+### Retention remediation
+
+Types can declare retention (see the schema reference). Audit reports a due record as a
+`retention-due` warning and includes the configured actions in JSON metadata. It uses one
+local-day snapshot for the entire run; the deadline is inclusive. A missing or invalid
+clock is a diagnostic, never an invented deadline.
+
+Retention is never an automatic fix. Target it explicitly, select the issue, and name an
+action; omission of `--execute` is a dry run:
+
+```bash
+bwrb audit --all --fix --only retention-due --retention-action archive
+bwrb audit --all --fix --only retention-due --retention-action archive --execute
+```
+
+Before writing, Bowerbird re-reads the note under its mutation lock and confirms it is
+still due. Archive updates wikilinks, tombstone applies only the schema-declared patch,
+and delete refuses live lineage, backlinks, or typed relations.
 
 `unlinked-mention` auto-fixes normally link every eligible exact/alias occurrence. Set
 `config.mention_link_once: true` or pass `--mention-link-once` to make
@@ -106,6 +126,7 @@ Delete semantics in repair mode:
 | `relative-date-invalid-ref` | A relative-date anchor reference is missing or ambiguous (warning; flag-only) |
 | `missing-successor` | A [recurring](/automation/task-system/) note satisfies its trigger (e.g. `status = done`) but its chain field (`next`) is empty — a successor was never spawned (e.g. completed outside bwrb). Warning; **auto-fixable** (`--fix` spawns it, identical to the fast path) |
 | `invalid-recurrence` | A [recurrence](/automation/task-system/) rule is broken at the config level — a malformed trigger, a non-date offset base, or a template that doesn't exist (error; **never auto-fixable** — a config error gets the same safety net as data) |
+| `retention-due` | A type's explicit retention clock is due, or its clock value is invalid. Warning; never auto-fixed. Remediation requires `--only retention-due`, explicit targeting, `--retention-action`, and `--execute` after reviewing the dry run |
 
 Note: built-in fields (`id`, `name`, and reserved provenance field `forked-from`) are always allowed and do not produce `unknown-field` issues. Ordinary `bwrb new --json`, `bwrb edit`, template input, schema defaults, and audit fixes cannot mutate reserved fields. Use `bwrb new --fork` for a new child or guarded [`bwrb lineage adopt`](/reference/commands/lineage/) for known derivation between two existing notes; all stored provenance receives the lineage checks above.
 Invalid option values inside list fields are reported as `invalid-option` with `listIndex` metadata, not a separate issue code.

--- a/docs-site/src/content/docs/reference/commands/bulk.md
+++ b/docs-site/src/content/docs/reference/commands/bulk.md
@@ -79,6 +79,10 @@ bwrb bulk --type task --set status=settled
 bwrb bulk --type task --set status=settled --execute
 ```
 
+When a change enters a trait-configured guarded transition, bulk evaluates the
+same relation requirements as `edit`. Each blocked file is reported as an error
+and remains unchanged; dry-runs report the block too.
+
 ### Non-interactive Confirmation
 
 If `stdin` is not a TTY and the operation requires confirmation (cross-type `--all` or large operations), bwrb does not prompt. Use `--force`/`--yes` to skip the confirmation or pipe a single `y/yes` or `n/no` answer. Otherwise the command fails fast with a clear error.

--- a/docs-site/src/content/docs/reference/commands/bulk.md
+++ b/docs-site/src/content/docs/reference/commands/bulk.md
@@ -83,6 +83,10 @@ When a change enters a trait-configured guarded transition, bulk evaluates the
 same relation requirements as `edit`. Each blocked file is reported as an error
 and remains unchanged; dry-runs report the block too.
 
+Bulk also validates and applies entered `transition_effects` with the same
+source-and-target lock and byte checks as `edit`. A target effect is direct and
+non-cascading; dry-runs surface invalid target patches before reporting a change.
+
 ### Non-interactive Confirmation
 
 If `stdin` is not a TTY and the operation requires confirmation (cross-type `--all` or large operations), bwrb does not prompt. Use `--force`/`--yes` to skip the confirmation or pipe a single `y/yes` or `n/no` answer. Otherwise the command fails fast with a clear error.

--- a/docs-site/src/content/docs/reference/commands/edit.md
+++ b/docs-site/src/content/docs/reference/commands/edit.md
@@ -88,6 +88,13 @@ edits reject a blocked transition without writing and JSON reports
 `bwrb explain "Candidate 417" --transition accepted --output json` to inspect
 the same result before attempting the edit.
 
+### Related-note transition effects
+
+When an entered trait transition has `transition_effects`, `edit` applies its
+validated flat patch to the configured scalar relation target in the same
+guarded commit. Empty relations are no-ops. Effects do not cascade from the
+target into more effects or recurrence; cross-type creation remains recurrence.
+
 ## Concurrent lineage changes
 
 The final edit commit shares the note's lineage mutation lock with `new --fork`

--- a/docs-site/src/content/docs/reference/commands/edit.md
+++ b/docs-site/src/content/docs/reference/commands/edit.md
@@ -79,6 +79,15 @@ It never replays a guarded patch: list/read again and reconsider the change.
 Successful JSON edits return the note's new opaque `revision`. Interactive edits
 do not accept revision preconditions.
 
+### Relation-backed transition guards
+
+Traits can declare `transition_guards` that require direct related notes to be
+satisfied before a field enters a configured value. Both JSON and interactive
+edits reject a blocked transition without writing and JSON reports
+`TRANSITION_GUARD_FAILED` with the complete explanation DTO. Use
+`bwrb explain "Candidate 417" --transition accepted --output json` to inspect
+the same result before attempting the edit.
+
 ## Concurrent lineage changes
 
 The final edit commit shares the note's lineage mutation lock with `new --fork`

--- a/docs-site/src/content/docs/reference/commands/edit.md
+++ b/docs-site/src/content/docs/reference/commands/edit.md
@@ -28,6 +28,7 @@ third excess positional is rejected.
 | `-w, --where <expr>` | Filter by frontmatter expression (repeatable) |
 | `-b, --body <pattern>` | Filter by Markdown body content; YAML frontmatter is excluded |
 | `--json <patch>` | Non-interactive patch/merge mode |
+| `--expected-revision <revision>` | Require an opaque revision from `list --output json`; requires `--json` |
 | `-o, --open` | Open the note after editing |
 | `--app <mode>` | App mode for `--open`: `system`, `editor`, `visual`, `obsidian`, `print` |
 | `--picker <mode>` | Picker mode: `fzf`, `numbered`, `none` |
@@ -60,6 +61,23 @@ bwrb edit -t task --where "status == 'active'" "Deploy" --json '{"priority":"hig
 ```
 
 `--json` mode rejects patch fields that are not defined for the resolved note type. Existing legacy or unknown fields in the note are preserved unless the patch changes them.
+
+### Guarded JSON edits
+
+For a contested record, retain the opaque `revision` returned by `bwrb list
+--output json` and send it back with the patch:
+
+```bash
+bwrb edit "Candidate 417" --json '{"status":"awaiting-review"}' \
+  --expected-revision '<revision from list>' --output json
+```
+
+Bowerbird compares it to the read snapshot and again immediately before the
+write under its mutation lock. A mismatch exits `2`, leaves the note untouched,
+and returns `REVISION_MISMATCH` plus `expectedRevision` and `currentRevision`.
+It never replays a guarded patch: list/read again and reconsider the change.
+Successful JSON edits return the note's new opaque `revision`. Interactive edits
+do not accept revision preconditions.
 
 ## Concurrent lineage changes
 

--- a/docs-site/src/content/docs/reference/commands/explain.md
+++ b/docs-site/src/content/docs/reference/commands/explain.md
@@ -1,0 +1,30 @@
+---
+title: bwrb explain
+description: Explain whether a relation-backed transition is currently allowed
+---
+
+`explain` evaluates a note's configured transition guards without writing.
+
+## Synopsis
+
+```bash
+bwrb explain <query> --transition <field=value|value> [--output text|json]
+```
+
+The query must resolve exactly by path, name, alias, or ID-compatible exact
+targeting. The full `field = value` form is always deterministic. A value-only
+shorthand such as `accepted` works only when exactly one configured guard enters
+that value.
+
+```bash
+bwrb explain "Candidate 417" --transition "status = accepted"
+bwrb explain "Candidate 417" --transition accepted --output json
+```
+
+Text output begins with `Allowed` or `Blocked` and reports every relation
+requirement as missing, unresolved, stale, failed, or satisfied. JSON returns
+the same complete explanation DTO used by guarded edit failures.
+
+A valid blocked explanation exits `0`: blocked is workflow state, not a command
+failure. Invalid targeting, ambiguous shorthand, malformed transition syntax,
+or invalid schema configuration exits nonzero.

--- a/docs-site/src/content/docs/reference/commands/list.md
+++ b/docs-site/src/content/docs/reference/commands/list.md
@@ -83,7 +83,11 @@ rejected.
 Name, fuzzy, and detailed-match modes use the established search JSON shapes.
 Fuzzy JSON includes similarity scores and the field that matched; detailed body
 JSON includes line matches and context. Normal filtered-list JSON remains the
-array of note frontmatter objects used by existing scripts.
+array of note frontmatter objects used by existing scripts. Each row also has a
+`revision`: an opaque digest of the exact Markdown bytes read for that row.
+Treat it only as an observation token—do not infer ordering or meaning from its
+format. Pass it unchanged to guarded JSON edits when a shared record must not
+silently overwrite a newer change.
 
 With `--matches`, text output shows grep-style line details and JSON preserves
 structured match details. `paths` and `link` emit each matching note once, while

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -358,13 +358,16 @@ Fields with `value` are not prompted—they're computed automatically:
 {
   "type": { "value": "task" },
   "created": { "value": "$NOW" },
-  "date": { "value": "$TODAY" }
+  "date": { "value": "$TODAY" },
+  "actor": { "value": "$ACTOR" }
 }
 ```
 
 **Special values:**
 - `$NOW` — Current datetime: `2025-01-07 14:30`
 - `$TODAY` — Current date: `2025-01-07`
+- `$ACTOR` — Logical runner identity resolved from root `--actor`, then
+  `BWRB_ACTOR`, then `unknown`. This is provenance, not authentication.
 
 ### text
 

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -213,6 +213,7 @@ A `task` now has every field from `objective` (and its ancestors) **plus** `stat
 | `description` | string | What the trait bundles and when to use it. Surfaced by `bwrb schema list` |
 | `fields` | object | Field definitions contributed by the trait |
 | `recurrence` | object | Spawn-on-transition recurrence config (see [Recurrence](#recurrence)) |
+| `transition_guards` | array | Direct relation-backed requirements checked when a field enters a value |
 
 Traits are **flat**: a trait carries only `fields` (and an optional `description`, plus an optional `recurrence` block). A trait cannot `extends` a type or compose other traits. This keeps resolution simple and deterministic.
 
@@ -243,6 +244,34 @@ A trait may carry a `recurrence` block. Any type that composes the trait then sp
 | `set` | object | No | Field-offset assignments. Each value is `<dateField> + <duration>` (e.g. `"deadline + 7d"`); the base **must** be a date field |
 
 The `next` relation field does triple duty: it is the **chain link** (history), the **idempotency guard** (a successor is spawned only when `next` is empty), and the basis for the audit **backstop** (`missing-successor`). See the [task system guide](/automation/task-system/) for the full two-path execution model and validation rules.
+
+### Transition guards
+
+A trait may require direct related notes to satisfy constrained predicates
+before a field enters a value:
+
+```json
+"transition_guards": [{
+  "on": "status = accepted",
+  "requires": [{
+    "relation": "requirements",
+    "min": 1,
+    "all": { "field": "status", "equals": "satisfied" },
+    "failed_when": { "field": "status", "in": ["failed", "needs-revision"] },
+    "stale_when": { "field": "status", "in": ["stale", "superseded"] }
+  }]
+}]
+```
+
+`relation` must name an effective relation field; its `source` constrains the
+target type. Predicates inspect one target field using exactly one of `equals`
+or `in`. `min` defaults to one. Every resolved target must satisfy `all`, and
+missing, unresolved, stale, or failed evidence blocks the transition.
+
+Guards are checked only when the source field enters the configured value.
+Bowerbird locks the source and all resolved evidence notes together before the
+final check and write. Use [`bwrb explain`](/reference/commands/explain/) to
+inspect the same result without mutating the note.
 
 ### Precedence
 

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -72,6 +72,7 @@ Types define categories of notes. Each type has a name (the object key) and a de
 | `traits` | array | — | Trait names composed into this type (see [Traits](#traits)) |
 | `description` | string | — | What this type is for and when to use it. Surfaced by `bwrb schema list` |
 | `output_dir` | string | no | Vault-relative folder where this type's notes live (e.g., `"Objectives/Tasks"`). When omitted, creation uses the computed pluralized type hierarchy; see [Output directories](#output-directories) |
+| `retention` | object | no | Type-local end-of-life policy evaluated by `bwrb audit`; it is not inherited by child types |
 | `fields` | object | `{}` | Field definitions |
 | `field_order` | array | — | Order of fields in frontmatter |
 | `body_sections` | array | — | Body structure after frontmatter |

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -214,6 +214,7 @@ A `task` now has every field from `objective` (and its ancestors) **plus** `stat
 | `fields` | object | Field definitions contributed by the trait |
 | `recurrence` | object | Spawn-on-transition recurrence config (see [Recurrence](#recurrence)) |
 | `transition_guards` | array | Direct relation-backed requirements checked when a field enters a value |
+| `transition_effects` | array | Bounded patches applied to a direct related note when a field enters a value |
 
 Traits are **flat**: a trait carries only `fields` (and an optional `description`, plus an optional `recurrence` block). A trait cannot `extends` a type or compose other traits. This keeps resolution simple and deterministic.
 
@@ -272,6 +273,26 @@ Guards are checked only when the source field enters the configured value.
 Bowerbird locks the source and all resolved evidence notes together before the
 final check and write. Use [`bwrb explain`](/reference/commands/explain/) to
 inspect the same result without mutating the note.
+
+### Transition effects
+
+A trait may update one directly related note when a source field enters a value:
+
+```json
+"transition_effects": [{
+  "on": "status = accepted",
+  "relation": "task",
+  "set": { "status": "done", "completed-at": "$TODAY" }
+}]
+```
+
+The relation must be a scalar effective `relation` field; an empty relation is
+a no-op. `set` is a flat literal patch. `$ACTOR`, `$NOW`, and `$TODAY` are the
+only expanded values. Bowerbird prepares and validates both notes, locks them
+in a stable shared order, rechecks their bytes, and writes the target directly.
+Target writes never trigger further effects or recurrence. If a later write
+fails, Bowerbird restores only its own earlier source bytes, never a newer
+writer's change.
 
 ### Precedence
 

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -258,6 +258,9 @@ bwrb list task --where "priority == 'high' && status != 'done'" --output json
 # Include specific fields in output
 bwrb list task --fields status,priority --output json
 
+# JSON list rows include an opaque revision for guarded shared-record edits.
+bwrb list task --where "status == 'active'" --output json
+
 # Sort matches before reading or limiting output
 bwrb list task --sort deadline --output json
 bwrb list task --sort priority --desc --output json
@@ -297,6 +300,23 @@ Schema fields with `prompt: "date"` may use creation-time expressions such as
 creation, scoped default restoration during edit, and reset-on-fork defaults.
 Non-date defaults remain literal. Custom-calendar date fields require literal
 dates in their configured calendar rather than Gregorian `@today` expressions.
+
+### Guarded shared-record edits
+
+When editing a shared record, copy its `revision` from a JSON list row exactly
+as returned. It guards against any note-byte change, including a Markdown-body
+edit:
+
+```bash
+bwrb edit "Candidate 417" --json '{"status":"awaiting-review"}' \
+  --expected-revision '<opaque revision>' --output json
+```
+
+On success, retain the new top-level `revision` returned by `edit`. On a stale
+observation, Bowerbird exits `2` with `code: "REVISION_MISMATCH"`,
+`expectedRevision`, and `currentRevision`; do not retry the same patch blindly.
+Relist/read the note and decide again. `--expected-revision` requires `--json`;
+interactive edits do not support it.
 
 ### Relative-Date Fields
 

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -31,6 +31,11 @@ guard. A blocked explanation exits successfully because it is useful state.
 `bwrb edit --json` and interactive `bwrb edit` enforce the same guards;
 `bwrb bulk` reports blocked files individually and does not change them.
 
+Traits can also declare `transition_effects` for a scalar direct relation. On
+an entered transition, bwrb validates and applies the flat target patch in the
+same guarded commit. `$ACTOR`, `$NOW`, and `$TODAY` expand; target effects do
+not cascade into more effects or recurrence. An empty relation is a no-op.
+
 ## Vault Resolution
 
 bwrb finds the vault in this order:

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -680,6 +680,22 @@ bwrb list --name "Target Note" --output link --picker none  # Output: [[Target N
 
 ## Error Handling
 
+## Retention
+
+Retention is a schema-declared, audit-reported lifecycle policy. It is intentionally never
+chosen by `audit --fix --auto`. To remediate records, use an explicit selector, the
+`retention-due` issue filter, a configured action, and `--execute` only after reviewing the
+dry run:
+
+```bash
+bwrb audit --all --fix --only retention-due --retention-action tombstone
+bwrb audit --all --fix --only retention-due --retention-action tombstone --execute
+```
+
+Do not infer a retention due date from filesystem timestamps. The schema clock must be a
+day-granularity date field. Delete actions remain safety-checked and can refuse records
+with live relations, backlinks, or fork lineage.
+
 bwrb exits with non-zero status on errors. JSON output includes error information:
 
 ```bash

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -36,6 +36,11 @@ an entered transition, bwrb validates and applies the flat target patch in the
 same guarded commit. `$ACTOR`, `$NOW`, and `$TODAY` expand; target effects do
 not cascade into more effects or recurrence. An empty relation is a no-op.
 
+For schema-declared logical provenance (`{ "value": "$ACTOR" }`), establish
+identity once with root `--actor <value>` or `BWRB_ACTOR`. Explicit `--actor`
+wins; missing identity becomes `unknown`. Treat it as workflow provenance,
+never authentication or permission.
+
 ## Vault Resolution
 
 bwrb finds the vault in this order:

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -15,6 +15,21 @@ Use bwrb when you need to:
 - Edit note frontmatter programmatically
 - Generate wikilinks for Obsidian
 - Validate notes against a schema
+- Explain or safely advance relation-backed workflow transitions
+
+## Guarded transitions
+
+Schemas may put `transition_guards` on traits. Before setting a guarded value,
+inspect the relation-backed requirements without writing:
+
+```bash
+bwrb explain "Candidate 417" --transition accepted --output json
+```
+
+The value-only shorthand is accepted only when it identifies one configured
+guard. A blocked explanation exits successfully because it is useful state.
+`bwrb edit --json` and interactive `bwrb edit` enforce the same guards;
+`bwrb bulk` reports blocked files individually and does not change them.
 
 ## Vault Resolution
 

--- a/plans/features/agent-change-candidate-review.md
+++ b/plans/features/agent-change-candidate-review.md
@@ -84,15 +84,149 @@ Focused tests must prove:
 
 Run a disposable-vault CLI acceptance flow using built `dist/`: create schema and candidate note, list it, guarded-edit it, modify its body natively, demonstrate rejection with the old revision, relist, and succeed with the new revision.
 
-## Later slices
+## Remaining production slices
 
-1. Constrained relation-aware transition guards with explanatory missing/failed/stale relation output.
-2. A read-only transition explanation surface before mutation.
-3. Bounded related-note effects, generalized carefully from cross-type recurrence rather than overloading recurrence syntax.
-4. Actor provenance inherited from a session/global runner context.
-5. Retention-due audit findings and targeted explicit fixes.
+Each slice remains general-purpose. The `teenylilthoughts` schema supplies
+workflow vocabulary; Bowerbird supplies typed Markdown mechanics.
 
-Each later slice must remain general-purpose. The `teenylilthoughts` schema supplies workflow vocabulary; Bowerbird supplies typed Markdown mechanics.
+### Relation-aware transition guards
+
+Traits may declare direct-relation requirements for a field transition:
+
+```json
+{
+  "transition_guards": [
+    {
+      "on": "status = accepted",
+      "requires": [
+        {
+          "relation": "requirements",
+          "min": 1,
+          "all": { "field": "status", "equals": "satisfied" },
+          "failed_when": { "field": "status", "in": ["failed", "needs-revision"] },
+          "stale_when": { "field": "status", "in": ["stale", "superseded"] }
+        }
+      ]
+    }
+  ]
+}
+```
+
+- `on` reuses recurrence's constrained `<field> = <value>` grammar.
+- `relation` names one effective `prompt: "relation"` field. Its `source`
+  remains the target-type contract.
+- `min` defaults to `1`; every resolved target must satisfy `all`.
+- Predicates are deliberately limited to one target field and `equals` or
+  `in`. No arbitrary expressions, reverse traversal, or nested joins.
+- `failed_when` and `stale_when` classify failures using schema vocabulary.
+- Missing, unresolved, stale, failed, and satisfied results are all reported;
+  evaluation never stops at the first failure.
+- A transition is checked only when its field enters the configured value.
+- Duplicate guards for the same effective field/value are invalid schema.
+
+JSON edit and interactive edit must reject blocked transitions without writing.
+Bulk must report each blocked file explicitly and leave that file unchanged.
+
+### Read-only transition explanation
+
+```sh
+bwrb explain "Candidate 417" --transition "status = accepted"
+bwrb explain "Candidate 417" --transition accepted --output json
+```
+
+Value-only shorthand is valid only when it identifies exactly one configured
+guard. A valid but blocked explanation exits `0`: blocked is useful workflow
+state, not a command failure. Invalid targeting, grammar, or schema remains an
+error. The explanation DTO is the single source used by both `explain` and
+mutation errors (`TRANSITION_GUARD_FAILED`).
+
+### Bounded related-note transition effects
+
+Cross-type creation remains the existing recurrence primitive: it already
+creates from a named template and carries an audit backstop. Related-note state
+changes use a separate trait property:
+
+```json
+{
+  "transition_effects": [
+    {
+      "on": "status = accepted",
+      "relation": "task",
+      "set": { "status": "done" }
+    }
+  ]
+}
+```
+
+- The relation must be scalar and direct; an empty value is a no-op.
+- The patch is flat and literal, with `$ACTOR`, `$NOW`, and `$TODAY` as the only
+  dynamic values.
+- Effects do not cascade into more effects or recurrence.
+- Source and target are prepared and validated before writing, then re-read
+  under ordered shared mutation locks.
+- The implementation must roll back its own earlier write when a later write
+  fails, without erasing a newer writer.
+- Native edits have no effect backstop because a static snapshot cannot prove
+  that a transition occurred.
+
+### Session-level logical actor provenance
+
+Actor identity is provenance, not authentication. Resolve it once per process:
+
+1. root `--actor <value>` administrative override;
+2. `BWRB_ACTOR` supplied by the runner/session;
+3. literal `unknown`.
+
+Do not infer a human from the OS user, Git identity, or hostname. Schemas opt in
+with a static field value:
+
+```json
+{ "actor": { "value": "$ACTOR" } }
+```
+
+`$ACTOR` behaves like `$NOW` and `$TODAY`: it materializes on creation or when a
+missing static field is deliberately restored. It does not overwrite an
+attestation's original actor on every later edit. Transition-effect patches may
+also use `$ACTOR`. Runner identity is global/session-level; vault schemas do not
+declare which runner is active.
+
+### Retention findings and explicit remediation
+
+Retention belongs to a type and is evaluated by audit:
+
+```json
+{
+  "retention": {
+    "when": { "status": { "in": ["accepted", "rejected"] } },
+    "clock": { "field": "resolved-at", "after": "180d" },
+    "resolved_when": { "retention-state": { "in": ["archived", "tombstoned"] } },
+    "actions": [
+      { "kind": "archive", "directory": "Archive/Change Candidates" },
+      {
+        "kind": "tombstone",
+        "set": {
+          "retention-state": "tombstoned",
+          "tombstoned-at": "$TODAY"
+        }
+      },
+      { "kind": "delete" }
+    ]
+  }
+}
+```
+
+- The clock is an explicit day-granularity date field; file timestamps never
+  drive retention.
+- Due is inclusive: local `today >= clock + after` using one audit-run clock.
+- Missing or invalid clocks are diagnostics, never guessed deadlines.
+- `retention-due` is a warning with available action metadata.
+- Remediation requires `--only retention-due`, explicit targeting or `--all`,
+  `--retention-action`, and `--execute`; otherwise it is a dry-run.
+- Archive moves to the configured directory and updates links. Tombstone applies
+  only the configured schema-valid patch. Delete reuses canonical lineage and
+  relation safety and never occurs through ordinary automatic audit fixing.
+- Every action re-reads the live note and confirms it is still due immediately
+  before mutation.
 
 ## Non-goals
 

--- a/plans/features/agent-change-candidate-review.md
+++ b/plans/features/agent-change-candidate-review.md
@@ -1,0 +1,105 @@
+# Agent change-candidate and review system
+
+## What
+
+Make Bowerbird a reliable durable-state substrate for stateless agent workflows without adding agent-specific record types to the CLI or turning Markdown frontmatter into an opaque workflow object.
+
+Workflow records remain ordinary schema-defined notes—change candidates, requirements, attestations, and workflow events—connected through typed relations. Bowerbird supplies the general primitives those schemas need: safe contested edits, explainable relation-aware transitions, bounded transition effects, and retention findings.
+
+The first production slice is **revision-checked machine edits**. `bwrb list --output json` exposes an opaque revision for each result, and `bwrb edit --json ... --expected-revision <revision>` refuses to write when the note has changed since it was read.
+
+## Why this slice first
+
+Revision checking is the smallest coherent behavior that proves a necessary architectural contract:
+
+- stateless agents can read durable typed records through Bowerbird;
+- they can carry forward an opaque observation token;
+- contested candidate state cannot silently overwrite newer truth;
+- failures are explicit and retryable by rereading;
+- Markdown remains the source of truth, with no stored counter or hidden database.
+
+Adding transition-guard schema syntax first would leave the most important shared-record mutation unsafe. Revision checks also reuse Bowerbird's existing exact-byte concurrency protection instead of creating a parallel mechanism.
+
+## Resolved boundaries
+
+- The revision is an opaque digest of the exact note bytes read by Bowerbird.
+- It is computed, not written into frontmatter.
+- Callers must not infer meaning from its algorithm or length.
+- A supplied expected revision is checked against the snapshot used for validation and again under the existing note mutation lock immediately before write.
+- Revision mismatch is a user/data error (exit code 2), does not write, and reports the expected and current opaque revisions in JSON output.
+- JSON edit must not auto-retry a stale expected revision. The agent must list/read again and reconsider its patch.
+- Interactive edit does not accept revision preconditions in this slice.
+- `list` text/table output does not gain a revision column by default.
+- Native body edits remain valid, but naturally invalidate a previously observed revision.
+
+## CLI contract
+
+```sh
+# Discover a record and retain its opaque revision.
+bwrb list change-candidate --where 'status = implementing' --output json
+
+# Advance it only if nothing—including the body—changed after that read.
+bwrb edit 'Candidate 417' \
+  --json '{"status":"awaiting-review"}' \
+  --expected-revision '<opaque revision>' \
+  --output json
+```
+
+Successful JSON list rows include `revision`. Successful JSON edit output includes the new `revision`, allowing the next guarded step without a redundant read.
+
+On mismatch:
+
+```json
+{
+  "success": false,
+  "error": "Note changed since it was read. Reread it and retry with the current revision.",
+  "code": "REVISION_MISMATCH",
+  "expectedRevision": "...",
+  "currentRevision": "..."
+}
+```
+
+Human-readable output says the same thing without presenting the digest as a version number.
+
+## Implementation map
+
+- Revision primitive: add a small helper beside `src/lib/note-write-concurrency.ts`; hash exact bytes and centralize mismatch construction.
+- List projection: compute revision from the same file contents used to construct each result in `src/commands/list.ts`; expose it only in structured rows.
+- Command boundary: register `--expected-revision <revision>` in `src/commands/edit.ts`, reject it unless `--json` is present, and pass it into the JSON editor.
+- Edit path: in `src/lib/edit.ts`, compare the expected revision to the read snapshot before validation and to the locked current bytes immediately before write. Disable concurrent replay when the caller supplied a revision.
+- Output: preserve established structured error conventions and exit code 2.
+- Docs: update canonical `docs-site` list/edit references and `docs/skill/SKILL.md` for agent usage.
+
+## Acceptance
+
+Focused tests must prove:
+
+1. JSON list results expose a deterministic opaque revision.
+2. Editing with the matching revision succeeds and returns a different revision when bytes change.
+3. Editing with a stale revision exits 2 and preserves the newer file byte-for-byte.
+4. A body-only native edit invalidates the revision.
+5. A stale guarded edit is not replayed across the existing concurrency retry path.
+6. `--expected-revision` without `--json` fails at the command boundary.
+7. Existing unguarded JSON and interactive edit concurrency behavior remains unchanged.
+
+Run a disposable-vault CLI acceptance flow using built `dist/`: create schema and candidate note, list it, guarded-edit it, modify its body natively, demonstrate rejection with the old revision, relist, and succeed with the new revision.
+
+## Later slices
+
+1. Constrained relation-aware transition guards with explanatory missing/failed/stale relation output.
+2. A read-only transition explanation surface before mutation.
+3. Bounded related-note effects, generalized carefully from cross-type recurrence rather than overloading recurrence syntax.
+4. Actor provenance inherited from a session/global runner context.
+5. Retention-due audit findings and targeted explicit fixes.
+
+Each later slice must remain general-purpose. The `teenylilthoughts` schema supplies workflow vocabulary; Bowerbird supplies typed Markdown mechanics.
+
+## Non-goals
+
+- No built-in change-candidate, requirement, attestation, or workflow-event types.
+- No arbitrary nested workflow object.
+- No authentication or authorization server.
+- No hosting, preview, build, feature-flag, or PR orchestration.
+- No retention deletion in the first slice.
+- No generalized transition language in the first slice.
+- No changes to `teenylilthoughts`.

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -242,6 +242,80 @@
         },
         "recurrence": {
           "$ref": "#/definitions/recurrence"
+        },
+        "transition_guards": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "on": {
+                "type": "string",
+                "minLength": 1
+              },
+              "requires": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "relation": {
+                      "type": "string",
+                      "pattern": "^(?!forked-from$).*$",
+                      "description": "Schema field name; \"forked-from\" is reserved for system-managed lineage"
+                    },
+                    "min": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "all": {
+                      "type": "object",
+                      "properties": {
+                        "field": {
+                          "$ref": "#/definitions/trait/properties/transition_guards/items/properties/requires/items/properties/relation"
+                        },
+                        "equals": {
+                          "type": "string"
+                        },
+                        "in": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1
+                        }
+                      },
+                      "required": [
+                        "field"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "failed_when": {
+                      "$ref": "#/definitions/trait/properties/transition_guards/items/properties/requires/items/properties/all"
+                    },
+                    "stale_when": {
+                      "$ref": "#/definitions/trait/properties/transition_guards/items/properties/requires/items/properties/all"
+                    }
+                  },
+                  "required": [
+                    "relation",
+                    "all"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1
+              }
+            },
+            "required": [
+              "on",
+              "requires"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "transition_effects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/transitionEffect"
+          }
         }
       },
       "additionalProperties": false
@@ -271,6 +345,30 @@
       },
       "required": [
         "on"
+      ],
+      "additionalProperties": false
+    },
+    "transitionEffect": {
+      "type": "object",
+      "properties": {
+        "on": {
+          "type": "string",
+          "minLength": 1
+        },
+        "relation": {
+          "$ref": "#/definitions/trait/properties/transition_guards/items/properties/requires/items/properties/relation"
+        },
+        "set": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "on",
+        "relation",
+        "set"
       ],
       "additionalProperties": false
     },

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -433,6 +433,132 @@
         "plural": {
           "type": "string",
           "description": "Custom plural form for folder naming (e.g., 'research' instead of 'researches'). Auto-pluralized if not specified."
+        },
+        "retention": {
+          "type": "object",
+          "properties": {
+            "when": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "in": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  }
+                },
+                "required": [
+                  "in"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "clock": {
+              "type": "object",
+              "properties": {
+                "field": {
+                  "$ref": "#/definitions/trait/properties/transition_guards/items/properties/requires/items/properties/relation"
+                },
+                "after": {
+                  "type": "string",
+                  "pattern": "^([1-9]\\d*)d$"
+                }
+              },
+              "required": [
+                "field",
+                "after"
+              ],
+              "additionalProperties": false
+            },
+            "resolved_when": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "in": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  }
+                },
+                "required": [
+                  "in"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "actions": {
+              "type": "array",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "archive"
+                      },
+                      "directory": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "directory"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "tombstone"
+                      },
+                      "set": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "set"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "delete"
+                      }
+                    },
+                    "required": [
+                      "kind"
+                    ],
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              "minItems": 1
+            }
+          },
+          "required": [
+            "when",
+            "clock",
+            "actions"
+          ],
+          "additionalProperties": false,
+          "description": "Type-local retention policy evaluated by audit"
         }
       },
       "additionalProperties": false

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -469,7 +469,7 @@
         },
         "value": {
           "type": "string",
-          "description": "Static value (use $NOW for current datetime, $TODAY for date)"
+          "description": "Static value (use $NOW for current datetime, $TODAY for date, or $ACTOR for logical runner provenance)"
         },
         "description": {
           "type": "string",

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -57,6 +57,7 @@ import {
   type UndocumentedSchemaEntries,
 } from '../lib/audit/schema-docs.js';
 import { parseFuzzyThreshold } from '../lib/audit/unlinked-mention.js';
+import { runRetentionRemediation } from '../lib/audit/retention.js';
 import chalk from 'chalk';
 
 const FIX_TARGETING_ERROR_SUMMARY =
@@ -202,6 +203,7 @@ Examples:
   .option('--auto', 'With --fix: automatically apply unambiguous fixes')
   .option('--dry-run', 'With --fix: preview fixes without writing')
   .option('--execute', 'With --fix --auto: apply fixes (omit to preview)')
+  .option('--retention-action <kind>', 'Explicit retention action: archive, tombstone, or delete (requires --only retention-due --fix)')
   .option('--allow-field <fields...>', 'Allow additional fields beyond schema (repeatable)')
   .option(
     '--mention-fuzzy-threshold <n>',
@@ -229,6 +231,7 @@ Examples:
     const autoMode = options.auto ?? false;
     const dryRunMode = options.dryRun ?? false;
     const executeMode = options.execute ?? false;
+    const retentionAction = options.retentionAction as 'archive' | 'tombstone' | 'delete' | undefined;
     const exitWithValidationError = (
       message: string,
       {
@@ -260,9 +263,10 @@ Examples:
       exitWithValidationError('--dry-run requires --fix');
     }
 
-    // --execute requires --fix --auto
-    if (executeMode && (!fixMode || !autoMode)) {
-      exitWithValidationError('--execute requires --fix --auto');
+    // Retention is deliberately never an auto-fix. It has its own explicit
+    // selector/action gate, while preserving ordinary audit's auto contract.
+    if (executeMode && (!fixMode || (!autoMode && !retentionAction))) {
+      exitWithValidationError('--execute requires --fix --auto (or --retention-action)');
     }
 
     // --fix is not compatible with JSON output
@@ -272,6 +276,15 @@ Examples:
 
     if (executeMode && dryRunMode) {
       exitWithValidationError('--execute cannot be used with --dry-run');
+    }
+    if (retentionAction && !['archive', 'tombstone', 'delete'].includes(retentionAction)) {
+      exitWithValidationError('--retention-action must be archive, tombstone, or delete');
+    }
+    if (retentionAction && (!fixMode || options.only !== 'retention-due')) {
+      exitWithValidationError('--retention-action requires --fix --only retention-due');
+    }
+    if (retentionAction && autoMode) {
+      exitWithValidationError('--retention-action cannot be combined with --auto');
     }
 
     try {
@@ -397,6 +410,12 @@ Examples:
 
       // Handle fix mode
       if (fixMode) {
+        if (retentionAction) {
+          const remediation = await runRetentionRemediation({ results, schema, vaultDir, action: retentionAction, execute: executeMode && !dryRunMode });
+          for (const message of remediation.messages) console.log(message);
+          console.log(`${executeMode && !dryRunMode ? 'Applied' : 'Dry run'}: ${remediation.applied || remediation.attempted} retention action(s)`);
+          return;
+        }
         const headlessDryRunPreview = dryRunMode && !autoMode && !process.stdin.isTTY;
 
         if (!autoMode && !headlessDryRunPreview && !process.stdin.isTTY && results.length > 0) {

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -313,7 +313,7 @@ Examples:
       }
       const mentionLinkOnce = options.mentionLinkOnce ?? schema.config.mentionLinkOnce;
 
-      if (globalOpts.nonInteractive && fixMode && !autoMode) {
+      if (globalOpts.nonInteractive && fixMode && !autoMode && !retentionAction) {
         exitWithValidationError('bwrb audit --fix requires --auto when --non-interactive is set.');
       }
 

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -28,6 +28,7 @@ import {
 import { resolveTargets, hasAnyTargeting, type TargetingOptions } from '../lib/targeting.js';
 import { ConcurrentNoteModificationError, UserCancelledError } from '../lib/errors.js';
 import { concurrentModificationData } from '../lib/note-write-concurrency.js';
+import { RevisionMismatchError } from '../lib/note-revision.js';
 import type { ResolvedConfig } from '../types/schema.js';
 
 // ============================================================================
@@ -42,6 +43,7 @@ interface EditOptions {
   id?: string;
   body?: string;
   json?: string;
+  expectedRevision?: string;
   output?: string;
   open?: boolean;
   app?: string;
@@ -82,10 +84,16 @@ function printEditSuccess(
   path: string,
   updatedFields: string[],
   jsonMode: boolean,
+  revision?: string,
   data?: EditOpenJsonData
 ): void {
   if (jsonMode) {
-    printJson(jsonSuccess({ path, updated: updatedFields, ...(data ? { data } : {}) }));
+    printJson(jsonSuccess({
+      path,
+      updated: updatedFields,
+      ...(revision ? { revision } : {}),
+      ...(data ? { data } : {}),
+    }));
     return;
   }
 
@@ -110,6 +118,7 @@ export const editCommand = new Command('edit')
   .option('--id <uuid>', 'Filter by stable note id')
   .option('-b, --body <pattern>', 'Filter by body content')
   .option('--json <patch>', 'Non-interactive patch/merge mode')
+  .option('--expected-revision <revision>', 'Require this opaque revision when using --json')
   .option('--output <format>', 'Output format: text or json (default: json with --json)')
   .option('-o, --open', 'Open the note in Obsidian after editing')
   .option('--app <mode>', 'App mode for --open: system (default), editor, visual, obsidian, print')
@@ -171,6 +180,16 @@ Precedence (for --open app mode):
       const outputFormat = options.output ?? globalOpts.output;
       if (outputFormat !== undefined && outputFormat !== 'json' && outputFormat !== 'text') {
         printError(`Unknown output format: ${outputFormat}`);
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+
+      if (options.expectedRevision !== undefined && !patchMode) {
+        const error = '--expected-revision requires --json <patch>';
+        if (jsonMode) {
+          printJson(jsonError(error));
+        } else {
+          printError(error);
+        }
         process.exit(ExitCodes.VALIDATION_ERROR);
       }
 
@@ -239,7 +258,12 @@ Precedence (for --open app mode):
         if (fileExists) {
           // It's a valid absolute path - use it directly.
           if (patchMode) {
-            const editResult = await editNoteFromJson(schema, vaultDir, query, options.json!, { jsonMode });
+            const editResult = await editNoteFromJson(schema, vaultDir, query, options.json!, {
+              jsonMode,
+              ...(options.expectedRevision !== undefined
+                ? { expectedRevision: options.expectedRevision }
+                : {}),
+            });
             let openData: EditOpenJsonData | undefined;
             if (options.open) {
               const appMode = resolveAppMode(appModeInput, schema.config);
@@ -250,7 +274,7 @@ Precedence (for --open app mode):
               }
               openData = await openAfterEdit(vaultDir, query, appMode, schema.config, jsonMode);
             }
-            printEditSuccess(relative(vaultDir, query), editResult.updatedFields, jsonMode, openData);
+            printEditSuccess(relative(vaultDir, query), editResult.updatedFields, jsonMode, editResult.revision, openData);
           } else {
             await editNoteInteractive(schema, vaultDir, query, {});
             printSuccess(`Updated ${basename(query, '.md')}`);
@@ -349,7 +373,12 @@ Precedence (for --open app mode):
       // Perform the edit
       if (patchMode) {
         // JSON patch mode: non-interactive patch with selectable output format
-        const editResult = await editNoteFromJson(schema, vaultDir, targetFile.path, options.json!, { jsonMode });
+        const editResult = await editNoteFromJson(schema, vaultDir, targetFile.path, options.json!, {
+          jsonMode,
+          ...(options.expectedRevision !== undefined
+            ? { expectedRevision: options.expectedRevision }
+            : {}),
+        });
         let openData: EditOpenJsonData | undefined;
 
         // Open after edit if requested
@@ -362,7 +391,7 @@ Precedence (for --open app mode):
           }
           openData = await openAfterEdit(vaultDir, targetFile.path, appMode, schema.config, jsonMode);
         }
-        printEditSuccess(targetFile.relativePath, editResult.updatedFields, jsonMode, openData);
+        printEditSuccess(targetFile.relativePath, editResult.updatedFields, jsonMode, editResult.revision, openData);
         return;
       } else {
         // Interactive mode
@@ -377,6 +406,18 @@ Precedence (for --open app mode):
         return;
       }
     } catch (err) {
+      if (err instanceof RevisionMismatchError) {
+        if (jsonMode) {
+          printJson(jsonError(err.message, {
+            code: 'REVISION_MISMATCH',
+            expectedRevision: err.expectedRevision,
+            currentRevision: err.currentRevision,
+          }));
+        } else {
+          printError(err.message);
+        }
+        process.exit(ExitCodes.IO_ERROR);
+      }
       if (err instanceof ConcurrentNoteModificationError) {
         if (jsonMode) {
           printJson(jsonError(err.message, {

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -418,6 +418,18 @@ Precedence (for --open app mode):
         }
         process.exit(ExitCodes.IO_ERROR);
       }
+      if ((err as { code?: string }).code === 'TRANSITION_GUARD_FAILED') {
+        const guardError = err as Error & { explanation: unknown };
+        if (jsonMode) {
+          printJson(jsonError(guardError.message, {
+            code: 'TRANSITION_GUARD_FAILED',
+            data: guardError.explanation,
+          }));
+        } else {
+          printError(guardError.message);
+        }
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
       if (err instanceof ConcurrentNoteModificationError) {
         if (jsonMode) {
           printJson(jsonError(err.message, {

--- a/src/commands/explain.ts
+++ b/src/commands/explain.ts
@@ -1,0 +1,56 @@
+import { Command } from 'commander';
+import { relative } from 'path';
+import { loadSchema, resolveTypeFromFrontmatter } from '../lib/schema.js';
+import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
+import { getGlobalOpts } from '../lib/command.js';
+import { buildNoteIndex, resolveExactNoteQuery } from '../lib/navigation.js';
+import { parseNote } from '../lib/frontmatter.js';
+import { explainTransition, getTransitionGuardsForType, parseTransitionTrigger } from '../lib/transition-guards.js';
+import { printJson, jsonError, ExitCodes } from '../lib/output.js';
+import { printError } from '../lib/prompt.js';
+
+export const explainCommand = new Command('explain')
+  .description('Explain relation-backed transition requirements for a note')
+  .argument('<query>', 'Exact note name or path')
+  .requiredOption('--transition <trigger>', 'Transition as "field = value", or a unique configured value')
+  .option('--output <format>', 'Output format: text or json', 'text')
+  .action(async (query: string, options: { transition: string; output?: string }, command: Command) => {
+    const global = getGlobalOpts(command);
+    const json = (options.output ?? global.output) === 'json';
+    try {
+      if (options.output && !['text', 'json'].includes(options.output)) throw new Error(`Unknown output format: ${options.output}`);
+      const vaultOptions: { vault?: string; jsonMode: boolean } = { jsonMode: json };
+      if (global.vault) vaultOptions.vault = global.vault;
+      const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
+      const schema = await loadSchema(vaultDir);
+      const index = await buildNoteIndex(schema, vaultDir);
+      const resolved = resolveExactNoteQuery(index, query);
+      if (!resolved.exact) throw new Error(resolved.isAmbiguous ? `Ambiguous note: ${query}` : `No exact note found: ${query}`);
+      const note = await parseNote(resolved.exact.path);
+      const type = resolveTypeFromFrontmatter(schema, note.frontmatter);
+      if (!type) throw new Error('Could not determine note type from frontmatter');
+      let transition = parseTransitionTrigger(options.transition);
+      if (!transition) {
+        const matches = getTransitionGuardsForType(schema, type)
+          .map((guard) => parseTransitionTrigger(guard.on)!)
+          .filter((candidate) => candidate.value === options.transition);
+        if (matches.length !== 1) throw new Error(`Transition value '${options.transition}' does not identify exactly one configured guard.`);
+        transition = matches[0]!;
+      }
+      const explanation = await explainTransition(schema, vaultDir, type, note.frontmatter, transition);
+      if (explanation.guards.length === 0) throw new Error(`No transition guard is configured for '${transition.field} = ${transition.value}'.`);
+      if (json) {
+        printJson({ success: true, data: { path: relative(vaultDir, resolved.exact.path), ...explanation } });
+      } else {
+        console.log(`${explanation.blocked ? 'Blocked' : 'Allowed'}: ${transition.field} = ${transition.value} (${relative(vaultDir, resolved.exact.path)})`);
+        for (const guard of explanation.guards) for (const requirement of guard.requirements) {
+          console.log(`  ${requirement.relation}: ${requirement.status} (${requirement.targets.length}/${requirement.min})`);
+          for (const target of requirement.targets) console.log(`    ${target.target}: ${target.status}`);
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (json) printJson(jsonError(message)); else printError(message);
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+  });

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -29,6 +29,8 @@ import {
   type FileStatMap,
 } from '../lib/list-helpers.js';
 import { readFile, stat } from 'fs/promises';
+import { parseNote } from '../lib/frontmatter.js';
+import { noteRevision } from '../lib/note-revision.js';
 
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts, resolveGlobalPickerMode } from '../lib/command.js';
@@ -1055,12 +1057,17 @@ export async function listObjects(
 
   switch (options.outputFormat) {
     case 'json': {
-      const jsonOutput = filteredFiles.map(({ path, frontmatter }) => {
+      const jsonOutput = await Promise.all(filteredFiles.map(async ({ path }) => {
+        // The row and revision must describe one observation, not adjacent
+        // reads of a note that an editor could change between them.
+        const snapshot = await parseNote(path);
+        const frontmatter = snapshot.frontmatter;
         const notePath = relative(vaultDir, path);
         const noteName = basename(path, '.md');
         const base = {
           _path: notePath,
           _name: noteName,
+          revision: noteRevision(snapshot.raw),
         };
 
         if (!options.fields || options.fields.length === 0) {
@@ -1099,7 +1106,7 @@ export async function listObjects(
         }
 
         return selected;
-      });
+      }));
       console.log(JSON.stringify(jsonOutput, null, 2));
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { lineageCommand } from './commands/lineage/index.js';
 import { configCommand } from './commands/config.js';
 import { dashboardCommand } from './commands/dashboard.js';
 import { initCommand } from './commands/init.js';
+import { explainCommand } from './commands/explain.js';
 import { handleCompletionRequest } from './lib/completion.js';
 import { cleanupPromptMode } from './lib/prompt.js';
 import { BWRB_VERSION } from './version.js';
@@ -68,6 +69,7 @@ if (completionsIndex !== -1) {
   // Query operations
   program.addCommand(listCommand);
   program.addCommand(recentCommand);
+  program.addCommand(explainCommand);
   // Compatibility commands remain callable, but `list` is the canonical
   // query/search/open surface shown in root help and command completion.
   program.addCommand(openCommand, { hidden: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { explainCommand } from './commands/explain.js';
 import { handleCompletionRequest } from './lib/completion.js';
 import { cleanupPromptMode } from './lib/prompt.js';
 import { BWRB_VERSION } from './version.js';
+import { configureLogicalActor } from './lib/logical-actor.js';
 
 const program = new Command();
 
@@ -53,6 +54,11 @@ if (completionsIndex !== -1) {
     .version(BWRB_VERSION)
     .option('-v, --vault <path>', 'Path to the vault directory')
     .option('--non-interactive', 'Disable interactive prompts and require explicit non-interactive flags')
+    .option('--actor <actor>', 'Logical workflow actor provenance (overrides BWRB_ACTOR)')
+    .hook('preAction', (_thisCommand, actionCommand) => {
+      const options = actionCommand.optsWithGlobals() as { actor?: string };
+      configureLogicalActor(options.actor);
+    })
     .hook('postAction', () => {
       cleanupPromptMode();
     })

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -18,6 +18,7 @@ import {
   resolveDateCalendar,
   resolveDateGranularity,
   getRecurrenceForType,
+  getRetentionForType,
 } from '../schema.js';
 import { readStructuralFrontmatter } from './structural.js';
 import { getOwnedChildFolder } from '../ownership-paths.js';
@@ -82,6 +83,7 @@ import {
 } from '../discovery.js';
 import { buildRelativeDateFieldMap, validateRelativeDateValue } from '../relative-date.js';
 import { parseCalendarDate } from '../calendar-date.js';
+import { formatLocalDate } from '../local-date.js';
 import { collectLineageIssues } from './lineage.js';
 
 // Import ownership tracking
@@ -128,6 +130,9 @@ export async function runAuditDetailed(
   vaultDir: string,
   options: AuditRunOptions
 ): Promise<AuditRunResult> {
+  // Capture once: a long audit must not split a midnight boundary into two
+  // different retention decisions.
+  const retentionToday = options.retentionToday ?? formatLocalDate();
   // Discover all managed files
   const files = await discoverManagedFiles(schema, vaultDir, options.typePath);
 
@@ -237,7 +242,7 @@ export async function runAuditDetailed(
 
   for (const file of filteredFiles) {
     const issues = [
-      ...(await auditFile(schema, vaultDir, file, options, noteIndex, ownershipIndex, parentMap, entityMentionIndex)),
+      ...(await auditFile(schema, vaultDir, file, { ...options, retentionToday }, noteIndex, ownershipIndex, parentMap, entityMentionIndex)),
       ...(lineageIssuesByPath.get(file.relativePath) ?? []),
     ];
 
@@ -543,6 +548,28 @@ export async function auditFile(
   // Get field definitions for this type
   const fields = getFieldsForType(schema, resolvedTypePath);
   const fieldNames = new Set(Object.keys(fields));
+
+  const retention = getRetentionForType(schema, resolvedTypePath);
+  if (retention && matchesRetentionCondition(frontmatter, retention.when)) {
+    const resolved = retention.resolved_when && matchesRetentionCondition(frontmatter, retention.resolved_when);
+    if (!resolved) {
+      const clockValue = frontmatter[retention.clock.field];
+      const due = retentionDue(clockValue, retention.clock.after, options.retentionToday!);
+      if (due.kind === 'due') {
+        issues.push({
+          severity: 'warning', code: 'retention-due', autoFixable: false,
+          field: retention.clock.field,
+          message: `Retention is due since ${due.dueDate} (clock ${retention.clock.field}: ${due.clockDate})`,
+          meta: { clockField: retention.clock.field, clockDate: due.clockDate, dueDate: due.dueDate, today: options.retentionToday, actions: retention.actions },
+        });
+      } else if (due.kind === 'invalid') {
+        issues.push({ severity: 'warning', code: 'retention-due', autoFixable: false, field: retention.clock.field,
+          message: `Retention clock is missing or invalid: ${due.reason}`,
+          meta: { clockField: retention.clock.field, today: options.retentionToday, diagnostic: 'invalid-clock', actions: retention.actions },
+        });
+      }
+    }
+  }
 
   // Combine allowed fields from different sources
   const allowedFields = new Set([
@@ -2750,6 +2777,27 @@ function checkSingularPluralMismatch(
   }
   
   return null;
+}
+
+function matchesRetentionCondition(frontmatter: Record<string, unknown>, condition: Record<string, { in: string[] }>): boolean {
+  return Object.entries(condition).every(([field, rule]) =>
+    typeof frontmatter[field] === 'string' && rule.in.includes(frontmatter[field] as string)
+  );
+}
+
+function retentionDue(value: unknown, after: string, today: string):
+  | { kind: 'due'; clockDate: string; dueDate: string }
+  | { kind: 'not-due' }
+  | { kind: 'invalid'; reason: string } {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return { kind: 'invalid', reason: 'expected a YYYY-MM-DD date' };
+  const clock = new Date(`${value}T00:00:00`);
+  const localClock = `${clock.getFullYear()}-${String(clock.getMonth() + 1).padStart(2, '0')}-${String(clock.getDate()).padStart(2, '0')}`;
+  if (Number.isNaN(clock.getTime()) || localClock !== value) return { kind: 'invalid', reason: 'expected a valid calendar date' };
+  const days = Number(after.slice(0, -1));
+  const due = new Date(clock);
+  due.setDate(due.getDate() + days);
+  const dueDate = `${due.getFullYear()}-${String(due.getMonth() + 1).padStart(2, '0')}-${String(due.getDate()).padStart(2, '0')}`;
+  return today >= dueDate ? { kind: 'due', clockDate: value, dueDate } : { kind: 'not-due' };
 }
 
 // ============================================================================

--- a/src/lib/audit/retention.ts
+++ b/src/lib/audit/retention.ts
@@ -1,0 +1,104 @@
+import { unlink } from 'fs/promises';
+import { getRetentionForType, getFieldsForType, resolveTypeFromFrontmatter } from '../schema.js';
+import { parseNote, writeNote } from '../frontmatter.js';
+import { validateFrontmatter } from '../validation.js';
+import { formatLocalDate } from '../local-date.js';
+import { withLineageMutationLocks } from '../lineage-lock.js';
+import { executeBulkMove, findAllMarkdownFiles, findWikilinksToFile } from '../bulk/move.js';
+import { buildVaultNoteSnapshot } from '../discovery.js';
+import { assessDeleteLineage } from '../delete-lineage-guard.js';
+import { basename, relative } from 'path';
+import type { LoadedSchema } from '../../types/schema.js';
+import type { FileAuditResult } from './types.js';
+
+type ActionKind = 'archive' | 'tombstone' | 'delete';
+
+function matches(fm: Record<string, unknown>, condition: Record<string, { in: string[] }>): boolean {
+  return Object.entries(condition).every(([key, rule]) => typeof fm[key] === 'string' && rule.in.includes(fm[key] as string));
+}
+function isDue(fm: Record<string, unknown>, retention: NonNullable<ReturnType<typeof getRetentionForType>>, today: string): boolean {
+  if (!matches(fm, retention.when) || (retention.resolved_when && matches(fm, retention.resolved_when))) return false;
+  const value = fm[retention.clock.field];
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const clock = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(clock.getTime())) return false;
+  clock.setDate(clock.getDate() + Number(retention.clock.after.slice(0, -1)));
+  const due = `${clock.getFullYear()}-${String(clock.getMonth() + 1).padStart(2, '0')}-${String(clock.getDate()).padStart(2, '0')}`;
+  return today >= due;
+}
+
+/** Explicit retention execution; intentionally separate from ordinary audit auto-fix. */
+export async function runRetentionRemediation(args: {
+  results: FileAuditResult[]; schema: LoadedSchema; vaultDir: string; action: ActionKind; execute: boolean;
+}): Promise<{ attempted: number; applied: number; skipped: number; messages: string[] }> {
+  const today = formatLocalDate();
+  const candidates = args.results.filter(r => r.issues.some(i => i.code === 'retention-due' && i.meta?.diagnostic !== 'invalid-clock'));
+  const messages: string[] = [];
+  let applied = 0; let skipped = 0;
+  for (const candidate of candidates) {
+    const initial = await parseNote(candidate.path);
+    const type = resolveTypeFromFrontmatter(args.schema, initial.frontmatter);
+    const retention = type ? getRetentionForType(args.schema, type) : undefined;
+    const action = retention?.actions.find(item => item.kind === args.action);
+    if (!type || !retention || !action || !isDue(initial.frontmatter, retention, today)) { skipped++; messages.push(`${candidate.relativePath}: no longer due or action is not configured`); continue; }
+    if (!args.execute) { messages.push(`Would ${args.action} ${candidate.relativePath}`); continue; }
+    if (action.kind === 'archive') {
+      // The move rewrites backlink source files too, so lock the complete
+      // mutation set rather than only the note being archived.
+      const allVaultFiles = await findAllMarkdownFiles(args.vaultDir);
+      const references = await findWikilinksToFile(args.vaultDir, candidate.path, allVaultFiles);
+      await withLineageMutationLocks(args.vaultDir, [candidate.path, ...references.map(reference => reference.sourceFile)], async () => {
+        const live = await parseNote(candidate.path);
+        const liveType = resolveTypeFromFrontmatter(args.schema, live.frontmatter);
+        const liveRetention = liveType ? getRetentionForType(args.schema, liveType) : undefined;
+        if (!liveRetention || !isDue(live.frontmatter, liveRetention, today)) { skipped++; messages.push(`${candidate.relativePath}: no longer due`); return; }
+        const result = await executeBulkMove({ vaultDir: args.vaultDir, targetDir: action.directory, filesToMove: [candidate.path], execute: true, allVaultFiles });
+        if (result.errors.length) { skipped++; messages.push(...result.errors); } else { applied++; messages.push(`Archived ${candidate.relativePath}`); }
+      });
+      continue;
+    }
+    await withLineageMutationLocks(args.vaultDir, [candidate.path], async () => {
+      const live = await parseNote(candidate.path);
+      const liveType = resolveTypeFromFrontmatter(args.schema, live.frontmatter);
+      const liveRetention = liveType ? getRetentionForType(args.schema, liveType) : undefined;
+      if (!liveType || !liveRetention || !isDue(live.frontmatter, liveRetention, today)) { skipped++; messages.push(`${candidate.relativePath}: no longer due`); return; }
+      if (action.kind === 'tombstone') {
+        const patch = Object.fromEntries(Object.entries(action.set).map(([key, value]) => [key, value === '$TODAY' ? today : value]));
+        const next = { ...live.frontmatter, ...patch };
+        const validation = validateFrontmatter(args.schema, liveType, next, { strictFields: true });
+        if (!validation.valid) { skipped++; messages.push(`${candidate.relativePath}: tombstone patch invalid: ${validation.errors[0]?.message}`); return; }
+        await writeNote(candidate.path, next, live.body, getFieldsForType(args.schema, liveType) ? Object.keys(getFieldsForType(args.schema, liveType)) : undefined);
+        applied++; messages.push(`Tombstoned ${candidate.relativePath}`); return;
+      }
+      const snapshot = await buildVaultNoteSnapshot(args.schema, args.vaultDir);
+      const lineage = assessDeleteLineage(snapshot, [candidate.path]);
+      const files = await findAllMarkdownFiles(args.vaultDir);
+      const links = await findWikilinksToFile(args.vaultDir, candidate.path, files);
+      const relationRefs = await findTypedRelationReferences(args.schema, args.vaultDir, candidate.path, files);
+      if (lineage.blocked.length || links.length || relationRefs.length) { skipped++; messages.push(`${candidate.relativePath}: refusing delete; live lineage, backlinks, or relations remain`); return; }
+      await unlink(candidate.path); applied++; messages.push(`Deleted ${candidate.relativePath}`);
+    });
+  }
+  return { attempted: candidates.length, applied, skipped, messages };
+}
+
+/** Conservative relation safety independent of wikilink vs markdown link format. */
+async function findTypedRelationReferences(schema: LoadedSchema, vaultDir: string, targetPath: string, files: string[]): Promise<string[]> {
+  const targetName = basename(targetPath, '.md');
+  const targetRelative = relative(vaultDir, targetPath).replace(/\.md$/, '');
+  const references: string[] = [];
+  for (const file of files) {
+    if (file === targetPath) continue;
+    const note = await parseNote(file);
+    const type = resolveTypeFromFrontmatter(schema, note.frontmatter);
+    if (!type) continue;
+    for (const [name, field] of Object.entries(getFieldsForType(schema, type))) {
+      if (field.prompt !== 'relation') continue;
+      const values = Array.isArray(note.frontmatter[name]) ? note.frontmatter[name] : [note.frontmatter[name]];
+      if (values.some(value => typeof value === 'string' && (value.includes(`[[${targetName}`) || value.includes(`[[${targetRelative}`) || value.includes(`](${targetRelative}.md`) || value === targetName || value === targetRelative))) {
+        references.push(file);
+      }
+    }
+  }
+  return references;
+}

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -97,7 +97,8 @@ export type IssueCode =
   | 'relative-date-bound-violation'
   | 'relative-date-unanchored'
   | 'relative-date-invalid-ref'
-  | 'relative-date-invalid-offset';
+  | 'relative-date-invalid-offset'
+  | 'retention-due';
 
 /**
  * A single audit issue.
@@ -242,6 +243,7 @@ export interface AuditOptions {
   dryRun?: boolean;
   /** With --fix --auto: apply fixes (omit to preview). */
   execute?: boolean;
+  retentionAction?: 'archive' | 'tombstone' | 'delete';
   all?: boolean;
   allowField?: string[];
   /**
@@ -289,6 +291,8 @@ export interface AuditRunOptions {
    * (#622). Undefined means enabled (default).
    */
   mentionFuzzyEnabled?: boolean | undefined;
+  /** One local day snapshot shared by every retention finding in this run. */
+  retentionToday?: string | undefined;
 }
 
 /**

--- a/src/lib/bulk/execute.ts
+++ b/src/lib/bulk/execute.ts
@@ -12,6 +12,9 @@ import { applyWhereExpressions } from '../where-targeting.js';
 import { applyOperations } from './operations.js';
 import { createBackup } from './backup.js';
 import { executeBulkMove, findAllMarkdownFiles } from './move.js';
+import { assertTransitionGuards, transitionGuardTargetPaths } from '../transition-guards.js';
+import { withLineageMutationLocks } from '../lineage-lock.js';
+import { assertNoteBytesUnchanged } from '../note-write-concurrency.js';
 import type {
   BulkOptions,
   BulkResult,
@@ -108,16 +111,18 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
     relativePath: string;
     frontmatter: Record<string, unknown>;
     body: string;
+    raw: string;
   }[] = [];
 
   for (const file of files) {
     try {
-      const { frontmatter, body } = await parseNote(file.path);
+      const { frontmatter, body, raw } = await parseNote(file.path);
       parsedFiles.push({
         path: file.path,
         relativePath: file.relativePath,
         frontmatter,
         body,
+        raw,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -188,6 +193,13 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
       const { modified, changes } = applyOperations({ ...file.frontmatter }, operations);
       fileChange.changes = changes;
 
+      // Guard evaluation happens for dry-runs too, so a bulk receipt never
+      // promises a change that execution would later reject.
+      const resolvedType = resolveTypeFromFrontmatter(schema, modified);
+      if (resolvedType) {
+        await assertTransitionGuards(schema, vaultDir, resolvedType, file.frontmatter, modified);
+      }
+
       if (execute && changes.length > 0) {
         // Recurrence fast path (atomicity, #107): VALIDATE + COMPUTE the
         // successor BEFORE writing the predecessor's change, so a spawn that
@@ -218,18 +230,27 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
           fileChange.error = recError;
           result.errors.push(`Recurrence spawn failed for ${file.relativePath}: ${recError}`);
         } else {
-          await writeNote(file.path, modified, file.body);
-          fileChange.applied = true;
-
-          // Commit the prepared spawn (create successor + back-link `next`).
-          if (fastPathPlan) {
-            try {
-              await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
-            } catch (recErr) {
-              const recMessage = recErr instanceof Error ? recErr.message : String(recErr);
-              result.errors.push(`Recurrence spawn failed for ${file.relativePath}: ${recMessage}`);
+          const guardPaths = resolvedType
+            ? await transitionGuardTargetPaths(schema, vaultDir, resolvedType, file.frontmatter, modified)
+            : [];
+          await withLineageMutationLocks(vaultDir, [file.path, ...guardPaths], async () => {
+            await assertNoteBytesUnchanged(file.path, file.raw);
+            if (resolvedType) {
+              await assertTransitionGuards(schema, vaultDir, resolvedType, file.frontmatter, modified);
             }
-          }
+            await writeNote(file.path, modified, file.body);
+            fileChange.applied = true;
+
+            // Commit the prepared spawn (create successor + back-link `next`).
+            if (fastPathPlan) {
+              try {
+                await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+              } catch (recErr) {
+                const recMessage = recErr instanceof Error ? recErr.message : String(recErr);
+                result.errors.push(`Recurrence spawn failed for ${file.relativePath}: ${recMessage}`);
+              }
+            }
+          });
         }
       }
     } catch (err) {

--- a/src/lib/bulk/execute.ts
+++ b/src/lib/bulk/execute.ts
@@ -2,7 +2,7 @@
  * Bulk execution orchestration.
  */
 
-import { parseNote, writeNote } from '../frontmatter.js';
+import { parseNote, writeNote, writeFileAtomic } from '../frontmatter.js';
 import { resolveTypeFromFrontmatter } from '../schema.js';
 import { prepareRecurrenceFastPath, commitRecurrenceFastPath } from '../recurrence-fast-path.js';
 import { discoverManagedFiles, dedupeByCanonicalPath } from '../discovery.js';
@@ -15,6 +15,7 @@ import { executeBulkMove, findAllMarkdownFiles } from './move.js';
 import { assertTransitionGuards, transitionGuardTargetPaths } from '../transition-guards.js';
 import { withLineageMutationLocks } from '../lineage-lock.js';
 import { assertNoteBytesUnchanged } from '../note-write-concurrency.js';
+import { commitTransitionEffects, prepareTransitionEffects, rollbackTransitionEffects, transitionEffectTargetPaths } from '../transition-effects.js';
 import type {
   BulkOptions,
   BulkResult,
@@ -198,6 +199,9 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
       const resolvedType = resolveTypeFromFrontmatter(schema, modified);
       if (resolvedType) {
         await assertTransitionGuards(schema, vaultDir, resolvedType, file.frontmatter, modified);
+        // Validate effect targets during dry-runs too, so the receipt cannot
+        // promise a source transition whose related-note patch would fail.
+        await prepareTransitionEffects(schema, vaultDir, resolvedType, file.frontmatter, modified, file.path);
       }
 
       if (execute && changes.length > 0) {
@@ -233,22 +237,32 @@ export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
           const guardPaths = resolvedType
             ? await transitionGuardTargetPaths(schema, vaultDir, resolvedType, file.frontmatter, modified)
             : [];
-          await withLineageMutationLocks(vaultDir, [file.path, ...guardPaths], async () => {
+          const transitionEffects = resolvedType
+            ? await prepareTransitionEffects(schema, vaultDir, resolvedType, file.frontmatter, modified, file.path)
+            : [];
+          await withLineageMutationLocks(vaultDir, [file.path, ...guardPaths, ...transitionEffectTargetPaths(transitionEffects)], async () => {
             await assertNoteBytesUnchanged(file.path, file.raw);
+            for (const effect of transitionEffects) await assertNoteBytesUnchanged(effect.path, effect.raw);
             if (resolvedType) {
               await assertTransitionGuards(schema, vaultDir, resolvedType, file.frontmatter, modified);
             }
             await writeNote(file.path, modified, file.body);
-            fileChange.applied = true;
-
-            // Commit the prepared spawn (create successor + back-link `next`).
-            if (fastPathPlan) {
-              try {
+            const writtenSource = await parseNote(file.path).then((note) => note.raw);
+            let committedEffects;
+            try {
+              committedEffects = await commitTransitionEffects(transitionEffects);
+              fileChange.applied = true;
+              // Commit the prepared spawn (create successor + back-link `next`).
+              if (fastPathPlan) {
                 await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
-              } catch (recErr) {
-                const recMessage = recErr instanceof Error ? recErr.message : String(recErr);
-                result.errors.push(`Recurrence spawn failed for ${file.relativePath}: ${recMessage}`);
               }
+            } catch (effectErr) {
+              if (await parseNote(file.path).then((note) => note.raw).catch(() => '') === writtenSource) {
+                await writeFileAtomic(file.path, file.raw);
+              }
+              if (committedEffects) await rollbackTransitionEffects(committedEffects);
+              fileChange.applied = false;
+              throw effectErr;
             }
           });
         }

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -341,6 +341,7 @@ const COMMAND_OPTIONS: Record<string, string[]> = {
     '--help',
   ],
   completion: ['--help'],
+  explain: ['--transition', '--output', '--help'],
   config: ['--output', '-o', '--vault', '-v', '--non-interactive', '--json', '--help'],
 };
 

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -250,6 +250,7 @@ const COMMANDS = [
   'delete',
   'list',
   'recent',
+  'explain',
   'schema',
   'audit',
   'bulk',

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -6,7 +6,7 @@
  * - `search --edit` (unified interface)
  */
 
-import { access, mkdir, writeFile } from 'fs/promises';
+import { access, mkdir, readFile, writeFile } from 'fs/promises';
 import { join, relative } from 'path';
 import {
   getTypeDefByPath,
@@ -51,6 +51,7 @@ import { validateRelativeDateCalendarOffsetsForWrite } from './relative-date.js'
 import { isBwrbReservedFrontmatterField } from './frontmatter/systemFields.js';
 import { withLineageMutationLocks } from './lineage-lock.js';
 import { assertNoteBytesUnchanged } from './note-write-concurrency.js';
+import { assertExpectedRevision, noteRevision } from './note-revision.js';
 
 // ============================================================================
 // Types
@@ -59,11 +60,14 @@ import { assertNoteBytesUnchanged } from './note-write-concurrency.js';
 export interface EditResult {
   updatedFields: string[];
   path: string;
+  revision: string;
 }
 
 export interface EditFromJsonOptions {
   /** Whether to output errors as JSON */
   jsonMode?: boolean;
+  /** Opaque raw-note revision that must still match before this patch writes. */
+  expectedRevision?: string;
 }
 
 export interface EditInteractiveOptions {
@@ -96,7 +100,7 @@ export async function editNoteFromJson(
   jsonInput: string,
   options: EditFromJsonOptions = {}
 ): Promise<EditResult> {
-  const { jsonMode = true } = options;
+  const { jsonMode = true, expectedRevision } = options;
 
   // Parse JSON input
   let patchData: Record<string, unknown>;
@@ -124,7 +128,10 @@ export async function editNoteFromJson(
     throw new Error(error);
   }
 
-  for (let attempt = 1; attempt <= JSON_EDIT_ATTEMPTS; attempt++) {
+  // A guarded caller must reread and reconsider a stale patch; replaying it
+  // against unseen bytes would defeat the revision precondition.
+  const attempts = expectedRevision === undefined ? JSON_EDIT_ATTEMPTS : 1;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
     try {
       return await editNoteFromJsonAttempt(
         schema,
@@ -132,12 +139,13 @@ export async function editNoteFromJson(
         filePath,
         patchData,
         jsonMode,
-        attempt
+        attempt,
+        expectedRevision
       );
     } catch (error) {
       if (
         error instanceof ConcurrentNoteModificationError &&
-        attempt < JSON_EDIT_ATTEMPTS
+        attempt < attempts
       ) {
         continue;
       }
@@ -145,7 +153,7 @@ export async function editNoteFromJson(
     }
   }
 
-  throw new ConcurrentNoteModificationError(filePath, JSON_EDIT_ATTEMPTS);
+  throw new ConcurrentNoteModificationError(filePath, attempts);
 }
 
 async function editNoteFromJsonAttempt(
@@ -154,11 +162,16 @@ async function editNoteFromJsonAttempt(
   filePath: string,
   patchData: Record<string, unknown>,
   jsonMode: boolean,
-  attempt: number
+  attempt: number,
+  expectedRevision: string | undefined
 ): Promise<EditResult> {
 
   // Parse existing note
   const { frontmatter, body, raw } = await parseNote(filePath);
+
+  if (expectedRevision !== undefined) {
+    assertExpectedRevision(expectedRevision, raw);
+  }
 
   // Resolve type path from existing frontmatter
   const typePath = resolveTypePathFromFrontmatter(schema, frontmatter);
@@ -350,7 +363,12 @@ async function editNoteFromJsonAttempt(
 
   await waitForEditCommitBarrier(attempt, filePath);
 
-  await withLineageMutationLocks(vaultDir, [filePath], async () => {
+  const revision = await withLineageMutationLocks(vaultDir, [filePath], async () => {
+    if (expectedRevision !== undefined) {
+      // Re-read while holding the shared mutation lock, closing the
+      // validation-to-write race with other Bowerbird writers.
+      assertExpectedRevision(expectedRevision, await readFile(filePath, 'utf-8'));
+    }
     await assertNoteBytesUnchanged(filePath, raw, attempt);
 
     // Recurrence prepare, predecessor write, and successor/back-link commit are
@@ -366,9 +384,16 @@ async function editNoteFromJsonAttempt(
     );
     await writeNote(filePath, resolvedFrontmatter, body, orderedFields);
     await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+    // Return the revision of the final bytes produced by this guarded commit
+    // while the shared Bowerbird mutation lock still excludes another writer.
+    return noteRevision(await readFile(filePath, 'utf-8'));
   });
 
-  return { updatedFields, path: filePath };
+  return {
+    updatedFields,
+    path: filePath,
+    revision,
+  };
 }
 
 // ============================================================================

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -52,6 +52,7 @@ import { isBwrbReservedFrontmatterField } from './frontmatter/systemFields.js';
 import { withLineageMutationLocks } from './lineage-lock.js';
 import { assertNoteBytesUnchanged } from './note-write-concurrency.js';
 import { assertExpectedRevision, noteRevision } from './note-revision.js';
+import { assertTransitionGuards, transitionGuardTargetPaths } from './transition-guards.js';
 
 // ============================================================================
 // Types
@@ -361,15 +362,23 @@ async function editNoteFromJsonAttempt(
   const fieldOrder = getFrontmatterOrder(typeDef);
   const orderedFields = fieldOrder.length > 0 ? fieldOrder : Object.keys(resolvedFrontmatter);
 
+  await assertTransitionGuards(schema, vaultDir, typeDef.name, frontmatter, resolvedFrontmatter);
+  const guardTargetPaths = await transitionGuardTargetPaths(
+    schema, vaultDir, typeDef.name, frontmatter, resolvedFrontmatter
+  );
+
   await waitForEditCommitBarrier(attempt, filePath);
 
-  const revision = await withLineageMutationLocks(vaultDir, [filePath], async () => {
+  const revision = await withLineageMutationLocks(vaultDir, [filePath, ...guardTargetPaths], async () => {
     if (expectedRevision !== undefined) {
       // Re-read while holding the shared mutation lock, closing the
       // validation-to-write race with other Bowerbird writers.
       assertExpectedRevision(expectedRevision, await readFile(filePath, 'utf-8'));
     }
     await assertNoteBytesUnchanged(filePath, raw, attempt);
+    // Relation state can change after validation. Re-evaluate immediately
+    // before the source write while its mutation lock is held.
+    await assertTransitionGuards(schema, vaultDir, typeDef.name, frontmatter, resolvedFrontmatter);
 
     // Recurrence prepare, predecessor write, and successor/back-link commit are
     // one guarded commit phase. A retry always re-prepares from fresh bytes.
@@ -485,8 +494,13 @@ export async function editNoteInteractive(
   }
 
   await beforeCommit?.();
-  const fastPath = await withLineageMutationLocks(vaultDir, [filePath], async () => {
+  await assertTransitionGuards(schema, vaultDir, typeDef.name, frontmatter, newFrontmatter);
+  const guardTargetPaths = await transitionGuardTargetPaths(
+    schema, vaultDir, typeDef.name, frontmatter, newFrontmatter
+  );
+  const fastPath = await withLineageMutationLocks(vaultDir, [filePath, ...guardTargetPaths], async () => {
     await assertNoteBytesUnchanged(filePath, raw);
+    await assertTransitionGuards(schema, vaultDir, typeDef.name, frontmatter, newFrontmatter);
     const fastPathPlan = await prepareRecurrenceFastPath(
       schema,
       vaultDir,

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -14,7 +14,7 @@ import {
   getFieldsForType,
   getFrontmatterOrder,
 } from './schema.js';
-import { parseNote, writeNote, generateBodySections } from './frontmatter.js';
+import { parseNote, writeNote, writeFileAtomic, generateBodySections } from './frontmatter.js';
 import {
   isBodySectionPresent,
   flattenBodySections,
@@ -53,6 +53,7 @@ import { withLineageMutationLocks } from './lineage-lock.js';
 import { assertNoteBytesUnchanged } from './note-write-concurrency.js';
 import { assertExpectedRevision, noteRevision } from './note-revision.js';
 import { assertTransitionGuards, transitionGuardTargetPaths } from './transition-guards.js';
+import { commitTransitionEffects, prepareTransitionEffects, rollbackTransitionEffects, transitionEffectTargetPaths } from './transition-effects.js';
 
 // ============================================================================
 // Types
@@ -366,16 +367,20 @@ async function editNoteFromJsonAttempt(
   const guardTargetPaths = await transitionGuardTargetPaths(
     schema, vaultDir, typeDef.name, frontmatter, resolvedFrontmatter
   );
+  const transitionEffects = await prepareTransitionEffects(
+    schema, vaultDir, typeDef.name, frontmatter, resolvedFrontmatter, filePath
+  );
 
   await waitForEditCommitBarrier(attempt, filePath);
 
-  const revision = await withLineageMutationLocks(vaultDir, [filePath, ...guardTargetPaths], async () => {
+  const revision = await withLineageMutationLocks(vaultDir, [filePath, ...guardTargetPaths, ...transitionEffectTargetPaths(transitionEffects)], async () => {
     if (expectedRevision !== undefined) {
       // Re-read while holding the shared mutation lock, closing the
       // validation-to-write race with other Bowerbird writers.
       assertExpectedRevision(expectedRevision, await readFile(filePath, 'utf-8'));
     }
     await assertNoteBytesUnchanged(filePath, raw, attempt);
+    for (const effect of transitionEffects) await assertNoteBytesUnchanged(effect.path, effect.raw, attempt);
     // Relation state can change after validation. Re-evaluate immediately
     // before the source write while its mutation lock is held.
     await assertTransitionGuards(schema, vaultDir, typeDef.name, frontmatter, resolvedFrontmatter);
@@ -392,7 +397,20 @@ async function editNoteFromJsonAttempt(
       body
     );
     await writeNote(filePath, resolvedFrontmatter, body, orderedFields);
-    await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+    const writtenSource = await readFile(filePath, 'utf-8');
+    let committedEffects;
+    try {
+      committedEffects = await commitTransitionEffects(transitionEffects);
+      await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+    } catch (error) {
+      // Restore only the exact source bytes this invocation wrote. A newer
+      // writer wins; it must never be erased by our compensating rollback.
+      if (await readFile(filePath, 'utf-8').catch(() => '') === writtenSource) {
+        await writeFileAtomic(filePath, raw);
+      }
+      if (committedEffects) await rollbackTransitionEffects(committedEffects);
+      throw error;
+    }
     // Return the revision of the final bytes produced by this guarded commit
     // while the shared Bowerbird mutation lock still excludes another writer.
     return noteRevision(await readFile(filePath, 'utf-8'));
@@ -498,8 +516,12 @@ export async function editNoteInteractive(
   const guardTargetPaths = await transitionGuardTargetPaths(
     schema, vaultDir, typeDef.name, frontmatter, newFrontmatter
   );
-  const fastPath = await withLineageMutationLocks(vaultDir, [filePath, ...guardTargetPaths], async () => {
+  const transitionEffects = await prepareTransitionEffects(
+    schema, vaultDir, typeDef.name, frontmatter, newFrontmatter, filePath
+  );
+  const fastPath = await withLineageMutationLocks(vaultDir, [filePath, ...guardTargetPaths, ...transitionEffectTargetPaths(transitionEffects)], async () => {
     await assertNoteBytesUnchanged(filePath, raw);
+    for (const effect of transitionEffects) await assertNoteBytesUnchanged(effect.path, effect.raw);
     await assertTransitionGuards(schema, vaultDir, typeDef.name, frontmatter, newFrontmatter);
     const fastPathPlan = await prepareRecurrenceFastPath(
       schema,
@@ -511,7 +533,18 @@ export async function editNoteInteractive(
       updatedBody
     );
     await writeNote(filePath, newFrontmatter, updatedBody, orderedFields);
-    return commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+    const writtenSource = await readFile(filePath, 'utf-8');
+    let committedEffects;
+    try {
+      committedEffects = await commitTransitionEffects(transitionEffects);
+      return await commitRecurrenceFastPath(schema, vaultDir, fastPathPlan);
+    } catch (error) {
+      if (await readFile(filePath, 'utf-8').catch(() => '') === writtenSource) {
+        await writeFileAtomic(filePath, raw);
+      }
+      if (committedEffects) await rollbackTransitionEffects(committedEffects);
+      throw error;
+    }
   });
   printSuccess(`\n✓ Updated: ${filePath}`);
   if (fastPath.successorPath) {

--- a/src/lib/local-date.ts
+++ b/src/lib/local-date.ts
@@ -25,6 +25,8 @@
  * - DD-MM-YYYY (EU format with dashes)
  */
 
+import { getLogicalActor } from './logical-actor.js';
+
 /** Default date format (ISO 8601) */
 export const DEFAULT_DATE_FORMAT = 'YYYY-MM-DD';
 
@@ -398,6 +400,8 @@ export function expandStaticValue(value: string, now: Date = new Date(), dateFor
       return formatLocalDateTime(now);
     case '$TODAY':
       return formatDateWithPattern(now, dateFormat);
+    case '$ACTOR':
+      return getLogicalActor();
     default:
       return value;
   }

--- a/src/lib/logical-actor.ts
+++ b/src/lib/logical-actor.ts
@@ -1,0 +1,26 @@
+let configuredActor: string | undefined;
+
+/** Resolve logical workflow provenance, never authentication or authorization. */
+export function resolveLogicalActor(
+  explicit: string | undefined,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const candidate = explicit ?? env.BWRB_ACTOR;
+  return candidate?.trim() || 'unknown';
+}
+
+/** Fix the actor once for this CLI process before command execution. */
+export function configureLogicalActor(explicit?: string): string {
+  configuredActor = resolveLogicalActor(explicit);
+  return configuredActor;
+}
+
+/** Return the process actor, falling back to runner environment when unconfigured. */
+export function getLogicalActor(): string {
+  return configuredActor ?? resolveLogicalActor(undefined);
+}
+
+/** Test isolation for modules exercised in one long-lived Vitest process. */
+export function resetLogicalActorForTests(): void {
+  configuredActor = undefined;
+}

--- a/src/lib/note-revision.ts
+++ b/src/lib/note-revision.ts
@@ -1,0 +1,24 @@
+import { createHash } from 'crypto';
+
+/** Opaque observation token for the exact note content Bowerbird read. */
+export function noteRevision(raw: string): string {
+  return createHash('sha256').update(raw, 'utf8').digest('hex');
+}
+
+export class RevisionMismatchError extends Error {
+  constructor(
+    public readonly expectedRevision: string,
+    public readonly currentRevision: string
+  ) {
+    super('Note changed since it was read. Reread it and retry with the current revision.');
+    this.name = 'RevisionMismatchError';
+  }
+}
+
+/** Throw a stable structured error when an observation token is stale. */
+export function assertExpectedRevision(expectedRevision: string, raw: string): void {
+  const currentRevision = noteRevision(raw);
+  if (expectedRevision !== currentRevision) {
+    throw new RevisionMismatchError(expectedRevision, currentRevision);
+  }
+}

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -38,6 +38,7 @@ export interface JsonSuccess<T = unknown> {
   data?: T;
   path?: string;
   updated?: string[];
+  revision?: string;
   message?: string;
 }
 
@@ -56,7 +57,9 @@ export interface JsonError {
     expected?: string[] | string;
     suggestion?: string;
   }>;
-  code?: number;
+  code?: number | string;
+  expectedRevision?: string;
+  currentRevision?: string;
 }
 
 /**

--- a/src/lib/schema-json-schema.ts
+++ b/src/lib/schema-json-schema.ts
@@ -7,6 +7,7 @@ import {
   FieldSchema,
   FilterConditionSchema,
   RecurrenceSchema,
+  TransitionEffectSchema,
   TraitSchema,
   TypeSchema,
 } from '../types/schema.js';
@@ -37,6 +38,7 @@ const DEFINITIONS = {
   config: ConfigSchema,
   trait: TraitSchema,
   recurrence: RecurrenceSchema,
+  transitionEffect: TransitionEffectSchema,
   typeNode: TypeSchema,
   frontmatterField: FieldSchema,
   bodySection: BodySectionSchema,

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -11,6 +11,7 @@ import {
   type Field,
   type Trait,
   type Recurrence,
+  type Retention,
   type ResolvedType,
   type ResolvedConfig,
   type LoadedSchema,
@@ -208,7 +209,67 @@ export function resolveSchema(schema: Schema): LoadedSchema {
   if (transitionEffectErrors.length > 0) {
     throw new Error(`Invalid transition effects: ${transitionEffectErrors.join(' ')}`);
   }
+  validateRetention(loaded);
   return loaded;
+}
+
+/** Return a type's own retention declaration. Retention intentionally does not inherit. */
+export function getRetentionForType(schema: LoadedSchema, typeName: string): Retention | undefined {
+  return schema.raw.types[typeName]?.retention;
+}
+
+function validateRetention(schema: LoadedSchema): void {
+  for (const [typeName, raw] of Object.entries(schema.raw.types)) {
+    const retention = raw.retention;
+    if (!retention) continue;
+    const fields = getFieldsForType(schema, typeName);
+    const clock = fields[retention.clock.field];
+    if (!clock || clock.prompt !== 'date' || resolveDateGranularity(clock, schema.config) !== 'day') {
+      throw new Error(`Invalid retention for type "${typeName}": clock.field "${retention.clock.field}" must be a day-granularity date field`);
+    }
+    for (const [fieldName, rule] of Object.entries(retention.when)) validateRetentionValues(typeName, fieldName, rule.in, fields);
+    for (const [fieldName, rule] of Object.entries(retention.resolved_when ?? {})) validateRetentionValues(typeName, fieldName, rule.in, fields);
+    for (const condition of [retention.when, retention.resolved_when ?? {}]) {
+      for (const fieldName of Object.keys(condition)) {
+        if (!fields[fieldName]) throw new Error(`Invalid retention for type "${typeName}": unknown field "${fieldName}"`);
+      }
+    }
+    for (const action of retention.actions) {
+      if (action.kind === 'archive') {
+        const directory = action.directory.replace(/\\/g, '/');
+        if (directory.startsWith('/') || directory.split('/').some(part => part === '..' || part.length === 0)) {
+          throw new Error(`Invalid retention for type "${typeName}": archive directory must be a normalized vault-relative path`);
+        }
+      }
+      if (action.kind !== 'tombstone') continue;
+      for (const [fieldName, value] of Object.entries(action.set)) {
+        const field = fields[fieldName];
+        if (!field) throw new Error(`Invalid retention for type "${typeName}": tombstone patch has unknown field "${fieldName}"`);
+        if (field.prompt === 'date' && value === '$TODAY' && resolveDateGranularity(field, schema.config) !== 'day') {
+          throw new Error(`Invalid retention for type "${typeName}": $TODAY requires day-granularity field "${fieldName}"`);
+        }
+        const options = getOptionValues(field.options);
+        if (options.length > 0 && value !== '$TODAY' && !options.includes(value)) {
+          throw new Error(`Invalid retention for type "${typeName}": tombstone value for "${fieldName}" is not an allowed option`);
+        }
+      }
+      if (retention.resolved_when && !matchesRetentionPatch(action.set, retention.resolved_when)) {
+        throw new Error(`Invalid retention for type "${typeName}": tombstone patch must satisfy resolved_when`);
+      }
+    }
+  }
+}
+
+function validateRetentionValues(typeName: string, fieldName: string, values: string[], fields: Record<string, Field>): void {
+  const field = fields[fieldName];
+  if (!field) throw new Error(`Invalid retention for type "${typeName}": unknown field "${fieldName}"`);
+  const options = getOptionValues(field.options);
+  if (options.length && values.some(value => !options.includes(value))) {
+    throw new Error(`Invalid retention for type "${typeName}": condition value for "${fieldName}" is not an allowed option`);
+  }
+}
+function matchesRetentionPatch(patch: Record<string, string>, condition: Record<string, { in: string[] }>): boolean {
+  return Object.entries(condition).every(([field, rule]) => typeof patch[field] === 'string' && rule.in.includes(patch[field]!));
 }
 
 /**

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -241,10 +241,29 @@ function validateRetention(schema: LoadedSchema): void {
           throw new Error(`Invalid retention for type "${typeName}": archive directory must be a normalized vault-relative path`);
         }
       }
+      if (action.kind === 'delete' && canTypeBeRelationTarget(schema, typeName)) {
+        throw new Error(`Invalid retention for type "${typeName}": delete is unsafe because relation fields can target this type; use archive or tombstone`);
+      }
       if (action.kind !== 'tombstone') continue;
+      const transitionFields = new Set(
+        getEffectiveTraitNames(schema, typeName).flatMap((name) => {
+          const trait = schema.raw.traits?.[name];
+          return [...(trait?.transition_guards ?? []), ...(trait?.transition_effects ?? [])]
+            .map(item => item.on.match(/^\s*([^=\s]+)\s*=/)?.[1])
+            .filter((field): field is string => Boolean(field));
+        })
+      );
       for (const [fieldName, value] of Object.entries(action.set)) {
         const field = fields[fieldName];
         if (!field) throw new Error(`Invalid retention for type "${typeName}": tombstone patch has unknown field "${fieldName}"`);
+        const safeScalar = field.prompt === 'text' || field.prompt === 'select' || field.prompt === 'date'
+          || (field.prompt === undefined && typeof field.value === 'string');
+        if (!safeScalar) {
+          throw new Error(`Invalid retention for type "${typeName}": tombstone patch field "${fieldName}" must be text, select, date, or static`);
+        }
+        if (transitionFields.has(fieldName)) {
+          throw new Error(`Invalid retention for type "${typeName}": tombstone patch cannot modify transition trigger field "${fieldName}"`);
+        }
         if (field.prompt === 'date' && value === '$TODAY' && resolveDateGranularity(field, schema.config) !== 'day') {
           throw new Error(`Invalid retention for type "${typeName}": $TODAY requires day-granularity field "${fieldName}"`);
         }
@@ -258,6 +277,24 @@ function validateRetention(schema: LoadedSchema): void {
       }
     }
   }
+}
+
+/**
+ * Delete is only safe when the schema makes the retained type impossible to
+ * reference through a typed relation. Runtime scans still protect legacy body
+ * links and lineage; this static restriction closes the create-a-reference
+ * race between a scan and unlink.
+ */
+function canTypeBeRelationTarget(schema: LoadedSchema, targetType: string): boolean {
+  for (const sourceType of schema.types.keys()) {
+    for (const field of Object.values(getFieldsForType(schema, sourceType))) {
+      if (field.prompt !== 'relation') continue;
+      const sources = Array.isArray(field.source) ? field.source : field.source ? [field.source] : [];
+      if (sources.length === 0 || sources.includes('any')) return true;
+      if (sources.some(source => source === targetType || getDescendants(schema, source).includes(targetType))) return true;
+    }
+  }
+  return false;
 }
 
 function validateRetentionValues(typeName: string, fieldName: string, values: string[], fields: Record<string, Field>): void {
@@ -748,6 +785,34 @@ export function getType(schema: LoadedSchema, typeName: string): ResolvedType | 
   }
 
   return undefined;
+}
+
+/**
+ * Return the traits that apply to a type through its inheritance chain.
+ *
+ * Resolved fields already include fields contributed by ancestor traits, so
+ * trait-owned behavior must follow the same root-to-leaf inheritance model.
+ * A repeated trait is included once, at its first (least-specific) position;
+ * this avoids running an inherited guard or effect twice when a subtype also
+ * names the trait explicitly.
+ */
+export function getEffectiveTraitNames(schema: LoadedSchema, typeName: string): string[] {
+  const type = getType(schema, typeName);
+  if (!type) return [];
+
+  const names: string[] = [];
+  const seen = new Set<string>();
+  const chain = [...type.ancestors].reverse().map((name) => schema.types.get(name)).filter(Boolean);
+  chain.push(type);
+
+  for (const current of chain) {
+    for (const traitName of current!.traits) {
+      if (seen.has(traitName)) continue;
+      seen.add(traitName);
+      names.push(traitName);
+    }
+  }
+  return names;
 }
 
 /**

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -20,6 +20,7 @@ import {
   getOptionValues,
 } from '../types/schema.js';
 import { validateTransitionGuards } from './transition-guards.js';
+import { validateTransitionEffects } from './transition-effects.js';
 
 const META_TYPE = 'meta';
 
@@ -200,6 +201,12 @@ export function resolveSchema(schema: Schema): LoadedSchema {
   );
   if (transitionGuardErrors.length > 0) {
     throw new Error(`Invalid transition guards: ${transitionGuardErrors.join(' ')}`);
+  }
+  const transitionEffectErrors = Array.from(types.keys()).flatMap((typeName) =>
+    validateTransitionEffects(loaded, typeName)
+  );
+  if (transitionEffectErrors.length > 0) {
+    throw new Error(`Invalid transition effects: ${transitionEffectErrors.join(' ')}`);
   }
   return loaded;
 }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -19,6 +19,7 @@ import {
   type OwnerInfo,
   getOptionValues,
 } from '../types/schema.js';
+import { validateTransitionGuards } from './transition-guards.js';
 
 const META_TYPE = 'meta';
 
@@ -193,7 +194,14 @@ export function resolveSchema(schema: Schema): LoadedSchema {
 
   validateCalendarReferences(types, config);
   
-  return { raw: schema, types, ownership, config };
+  const loaded = { raw: schema, types, ownership, config };
+  const transitionGuardErrors = Array.from(types.keys()).flatMap((typeName) =>
+    validateTransitionGuards(loaded, typeName)
+  );
+  if (transitionGuardErrors.length > 0) {
+    throw new Error(`Invalid transition guards: ${transitionGuardErrors.join(' ')}`);
+  }
+  return loaded;
 }
 
 /**

--- a/src/lib/transition-effects.ts
+++ b/src/lib/transition-effects.ts
@@ -8,7 +8,7 @@
 
 import { join } from 'path';
 import { getOptionValues, type LoadedSchema, type TransitionEffect } from '../types/schema.js';
-import { getDescendants, getFieldsForType, getType, resolveTypePathFromFrontmatter } from './schema.js';
+import { getDescendants, getEffectiveTraitNames, getFieldsForType, resolveTypePathFromFrontmatter } from './schema.js';
 import { buildNoteTargetIndex, resolveRelationTarget } from './discovery.js';
 import { extractLinkTargets } from './links.js';
 import { parseNote, writeFileAtomic, writeNote } from './frontmatter.js';
@@ -35,10 +35,8 @@ export interface CommittedTransitionEffects {
 }
 
 function getTransitionEffectsForType(schema: LoadedSchema, typeName: string): TransitionEffect[] {
-  const type = getType(schema, typeName);
-  if (!type) return [];
   const traits = schema.raw.traits ?? {};
-  return type.traits.flatMap((traitName) => traits[traitName]?.transition_effects ?? []);
+  return getEffectiveTraitNames(schema, typeName).flatMap((traitName) => traits[traitName]?.transition_effects ?? []);
 }
 
 export function validateTransitionEffects(schema: LoadedSchema, typeName: string): string[] {

--- a/src/lib/transition-effects.ts
+++ b/src/lib/transition-effects.ts
@@ -18,7 +18,7 @@ import { normalizeDateFields } from './validation.js';
 import { validateRelativeDateCalendarOffsetsForWrite } from './relative-date.js';
 import { relative } from 'path';
 import { isBwrbReservedFrontmatterField } from './frontmatter/systemFields.js';
-import { parseTransitionTrigger } from './transition-guards.js';
+import { getTransitionGuardsForType, parseTransitionTrigger } from './transition-guards.js';
 import { expandStaticValue } from './local-date.js';
 
 export interface PreparedTransitionEffect {
@@ -54,7 +54,13 @@ export function validateTransitionEffects(schema: LoadedSchema, typeName: string
       errors.push(`Transition effect '${effect.on}' relation '${effect.relation}' must be an effective scalar relation field.`);
     }
     const sources = Array.isArray(relation?.source) ? relation.source : relation?.source ? [relation.source] : [];
-    const targetTypes = sources.includes('any') ? [] : sources.flatMap((source) => [source, ...getDescendants(schema, source)]);
+    // An unconstrained relation can resolve to any note, so validation must be
+    // conservative across every type rather than silently skipping target
+    // checks. Effects stay deliberately non-cascading and therefore may not
+    // advance a target through one of its guarded transitions.
+    const targetTypes = sources.length === 0 || sources.includes('any')
+      ? [...schema.types.keys()]
+      : sources.flatMap((source) => [source, ...getDescendants(schema, source)]);
     for (const [field, value] of Object.entries(effect.set)) {
       if (isBwrbReservedFrontmatterField(field)) {
         errors.push(`Transition effect '${effect.on}' cannot modify system-managed field '${field}'.`);
@@ -64,6 +70,12 @@ export function validateTransitionEffects(schema: LoadedSchema, typeName: string
         if (!targetField) {
           errors.push(`Transition effect '${effect.on}' patch references unknown field '${field}' on relation target type '${targetType}'.`);
           continue;
+        }
+        const guardedTrigger = getTransitionGuardsForType(schema, targetType).some((guard) =>
+          parseTransitionTrigger(guard.on)?.field === field
+        );
+        if (guardedTrigger) {
+          errors.push(`Transition effect '${effect.on}' cannot modify guarded transition field '${targetType}.${field}'.`);
         }
         if (targetField.prompt === 'select' && targetField.options?.length && !['$ACTOR', '$NOW', '$TODAY'].includes(value) && !getOptionValues(targetField.options).includes(value)) {
           errors.push(`Transition effect '${effect.on}' value '${value}' is not an option for '${targetType}.${field}'.`);

--- a/src/lib/transition-effects.ts
+++ b/src/lib/transition-effects.ts
@@ -34,7 +34,7 @@ export interface CommittedTransitionEffects {
   writes: Array<{ effect: PreparedTransitionEffect; written: string }>;
 }
 
-export function getTransitionEffectsForType(schema: LoadedSchema, typeName: string): TransitionEffect[] {
+function getTransitionEffectsForType(schema: LoadedSchema, typeName: string): TransitionEffect[] {
   const type = getType(schema, typeName);
   if (!type) return [];
   const traits = schema.raw.traits ?? {};

--- a/src/lib/transition-effects.ts
+++ b/src/lib/transition-effects.ts
@@ -1,0 +1,172 @@
+/**
+ * Bounded related-note transition effects.
+ *
+ * Effects deliberately do not call edit/recurrence: the source mutation owns
+ * the transaction and writes validated target bytes directly. That prevents a
+ * target effect from cascading into further effects or successor creation.
+ */
+
+import { join } from 'path';
+import { getOptionValues, type LoadedSchema, type TransitionEffect } from '../types/schema.js';
+import { getDescendants, getFieldsForType, getType, resolveTypePathFromFrontmatter } from './schema.js';
+import { buildNoteTargetIndex, resolveRelationTarget } from './discovery.js';
+import { extractLinkTargets } from './links.js';
+import { parseNote, writeFileAtomic, writeNote } from './frontmatter.js';
+import { readFile } from 'fs/promises';
+import { validateContextFields, validateFrontmatter } from './validation.js';
+import { normalizeDateFields } from './validation.js';
+import { validateRelativeDateCalendarOffsetsForWrite } from './relative-date.js';
+import { relative } from 'path';
+import { isBwrbReservedFrontmatterField } from './frontmatter/systemFields.js';
+import { parseTransitionTrigger } from './transition-guards.js';
+import { expandStaticValue } from './local-date.js';
+
+export interface PreparedTransitionEffect {
+  path: string;
+  raw: string;
+  body: string;
+  before: Record<string, unknown>;
+  after: Record<string, unknown>;
+  order: string[];
+}
+
+export interface CommittedTransitionEffects {
+  writes: Array<{ effect: PreparedTransitionEffect; written: string }>;
+}
+
+export function getTransitionEffectsForType(schema: LoadedSchema, typeName: string): TransitionEffect[] {
+  const type = getType(schema, typeName);
+  if (!type) return [];
+  const traits = schema.raw.traits ?? {};
+  return type.traits.flatMap((traitName) => traits[traitName]?.transition_effects ?? []);
+}
+
+export function validateTransitionEffects(schema: LoadedSchema, typeName: string): string[] {
+  const fields = getFieldsForType(schema, typeName);
+  const errors: string[] = [];
+  for (const effect of getTransitionEffectsForType(schema, typeName)) {
+    const trigger = parseTransitionTrigger(effect.on);
+    if (!trigger) {
+      errors.push(`Invalid transition effect trigger '${effect.on}'. Expected '<field> = <value>'.`);
+      continue;
+    }
+    if (!fields[trigger.field]) errors.push(`Transition effect '${effect.on}' references unknown field '${trigger.field}'.`);
+    const relation = fields[effect.relation];
+    if (relation?.prompt !== 'relation' || relation.multiple === true) {
+      errors.push(`Transition effect '${effect.on}' relation '${effect.relation}' must be an effective scalar relation field.`);
+    }
+    const sources = Array.isArray(relation?.source) ? relation.source : relation?.source ? [relation.source] : [];
+    const targetTypes = sources.includes('any') ? [] : sources.flatMap((source) => [source, ...getDescendants(schema, source)]);
+    for (const [field, value] of Object.entries(effect.set)) {
+      if (isBwrbReservedFrontmatterField(field)) {
+        errors.push(`Transition effect '${effect.on}' cannot modify system-managed field '${field}'.`);
+      }
+      for (const targetType of targetTypes) {
+        const targetField = getFieldsForType(schema, targetType)[field];
+        if (!targetField) {
+          errors.push(`Transition effect '${effect.on}' patch references unknown field '${field}' on relation target type '${targetType}'.`);
+          continue;
+        }
+        if (targetField.prompt === 'select' && targetField.options?.length && !['$ACTOR', '$NOW', '$TODAY'].includes(value) && !getOptionValues(targetField.options).includes(value)) {
+          errors.push(`Transition effect '${effect.on}' value '${value}' is not an option for '${targetType}.${field}'.`);
+        }
+      }
+    }
+  }
+  return errors;
+}
+
+function entered(effect: TransitionEffect, before: Record<string, unknown>, after: Record<string, unknown>): boolean {
+  const trigger = parseTransitionTrigger(effect.on);
+  return Boolean(trigger
+    && String(before[trigger.field] ?? '') !== trigger.value
+    && String(after[trigger.field] ?? '') === trigger.value);
+}
+
+function expandEffectValue(value: string, schema: LoadedSchema): string {
+  // Keep the date expansion seam shared with ordinary static values.
+  if (value === '$ACTOR' || value === '$NOW' || value === '$TODAY') {
+    return expandStaticValue(value, new Date(), schema.config.dateFormat);
+  }
+  return value;
+}
+
+/** Prepare every entered effect and validate all target notes before any write. */
+export async function prepareTransitionEffects(
+  schema: LoadedSchema,
+  vaultDir: string,
+  typeName: string,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+  sourcePath?: string
+): Promise<PreparedTransitionEffect[]> {
+  const effects = getTransitionEffectsForType(schema, typeName).filter((effect) => entered(effect, before, after));
+  if (effects.length === 0) return [];
+  const errors = validateTransitionEffects(schema, typeName);
+  if (errors.length) throw new Error(errors.join(' '));
+  const index = await buildNoteTargetIndex(schema, vaultDir);
+  const fields = getFieldsForType(schema, typeName);
+  const prepared = new Map<string, PreparedTransitionEffect>();
+
+  for (const effect of effects) {
+    const relationValue = after[effect.relation];
+    if (relationValue === undefined || relationValue === null || (typeof relationValue === 'string' && relationValue.trim() === '')) continue;
+    const targets = extractLinkTargets(relationValue);
+    if (targets.length !== 1) throw new Error(`Transition effect '${effect.on}' relation '${effect.relation}' must contain one direct relation target.`);
+    const resolved = resolveRelationTarget(index, targets[0]!, { schema, source: fields[effect.relation]!.source });
+    if (resolved.resolution !== 'unique' || !resolved.resolvedPath) {
+      throw new Error(`Transition effect '${effect.on}' relation '${effect.relation}' does not resolve to one note.`);
+    }
+    const path = join(vaultDir, resolved.resolvedPath);
+    if (sourcePath === path) throw new Error(`Transition effect '${effect.on}' cannot target its source note.`);
+    let target = prepared.get(path);
+    if (!target) {
+      const parsed = await parseNote(path);
+      target = { path, raw: parsed.raw, body: parsed.body, before: parsed.frontmatter, after: { ...parsed.frontmatter }, order: [] };
+      prepared.set(path, target);
+    }
+    for (const [field, value] of Object.entries(effect.set)) target.after[field] = expandEffectValue(value, schema);
+  }
+
+  for (const target of prepared.values()) {
+    const targetType = resolveTypePathFromFrontmatter(schema, target.after);
+    if (!targetType) throw new Error(`Transition effect target '${relative(vaultDir, target.path)}' has no recognized type.`);
+    target.after = normalizeDateFields(schema, targetType, target.after);
+    const validation = validateFrontmatter(schema, targetType, target.after);
+    if (!validation.valid) throw new Error(`Transition effect target '${relative(vaultDir, target.path)}' is invalid: ${validation.errors.map((error) => error.message).join(', ')}`);
+    const context = await validateContextFields(schema, vaultDir, targetType, target.after);
+    if (!context.valid) throw new Error(`Transition effect target '${relative(vaultDir, target.path)}' has invalid relations: ${context.errors.map((error) => error.message).join(', ')}`);
+    const dates = await validateRelativeDateCalendarOffsetsForWrite(schema, vaultDir, targetType, target.after, relative(vaultDir, target.path));
+    if (dates.length) throw new Error(`Transition effect target '${relative(vaultDir, target.path)}' is invalid: ${dates.map((error) => error.message).join(', ')}`);
+    target.order = Object.keys(target.after);
+  }
+  return [...prepared.values()].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export function transitionEffectTargetPaths(effects: PreparedTransitionEffect[]): string[] {
+  return effects.map((effect) => effect.path);
+}
+
+/** Restore only bytes written by this transaction, preserving newer writers. */
+export async function rollbackTransitionEffects(committed: CommittedTransitionEffects): Promise<void> {
+  for (const { effect, written } of [...committed.writes].reverse()) {
+    if (await readFile(effect.path, 'utf-8').catch(() => '') === written) {
+      await writeFileAtomic(effect.path, effect.raw);
+    }
+  }
+}
+
+/** Write targets directly: no guard/effect/recurrence execution is re-entered. */
+export async function commitTransitionEffects(effects: PreparedTransitionEffect[]): Promise<CommittedTransitionEffects> {
+  const committed: CommittedTransitionEffects = { writes: [] };
+  try {
+    for (const effect of effects) {
+      await writeNote(effect.path, effect.after, effect.body, effect.order);
+      committed.writes.push({ effect, written: await readFile(effect.path, 'utf-8') });
+    }
+    return committed;
+  } catch (error) {
+    await rollbackTransitionEffects(committed);
+    throw error;
+  }
+}

--- a/src/lib/transition-guards.ts
+++ b/src/lib/transition-guards.ts
@@ -1,0 +1,183 @@
+import { join, relative } from 'path';
+import type { LoadedSchema, TransitionGuard } from '../types/schema.js';
+import { getType, getFieldsForType, getDescendants } from './schema.js';
+import { getOptionValues } from '../types/schema.js';
+import { buildNoteTargetIndex, resolveRelationTarget } from './discovery.js';
+import { parseNote } from './frontmatter.js';
+import { extractLinkTargets } from './links.js';
+
+export interface TransitionTrigger { field: string; value: string }
+export interface TransitionGuardTargetResult {
+  target: string;
+  path?: string;
+  status: 'unresolved' | 'stale' | 'failed' | 'satisfied';
+  value?: unknown;
+}
+export interface TransitionGuardRequirementResult {
+  relation: string;
+  min: number;
+  status: 'missing' | 'unresolved' | 'stale' | 'failed' | 'satisfied';
+  targets: TransitionGuardTargetResult[];
+}
+export interface TransitionGuardResult {
+  on: TransitionTrigger;
+  blocked: boolean;
+  requirements: TransitionGuardRequirementResult[];
+}
+export interface TransitionExplanation {
+  type: string;
+  transition: TransitionTrigger;
+  blocked: boolean;
+  guards: TransitionGuardResult[];
+}
+
+/** The deliberately small trigger grammar shared by guards and recurrence. */
+export function parseTransitionTrigger(input: string): TransitionTrigger | undefined {
+  const match = input.match(/^\s*([^=\s]+)\s*=\s*(.+?)\s*$/);
+  return match ? { field: match[1]!, value: match[2]! } : undefined;
+}
+
+export function getTransitionGuardsForType(schema: LoadedSchema, typeName: string): TransitionGuard[] {
+  const type = getType(schema, typeName);
+  if (!type) return [];
+  const traits = schema.raw.traits ?? {};
+  const guards: TransitionGuard[] = [];
+  for (const traitName of type.traits) guards.push(...(traits[traitName]?.transition_guards ?? []));
+  return guards;
+}
+
+/** Fail early on invalid effective trait configuration, before a write path sees it. */
+export function validateTransitionGuards(schema: LoadedSchema, typeName: string): string[] {
+  const fields = getFieldsForType(schema, typeName);
+  const seen = new Set<string>();
+  const errors: string[] = [];
+  for (const guard of getTransitionGuardsForType(schema, typeName)) {
+    const trigger = parseTransitionTrigger(guard.on);
+    if (!trigger) { errors.push(`Invalid transition guard trigger '${guard.on}'. Expected '<field> = <value>'.`); continue; }
+    const key = `${trigger.field}\u0000${trigger.value}`;
+    if (seen.has(key)) errors.push(`Duplicate transition guard for '${guard.on}' on type '${typeName}'.`);
+    seen.add(key);
+    if (!fields[trigger.field]) errors.push(`Transition guard '${guard.on}' references unknown field '${trigger.field}'.`);
+    for (const requirement of guard.requires) {
+      if (fields[requirement.relation]?.prompt !== 'relation') errors.push(`Transition guard '${guard.on}' relation '${requirement.relation}' must be an effective relation field.`);
+      const source = fields[requirement.relation]?.source;
+      const sources = Array.isArray(source) ? source : source ? [source] : [];
+      // An unconstrained/any relation deliberately has no static target type to
+      // inspect. Concrete sources include their descendants, just like normal
+      // relation validation.
+      const targetTypes = sources.includes('any') ? [] : sources.flatMap((name) => [name, ...getDescendants(schema, name)]);
+      for (const predicate of [requirement.all, requirement.failed_when, requirement.stale_when]) {
+        if (!predicate) continue;
+        for (const targetType of targetTypes) {
+          const targetField = getFieldsForType(schema, targetType)[predicate.field];
+          if (!targetField) { errors.push(`Transition guard '${guard.on}' predicate references unknown field '${predicate.field}' on relation target type '${targetType}'.`); continue; }
+          if (targetField.prompt === 'select' && targetField.options && targetField.options.length > 0) {
+            const allowed = new Set(getOptionValues(targetField.options));
+            const values = predicate.equals === undefined ? predicate.in! : [predicate.equals];
+            for (const value of values) if (!allowed.has(value)) errors.push(`Transition guard '${guard.on}' predicate value '${value}' is not an option for '${targetType}.${predicate.field}'.`);
+          }
+        }
+      }
+    }
+  }
+  return errors;
+}
+
+function matches(predicate: { field: string; equals?: string | undefined; in?: string[] | undefined }, frontmatter: Record<string, unknown>): boolean {
+  const value = frontmatter[predicate.field];
+  if (value === undefined || value === null) return false;
+  const expected = predicate.equals === undefined ? predicate.in! : [predicate.equals];
+  return expected.includes(String(value));
+}
+
+export async function explainTransition(
+  schema: LoadedSchema, vaultDir: string, typeName: string, frontmatter: Record<string, unknown>, transition: TransitionTrigger
+): Promise<TransitionExplanation> {
+  const errors = validateTransitionGuards(schema, typeName);
+  if (errors.length) throw new Error(errors.join(' '));
+  const matching = getTransitionGuardsForType(schema, typeName).filter((guard) => {
+    const trigger = parseTransitionTrigger(guard.on)!;
+    return trigger.field === transition.field && trigger.value === transition.value;
+  });
+  const index = await buildNoteTargetIndex(schema, vaultDir);
+  const fields = getFieldsForType(schema, typeName);
+  const guards: TransitionGuardResult[] = [];
+  for (const guard of matching) {
+    const trigger = parseTransitionTrigger(guard.on)!;
+    const requirements: TransitionGuardRequirementResult[] = [];
+    for (const requirement of guard.requires) {
+      const field = fields[requirement.relation]!;
+      const targets: TransitionGuardTargetResult[] = [];
+      for (const target of extractLinkTargets(frontmatter[requirement.relation])) {
+        const resolved = resolveRelationTarget(index, target, { schema, source: field.source });
+        if (resolved.resolution !== 'unique' || !resolved.resolvedPath) {
+          targets.push({ target, status: 'unresolved' });
+          continue;
+        }
+        try {
+          const note = await parseNote(join(vaultDir, resolved.resolvedPath));
+          const value = note.frontmatter[requirement.all.field];
+          const status = requirement.stale_when && matches(requirement.stale_when, note.frontmatter)
+            ? 'stale' : requirement.failed_when && matches(requirement.failed_when, note.frontmatter)
+              ? 'failed' : matches(requirement.all, note.frontmatter) ? 'satisfied' : 'failed';
+          targets.push({ target, path: relative(vaultDir, join(vaultDir, resolved.resolvedPath)), status, value });
+        } catch { targets.push({ target, path: resolved.resolvedPath, status: 'unresolved' }); }
+      }
+      const status = targets.length < (requirement.min ?? 1) ? 'missing'
+        : targets.some((target) => target.status === 'unresolved') ? 'unresolved'
+        : targets.some((target) => target.status === 'stale') ? 'stale'
+        : targets.some((target) => target.status === 'failed') ? 'failed' : 'satisfied';
+      requirements.push({ relation: requirement.relation, min: requirement.min ?? 1, status, targets });
+    }
+    guards.push({ on: trigger, blocked: requirements.some((requirement) => requirement.status !== 'satisfied'), requirements });
+  }
+  return { type: typeName, transition, blocked: guards.some((guard) => guard.blocked), guards };
+}
+
+export async function assertTransitionGuards(
+  schema: LoadedSchema, vaultDir: string, typeName: string, before: Record<string, unknown>, after: Record<string, unknown>
+): Promise<void> {
+  for (const guard of getTransitionGuardsForType(schema, typeName)) {
+    const trigger = parseTransitionTrigger(guard.on);
+    if (!trigger || String(before[trigger.field] ?? '') === trigger.value || String(after[trigger.field] ?? '') !== trigger.value) continue;
+    const explanation = await explainTransition(schema, vaultDir, typeName, after, trigger);
+    if (explanation.blocked) {
+      const error = new Error('Transition guard requirements are not satisfied.');
+      Object.assign(error, { code: 'TRANSITION_GUARD_FAILED', explanation });
+      throw error;
+    }
+  }
+}
+
+/** Resolve the direct evidence-note paths that participate in entered guards. */
+export async function transitionGuardTargetPaths(
+  schema: LoadedSchema,
+  vaultDir: string,
+  typeName: string,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>
+): Promise<string[]> {
+  const entered = getTransitionGuardsForType(schema, typeName).filter((guard) => {
+    const trigger = parseTransitionTrigger(guard.on);
+    return trigger
+      && String(before[trigger.field] ?? '') !== trigger.value
+      && String(after[trigger.field] ?? '') === trigger.value;
+  });
+  if (entered.length === 0) return [];
+
+  const index = await buildNoteTargetIndex(schema, vaultDir);
+  const fields = getFieldsForType(schema, typeName);
+  const paths = new Set<string>();
+  for (const guard of entered) {
+    for (const requirement of guard.requires) {
+      const field = fields[requirement.relation]!;
+      for (const target of extractLinkTargets(after[requirement.relation])) {
+        const resolved = resolveRelationTarget(index, target, { schema, source: field.source });
+        if (resolved.resolution === 'unique' && resolved.resolvedPath) {
+          paths.add(join(vaultDir, resolved.resolvedPath));
+        }
+      }
+    }
+  }
+  return [...paths].sort();
+}

--- a/src/lib/transition-guards.ts
+++ b/src/lib/transition-guards.ts
@@ -1,6 +1,6 @@
 import { join, relative } from 'path';
 import type { LoadedSchema, TransitionGuard } from '../types/schema.js';
-import { getType, getFieldsForType, getDescendants } from './schema.js';
+import { getEffectiveTraitNames, getFieldsForType, getDescendants } from './schema.js';
 import { getOptionValues } from '../types/schema.js';
 import { buildNoteTargetIndex, resolveRelationTarget } from './discovery.js';
 import { parseNote } from './frontmatter.js';
@@ -38,11 +38,9 @@ export function parseTransitionTrigger(input: string): TransitionTrigger | undef
 }
 
 export function getTransitionGuardsForType(schema: LoadedSchema, typeName: string): TransitionGuard[] {
-  const type = getType(schema, typeName);
-  if (!type) return [];
   const traits = schema.raw.traits ?? {};
   const guards: TransitionGuard[] = [];
-  for (const traitName of type.traits) guards.push(...(traits[traitName]?.transition_guards ?? []));
+  for (const traitName of getEffectiveTraitNames(schema, typeName)) guards.push(...(traits[traitName]?.transition_guards ?? []));
   return guards;
 }
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -115,7 +115,7 @@ export const FieldSchema = z.object({
   value: z
     .string()
     .optional()
-    .describe('Static value (use $NOW for current datetime, $TODAY for date)'),
+    .describe('Static value (use $NOW for current datetime, $TODAY for date, or $ACTOR for logical runner provenance)'),
   // Human-readable description of what this field is for and when to use it.
   // Surfaced by `bwrb schema list` (text + JSON); distinct from `label`, which
   // is the imperative prompt shown during input.

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -342,6 +342,24 @@ export const TransitionEffectSchema = z.object({
 });
 export type TransitionEffect = z.infer<typeof TransitionEffectSchema>;
 
+/** A type-local, explicit policy for records that have reached their end of life. */
+export const RetentionSchema = z.object({
+  when: z.record(z.object({ in: z.array(z.string()).min(1) })).refine(v => Object.keys(v).length > 0, {
+    message: 'Retention when requires at least one field condition',
+  }),
+  clock: z.object({
+    field: SchemaFieldNameSchema,
+    after: z.string().regex(/^([1-9]\d*)d$/, 'Retention clock.after must be a positive whole-day duration such as "180d"'),
+  }),
+  resolved_when: z.record(z.object({ in: z.array(z.string()).min(1) })).optional(),
+  actions: z.array(z.union([
+    z.object({ kind: z.literal('archive'), directory: z.string().min(1) }),
+    z.object({ kind: z.literal('tombstone'), set: z.record(z.string(), z.string()).refine(v => Object.keys(v).length > 0) }),
+    z.object({ kind: z.literal('delete') }),
+  ])).min(1),
+});
+export type Retention = z.infer<typeof RetentionSchema>;
+
 /**
  * A reusable bundle of fields composed into a type via `traits`.
  *
@@ -458,6 +476,7 @@ export const TypeSchema = z.object({
     .describe(
       "Custom plural form for folder naming (e.g., 'research' instead of 'researches'). Auto-pluralized if not specified."
     ),
+  retention: RetentionSchema.optional().describe('Type-local retention policy evaluated by audit'),
 });
 
 // ============================================================================

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -308,6 +308,28 @@ export const RecurrenceSchema = z.object({
 
 export type Recurrence = z.infer<typeof RecurrenceSchema>;
 
+const TransitionPredicateSchema = z.object({
+  field: SchemaFieldNameSchema,
+  equals: z.string().optional(),
+  in: z.array(z.string()).min(1).optional(),
+}).refine((value) => (value.equals === undefined) !== (value.in === undefined), {
+  message: 'A transition predicate requires exactly one of equals or in',
+});
+
+const TransitionRequirementSchema = z.object({
+  relation: SchemaFieldNameSchema,
+  min: z.number().int().min(1).optional(),
+  all: TransitionPredicateSchema,
+  failed_when: TransitionPredicateSchema.optional(),
+  stale_when: TransitionPredicateSchema.optional(),
+});
+
+export const TransitionGuardSchema = z.object({
+  on: z.string().min(1),
+  requires: z.array(TransitionRequirementSchema).min(1),
+});
+export type TransitionGuard = z.infer<typeof TransitionGuardSchema>;
+
 /**
  * A reusable bundle of fields composed into a type via `traits`.
  *
@@ -338,6 +360,8 @@ export const TraitSchema = z.object({
   // Recurrence configuration (spawn-on-transition). When present, types that
   // compose this trait gain event-driven successor spawning. See RecurrenceSchema.
   recurrence: RecurrenceSchema.optional(),
+  // Relation-backed invariants evaluated when a note enters a configured value.
+  transition_guards: z.array(TransitionGuardSchema).optional(),
 });
 
 // ============================================================================

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -330,6 +330,18 @@ export const TransitionGuardSchema = z.object({
 });
 export type TransitionGuard = z.infer<typeof TransitionGuardSchema>;
 
+/** A bounded direct-relation patch applied when a source field enters a value. */
+export const TransitionEffectSchema = z.object({
+  on: z.string().min(1),
+  relation: SchemaFieldNameSchema,
+  // String-only means patches stay flat literals. The transition executor
+  // expands only $ACTOR, $NOW, and $TODAY at commit time.
+  set: z.record(z.string(), z.string()).refine((set) => Object.keys(set).length > 0, {
+    message: 'A transition effect requires at least one field assignment',
+  }),
+});
+export type TransitionEffect = z.infer<typeof TransitionEffectSchema>;
+
 /**
  * A reusable bundle of fields composed into a type via `traits`.
  *
@@ -362,6 +374,8 @@ export const TraitSchema = z.object({
   recurrence: RecurrenceSchema.optional(),
   // Relation-backed invariants evaluated when a note enters a configured value.
   transition_guards: z.array(TransitionGuardSchema).optional(),
+  // Direct related-note patches evaluated when a note enters a configured value.
+  transition_effects: z.array(TransitionEffectSchema).optional(),
 });
 
 // ============================================================================

--- a/tests/ts/commands/actor.test.ts
+++ b/tests/ts/commands/actor.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runCLI } from '../fixtures/setup.js';
+
+const vaults: string[] = [];
+afterEach(async () => Promise.all(vaults.splice(0).map((vault) => rm(vault, { recursive: true, force: true }))));
+
+async function actorVault(): Promise<string> {
+  const vault = await mkdtemp(join(tmpdir(), 'bwrb-actor-'));
+  vaults.push(vault);
+  await mkdir(join(vault, '.bwrb'), { recursive: true });
+  await writeFile(join(vault, '.bwrb', 'schema.json'), JSON.stringify({
+    version: 2,
+    types: {
+      attestation: {
+        output_dir: 'Attestations',
+        fields: {
+          actor: { value: '$ACTOR' },
+          outcome: { prompt: 'select', options: ['passed', 'failed'] },
+        },
+      },
+    },
+  }));
+  return vault;
+}
+
+describe('logical actor CLI context', () => {
+  it('uses root --actor before BWRB_ACTOR for schema-declared provenance', async () => {
+    const vault = await actorVault();
+    const result = await runCLI(
+      ['new', 'attestation', '--json', '{"name":"CI","outcome":"passed"}'],
+      undefined,
+      undefined,
+      { env: { BWRB_ACTOR: 'claude:runner' }, cwd: vault }
+    );
+    expect(result.exitCode).toBe(0);
+    expect(await readFile(join(vault, 'Attestations', 'CI.md'), 'utf8')).toContain('actor: claude:runner');
+
+    const override = await runCLI(
+      ['--actor', 'codex:admin', 'new', 'attestation', '--json', '{"name":"Review","outcome":"passed"}'],
+      undefined,
+      undefined,
+      { env: { BWRB_ACTOR: 'claude:runner' }, cwd: vault }
+    );
+    expect(override.exitCode).toBe(0);
+    expect(await readFile(join(vault, 'Attestations', 'Review.md'), 'utf8')).toContain('actor: codex:admin');
+  });
+
+  it('materializes unknown instead of attributing a missing runner to a human', async () => {
+    const vault = await actorVault();
+    const result = await runCLI(
+      ['new', 'attestation', '--json', '{"name":"Unknown","outcome":"passed"}'],
+      undefined,
+      undefined,
+      { env: { BWRB_ACTOR: '' }, cwd: vault }
+    );
+    expect(result.exitCode).toBe(0);
+    expect(await readFile(join(vault, 'Attestations', 'Unknown.md'), 'utf8')).toContain('actor: unknown');
+  });
+});

--- a/tests/ts/commands/agent-workflow-acceptance.test.ts
+++ b/tests/ts/commands/agent-workflow-acceptance.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runCLI } from '../fixtures/setup.js';
+
+const vaults: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(vaults.splice(0).map((vault) => rm(vault, { recursive: true, force: true })));
+});
+
+async function createWorkflowVault(): Promise<string> {
+  const vault = await mkdtemp(join(tmpdir(), 'bwrb-agent-workflow-'));
+  vaults.push(vault);
+  await Promise.all(
+    ['.bwrb', 'Candidates', 'Requirements', 'Tasks'].map((dir) =>
+      mkdir(join(vault, dir), { recursive: true })
+    )
+  );
+
+  await writeFile(join(vault, '.bwrb', 'schema.json'), JSON.stringify({
+    version: 2,
+    traits: {
+      reviewable: {
+        transition_guards: [{
+          on: 'status = accepted',
+          requires: [{
+            relation: 'requirements',
+            all: { field: 'status', equals: 'satisfied' },
+          }],
+        }],
+        transition_effects: [{
+          on: 'status = accepted',
+          relation: 'task',
+          set: { status: 'done' },
+        }],
+      },
+    },
+    types: {
+      attestation: {
+        output_dir: 'Attestations',
+        fields: {
+          actor: { value: '$ACTOR' },
+          outcome: { prompt: 'select', options: ['passed', 'failed'] },
+        },
+      },
+      candidate: {
+        output_dir: 'Candidates',
+        traits: ['reviewable'],
+        fields: {
+          status: { prompt: 'select', options: ['implementing', 'accepted'] },
+          requirements: { prompt: 'relation', source: 'requirement', multiple: true },
+          task: { prompt: 'relation', source: 'task' },
+          'resolved-at': { prompt: 'date', granularity: 'day' },
+          'retention-state': { prompt: 'select', options: ['active', 'tombstoned'] },
+          'tombstoned-at': { prompt: 'date', granularity: 'day' },
+        },
+        retention: {
+          when: { status: { in: ['accepted'] } },
+          clock: { field: 'resolved-at', after: '1d' },
+          resolved_when: { 'retention-state': { in: ['tombstoned'] } },
+          actions: [{
+            kind: 'tombstone',
+            set: { 'retention-state': 'tombstoned', 'tombstoned-at': '$TODAY' },
+          }],
+        },
+      },
+      requirement: {
+        output_dir: 'Requirements',
+        fields: { status: { prompt: 'select', options: ['pending', 'satisfied'] } },
+      },
+      task: {
+        output_dir: 'Tasks',
+        fields: { status: { prompt: 'select', options: ['open', 'done'] } },
+      },
+    },
+  }, null, 2));
+
+  await writeFile(
+    join(vault, 'Candidates', 'Candidate 417.md'),
+    '---\ntype: candidate\nstatus: implementing\nrequirements:\n  - "[[Requirement 1]]"\ntask: "[[Task 1]]"\nresolved-at: 2000-01-01\nretention-state: active\n---\nCandidate body.\n'
+  );
+  await writeFile(
+    join(vault, 'Requirements', 'Requirement 1.md'),
+    '---\ntype: requirement\nstatus: satisfied\n---\n'
+  );
+  await writeFile(join(vault, 'Tasks', 'Task 1.md'), '---\ntype: task\nstatus: open\n---\n');
+  return vault;
+}
+
+describe('agent workflow CLI acceptance', () => {
+  it('carries provenance through guarded review, downstream work, and explicit retention', async () => {
+    const vault = await createWorkflowVault();
+
+    const attestation = await runCLI(
+      ['--actor', 'codex:acceptance-runner', 'new', 'attestation', '--json', '{"name":"Review proof","outcome":"passed"}'],
+      vault
+    );
+    expect(attestation.exitCode).toBe(0);
+    expect(await readFile(join(vault, 'Attestations', 'Review proof.md'), 'utf8'))
+      .toContain('actor: codex:acceptance-runner');
+
+    const listed = await runCLI(['list', 'candidate', '--output', 'json'], vault);
+    expect(listed.exitCode).toBe(0);
+    const [candidate] = JSON.parse(listed.stdout) as Array<{ revision: string }>;
+    expect(candidate.revision).toMatch(/^[a-f0-9]{64}$/);
+
+    const explanation = await runCLI(
+      ['explain', 'Candidate 417', '--transition', 'accepted', '--output', 'json'],
+      vault
+    );
+    expect(explanation.exitCode).toBe(0);
+    expect(JSON.parse(explanation.stdout)).toMatchObject({
+      success: true,
+      data: { blocked: false, transition: { field: 'status', value: 'accepted' } },
+    });
+
+    const accepted = await runCLI([
+      'edit', 'Candidates/Candidate 417.md', '--json', '{"status":"accepted"}',
+      '--expected-revision', candidate.revision, '--output', 'json',
+    ], vault);
+    expect(accepted.exitCode).toBe(0);
+    expect(JSON.parse(accepted.stdout).revision).toMatch(/^[a-f0-9]{64}$/);
+    expect(await readFile(join(vault, 'Tasks', 'Task 1.md'), 'utf8')).toContain('status: done');
+
+    const report = await runCLI(['audit', '--only', 'retention-due'], vault);
+    expect(report.exitCode).toBe(0);
+    expect(report.stdout).toContain('Retention is due');
+
+    const dryRun = await runCLI([
+      'audit', '--path', 'Candidates/Candidate 417.md', '--fix', '--only', 'retention-due',
+      '--retention-action', 'tombstone',
+    ], vault);
+    expect(dryRun.stdout).toContain('Would tombstone');
+    expect(await readFile(join(vault, 'Candidates', 'Candidate 417.md'), 'utf8'))
+      .toContain('retention-state: active');
+
+    const execute = await runCLI([
+      'audit', '--path', 'Candidates/Candidate 417.md', '--fix', '--only', 'retention-due',
+      '--retention-action', 'tombstone', '--execute',
+    ], vault);
+    expect(execute.exitCode).toBe(0);
+    expect(execute.stdout).toContain('Tombstoned');
+    const retained = await readFile(join(vault, 'Candidates', 'Candidate 417.md'), 'utf8');
+    expect(retained).toContain('retention-state: tombstoned');
+    expect(retained).toMatch(/tombstoned-at: \d{4}-\d{2}-\d{2}/);
+  });
+});

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -6837,4 +6837,73 @@ priority: medium
       expect(content).toContain('status: raw');
     });
   });
+
+  describe('retention', () => {
+    let tempVaultDir: string;
+    beforeEach(async () => {
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-retention-test-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await mkdir(join(tempVaultDir, 'Candidates'), { recursive: true });
+      await writeFile(join(tempVaultDir, '.bwrb', 'schema.json'), JSON.stringify({
+        version: 2,
+        types: {
+          candidate: {
+            output_dir: 'Candidates',
+            fields: {
+              status: { prompt: 'select', options: ['accepted', 'open'] },
+              'resolved-at': { prompt: 'date', granularity: 'day' },
+              'retention-state': { prompt: 'select', options: ['active', 'tombstoned'] },
+              'tombstoned-at': { prompt: 'date', granularity: 'day' },
+              related: { prompt: 'relation', source: 'candidate' },
+            },
+            retention: {
+              when: { status: { in: ['accepted'] } },
+              clock: { field: 'resolved-at', after: '1d' },
+              resolved_when: { 'retention-state': { in: ['tombstoned'] } },
+              actions: [
+                { kind: 'archive', directory: 'Archive/Candidates' },
+                { kind: 'tombstone', set: { 'retention-state': 'tombstoned', 'tombstoned-at': '$TODAY' } },
+                { kind: 'delete' },
+              ],
+            },
+          },
+        },
+      }, null, 2));
+      await writeFile(join(tempVaultDir, 'Candidates', 'Old.md'), '---\ntype: candidate\nstatus: accepted\nresolved-at: 2000-01-01\nretention-state: active\n---\n');
+    });
+    afterEach(async () => rm(tempVaultDir, { recursive: true, force: true }));
+    it('reports due retention and requires explicit remediation execution', async () => {
+      const report = await runCLI(['audit', '--only', 'retention-due'], tempVaultDir);
+      expect(report.stdout).toContain('Retention is due');
+      const dry = await runCLI(['audit', '--all', '--fix', '--only', 'retention-due', '--retention-action', 'tombstone'], tempVaultDir);
+      expect(dry.stdout).toContain('Would tombstone');
+      expect(await readFile(join(tempVaultDir, 'Candidates', 'Old.md'), 'utf8')).toContain('retention-state: active');
+      const applied = await runCLI(['audit', '--all', '--fix', '--only', 'retention-due', '--retention-action', 'tombstone', '--execute'], tempVaultDir);
+      expect(applied.stdout).toContain('Tombstoned');
+      expect(await readFile(join(tempVaultDir, 'Candidates', 'Old.md'), 'utf8')).toContain('retention-state: tombstoned');
+    });
+
+    it('archives only on explicit execute', async () => {
+      const applied = await runCLI([
+        'audit', '--path', 'Candidates/Old.md', '--fix', '--only', 'retention-due',
+        '--retention-action', 'archive', '--execute',
+      ], tempVaultDir);
+      expect(applied.stdout).toContain('Archived');
+      expect(await readFile(join(tempVaultDir, 'Archive', 'Candidates', 'Old.md'), 'utf8')).toContain('type: candidate');
+      await expect(readFile(join(tempVaultDir, 'Candidates', 'Old.md'), 'utf8')).rejects.toThrow();
+    });
+
+    it('refuses retention delete while a typed relation remains', async () => {
+      await writeFile(
+        join(tempVaultDir, 'Candidates', 'Ref.md'),
+        '---\ntype: candidate\nstatus: open\nrelated: "[[Old]]"\n---\n'
+      );
+      const applied = await runCLI([
+        'audit', '--path', 'Candidates/Old.md', '--fix', '--only', 'retention-due',
+        '--retention-action', 'delete', '--execute',
+      ], tempVaultDir);
+      expect(applied.stdout).toContain('refusing delete');
+      expect(await readFile(join(tempVaultDir, 'Candidates', 'Old.md'), 'utf8')).toContain('type: candidate');
+    });
+  });
 });

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -6854,7 +6854,6 @@ priority: medium
               'resolved-at': { prompt: 'date', granularity: 'day' },
               'retention-state': { prompt: 'select', options: ['active', 'tombstoned'] },
               'tombstoned-at': { prompt: 'date', granularity: 'day' },
-              related: { prompt: 'relation', source: 'candidate' },
             },
             retention: {
               when: { status: { in: ['accepted'] } },
@@ -6893,17 +6892,55 @@ priority: medium
       await expect(readFile(join(tempVaultDir, 'Candidates', 'Old.md'), 'utf8')).rejects.toThrow();
     });
 
-    it('refuses retention delete while a typed relation remains', async () => {
-      await writeFile(
-        join(tempVaultDir, 'Candidates', 'Ref.md'),
-        '---\ntype: candidate\nstatus: open\nrelated: "[[Old]]"\n---\n'
-      );
+    it('allows an explicit retention action in non-interactive mode without --auto', async () => {
+      const applied = await runCLI([
+        '--non-interactive', 'audit', '--path', 'Candidates/Old.md', '--fix', '--only', 'retention-due',
+        '--retention-action', 'tombstone', '--execute',
+      ], tempVaultDir);
+      expect(applied.exitCode).toBe(0);
+      expect(applied.stdout).toContain('Tombstoned');
+    });
+
+    it('deletes only when the retained type cannot be targeted by a relation', async () => {
       const applied = await runCLI([
         'audit', '--path', 'Candidates/Old.md', '--fix', '--only', 'retention-due',
         '--retention-action', 'delete', '--execute',
       ], tempVaultDir);
-      expect(applied.stdout).toContain('refusing delete');
-      expect(await readFile(join(tempVaultDir, 'Candidates', 'Old.md'), 'utf8')).toContain('type: candidate');
+      expect(applied.stdout).toContain('Deleted');
+      await expect(readFile(join(tempVaultDir, 'Candidates', 'Old.md'), 'utf8')).rejects.toThrow();
+    });
+
+    it('rejects delete retention when any relation can target the retained type', async () => {
+      const schemaPath = join(tempVaultDir, '.bwrb', 'schema.json');
+      const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+      schema.types.reference = { fields: { candidate: { prompt: 'relation', source: 'candidate' } } };
+      await writeFile(schemaPath, JSON.stringify(schema));
+      const result = await runCLI(['audit', '--only', 'retention-due'], tempVaultDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('delete is unsafe because relation fields can target this type');
+    });
+
+    it('rejects complex and transition-trigger tombstone patches', async () => {
+      const schemaPath = join(tempVaultDir, '.bwrb', 'schema.json');
+      const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+      schema.types.candidate.fields.related = { prompt: 'relation', source: 'candidate' };
+      schema.types.candidate.retention.actions = [
+        { kind: 'tombstone', set: { related: '[[Old]]', 'retention-state': 'tombstoned' } },
+      ];
+      await writeFile(schemaPath, JSON.stringify(schema));
+      const complex = await runCLI(['audit', '--only', 'retention-due'], tempVaultDir);
+      expect(complex.exitCode).toBe(1);
+      expect(complex.stderr).toContain('must be text, select, date, or static');
+
+      schema.types.candidate.traits = ['workflow'];
+      schema.traits = { workflow: { transition_guards: [{ on: 'status = accepted', requires: [{ relation: 'related', all: { field: 'status', equals: 'accepted' } }] }] } };
+      schema.types.candidate.retention.actions = [
+        { kind: 'tombstone', set: { status: 'accepted', 'retention-state': 'tombstoned' } },
+      ];
+      await writeFile(schemaPath, JSON.stringify(schema));
+      const trigger = await runCLI(['audit', '--only', 'retention-due'], tempVaultDir);
+      expect(trigger.exitCode).toBe(1);
+      expect(trigger.stderr).toContain('cannot modify transition trigger field "status"');
     });
   });
 });

--- a/tests/ts/commands/edit-lineage-concurrency.test.ts
+++ b/tests/ts/commands/edit-lineage-concurrency.test.ts
@@ -15,6 +15,7 @@ import { insertFrontmatterScalarPreservingBytes, parseNote } from '../../../src/
 import { loadSchema } from '../../../src/lib/schema.js';
 import { editNoteInteractive } from '../../../src/lib/edit.js';
 import { ConcurrentNoteModificationError } from '../../../src/lib/errors.js';
+import { noteRevision } from '../../../src/lib/note-revision.js';
 
 const CLI_SRC_PATH = join(PROJECT_ROOT, 'src/index.ts');
 const TSX_CLI = join(PROJECT_ROOT, 'node_modules', 'tsx', 'dist', 'cli.mjs');
@@ -120,6 +121,33 @@ describe('edit versus lineage identity writes', () => {
     ], vaultDir);
     expect(sequential.exitCode, sequential.stderr || sequential.stdout).toBe(0);
     expect(await readFile(sourcePath, 'utf-8')).toBe(await readFile(expectedPath, 'utf-8'));
+  });
+
+  it('does not replay a stale revision-guarded JSON edit', async () => {
+    const notePath = join(vaultDir, 'Ideas/Guarded Race.md');
+    const originalRaw = '---\ntype: idea\nstatus: raw\npriority: medium\n---\nOriginal body.\n';
+    const newerRaw = `${originalRaw}\nExternal body edit.\n`;
+    await writeFile(notePath, originalRaw);
+    const barrierDir = join(vaultDir, '.barrier-guarded');
+    const edit = spawnCli([
+      'edit', notePath, '--json', '{"priority":"high"}',
+      '--expected-revision', noteRevision(originalRaw), '--output', 'json',
+    ], vaultDir, barrierDir);
+    running.push(edit);
+
+    await waitForFile(join(barrierDir, 'edit-read-1.ready'), { timeoutMs: 10_000 });
+    await writeFile(notePath, newerRaw);
+    await writeFile(join(barrierDir, 'edit-commit-1.go'), 'go\n');
+
+    const result = await edit.completion;
+    expect(result.exitCode).toBe(2);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      success: false,
+      code: 'REVISION_MISMATCH',
+      expectedRevision: noteRevision(originalRaw),
+      currentRevision: noteRevision(newerRaw),
+    });
+    expect(await readFile(notePath, 'utf-8')).toBe(newerRaw);
   });
 
   it('replays a JSON edit after lineage adopt writes immutable provenance', async () => {

--- a/tests/ts/commands/edit.test.ts
+++ b/tests/ts/commands/edit.test.ts
@@ -128,6 +128,39 @@ describe('edit command', () => {
       expect(json.success).toBe(true);
       expect(json.path).toBe('Ideas/Sample Idea.md');
       expect(json.updated).toContain('status');
+      expect(json.revision).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('rejects --expected-revision without a JSON patch at the command boundary', async () => {
+      const result = await runCLI(
+        ['edit', 'Ideas/Sample Idea.md', '--expected-revision', 'opaque-token'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('--expected-revision requires --json <patch>');
+    });
+
+    it('rejects a body-invalidated revision and preserves the newer bytes', async () => {
+      const notePath = join(vaultDir, 'Ideas/Sample Idea.md');
+      const listed = await runCLI(['list', 'idea', '--output', 'json'], vaultDir);
+      const row = (JSON.parse(listed.stdout) as Array<{ _path: string; revision: string }>)
+        .find(note => note._path === 'Ideas/Sample Idea.md')!;
+      const newerRaw = `${await readFile(notePath, 'utf-8')}\nA native body edit.\n`;
+      await writeFile(notePath, newerRaw);
+
+      const result = await runCLI([
+        'edit', 'Ideas/Sample Idea.md', '--json', '{"status":"backlog"}',
+        '--expected-revision', row.revision, '--output', 'json',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(2);
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        success: false,
+        code: 'REVISION_MISMATCH',
+        expectedRevision: row.revision,
+      });
+      expect(await readFile(notePath, 'utf-8')).toBe(newerRaw);
     });
 
     it('should accept --output text with JSON patch mode', async () => {

--- a/tests/ts/commands/explain.test.ts
+++ b/tests/ts/commands/explain.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runCLI } from '../fixtures/setup.js';
+
+const vaults: string[] = [];
+afterEach(async () => { await Promise.all(vaults.splice(0).map((vault) => rm(vault, { recursive: true, force: true }))); });
+
+async function createGuardVault() {
+  const vault = await mkdtemp(join(tmpdir(), 'bwrb-explain-')); vaults.push(vault);
+  await Promise.all(['.bwrb', 'Candidates', 'Requirements'].map((dir) => mkdir(join(vault, dir), { recursive: true })));
+  await writeFile(join(vault, '.bwrb', 'schema.json'), JSON.stringify({ version: 2, traits: { guarded: { transition_guards: [{ on: 'status = accepted', requires: [{ relation: 'requirements', all: { field: 'status', equals: 'satisfied' } }] }] } }, types: { candidate: { traits: ['guarded'], fields: { status: { prompt: 'select' }, requirements: { prompt: 'relation', source: 'requirement', multiple: true } }, output_dir: 'Candidates' }, requirement: { fields: { status: { prompt: 'select' } }, output_dir: 'Requirements' } } }), 'utf8');
+  await writeFile(join(vault, 'Candidates', 'Candidate 417.md'), '---\ntype: candidate\nstatus: implementing\n---\n', 'utf8');
+  return vault;
+}
+
+describe('explain command', () => {
+  it('returns a blocked explanation with exit 0 for a unique value shorthand', async () => {
+    const vault = await createGuardVault();
+    const result = await runCLI(['explain', 'Candidate 417', '--transition', 'accepted', '--output', 'json'], vault);
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({ success: true, data: { blocked: true, transition: { field: 'status', value: 'accepted' }, guards: [{ requirements: [{ status: 'missing' }] }] } });
+  });
+});

--- a/tests/ts/commands/help.contract.test.ts
+++ b/tests/ts/commands/help.contract.test.ts
@@ -29,6 +29,7 @@ describe('help output contract snapshots', () => {
       'delete',
       'list',
       'recent',
+      'explain',
       'schema',
       'audit',
       'bulk',

--- a/tests/ts/commands/list.test.ts
+++ b/tests/ts/commands/list.test.ts
@@ -158,6 +158,11 @@ describe('list command', () => {
       expect(json.length).toBeGreaterThan(0);
       expect(json[0]).toHaveProperty('_path');
       expect(json[0]).toHaveProperty('_name');
+      expect(json[0].revision).toMatch(/^[a-f0-9]{64}$/);
+
+      const repeated = await runCLI(['list', '--output', 'json', 'idea'], vaultDir);
+      const repeatedJson = JSON.parse(repeated.stdout);
+      expect(repeatedJson[0].revision).toBe(json[0].revision);
     });
   });
 
@@ -238,6 +243,7 @@ describe('list command', () => {
         {
           _path: 'Ideas/Another Idea.md',
           _name: 'Another Idea',
+          revision: expect.stringMatching(/^[a-f0-9]{64}$/),
           name: 'Another Idea',
           status: 'backlog',
           priority: 'high',
@@ -245,6 +251,7 @@ describe('list command', () => {
         {
           _path: 'Ideas/Sample Idea.md',
           _name: 'Sample Idea',
+          revision: expect.stringMatching(/^[a-f0-9]{64}$/),
           name: 'Sample Idea',
           status: 'raw',
           priority: 'medium',

--- a/tests/ts/helpers/help.ts
+++ b/tests/ts/helpers/help.ts
@@ -4,6 +4,7 @@ const CANONICAL_HELP_COMMAND_ORDER = [
   'delete',
   'list',
   'recent',
+  'explain',
   'schema',
   'audit',
   'bulk',

--- a/tests/ts/lib/logical-actor.test.ts
+++ b/tests/ts/lib/logical-actor.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { expandStaticValue } from '../../../src/lib/local-date.js';
+import {
+  configureLogicalActor,
+  resetLogicalActorForTests,
+  resolveLogicalActor,
+} from '../../../src/lib/logical-actor.js';
+
+afterEach(() => resetLogicalActorForTests());
+
+describe('logical actor provenance', () => {
+  it('resolves explicit override, runner environment, then unknown', () => {
+    expect(resolveLogicalActor(' codex:session-17 ', { BWRB_ACTOR: 'claude' })).toBe('codex:session-17');
+    expect(resolveLogicalActor(undefined, { BWRB_ACTOR: 'claude:runner' })).toBe('claude:runner');
+    expect(resolveLogicalActor(undefined, {})).toBe('unknown');
+  });
+
+  it('expands $ACTOR from the actor fixed for this process', () => {
+    configureLogicalActor('codex:child-reviewer');
+    expect(expandStaticValue('$ACTOR')).toBe('codex:child-reviewer');
+  });
+});

--- a/tests/ts/lib/transition-effects.test.ts
+++ b/tests/ts/lib/transition-effects.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { resolveSchema } from '../../../src/lib/schema.js';
+import { editNoteFromJson } from '../../../src/lib/edit.js';
+import { executeBulk } from '../../../src/lib/bulk/execute.js';
+import { commitTransitionEffects } from '../../../src/lib/transition-effects.js';
+
+const dirs: string[] = [];
+afterEach(async () => { await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))); });
+
+async function fixture() {
+  const vault = await mkdtemp(join(tmpdir(), 'bwrb-effects-')); dirs.push(vault);
+  await mkdir(join(vault, 'Candidates'), { recursive: true });
+  await mkdir(join(vault, 'Tasks'), { recursive: true });
+  const schema = resolveSchema({ version: 2, traits: { advancing: { transition_effects: [{ on: 'status = accepted', relation: 'task', set: { status: 'done' } }] } }, types: {
+    candidate: { traits: ['advancing'], fields: { status: { prompt: 'select', options: ['implementing', 'accepted'] }, task: { prompt: 'relation', source: 'task' } }, output_dir: 'Candidates' },
+    task: { fields: { status: { prompt: 'select', options: ['open', 'done'] } }, output_dir: 'Tasks' },
+  }});
+  const target = join(vault, 'Tasks', 'T.md');
+  await writeFile(target, '---\ntype: task\nstatus: open\n---\nTarget\n', 'utf8');
+  const source = join(vault, 'Candidates', 'C.md');
+  await writeFile(source, '---\ntype: candidate\nstatus: implementing\ntask: "[[T]]"\n---\nSource\n', 'utf8');
+  return { vault, schema, source, target };
+}
+
+describe('transition effects', () => {
+  it('updates a scalar relation target only when the source enters its trigger', async () => {
+    const { vault, schema, source, target } = await fixture();
+    await editNoteFromJson(schema, vault, source, '{"status":"accepted"}');
+    expect((await readFile(target, 'utf8'))).toContain('status: done');
+    await editNoteFromJson(schema, vault, source, '{"task":"[[T]]"}');
+    expect((await readFile(target, 'utf8'))).toContain('status: done');
+  });
+
+  it('uses the same target update through bulk', async () => {
+    const { vault, schema, target } = await fixture();
+    const result = await executeBulk({ vaultDir: vault, schema, typePath: 'candidate', operations: [{ type: 'set', field: 'status', value: 'accepted' }], whereExpressions: [], execute: true, backup: false, verbose: false, quiet: true, jsonMode: true });
+    expect(result.errors).toEqual([]);
+    expect((await readFile(target, 'utf8'))).toContain('status: done');
+  });
+
+  it('rolls back an earlier target when a later target write fails', async () => {
+    const { vault, target } = await fixture();
+    const original = await readFile(target, 'utf8');
+    await expect(commitTransitionEffects([
+      { path: target, raw: original, body: 'Target\n', before: { type: 'task', status: 'open' }, after: { type: 'task', status: 'done' }, order: ['type', 'status'] },
+      { path: join(target, 'nested.md'), raw: '', body: '', before: {}, after: { type: 'task', status: 'done' }, order: ['type', 'status'] },
+    ])).rejects.toThrow();
+    expect(await readFile(target, 'utf8')).toBe(original);
+  });
+});

--- a/tests/ts/lib/transition-effects.test.ts
+++ b/tests/ts/lib/transition-effects.test.ts
@@ -42,6 +42,28 @@ async function inheritedFixture() {
 }
 
 describe('transition effects', () => {
+  it('rejects effects that would bypass a target transition guard', () => {
+    expect(() => resolveSchema({ version: 2, traits: {
+      advancing: { transition_effects: [{ on: 'status = accepted', relation: 'task', set: { status: 'done' } }] },
+      guarded: { transition_guards: [{ on: 'status = done', requires: [{ relation: 'requirements', all: { field: 'status', equals: 'satisfied' } }] }] },
+    }, types: {
+      candidate: { traits: ['advancing'], fields: { status: { prompt: 'select', options: ['implementing', 'accepted'] }, task: { prompt: 'relation', source: 'task' } } },
+      task: { traits: ['guarded'], fields: { status: { prompt: 'select', options: ['open', 'done'] }, requirements: { prompt: 'relation', source: 'requirement', multiple: true } } },
+      requirement: { fields: { status: { prompt: 'select', options: ['pending', 'satisfied'] } } },
+    }})).toThrow("cannot modify guarded transition field 'task.status'");
+  });
+
+  it('checks every possible target type for unconstrained effect relations', () => {
+    expect(() => resolveSchema({ version: 2, traits: {
+      advancing: { transition_effects: [{ on: 'status = accepted', relation: 'target', set: { status: 'done' } }] },
+      guarded: { transition_guards: [{ on: 'status = done', requires: [{ relation: 'requirements', all: { field: 'status', equals: 'satisfied' } }] }] },
+    }, types: {
+      candidate: { traits: ['advancing'], fields: { status: { prompt: 'select', options: ['implementing', 'accepted'] }, target: { prompt: 'relation', source: 'any' } } },
+      task: { traits: ['guarded'], fields: { status: { prompt: 'select', options: ['open', 'done'] }, requirements: { prompt: 'relation', source: 'requirement', multiple: true } } },
+      requirement: { fields: { status: { prompt: 'select', options: ['pending', 'satisfied'] } } },
+    }})).toThrow("cannot modify guarded transition field 'task.status'");
+  });
+
   it('inherits effects from traits composed by an ancestor type', async () => {
     const { vault, schema, source, target } = await inheritedFixture();
     await editNoteFromJson(schema, vault, source, '{"status":"accepted"}');

--- a/tests/ts/lib/transition-effects.test.ts
+++ b/tests/ts/lib/transition-effects.test.ts
@@ -25,7 +25,29 @@ async function fixture() {
   return { vault, schema, source, target };
 }
 
+async function inheritedFixture() {
+  const vault = await mkdtemp(join(tmpdir(), 'bwrb-effects-inherited-')); dirs.push(vault);
+  await mkdir(join(vault, 'Candidates'), { recursive: true });
+  await mkdir(join(vault, 'Tasks'), { recursive: true });
+  const schema = resolveSchema({ version: 2, traits: { advancing: { transition_effects: [{ on: 'status = accepted', relation: 'task', set: { status: 'done' } }] } }, types: {
+    candidate: { traits: ['advancing'], fields: { status: { prompt: 'select', options: ['implementing', 'accepted'] }, task: { prompt: 'relation', source: 'task' } }, output_dir: 'Candidates' },
+    'special-candidate': { extends: 'candidate', fields: {}, output_dir: 'Candidates' },
+    task: { fields: { status: { prompt: 'select', options: ['open', 'done'] } }, output_dir: 'Tasks' },
+  }});
+  const target = join(vault, 'Tasks', 'T.md');
+  await writeFile(target, '---\ntype: task\nstatus: open\n---\nTarget\n', 'utf8');
+  const source = join(vault, 'Candidates', 'C.md');
+  await writeFile(source, '---\ntype: special-candidate\nstatus: implementing\ntask: "[[T]]"\n---\nSource\n', 'utf8');
+  return { vault, schema, source, target };
+}
+
 describe('transition effects', () => {
+  it('inherits effects from traits composed by an ancestor type', async () => {
+    const { vault, schema, source, target } = await inheritedFixture();
+    await editNoteFromJson(schema, vault, source, '{"status":"accepted"}');
+    expect(await readFile(target, 'utf8')).toContain('status: done');
+  });
+
   it('updates a scalar relation target only when the source enters its trigger', async () => {
     const { vault, schema, source, target } = await fixture();
     await editNoteFromJson(schema, vault, source, '{"status":"accepted"}');

--- a/tests/ts/lib/transition-guards.test.ts
+++ b/tests/ts/lib/transition-guards.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { resolveSchema } from '../../../src/lib/schema.js';
+import { explainTransition } from '../../../src/lib/transition-guards.js';
+import { editNoteFromJson } from '../../../src/lib/edit.js';
+import { executeBulk } from '../../../src/lib/bulk/execute.js';
+
+const dirs: string[] = [];
+afterEach(async () => { await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))); });
+
+async function fixture(requirementStatus: string) {
+  const vault = await mkdtemp(join(tmpdir(), 'bwrb-transition-')); dirs.push(vault);
+  await mkdir(join(vault, 'Candidates'), { recursive: true });
+  await mkdir(join(vault, 'Requirements'), { recursive: true });
+  const schema = resolveSchema({ version: 2, traits: { guarded: { transition_guards: [{ on: 'status = accepted', requires: [{ relation: 'requirements', all: { field: 'status', equals: 'satisfied' }, failed_when: { field: 'status', in: ['failed'] }, stale_when: { field: 'status', in: ['stale'] } }] }] } }, types: {
+    candidate: { traits: ['guarded'], fields: { status: { prompt: 'select' }, requirements: { prompt: 'relation', source: 'requirement', multiple: true } }, output_dir: 'Candidates' },
+    requirement: { fields: { status: { prompt: 'select' } }, output_dir: 'Requirements' },
+  }});
+  await writeFile(join(vault, 'Requirements', 'R.md'), `---\ntype: requirement\nstatus: ${requirementStatus}\n---\n`, 'utf8');
+  return { vault, schema };
+}
+
+describe('transition guards', () => {
+  it('reports every relation state deterministically', async () => {
+    const { vault, schema } = await fixture('stale');
+    const result = await explainTransition(schema, vault, 'candidate', { status: 'accepted', requirements: ['[[R]]', '[[Missing]]'] }, { field: 'status', value: 'accepted' });
+    expect(result.blocked).toBe(true);
+    expect(result.guards[0]!.requirements[0]).toMatchObject({ status: 'unresolved', targets: [{ target: 'R', status: 'stale' }, { target: 'Missing', status: 'unresolved' }] });
+  });
+
+  it('reports missing and satisfied requirements', async () => {
+    const { vault, schema } = await fixture('satisfied');
+    const missing = await explainTransition(schema, vault, 'candidate', { status: 'accepted' }, { field: 'status', value: 'accepted' });
+    expect(missing.guards[0]!.requirements[0]!.status).toBe('missing');
+    const satisfied = await explainTransition(schema, vault, 'candidate', { status: 'accepted', requirements: ['[[R]]'] }, { field: 'status', value: 'accepted' });
+    expect(satisfied.blocked).toBe(false);
+  });
+
+  it('prevents a blocked JSON edit without writing', async () => {
+    const { vault, schema } = await fixture('failed');
+    const path = join(vault, 'Candidates', 'C.md');
+    const original = '---\ntype: candidate\nstatus: implementing\nrequirements: "[[R]]"\n---\nBody\n';
+    await writeFile(path, original, 'utf8');
+    await expect(editNoteFromJson(schema, vault, path, '{"status":"accepted"}')).rejects.toMatchObject({ code: 'TRANSITION_GUARD_FAILED' });
+    expect(await readFile(path, 'utf8')).toBe(original);
+  });
+
+  it('reports a blocked bulk file and leaves it unchanged', async () => {
+    const { vault, schema } = await fixture('failed');
+    const path = join(vault, 'Candidates', 'C.md');
+    const original = '---\ntype: candidate\nstatus: implementing\nrequirements: "[[R]]"\n---\n';
+    await writeFile(path, original, 'utf8');
+    const result = await executeBulk({ vaultDir: vault, schema, typePath: 'candidate', operations: [{ type: 'set', field: 'status', value: 'accepted' }], whereExpressions: [], execute: true, backup: false, verbose: false, quiet: true, jsonMode: true });
+    expect(result.errors[0]).toContain('Transition guard requirements');
+    expect(await readFile(path, 'utf8')).toBe(original);
+  });
+});

--- a/tests/ts/lib/transition-guards.test.ts
+++ b/tests/ts/lib/transition-guards.test.ts
@@ -23,6 +23,19 @@ async function fixture(requirementStatus: string) {
 }
 
 describe('transition guards', () => {
+  it('inherits guards from traits composed by an ancestor type', async () => {
+    const { vault } = await fixture('failed');
+    const schema = resolveSchema({ version: 2, traits: { guarded: { transition_guards: [{ on: 'status = accepted', requires: [{ relation: 'requirements', all: { field: 'status', equals: 'satisfied' } }] }] } }, types: {
+      candidate: { traits: ['guarded'], fields: { status: { prompt: 'select' }, requirements: { prompt: 'relation', source: 'requirement', multiple: true } }, output_dir: 'Candidates' },
+      'special-candidate': { extends: 'candidate', fields: {}, output_dir: 'Candidates' },
+      requirement: { fields: { status: { prompt: 'select' } }, output_dir: 'Requirements' },
+    }});
+
+    const result = await explainTransition(schema, vault, 'special-candidate', { status: 'accepted', requirements: ['[[R]]'] }, { field: 'status', value: 'accepted' });
+    expect(result.blocked).toBe(true);
+    expect(result.guards).toHaveLength(1);
+  });
+
   it('reports every relation state deterministically', async () => {
     const { vault, schema } = await fixture('stale');
     const result = await explainTransition(schema, vault, 'candidate', { status: 'accepted', requirements: ['[[R]]', '[[Missing]]'] }, { field: 'status', value: 'accepted' });


### PR DESCRIPTION
## Summary

- add revision-checked edits and logical actor provenance
- add relation-backed transition guards, explain output, and bounded downstream effects
- add explicit retention audit/remediation with archive, tombstone, and guarded delete
- document the production slice and add integrated source/dist CLI acceptance coverage

## Why

This gives typed Markdown vaults the general-purpose primitives needed to model agent change candidates and review without embedding project-specific workflow state in Bowerbird.

## Verification

- pnpm build
- pnpm verify:pack
- pnpm typecheck
- pnpm lint
- pnpm knip
- pnpm test -- --exclude=**/*.pty.test.ts (121 files; 3064 passed, 3 skipped)
- built-dist integrated workflow acceptance after rebasing onto origin/main