### PR TITLE
Support revision-safe body and file-backed JSON writes

### DIFF
--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -449,9 +449,21 @@ bwrb edit --type task "Fix bug" --json '{"priority": "high"}'
 bwrb edit --type task --where "status == 'active'" "Deploy" --json '{"status": "done"}'
 ```
 
+Replace an existing note body in the same revision-guarded JSON edit:
+
+```bash
+bwrb edit --id "<uuid>" --expected-revision "<revision>" \
+  --json '{"_body":"A replacement Markdown body."}'
+bwrb edit --id "<uuid>" --expected-revision "<revision>" \
+  --json '{"_body":{"Steps":["One","Two"],"Notes":"Cleaned notes"}}'
+```
+
+`_body` is a body replacement, not frontmatter. A raw Markdown string replaces the body verbatim; an object
+uses the type's declared body-section names. Frontmatter and body are written under the same revision check.
+
 Notes:
 - If multiple notes share the same name, `bwrb edit` errors, lists candidate paths, and asks for an exact-path retry. Disambiguate with `--type`, `--path`, or a listed vault-relative path.
-- `bwrb new --json` rejects unknown frontmatter fields after merging template defaults. `bwrb edit --json` rejects unknown fields in the patch.
+- `bwrb new --json` rejects unknown frontmatter fields after merging template defaults. `bwrb edit --json` rejects unknown fields in the frontmatter patch while reserving `_body` for revision-safe body replacement.
 - A validated JSON patch with no semantic change preserves the note's exact bytes and raw-byte revision.
 - Edit commits coordinate with fork/adopt lineage writes. JSON patches make up to three total attempts (the initial attempt plus at most two retries) from fresh bytes; on exhaustion, retry only when JSON has numeric `code: 2`, `data.reason: "note-modified-concurrently"`, and `data.retryable: true`. Interactive edits do not replay answers gathered from stale values.
 

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -144,9 +144,15 @@ Examples:
 
   # Non-interactive JSON mode (scripting)
   bwrb edit "My Task" --json '{"status":"done"}'
+  bwrb edit "My Task" --json '{"_body":"A replacement Markdown body."}'
+  bwrb edit "My Task" --json '{"_body":{"Steps":["One","Two"]}}'
   bwrb edit "My Task" --json '{"status":"done"}' --output json
   bwrb edit "My Task" --json '{"status":"done"}' --output text
   bwrb edit -t task --where "status == 'active'" "Deploy" --json '{"priority":"high"}'
+
+Body replacement (JSON mode):
+  The _body field replaces the current body atomically. It accepts a raw Markdown
+  string or section names as keys, with string or string[] values.
 
   # Edit and open
   bwrb edit "My Note" --open                # Open the note after editing

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -48,6 +48,7 @@ interface EditOptions {
   id?: string;
   body?: string;
   json?: string;
+  jsonFile?: string;
   expectedRevision?: string;
   output?: string;
   open?: boolean;
@@ -57,7 +58,7 @@ interface EditOptions {
 function resolveEditJsonMode(options: EditOptions, globalOutput?: string): boolean {
   const requested = options.output ?? globalOutput;
   if (requested === undefined) {
-    return options.json !== undefined;
+    return options.json !== undefined || options.jsonFile !== undefined;
   }
   return requested === 'json';
 }
@@ -123,6 +124,7 @@ export const editCommand = new Command('edit')
   .option('--id <uuid>', 'Filter by stable note id')
   .option('-b, --body <pattern>', 'Filter by body content')
   .option('--json <patch>', 'Non-interactive patch/merge mode')
+  .option('--json-file <path>', 'Read the non-interactive JSON patch from a file (avoids command-line size limits)')
   .option('--expected-revision <revision>', 'Require this opaque revision when using --json')
   .option('--output <format>', 'Output format: text or json (default: json with --json)')
   .option('-o, --open', 'Open the note in Obsidian after editing')
@@ -144,6 +146,7 @@ Examples:
 
   # Non-interactive JSON mode (scripting)
   bwrb edit "My Task" --json '{"status":"done"}'
+  bwrb edit "My Task" --json-file /secure/path/task-patch.json
   bwrb edit "My Task" --json '{"_body":"A replacement Markdown body."}'
   bwrb edit "My Task" --json '{"_body":{"Steps":["One","Two"]}}'
   bwrb edit "My Task" --json '{"status":"done"}' --output json
@@ -177,7 +180,7 @@ Precedence (for --open app mode):
   // typo, and silently swallowing it (commander's default) hides the mistake.
   .allowExcessArguments(false)
   .action(async (query: string | undefined, mode: string | undefined, options: EditOptions, cmd: Command) => {
-    const patchMode = options.json !== undefined;
+    const patchMode = options.json !== undefined || options.jsonFile !== undefined;
     // App-mode precedence: an explicit --app flag wins over the positional
     // [mode]; the positional is the convenience form. An invalid positional
     // mode surfaces via parseAppMode (inside resolveAppMode) as a clear error
@@ -187,6 +190,12 @@ Precedence (for --open app mode):
     let resolvedVaultDir: string | undefined;
     let selectedTargetPath: string | undefined;
     try {
+      if (options.json !== undefined && options.jsonFile !== undefined) {
+        throw new Error('--json and --json-file are mutually exclusive.');
+      }
+      const jsonPatch = options.json ?? (options.jsonFile !== undefined
+        ? await fs.readFile(options.jsonFile, 'utf8')
+        : undefined);
       const globalOpts = getGlobalOpts(cmd);
       jsonMode = resolveEditJsonMode(options, globalOpts.output);
       const outputFormat = options.output ?? globalOpts.output;
@@ -270,7 +279,7 @@ Precedence (for --open app mode):
         if (fileExists) {
           // It's a valid absolute path - use it directly.
           if (patchMode) {
-            const editResult = await editNoteFromJson(schema, vaultDir, query, options.json!, {
+            const editResult = await editNoteFromJson(schema, vaultDir, query, jsonPatch!, {
               jsonMode,
               ...(options.expectedRevision !== undefined
                 ? { expectedRevision: options.expectedRevision }
@@ -404,7 +413,7 @@ Precedence (for --open app mode):
       // Perform the edit
       if (patchMode) {
         // JSON patch mode: non-interactive patch with selectable output format
-        const editResult = await editNoteFromJson(schema, vaultDir, targetFile.path, options.json!, {
+        const editResult = await editNoteFromJson(schema, vaultDir, targetFile.path, jsonPatch!, {
           jsonMode,
           ...(options.expectedRevision !== undefined
             ? { expectedRevision: options.expectedRevision }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { readFile } from 'fs/promises';
 import { relative } from 'path';
 import { loadSchema, getType, formatUnknownTypeError } from '../lib/schema.js';
 import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
@@ -40,6 +41,7 @@ export const newCommand = new Command('new')
   .option('-t, --type <type>', 'Type of note to create (alternative to positional argument)')
   .option('-o, --open', 'Open the note after creation (uses BWRB_DEFAULT_APP or system default)')
   .option('--json <frontmatter>', 'Create note non-interactively with JSON frontmatter')
+  .option('--json-file <path>', 'Read JSON frontmatter from a file (avoids command-line size limits)')
   .option('--template <name>', 'Use a specific template (use "default" for default.md)')
   // NOTE: Commander maps --no-template to options.template === false.
   .option('--no-template', 'Skip template selection, use schema only')
@@ -74,6 +76,7 @@ Instance scaffolding:
 
 Non-interactive (JSON) mode:
   bwrb new idea --json '{"name": "My Idea", "status": "raw"}'
+  bwrb new idea --json-file /secure/path/idea.json
   bwrb new task --json '{"name": "Fix bug", "status": "in-progress"}'
   bwrb new task --json '{"name": "Bug"}' --template bug-report
 
@@ -94,11 +97,17 @@ Template management:
   .action(async (positionalType: string | undefined, options: NewCommandOptions, cmd: Command) => {
     const forkMode = options.fork !== undefined;
     const forkJsonMode = forkMode && options.output === 'json';
-    const jsonMode = options.json !== undefined || forkJsonMode;
+    const jsonMode = options.json !== undefined || options.jsonFile !== undefined || forkJsonMode;
     const typePath = options.type ?? positionalType;
     let resolvedVaultDir: string | undefined;
 
     try {
+      if (options.json !== undefined && options.jsonFile !== undefined) {
+        throw new Error('--json and --json-file are mutually exclusive.');
+      }
+      const jsonInput = options.json ?? (options.jsonFile !== undefined
+        ? await readFile(options.jsonFile, 'utf8')
+        : undefined);
       const globalOpts = getGlobalOpts(cmd);
       configurePromptMode({
         forcedNonInteractive: globalOpts.nonInteractive === true,
@@ -177,7 +186,7 @@ Template management:
           schema,
           vaultDir,
           typePath,
-          options.json!,
+          jsonInput!,
           template,
           { owner: options.owner, standalone: options.standalone, noInstances: options.instances === false }
         );
@@ -368,6 +377,7 @@ function validateForkOptions(
     options.template !== undefined ? (options.template === false ? '--no-template' : '--template') : undefined,
     options.instances === false ? '--no-instances' : undefined,
     options.json !== undefined ? '--json' : undefined,
+    options.jsonFile !== undefined ? '--json-file' : undefined,
     options.owner !== undefined ? '--owner' : undefined,
     options.standalone ? '--standalone' : undefined,
   ].filter((flag): flag is string => Boolean(flag));

--- a/src/commands/new/types.ts
+++ b/src/commands/new/types.ts
@@ -5,6 +5,7 @@ import type { FilenameTransformation } from '../../lib/filename.js';
 export interface NewCommandOptions {
   open?: boolean;
   json?: string;
+  jsonFile?: string;
   type?: string;
   template?: string | boolean;
   noTemplate?: boolean;

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -273,8 +273,8 @@ async function resolveVaultDirForCompletion(options: { vault?: string }): Promis
  * Only includes options that make sense to complete.
  */
 const COMMAND_OPTIONS: Record<string, string[]> = {
-  new: ['--type', '-t', '--vault', '-v', '--non-interactive', '--template', '--no-template', '--no-instances', '--owner', '--standalone', '--json', '--open', '-o', '--fork', '--label', '--name', '--output', '--help'],
-  edit: ['--type', '-t', '--path', '-p', '--where', '-w', '--id', '--body', '-b', '--picker', '--json', '--output', '--open', '--app', '--vault', '-v', '--non-interactive', '--help'],
+  new: ['--type', '-t', '--vault', '-v', '--non-interactive', '--template', '--no-template', '--no-instances', '--owner', '--standalone', '--json', '--json-file', '--open', '-o', '--fork', '--label', '--name', '--output', '--help'],
+  edit: ['--type', '-t', '--path', '-p', '--where', '-w', '--id', '--body', '-b', '--picker', '--json', '--json-file', '--output', '--open', '--app', '--vault', '-v', '--non-interactive', '--help'],
   list: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--name', '--fuzzy', '--matches', '--threshold', '--context', '-C', '--no-context', '--case-sensitive', '-S', '--regex', '-E', '--id', '--lineage', '--fields', '--sort', '--desc', '--limit', '--count', '--output', '--open', '-o', '--app', '--picker', '--preview', '--vault', '-v', '--non-interactive', '--help'],
   recent: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--limit', '--output', '--open', '-o', '--app', '--save-as', '--force', '--vault', '-v', '--non-interactive', '--help'],
   audit: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--all', '-a', '--strict', '--only', '--ignore', '--output', '--fix', '--auto', '--dry-run', '--execute', '--allow-field', '--vault', '-v', '--non-interactive', '--help'],

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -14,7 +14,7 @@ import {
   resolveTypeFromFrontmatter,
   getFieldsForType,
 } from './schema.js';
-import { parseNote, writeNote, writeFileAtomic, generateBodySections } from './frontmatter.js';
+import { parseNote, writeNote, writeFileAtomic, generateBodySections, generateBodyWithContent, parseBodyInput } from './frontmatter.js';
 import {
   isBodySectionPresent,
   flattenBodySections,
@@ -127,9 +127,9 @@ export async function editNoteFromJson(
   const { jsonMode = true, expectedRevision, mutationFaultInjector } = options;
 
   // Parse JSON input
-  let patchData: Record<string, unknown>;
+  let inputData: Record<string, unknown>;
   try {
-    patchData = JSON.parse(jsonInput) as Record<string, unknown>;
+    inputData = JSON.parse(jsonInput) as Record<string, unknown>;
   } catch (e) {
     const error = `Invalid JSON: ${(e as Error).message}`;
     if (jsonMode) {
@@ -137,6 +137,23 @@ export async function editNoteFromJson(
       process.exit(ExitCodes.VALIDATION_ERROR);
     }
     throw new Error(error);
+  }
+
+  const { _body: rawBodyInput, ...patchData } = inputData;
+  let bodyInput: string | Record<string, unknown> | undefined;
+  if (rawBodyInput !== undefined && rawBodyInput !== null) {
+    if (typeof rawBodyInput === 'string') {
+      bodyInput = rawBodyInput;
+    } else if (typeof rawBodyInput === 'object' && !Array.isArray(rawBodyInput)) {
+      bodyInput = rawBodyInput as Record<string, unknown>;
+    } else {
+      const error = '_body must be a string or an object with section names as keys';
+      if (jsonMode) {
+        printJson(jsonError(error));
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
+      throw new Error(error);
+    }
   }
 
   // Disallow editing system-managed fields
@@ -162,6 +179,7 @@ export async function editNoteFromJson(
         vaultDir,
         filePath,
         patchData,
+        bodyInput,
         jsonMode,
         attempt,
         expectedRevision,
@@ -186,6 +204,7 @@ async function editNoteFromJsonAttempt(
   vaultDir: string,
   filePath: string,
   patchData: Record<string, unknown>,
+  bodyInput: string | Record<string, unknown> | undefined,
   jsonMode: boolean,
   attempt: number,
   expectedRevision: string | undefined,
@@ -224,6 +243,12 @@ async function editNoteFromJsonAttempt(
     throw new Error(error);
   }
 
+  const resolvedBody = typeof bodyInput === 'string'
+    ? bodyInput
+    : bodyInput
+      ? generateBodyWithContent(typeDef.bodySections ?? [], parseBodyInput(bodyInput, typeDef.bodySections ?? []))
+      : body;
+
   const patchValidation = validateFrontmatter(schema, typePath, patchData, { strictFields: true });
   const unknownPatchErrors = patchValidation.errors.filter(error => error.type === 'unknown_field');
   if (unknownPatchErrors.length > 0) {
@@ -245,7 +270,10 @@ async function editNoteFromJsonAttempt(
 
   // Merge patch data into existing frontmatter
   const mergedFrontmatter = mergeFrontmatter(frontmatter, patchData);
-  const updatedFields = Object.keys(patchData).filter(k => patchData[k] !== undefined);
+  const updatedFields = [
+    ...Object.keys(patchData).filter(k => patchData[k] !== undefined),
+    ...(bodyInput !== undefined ? ['_body'] : []),
+  ];
 
   // Materialize defaults BEFORE validating/writing — but ONLY for the parity
   // case, SURGICALLY scoped to the keys the user blanked in THIS patch.
@@ -392,7 +420,7 @@ async function editNoteFromJsonAttempt(
   // style and frontmatter key order. Keep the normal guarded-read semantics:
   // wait at the commit barrier, acquire the source lock, and confirm that the
   // exact bytes we observed are still current before returning their revision.
-  if (isDeepStrictEqual(resolvedFrontmatter, frontmatter)) {
+  if (isDeepStrictEqual(resolvedFrontmatter, frontmatter) && resolvedBody === body) {
     await waitForEditCommitBarrier(attempt, filePath);
     await injectMutationFault(mutationFaultInjector, 'before', 'lock-acquisition');
     const revision = await withLineageMutationLocks(vaultDir, [filePath], async () => {
@@ -452,14 +480,14 @@ async function editNoteFromJsonAttempt(
       filePath,
       frontmatter,
       resolvedFrontmatter,
-      body
+      resolvedBody
     );
     await injectMutationFault(mutationFaultInjector, 'after', 'recurrence');
     let writtenSource = '';
     let committedEffects;
     try {
       await injectMutationFault(mutationFaultInjector, 'before', 'source-write');
-      await writeNote(filePath, resolvedFrontmatter, body, orderedFields);
+      await writeNote(filePath, resolvedFrontmatter, resolvedBody, orderedFields);
       writtenSource = await readFile(filePath, 'utf-8');
       await injectMutationFault(mutationFaultInjector, 'after', 'source-write');
       await injectMutationFault(mutationFaultInjector, 'before', 'related-effects');

--- a/tests/ts/commands/edit.test.ts
+++ b/tests/ts/commands/edit.test.ts
@@ -694,6 +694,38 @@ console.log("code block");
       expect(updatedContent).toContain('deadline: 2025-01-01');
     });
 
+    it('should replace the body from a raw string _body JSON patch', async () => {
+      const path = join(vaultDir, 'Ideas/Sample Idea.md');
+      const revision = noteRevision(await readFile(path, 'utf-8'));
+      const result = await runCLI(
+        ['edit', 'Ideas/Sample Idea.md', '--expected-revision', revision, '--json', JSON.stringify({ status: 'backlog', _body: 'A cleaned reading surface.\n\n- Speaker A: Hello.' })],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.updated).toContain('_body');
+      const content = await readFile(path, 'utf-8');
+      expect(content).toContain('status: backlog');
+      expect(content).toContain('A cleaned reading surface.');
+      expect(content).toContain('- Speaker A: Hello.');
+    });
+
+    it('should replace the body from schema section _body JSON input', async () => {
+      const result = await runCLI(
+        ['edit', 'Objectives/Tasks/Sample Task.md', '--json', JSON.stringify({ _body: { Steps: ['One', 'Two'], Notes: 'Cleaned notes' } })],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const content = await readFile(join(vaultDir, 'Objectives/Tasks/Sample Task.md'), 'utf-8');
+      expect(content).toContain('## Steps');
+      expect(content).toContain('One');
+      expect(content).toContain('Two');
+      expect(content).toContain('## Notes');
+      expect(content).toContain('Cleaned notes');
+    });
+
     it('should preserve empty body', async () => {
       // Create file with minimal body
       const testFilePath = join(vaultDir, 'Ideas/Minimal Body.md');

--- a/tests/ts/commands/edit.test.ts
+++ b/tests/ts/commands/edit.test.ts
@@ -711,6 +711,24 @@ console.log("code block");
       expect(content).toContain('- Speaker A: Hello.');
     });
 
+    it('should replace the body from a file-backed patch too large for a command-line argument', async () => {
+      const path = join(vaultDir, 'Ideas/Sample Idea.md');
+      const revision = noteRevision(await readFile(path, 'utf-8'));
+      const payloadPath = join(vaultDir, '.bwrb', 'large-edit.json');
+      const body = 'large-edit-marker\n'.repeat(20_000);
+      await writeFile(payloadPath, JSON.stringify({ _body: body }), 'utf-8');
+
+      const result = await runCLI(
+        ['edit', 'Ideas/Sample Idea.md', '--expected-revision', revision, '--json-file', payloadPath],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      const content = await readFile(path, 'utf-8');
+      expect(content).toContain('large-edit-marker');
+      expect(content.length).toBeGreaterThan(300_000);
+    });
+
     it('should replace the body from schema section _body JSON input', async () => {
       const result = await runCLI(
         ['edit', 'Objectives/Tasks/Sample Task.md', '--json', JSON.stringify({ _body: { Steps: ['One', 'Two'], Notes: 'Cleaned notes' } })],

--- a/tests/ts/commands/new.test.ts
+++ b/tests/ts/commands/new.test.ts
@@ -104,6 +104,36 @@ describe('new command', () => {
     });
   });
 
+  describe('file-backed JSON input', () => {
+    it('creates a note from a payload too large for a command-line argument', async () => {
+      const payloadPath = join(vaultDir, '.bwrb', 'large-create.json');
+      const body = 'large-payload-marker\n'.repeat(20_000);
+      await writeFile(payloadPath, JSON.stringify({ name: 'Large File Input', _body: body }), 'utf-8');
+
+      const result = await runCLI(
+        ['new', 'idea', '--json-file', payloadPath, '--no-template'],
+        vaultDir
+      );
+
+      expect(result.exitCode).toBe(ExitCodes.SUCCESS);
+      const output = JSON.parse(result.stdout);
+      const content = await readFile(join(vaultDir, output.path), 'utf-8');
+      expect(content).toContain('large-payload-marker');
+      expect(content.length).toBeGreaterThan(300_000);
+    });
+
+    it('rejects ambiguous direct and file-backed JSON input', async () => {
+      const payloadPath = join(vaultDir, '.bwrb', 'create.json');
+      await writeFile(payloadPath, '{"name":"From file"}', 'utf-8');
+      const result = await runCLI(
+        ['new', 'idea', '--json', '{"name":"Direct"}', '--json-file', payloadPath],
+        vaultDir
+      );
+      expect(result.exitCode).toBe(ExitCodes.VALIDATION_ERROR);
+      expect(result.stdout).toContain('mutually exclusive');
+    });
+  });
+
   describe('output directory resolution', () => {
     it('creates pooled notes in the computed hierarchy when output_dir is omitted', async () => {
       const schemaPath = join(vaultDir, '.bwrb', 'schema.json');


### PR DESCRIPTION
## Summary

- reserve `_body` in `bwrb edit --json` for body replacement
- support raw Markdown and schema-section body input under the existing revision guard
- add `--json-file` to `bwrb new` and `bwrb edit` so large private payloads never hit command-line size limits
- document both contracts and add CLI coverage, including payloads larger than 300 KB

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run tests/ts/commands/new.test.ts tests/ts/commands/edit.test.ts`
- focused file-backed JSON tests: 3/3
- close-the-day integration through the built CLI: create then revision-safe rerun passed

## Context

This unblocks idempotent close-the-day Plaud episode updates: existing transcript notes need their cleaned reading surface updated without bypassing Bowerbird lineage or hand-editing note files. The real 3h42m fixture also exceeds macOS command-line argument limits, so file-backed JSON is required for both creation and reruns.

Do not merge until the dependent close-the-day real-file QA is complete.
