### PR TITLE
Fix docs production deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ docs-site/.astro/
 # Beads artifacts (deprecated)
 .beads/
 .beads-backup/
+.vercel

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -53,8 +53,12 @@ The docs are hosted on Vercel and connected to GitHub.
 Vercel is configured with an **Ignored Build Step** to only build when `docs-site/` changes:
 
 ```bash
-git diff HEAD^ HEAD --quiet -- ./docs-site
+git diff HEAD^ HEAD --quiet -- .
 ```
+
+Vercel runs this command from the configured `docs-site` project root, so `.`
+is the docs tree. A repository-relative `./docs-site` path would incorrectly
+resolve to `docs-site/docs-site` and cancel every deployment.
 
 This means:
 - PRs that only touch source code (`src/`, `tests/`) → **no Vercel build**

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -69,12 +69,14 @@ This means:
 If you need to trigger a manual deployment (e.g., after rate limiting):
 
 ```bash
-cd docs-site
+# Run from the repository root; the Vercel project enters docs-site itself.
+vercel link --project docs-site --scope alice-moores-projects
 vercel          # Deploy preview
 vercel --prod   # Deploy to production
 ```
 
-> **Note**: You need to be authenticated with the Vercel CLI (`vercel login`) and have access to the project.
+> **Note**: You need to be authenticated with the Vercel CLI (`vercel login`),
+> have access to the project, and use Vercel CLI 47.2.2 or newer.
 
 ### Rate Limiting
 

--- a/docs-site/vercel.json
+++ b/docs-site/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "astro",
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- .",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "installCommand": "npm install"


### PR DESCRIPTION
## Summary

- version the Vercel ignore command from the configured docs project root
- correct the deployment documentation to match Vercel execution semantics
- restore preview and production builds for docs-site changes

## Verification

- npm install --no-package-lock
- npm run build
- exact ignore command exits 1 for this docs-changing commit

The previous project-level command checked ./docs-site while already running inside docs-site, so Vercel canceled every deployment while reporting a successful status context.