### PR TITLE
Show retention actions in text audit output

### DIFF
--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -55,9 +55,10 @@ Use `--dry-run` to preview fixes without writing.
 ### Retention remediation
 
 Types can declare retention (see the schema reference). Audit reports a due record as a
-`retention-due` warning and includes the configured actions in JSON metadata. It uses one
-local-day snapshot for the entire run; the deadline is inclusive. A missing or invalid
-clock is a diagnostic, never an invented deadline.
+`retention-due` warning. Text output names the available action kinds, while JSON includes
+the full configured actions in issue metadata. It uses one local-day snapshot for the
+entire run; the deadline is inclusive. A missing or invalid clock is a diagnostic, never
+an invented deadline, so no actions are suggested until the clock is repaired.
 
 Retention is never an automatic fix. Target it explicitly, select the issue, and name an
 action; omission of `--execute` is a dry run:

--- a/src/lib/audit/output.ts
+++ b/src/lib/audit/output.ts
@@ -138,6 +138,18 @@ export function outputTextResults(
       const symbol = issue.severity === 'error' ? chalk.red('✗') : chalk.yellow('⚠');
       console.log(`  ${symbol} ${issue.message}`);
 
+      if (issue.code === 'retention-due' && issue.meta?.diagnostic !== 'invalid-clock') {
+        const actions = Array.isArray(issue.meta?.actions)
+          ? issue.meta.actions.flatMap(action => {
+            if (!action || typeof action !== 'object' || !('kind' in action)) return [];
+            return typeof action.kind === 'string' ? [action.kind] : [];
+          })
+          : [];
+        if (actions.length > 0) {
+          console.log(chalk.dim(`    Available actions: ${actions.join(', ')}`));
+        }
+      }
+
       if (issue.expected && Array.isArray(issue.expected)) {
         const display = issue.expected.length <= 6
           ? issue.expected.join(', ')

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -6874,12 +6874,40 @@ priority: medium
     it('reports due retention and requires explicit remediation execution', async () => {
       const report = await runCLI(['audit', '--only', 'retention-due'], tempVaultDir);
       expect(report.stdout).toContain('Retention is due');
+      expect(report.stdout).toContain('Available actions: archive, tombstone, delete');
       const dry = await runCLI(['audit', '--all', '--fix', '--only', 'retention-due', '--retention-action', 'tombstone'], tempVaultDir);
       expect(dry.stdout).toContain('Would tombstone');
       expect(await readFile(join(tempVaultDir, 'Candidates', 'Old.md'), 'utf8')).toContain('retention-state: active');
       const applied = await runCLI(['audit', '--all', '--fix', '--only', 'retention-due', '--retention-action', 'tombstone', '--execute'], tempVaultDir);
       expect(applied.stdout).toContain('Tombstoned');
       expect(await readFile(join(tempVaultDir, 'Candidates', 'Old.md'), 'utf8')).toContain('retention-state: tombstoned');
+    });
+
+    it('shows one available retention action in text without changing JSON metadata', async () => {
+      const schemaPath = join(tempVaultDir, '.bwrb', 'schema.json');
+      const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+      schema.types.candidate.retention.actions = [
+        { kind: 'tombstone', set: { 'retention-state': 'tombstoned', 'tombstoned-at': '$TODAY' } },
+      ];
+      await writeFile(schemaPath, JSON.stringify(schema));
+
+      const text = await runCLI(['audit', '--only', 'retention-due'], tempVaultDir);
+      expect(text.stdout).toContain('Available actions: tombstone');
+
+      const json = await runCLI(['audit', '--only', 'retention-due', '--output', 'json'], tempVaultDir);
+      const payload = JSON.parse(json.stdout);
+      expect(payload.files[0].issues[0]).toMatchObject({
+        code: 'retention-due',
+        message: 'Retention is due since 2000-01-02 (clock resolved-at: 2000-01-01)',
+        meta: { actions: [{ kind: 'tombstone' }] },
+      });
+    });
+
+    it('does not suggest retention actions until an invalid clock is repaired', async () => {
+      await writeFile(join(tempVaultDir, 'Candidates', 'Old.md'), '---\ntype: candidate\nstatus: accepted\nretention-state: active\n---\n');
+      const report = await runCLI(['audit', '--only', 'retention-due'], tempVaultDir);
+      expect(report.stdout).toContain('Retention clock is missing or invalid');
+      expect(report.stdout).not.toContain('Available actions:');
     });
 
     it('archives only on explicit execute', async () => {


### PR DESCRIPTION
## Summary

- show configured retention action kinds beneath due warnings in human-readable audit output
- suppress action suggestions for missing or invalid retention clocks
- preserve structured JSON output and document the presentation contract

Closes #830

## Verification

- built CLI disposable-vault replay of the human-QA finding
- `pnpm build`
- `pnpm verify:pack`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm test -- --exclude=**/*.pty.test.ts` (121 files; 3068 passed, 3 skipped)
- `pnpm docs:doctor`