### PR TITLE
Add query receipts and strict typed validation

### DIFF
--- a/docs-site/src/content/docs/automation/json-mode.md
+++ b/docs-site/src/content/docs/automation/json-mode.md
@@ -40,6 +40,7 @@ complete JSON value, but success shapes differ by workflow:
 | Workflow | Success shape |
 | --- | --- |
 | `list [filters] --output json` | Raw array of note objects with `_path`, `_name`, and frontmatter |
+| `list [filters] --receipt --output json` | Query receipt with selectors/settings, counts, `truncated`, and `data` rows |
 | `list --count --output json` | Raw `{ "count": number }` object |
 | `list --name ... --output json` | `{ "success": true, "data": [...] }` |
 | `list --fuzzy ... --output json` | `{ "success": true, "data": [...] }`, including scores and match metadata |
@@ -60,6 +61,10 @@ Normal list output is intentionally a raw array:
 ```bash
 bwrb list task --output json | jq -r '.[] | ._path'
 ```
+
+The opt-in receipt adds query metadata and limit accounting without changing
+the default array contract. It is incompatible with `--count`, `--open`,
+lineage, and name/fuzzy/detailed-match modes.
 
 Name and fuzzy resolution use a success envelope:
 

--- a/docs-site/src/content/docs/reference/commands/dashboard.md
+++ b/docs-site/src/content/docs/reference/commands/dashboard.md
@@ -26,6 +26,7 @@ bwrb dashboard inbox --output json   # Override output format
 | Option | Description |
 |--------|-------------|
 | `--output <format>` | Override output format: `text`, `paths`, `tree`, `link`, `json` |
+| `--receipt` | With JSON output, return dashboard identity, its saved definition, the applied query, counts, truncation, and data rows |
 
 ## Subcommands
 
@@ -82,6 +83,13 @@ bwrb dashboard edit my-tasks
 bwrb dashboard delete my-tasks --force
 bwrb dashboard delete my-tasks -o json --force
 ```
+
+## Query Receipts
+
+With `--receipt` and effective JSON output, dashboard output identifies the dashboard name
+and saved definition alongside the applied query, then reports matched and returned counts,
+`truncated`, and rows under `data`. It is JSON-only, incompatible with
+`--count`, and receipt metadata is not persisted when saving a dashboard.
 
 ## See Also
 

--- a/docs-site/src/content/docs/reference/commands/list.md
+++ b/docs-site/src/content/docs/reference/commands/list.md
@@ -55,6 +55,7 @@ rejected.
 | `--desc` | Sort descending (requires `--sort`) |
 | `--limit <n>` | Limit displayed results; never narrows name-mode selection |
 | `--count` | Print only the number of matching notes |
+| `--receipt` | With `--output json`, return query metadata, counts, truncation, and data rows |
 | `-L, --depth <n>` | Limit tree depth |
 
 ### Actions
@@ -80,6 +81,12 @@ rejected.
 | `json` | Full JSON data |
 
 Name, fuzzy, and detailed-match modes use the established search JSON shapes.
+
+Use `--receipt --output json` for applied selectors/settings, pre-limit matched
+count, returned count, `truncated`, and rows under `data`. Without `--receipt`,
+normal filtered-list JSON remains the raw array. Receipt mode is JSON-only and
+incompatible with `--count`, `--open`, lineage, and name/fuzzy/detailed-match
+modes; it reports one execution's target set, not an atomic vault snapshot.
 Fuzzy JSON includes similarity scores and the field that matched; detailed body
 JSON includes line matches and context. Normal filtered-list JSON remains the
 array of note frontmatter objects used by existing scripts. Each row also has a

--- a/docs-site/src/content/docs/reference/targeting.md
+++ b/docs-site/src/content/docs/reference/targeting.md
@@ -65,7 +65,7 @@ bwrb audit --where "isEmpty(tags)"
 - System fields are always available: `name` (falls back to filename) and `id`.
 
 **Type-checking behavior:**
-- With `--type`: strict validation (error on unknown fields and invalid select values)
+- With `--type`: every field reference is validated against the type's schema, including function arguments such as the relation field passed to `under()`; unknown fields and invalid select values are errors
 - Without `--type`: unknown fields are permissive (no unknown-field validation)
 - In all modes: invalid expression syntax and runtime expression errors are hard errors
 

--- a/docs/product/cli-output-contract.md
+++ b/docs/product/cli-output-contract.md
@@ -28,6 +28,7 @@ are part of the compatibility contract:
 | Workflow | Success JSON |
 | --- | --- |
 | Normal `list --output json` | Raw array of note objects |
+| `list --receipt --output json` | Receipt with applied selectors/settings, pre-limit matched count, returned count, `truncated`, and `data` rows |
 | `list --count --output json` | Raw `{ count }` object |
 | Canonical name/fuzzy modes | `{ success: true, data: [...] }` |
 | Detailed body matches | `{ success: true, data: [...], totalMatches, truncated }` |
@@ -37,6 +38,12 @@ are part of the compatibility contract:
 
 Do not wrap a legacy raw success shape merely to make the prose look uniform.
 That would be a product/API change, not a documentation correction.
+
+`--receipt` is an explicit JSON-only opt-in for normal filtered-list output. It
+preserves the raw array when omitted and is incompatible with `--count`,
+`--open`, lineage, and name/fuzzy/detailed-match modes. Typed queries validate
+all field references against the selected schema type; queries without
+`--type` remain permissive.
 
 ## Error contract
 

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -278,6 +278,7 @@ bwrb list task --output json
 
 # Filter by frontmatter fields
 bwrb list task --where "status == 'active'" --output json
+bwrb list task --limit 10 --receipt --output json  # selectors, counts, and rows
 bwrb list task --where "priority == 'high' && status != 'done'" --output json
 
 # Include specific fields in output

--- a/plans/query-intent-receipt-research-2026-07-14.md
+++ b/plans/query-intent-receipt-research-2026-07-14.md
@@ -1,0 +1,198 @@
+# Does BWRB already give agents enough information to form safe, bounded queries?
+
+## Answer
+
+**Shaped decision:** BWRB already has the right semantic home for query intent: the vault schema, plus reusable dashboards for curated query mechanics. It does **not** need a second schema-level `query-intent` language now. But the current surface is not yet sufficient for an agent to know that an executed, bounded query returned a faithful slice of a larger match set.
+
+The gap is narrower and more mechanical:
+
+1. finish the typed-query validation contract so every referenced field in a typed `--where` expression is actually validated; and
+2. add an **opt-in query receipt mode** that reports the resolved selectors and result cardinality (`matched`, `returned`, `limited`/`truncated`) while leaving the legacy raw-array JSON output unchanged.
+
+This is not a claim that every query needs ceremony. Ordinary `list --output json` should remain a raw array for compatibility and direct row consumption. But **the raw array is not the best complete design for bounded agent retrieval**: once `--limit` is present, array length alone is ambiguous. The best design is two explicit contracts—raw rows when the caller asks only for rows, and an opt-in receipt when the caller needs to prove scope and completeness. The receipt is a small lantern, not a new moon.
+
+**Priority decision from shaping:** both gaps should be fixed. Incomplete typed-field validation is a correctness defect because invalid queries can look like valid empty results. Missing limited-result cardinality is an agent-safety defect because partial results can look complete.
+
+## Evidence
+
+### 1. The shipped schema can already explain what to query
+
+The schema model supports descriptions at the three semantic levels an agent needs:
+
+- a type description says what the type is for and when to use it;
+- a field description says what the field is for and when to use it; and
+- a select option can be either a legacy bare value or `{ value, description }`, where the description explains what the option means or when to choose it. The object form is explicitly additive so existing schemas remain valid. ([`src/types/schema.ts`](../src/types/schema.ts#L72-L85), [`src/types/schema.ts`](../src/types/schema.ts#L119-L135), [`src/types/schema.ts`](../src/types/schema.ts#L430-L437))
+
+Descriptions survive field inheritance and subtype overrides, so the effective type view can carry inherited meaning rather than forcing an agent to reconstruct it from raw ancestors. ([`tests/ts/lib/schema-descriptions.test.ts`](../tests/ts/lib/schema-descriptions.test.ts#L73-L108))
+
+`schema list type <type> --output json` returns the type description, resolved own/trait/inherited fields, prompt type, allowed options (including option descriptions), relation source, defaults, and other selected field properties. ([`src/commands/schema/helpers/output.ts`](../src/commands/schema/helpers/output.ts#L52-L127), [`src/commands/schema/helpers/output.ts`](../src/commands/schema/helpers/output.ts#L161-L196)) The verbose all-type JSON view uses the same field formatter. ([`src/commands/schema/helpers/output.ts`](../src/commands/schema/helpers/output.ts#L750-L851)) Canonical docs explicitly present this as the self-documenting agent discovery path. ([`docs-site/src/content/docs/reference/commands/schema.md`](../docs-site/src/content/docs/reference/commands/schema.md#L58-L67))
+
+Documentation coverage is enforceable, but opt-in: `audit --check-schema-docs` reports types and own fields that lack descriptions and deliberately skips inherited duplicates and static identity fields. ([`src/lib/audit/schema-docs.ts`](../src/lib/audit/schema-docs.ts#L1-L53), [`src/commands/audit.ts`](../src/commands/audit.ts#L214-L221))
+
+**Limit of this evidence:** descriptions are optional. The coverage audit does not require descriptions on individual select options. Also, the type-detail/verbose JSON formatter omits some raw field properties that can matter to query construction, including `multiple` and `filter`; `schema list fields --output json` does expose the full raw `definition` with origin, but an agent must know to use that second surface. ([`src/commands/schema/helpers/output.ts`](../src/commands/schema/helpers/output.ts#L161-L196), [`src/commands/schema/list.ts`](../src/commands/schema/list.ts#L240-L275)) The self-documenting surface is therefore capable, but not uniformly complete from one recommended call.
+
+### 2. The query language and type boundary already prevent several unsafe mistakes
+
+The canonical targeting model says selectors compose by intersection and recommends `--type` as the boundary that enables strict `--where` validation. It documents comparison, boolean, hierarchy, and relation-dereferencing semantics, including the important difference between `isDescendantOf(...)` and `under(field, ...)`. ([`docs-site/src/content/docs/reference/targeting.md`](../docs-site/src/content/docs/reference/targeting.md#L6-L25), [`docs-site/src/content/docs/reference/targeting.md`](../docs-site/src/content/docs/reference/targeting.md#L48-L91))
+
+At runtime, typed equality/inequality and `contains(...)` comparisons reject unknown fields and invalid select values with allowed values and spelling suggestions. `under(...)` separately verifies that its first argument exists and is relation-typed. ([`src/lib/expression-validation.ts`](../src/lib/expression-validation.ts#L66-L166), [`src/lib/expression-validation.ts`](../src/lib/expression-validation.ts#L274-L356), [`tests/ts/lib/expression-validation.test.ts`](../tests/ts/lib/expression-validation.test.ts#L295-L364)) The 0.3.0 fixture build directly rejected both `status == 'settledd'` (suggesting `settled`) and `statsu == 'raw'` (suggesting `status`).
+
+`under()` is not merely documented aspiration: its relation-field validation was a tracked follow-up to the original operator, and alias-related silent omissions were treated as a correctness bug rather than acceptable best effort. ([issue #602](https://github.com/3mdistal/bwrb/issues/602), [issue #634](https://github.com/3mdistal/bwrb/issues/634), [issue #636](https://github.com/3mdistal/bwrb/issues/636))
+
+**Limit of this evidence:** the shipped validator does not actually validate every field reference, despite the broad “strict validation” language in the canonical targeting docs. Its comparison extractor covers only `==`, `!=`, `contains`, `hasTag`, and the special `under` path. ([`src/lib/expression-validation.ts`](../src/lib/expression-validation.ts#L66-L117), [`src/lib/expression-validation.ts`](../src/lib/expression-validation.ts#L168-L225)) Direct 0.3.0 probes showed that both of these typed misspellings exited `0` with `[]`:
+
+```bash
+bwrb list --type idea --where "statsu < 3" --output json
+bwrb list --type idea --where "startsWith(statsu, 'r')" --output json
+```
+
+That is a real correctness/ergonomics defect, not a reason to invent query intent metadata. An agent can currently mistake “invalid field reference” for “valid query, no matches.”
+
+### 3. The observed limited JSON is intentional behavior, not a regression
+
+Normal filtered `list --output json` is explicitly a legacy raw array. `list --count --output json` is a separate raw `{ "count": number }` shape. Existing shapes are a compatibility contract and must not be wrapped merely for uniformity. ([`docs/product/cli-output-contract.md`](../docs/product/cli-output-contract.md#L22-L39), [`docs-site/src/content/docs/automation/json-mode.md`](../docs-site/src/content/docs/automation/json-mode.md#L35-L75))
+
+Implementation calculates the full `matchCount`, returns it only when `--count` is selected, then applies `--limit` before serializing rows. The normal JSON branch emits only the row array; each row always carries `_path`, `_name`, and a revision of the exact bytes observed, even when `--fields` projects the frontmatter. ([`src/commands/list.ts`](../src/commands/list.ts#L875-L895), [`src/commands/list.ts`](../src/commands/list.ts#L942-L998)) Tests pin all three behaviors: raw array, limited array length, and count-before-limit. ([`tests/ts/commands/list.test.ts`](../tests/ts/commands/list.test.ts#L151-L166), [`tests/ts/commands/list.test.ts`](../tests/ts/commands/list.test.ts#L396-L443))
+
+The feature's originating issue asked for `--limit` to restrict output and `--count` to provide the count as a distinct operation; it did not specify combined row-plus-cardinality metadata. ([issue #520](https://github.com/3mdistal/bwrb/issues/520))
+
+Therefore Alice's observed “one projected record with a revision, while a separate count says 27” is:
+
+- **not a bug** relative to the documented and tested 0.3.0 contract;
+- **intentional compatibility behavior** at the output-shape level; and
+- **an agent-ergonomics gap** because the limited response alone cannot distinguish “exactly one match” from “the first of 27 matches.”
+
+The row revision solves a different problem: it proves which bytes were read for a later guarded edit. It says nothing about query completeness. ([`docs-site/src/content/docs/reference/commands/list.md`](../docs-site/src/content/docs/reference/commands/list.md#L82-L89))
+
+#### Is the intentional raw-array behavior the best design?
+
+Not by itself. It was a reasonable design for the original compatibility goal: a homogeneous array is easy to pipe through `jq`, existing consumers already parse it, and an unbounded array is self-counting. The design becomes insufficient when the command itself applies a bound, because `length == 1` cannot distinguish one total match from one returned row out of 27.
+
+The obvious alternatives are worse than an opt-in receipt:
+
+- **Always wrap the array:** complete, but breaks the established machine contract.
+- **Wrap only when `--limit` is present:** makes the top-level JSON shape depend on an otherwise orthogonal modifier and breaks limited-query consumers.
+- **Repeat count metadata on every row:** wasteful, semantically awkward, and cannot describe an empty result.
+- **Put metadata on stderr:** separates rows from metadata, but produces a fragile two-channel machine contract.
+- **Require a separate `--count` call:** compatible, but introduces an extra round trip and the count and fetch may observe different vault states.
+
+An explicitly requested receipt is therefore the best current design direction: it makes the richer contract deliberate while preserving the raw-array contract exactly for existing callers.
+
+### 4. Dashboards help with reusable mechanics, but they do not document intent or execution completeness
+
+Dashboards are stored, validated saved `list` queries. They preserve type, path, where clauses, body search, output, projection, limit, count, and sort. ([`src/types/schema.ts`](../src/types/schema.ts#L981-L1020), [`src/commands/list.ts`](../src/commands/list.ts#L741-L755)) Running one resolves targets through the same targeting module and delegates to the same `listObjects` output path, so a limited JSON dashboard has the same missing cardinality signal. ([`src/commands/dashboard.ts`](../src/commands/dashboard.ts#L128-L166))
+
+`dashboard list --output json` does make the complete saved definitions inspectable. ([`src/commands/dashboard.ts`](../src/commands/dashboard.ts#L287-L311)) But a dashboard has no description, rationale, expected cardinality, or “safe for” field. ([`src/types/schema.ts`](../src/types/schema.ts#L985-L1010)) It is useful as a curated query example and stable alias, not yet a query-intent contract or an execution receipt.
+
+### 5. Agent guidance encourages bounded retrieval, but it currently requires two calls to prove completeness
+
+The maintained agent skill tells agents to inspect the schema first, use `--where` rather than fetch everything, project fields, and use `--limit` or `--count`. ([`docs/skill/SKILL.md`](../docs/skill/SKILL.md#L83-L104), [`docs/skill/SKILL.md`](../docs/skill/SKILL.md#L270-L315), [`docs/skill/SKILL.md`](../docs/skill/SKILL.md#L631-L639)) That is sound discipline. It does not say that a limited raw array carries no total count or prescribe a count-then-fetch protocol when completeness matters.
+
+The docs already use a richer receipt-like JSON contract where the workflow demands it: detailed body-match mode reports `totalMatches` and `truncated`. ([`docs-site/src/content/docs/automation/json-mode.md`](../docs-site/src/content/docs/automation/json-mode.md#L35-L47)) This is precedent for an opt-in query receipt, not precedent for changing ordinary list JSON.
+
+## Inferences
+
+1. **Query formation and query verification are separate contracts.** Schema metadata answers “which type, field, and value represent this intent?” A receipt answers “what selectors did BWRB apply, how many records matched, and is this response complete?” Adding more prose to the schema cannot answer the second question.
+
+2. **A new query-intent DSL would duplicate the agent's job.** The product boundary says BWRB remains the deterministic layer beneath an AI agent, while `list` remains the canonical read surface. ([`docs/product/roadmap.md`](../docs/product/roadmap.md#L29-L45)) Natural-language interpretation belongs above BWRB; deterministic validation and reporting belong inside it.
+
+3. **Saved dashboards are the right place for curated query examples, but only after their semantics are made inspectable enough.** A dashboard can keep a known-good filter stable. A future description could say what it is for, but it still would not prove the completeness of a particular run.
+
+4. **The highest-risk current failure is false emptiness, not ambiguous intent.** A typo in an unvalidated expression shape can produce `[]` with success, and a limited result can look complete. Both mislead the agent about data coverage after intent has already been chosen.
+
+## Uncertainties
+
+1. There is no primary-repo evidence yet about how often real agents misconstruct a query after reading a well-described schema versus how often they merely misread a limited result. The recent behavior establishes one concrete receipt gap, not its frequency across workloads.
+
+2. The best public name and exact output shape for a receipt remain product choices. `--explain`, `--receipt`, and an explicit receipt-oriented JSON output mode imply different expectations. This research settles the capability boundary, not the final flag spelling.
+
+3. It is unresolved whether dashboard descriptions are valuable enough to add now. They would improve discovery among multiple saved queries, but they should not be bundled as a prerequisite for execution receipts.
+
+4. A complete field-reference validator must define how to treat dynamic or nested access without breaking the documented permissive no-`--type` mode. The recommendation is strict only when a type is present, matching the existing public contract.
+
+## Recommendation
+
+### Decision: strengthen the existing layers; do not add a new query-intent layer
+
+Park two near-term work packets, in this order, while the surrounding product direction continues through shape:
+
+#### Work item A — Make typed query validation honest and complete
+
+- With `--type`, walk the complete expression AST and reject every unknown frontmatter field reference, including relational/numeric comparisons and function arguments such as `startsWith(statsu, ...)`.
+- Preserve permissive cross-type behavior when `--type` is absent.
+- Keep the existing select-option and `under()` checks.
+- Add regression tests for misspelled fields under every supported operator/function family.
+- Reconcile the canonical “strict validation” docs with the shipped behavior.
+
+This is the first fix: it closes a correctness gap before adding a nicer report about it.
+
+#### Work item B — Add an explicit, compatibility-safe query receipt
+
+Add an opt-in mode for normal `list` and saved-dashboard execution. It should leave existing raw-array and `{ count }` outputs byte-shape compatible when the flag is absent. The receipt contract should include, at minimum:
+
+```json
+{
+  "query": {
+    "type": "task",
+    "path": null,
+    "where": ["status == 'in-progress'"],
+    "body": null,
+    "sort": "deadline",
+    "desc": false,
+    "limit": 1,
+    "fields": ["status", "deadline"]
+  },
+  "matched": 27,
+  "returned": 1,
+  "truncated": true,
+  "data": ["...ordinary projected rows..."]
+}
+```
+
+Contract requirements:
+
+- `matched` is computed before limit; `returned` is the emitted row count.
+- `truncated` is equivalent to `returned < matched` for ordinary bounded list results.
+- The receipt echoes normalized/applied selectors, not the agent's natural-language rationale.
+- Dashboard runs identify the dashboard name and saved definition alongside the applied query.
+- Empty results distinguish a valid zero-match query from validation failure via exit status and the receipt.
+- The existing revision remains per row and retains its current meaning.
+- Ordinary `list --output json`, `list --count --output json`, and dashboard JSON remain unchanged unless the receipt is explicitly requested.
+
+The final CLI spelling should be chosen during `/work` from two compatibility-safe forms:
+
+1. **Preferred:** an explicit receipt flag valid only with JSON (for example, `--receipt`), returning the receipt plus `data` in one execution.
+2. **Fallback:** a separate explain/receipt-only mode that returns the applied query and match count without rows. This is simpler but preserves the current two-call cost and cannot prove that a later row fetch saw the same vault state.
+
+Do not put receipt metadata on stderr and do not silently wrap the default array. Both would make a clean machine contract murkier.
+
+### Compatibility fallback for older BWRB versions
+
+Update the agent skill to prescribe:
+
+1. inspect the effective type schema;
+2. include `--type` for strict validation;
+3. run the exact query with `--count --output json` when coverage matters;
+4. then run the same query with explicit `--fields`, `--sort`, and `--limit`;
+5. never infer completeness from raw array length when `--limit` is present.
+
+This is coherent and compatible for versions without receipts, but it cannot guarantee that the count and fetch observed the same vault state.
+
+## Sources
+
+- [`src/types/schema.ts`](../src/types/schema.ts) — schema descriptions, select-option metadata, dashboard definition
+- [`src/commands/schema/list.ts`](../src/commands/schema/list.ts) and [`src/commands/schema/helpers/output.ts`](../src/commands/schema/helpers/output.ts) — shipped schema introspection shapes
+- [`src/lib/expression-validation.ts`](../src/lib/expression-validation.ts), [`src/lib/where-targeting.ts`](../src/lib/where-targeting.ts), and [`src/lib/query.ts`](../src/lib/query.ts) — typed validation and query evaluation
+- [`src/commands/list.ts`](../src/commands/list.ts) — list projection, count, limit, revision, and JSON behavior
+- [`src/commands/dashboard.ts`](../src/commands/dashboard.ts) and [`src/lib/dashboard.ts`](../src/lib/dashboard.ts) — saved-query execution and persistence
+- [`docs-site/src/content/docs/reference/targeting.md`](../docs-site/src/content/docs/reference/targeting.md), [`docs-site/src/content/docs/reference/commands/list.md`](../docs-site/src/content/docs/reference/commands/list.md), and [`docs-site/src/content/docs/automation/json-mode.md`](../docs-site/src/content/docs/automation/json-mode.md) — canonical user-facing query and JSON contracts
+- [`docs/skill/SKILL.md`](../docs/skill/SKILL.md) — maintained agent usage guidance
+- [`docs/product/cli-output-contract.md`](../docs/product/cli-output-contract.md) and [`docs/product/roadmap.md`](../docs/product/roadmap.md) — compatibility and product-boundary constraints
+- [`tests/ts/commands/list.test.ts`](../tests/ts/commands/list.test.ts), [`tests/ts/lib/expression-validation.test.ts`](../tests/ts/lib/expression-validation.test.ts), and [`tests/ts/lib/schema-descriptions.test.ts`](../tests/ts/lib/schema-descriptions.test.ts) — pinned behavior
+- [issue #520](https://github.com/3mdistal/bwrb/issues/520), [issue #602](https://github.com/3mdistal/bwrb/issues/602), [issue #634](https://github.com/3mdistal/bwrb/issues/634), and [issue #636](https://github.com/3mdistal/bwrb/issues/636) — primary issue history
+
+## Handoff
+
+**Output:** the decision is implemented on `codex/query-receipts-strict-validation`: typed queries validate all referenced fields, while `list` and named dashboards offer an explicit JSON-only `--receipt` without changing legacy output shapes.
+
+**Next:** verify and land the implementation. The two-call protocol remains a compatibility fallback for older versions, not the destination.

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -53,6 +53,7 @@ function resolveOutputFormat(format?: string): ListOutputFormat {
 
 interface DashboardRunOptions {
   output?: string;
+  receipt?: boolean;
 }
 
 interface DashboardListOptions {
@@ -63,6 +64,7 @@ export const dashboardCommand = new Command('dashboard')
   .description('Run or manage saved dashboard queries')
   .argument('[name]', 'Dashboard name to run')
   .option('--output <format>', 'Output format: text (default), paths, tree, link, json')
+  .option('--receipt', 'Return a JSON receipt with the dashboard definition and result cardinality')
   .enablePositionalOptions()
   .addHelpText('after', `
 A dashboard is a saved list query. Running a dashboard executes the saved
@@ -84,6 +86,15 @@ Examples:
   .action(async (name: string | undefined, options: DashboardRunOptions, cmd: Command) => {
     // If no name provided, show picker or run default dashboard
     if (!name) {
+      if (options.receipt) {
+        const error = '--receipt requires a named dashboard.';
+        if (options.output === 'json') {
+          printJson(jsonError(error));
+        } else {
+          printError(error);
+        }
+        process.exit(ExitCodes.VALIDATION_ERROR);
+      }
       await runDashboardPickerOrDefault(options, cmd);
       return;
     }
@@ -131,6 +142,16 @@ async function runDashboard(
       : resolveOutputFormat(dashboard.output);
     jsonMode = effectiveFormat === 'json';
 
+    if (options.receipt && !jsonMode) {
+      printError('--receipt requires JSON output. Use --output json or a dashboard with output: json.');
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+
+    if (options.receipt && dashboard.count) {
+      printJson(jsonError('--receipt cannot be combined with a dashboard configured with count: true.'));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+
     // 3. Load schema
     const schema = await loadSchema(vaultDir);
 
@@ -159,6 +180,25 @@ async function runDashboard(
       fields: dashboard.fields,
       limit: dashboard.limit,
       count: dashboard.count,
+      receipt: options.receipt
+        ? {
+            query: {
+              type: targeting.type ?? null,
+              path: targeting.path ?? null,
+              where: targeting.where ?? [],
+              body: targeting.body ?? null,
+              id: null,
+              sort: dashboard.sort ?? null,
+              desc: dashboard.desc === true,
+              limit: dashboard.limit ?? null,
+              fields: dashboard.fields ?? null,
+            },
+            dashboard: {
+              name,
+              definition: dashboard,
+            },
+          }
+        : undefined,
       sortField: dashboard.sort,
       sortDesc: dashboard.desc,
     };

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -130,6 +130,7 @@ interface ListCommandOptions {
   lineage?: string;
   limit?: string;
   count?: boolean;
+  receipt?: boolean;
   sort?: string;
   desc?: boolean;
   output?: string;
@@ -171,6 +172,7 @@ function validateLineageMode(
   if (options.desc === true) conflicts.push('--desc');
   if (options.limit !== undefined) conflicts.push('--limit');
   if (options.count === true) conflicts.push('--count');
+  if (options.receipt === true) conflicts.push('--receipt');
   if (options.depth !== undefined) conflicts.push('--depth');
   if (options.open === true) conflicts.push('--open');
   if (options.app !== undefined) conflicts.push('--app');
@@ -223,8 +225,8 @@ function validateCanonicalSearchMode(
   if (hasCanonicalSearchMode(options) && (positional !== undefined || mode !== undefined)) {
     return 'Search modes do not accept positional filters or app modes; use targeting flags and --app instead.';
   }
-  if (hasCanonicalSearchMode(options) && (options.fields || options.count || options.sort || options.desc || options.depth || options.saveAs || options.force)) {
-    return '--name, --fuzzy, and --matches cannot be combined with table, hierarchy, sort, count, or dashboard options.';
+  if (hasCanonicalSearchMode(options) && (options.fields || options.count || options.receipt || options.sort || options.desc || options.depth || options.saveAs || options.force)) {
+    return '--name, --fuzzy, and --matches cannot be combined with table, hierarchy, sort, count, receipt, or dashboard options.';
   }
   if (hasCanonicalSearchMode(options) && options.id) {
     return '--id cannot be combined with --name, --fuzzy, or --matches; use --id with normal list targeting.';
@@ -536,6 +538,7 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
   .option('--desc', 'Sort descending (requires --sort)')
   .option('--limit <n>', 'Limit displayed results (never narrows --name selection)')
   .option('--count', 'Print only the number of matching notes')
+  .option('--receipt', 'Return a JSON receipt with applied query settings and result cardinality (requires --output json)')
   .option('--output <format>', 'Output format: text (default), paths, tree, link, content, json')
   // Open options
   .option('-o, --open', 'Open the first result (or pick from results interactively)')
@@ -558,6 +561,26 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
       } else {
         console.error(`error: ${excessError}`);
       }
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+
+    if (options.receipt && options.output !== 'json') {
+      printError('--receipt requires --output json.');
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+
+    if (options.receipt && options.count) {
+      printJson(jsonError('--receipt cannot be combined with --count.'));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+
+    if (options.receipt && options.open) {
+      printJson(jsonError('--receipt cannot be combined with --open.'));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+
+    if (options.receipt && hasCanonicalSearchMode(options)) {
+      printJson(jsonError('--receipt is only available for normal filtered list mode; it cannot be combined with --name, --fuzzy, or --matches.'));
       process.exit(ExitCodes.VALIDATION_ERROR);
     }
 
@@ -733,6 +756,21 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
         preview: options.preview,
         depth,
         count: options.count,
+        receipt: options.receipt
+          ? {
+              query: {
+                type: targeting.type ?? null,
+                path: targeting.path ?? null,
+                where: targeting.where ?? [],
+                body: targeting.body ?? null,
+                id: targeting.id ?? null,
+                sort: options.sort ?? null,
+                desc: options.desc === true,
+                limit: limit ?? null,
+                fields: fields ?? null,
+              },
+            }
+          : undefined,
         sortField: options.sort,
         sortDesc: options.desc,
         ...(limit !== undefined && { limit }),
@@ -804,6 +842,7 @@ export interface ListOptions {
   fields?: string[] | undefined;
   limit?: number | undefined;
   count?: boolean | undefined;
+  receipt?: QueryReceiptContext | undefined;
   sortField?: string | undefined;
   sortDesc?: boolean | undefined;
   // Open options
@@ -812,6 +851,24 @@ export interface ListOptions {
   pickerMode?: string | undefined;
   preview?: boolean | undefined;
   depth?: number | undefined;
+}
+
+export interface QueryReceiptContext {
+  query: {
+    type: string | null;
+    path: string | null;
+    where: string[];
+    body: string | null;
+    id: string | null;
+    sort: string | null;
+    desc: boolean;
+    limit: number | null;
+    fields: string[] | null;
+  };
+  dashboard?: {
+    name: string;
+    definition: DashboardDefinition;
+  };
 }
 
 /**
@@ -887,8 +944,8 @@ export async function listObjects(
     filteredFiles = filteredFiles.slice(0, options.limit);
   }
 
-  // Handle no results
-  if (filteredFiles.length === 0) {
+  // Preserve legacy empty JSON arrays unless an explicit receipt was requested.
+  if (filteredFiles.length === 0 && !options.receipt) {
     if (jsonMode) {
       console.log(JSON.stringify([], null, 2));
     }
@@ -994,7 +1051,17 @@ export async function listObjects(
 
         return selected;
       }));
-      console.log(JSON.stringify(jsonOutput, null, 2));
+      const output = options.receipt
+        ? {
+            ...(options.receipt.dashboard ? { dashboard: options.receipt.dashboard } : {}),
+            query: options.receipt.query,
+            matched: matchCount,
+            returned: jsonOutput.length,
+            truncated: jsonOutput.length < matchCount,
+            data: jsonOutput,
+          }
+        : jsonOutput;
+      console.log(JSON.stringify(output, null, 2));
       return;
     }
 

--- a/src/lib/expression-validation.ts
+++ b/src/lib/expression-validation.ts
@@ -131,10 +131,8 @@ function extractUnderFieldRefs(expr: Expression): string[] {
     switch (node.type) {
       case 'BinaryExpression': {
         const binary = node as BinaryExpression;
-        if (binary.operator === '&&' || binary.operator === '||') {
-          walk(binary.left);
-          walk(binary.right);
-        }
+        walk(binary.left);
+        walk(binary.right);
         break;
       }
       case 'UnaryExpression': {
@@ -150,10 +148,93 @@ function extractUnderFieldRefs(expr: Expression): string[] {
           const fieldName = arg1 ? getFieldName(arg1) : null;
           if (fieldName) fields.push(fieldName);
         }
-        // `under` is never nested inside another call's args in practice, but
-        // walk any call arguments that are themselves logical/call expressions
-        // so a future `... && under(...)` inside a call still gets validated.
+        // Walk all arguments so nested `under()` calls remain visible.
         for (const arg of call.arguments) {
+          walk(arg);
+        }
+        break;
+      }
+      case 'MemberExpression': {
+        const member = node as MemberExpression;
+        walk(member.object);
+        if (member.computed) walk(member.property);
+        break;
+      }
+    }
+  }
+
+  walk(expr);
+  return fields;
+}
+
+/**
+ * Extract every frontmatter field reference from an expression AST.
+ *
+ * Bare identifiers resolve against frontmatter at evaluation time, except for
+ * the evaluator's special identifiers (`file`, `__frontmatter`, and boolean/
+ * null literals). `file.*` is metadata rather than frontmatter and must remain
+ * valid for every type. Function names are callees, not field references.
+ *
+ * `under`'s first argument is intentionally omitted here: it has a more
+ * specific validation path below which also confirms that the field is a
+ * relation. Its remaining arguments are still walked normally.
+ */
+function extractFrontmatterFieldRefs(expr: Expression): string[] {
+  const fields: string[] = [];
+
+  function walk(node: Expression): void {
+    switch (node.type) {
+      case 'Identifier': {
+        const name = (node as Identifier).name;
+        if (!isSpecialIdentifier(name)) {
+          fields.push(name);
+        }
+        break;
+      }
+
+      case 'MemberExpression': {
+        const member = node as MemberExpression;
+        const fieldName = getFieldName(member);
+        if (fieldName) {
+          fields.push(fieldName);
+          break;
+        }
+
+        // `file.*` is a documented metadata namespace, not a frontmatter
+        // field reference. Do not treat either `file` or its property as one.
+        if (member.object.type === 'Identifier' &&
+            (member.object as Identifier).name === 'file') {
+          break;
+        }
+
+        walk(member.object);
+        if (member.computed) walk(member.property);
+        break;
+      }
+
+      case 'BinaryExpression': {
+        const binary = node as BinaryExpression;
+        walk(binary.left);
+        walk(binary.right);
+        break;
+      }
+
+      case 'UnaryExpression':
+        walk((node as UnaryExpression).argument);
+        break;
+
+      case 'CallExpression': {
+        const call = node as CallExpression;
+        const callee = call.callee as Identifier;
+        const isUnder = callee?.type === 'Identifier' && callee.name === 'under';
+        for (const [index, arg] of call.arguments.entries()) {
+          // `under` validates its direct first field argument separately so it
+          // can enforce the relation-field contract without duplicate errors.
+          // Non-direct expressions still need a full walk for any fields they
+          // dereference (e.g. under(lower(statsu), ...)).
+          if (isUnder && index === 0 && getFieldName(arg) !== null) {
+            continue;
+          }
           walk(arg);
         }
         break;
@@ -163,6 +244,14 @@ function extractUnderFieldRefs(expr: Expression): string[] {
 
   walk(expr);
   return fields;
+}
+
+function isSpecialIdentifier(name: string): boolean {
+  return name === 'true' ||
+    name === 'false' ||
+    name === 'null' ||
+    name === 'file' ||
+    name === FRONTMATTER_IDENTIFIER;
 }
 
 /**
@@ -353,6 +442,34 @@ export function validateWhereExpressions(
         if (error) {
           errors.push(error);
         }
+      }
+
+      // Comparisons above retain their existing select-option behavior. This
+      // complete AST pass closes the gap for every other expression shape:
+      // relational/numeric operators, standalone truthiness checks, nested
+      // calls, and function arguments all dereference frontmatter too.
+      for (const fieldName of extractFrontmatterFieldRefs(expr)) {
+        if (allowedFields.has(fieldName)) continue;
+
+        // A comparison or `under()` reference may already have emitted the
+        // more specific historical error. Avoid turning one typo into two.
+        const alreadyReported = errors.some(error =>
+          error.expression === exprString &&
+          error.field === fieldName &&
+          error.message.startsWith('Unknown field')
+        );
+        if (alreadyReported) continue;
+
+        const fieldList = Array.from(allowedFields);
+        const suggestion = suggestFieldName(fieldName, fieldList);
+        errors.push({
+          expression: exprString,
+          field: fieldName,
+          value: '',
+          message: `Unknown field '${fieldName}' for type '${typeName}'`,
+          validOptions: fieldList,
+          ...(suggestion && { suggestion }),
+        });
       }
     } catch {
       // Parse errors are handled separately by the expression evaluator

--- a/tests/ts/commands/dashboard.test.ts
+++ b/tests/ts/commands/dashboard.test.ts
@@ -127,6 +127,91 @@ describe('dashboard command', () => {
       expect(result.stdout).toContain('Sample Idea');
       expect(result.stdout).toContain('Sample Task');
     });
+
+    it('returns a receipt with the saved dashboard definition and applied query', async () => {
+      await createDashboards({
+        dashboards: {
+          'limited-raw-ideas': {
+            type: 'idea',
+            where: ["status == 'raw'"],
+            fields: ['status'],
+            limit: 1,
+            output: 'json',
+          },
+        },
+      });
+
+      const result = await runCLI(['dashboard', 'limited-raw-ideas', '--receipt'], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const receipt = JSON.parse(result.stdout);
+      expect(receipt).toMatchObject({
+        dashboard: {
+          name: 'limited-raw-ideas',
+          definition: {
+            type: 'idea',
+            where: ["status == 'raw'"],
+            fields: ['status'],
+            limit: 1,
+            output: 'json',
+          },
+        },
+        query: {
+          type: 'idea',
+          where: ["status == 'raw'"],
+          fields: ['status'],
+          limit: 1,
+        },
+        matched: 1,
+        returned: 1,
+        truncated: false,
+      });
+      expect(receipt.data[0]).toMatchObject({ _name: 'Sample Idea', status: 'raw' });
+    });
+
+    it('rejects receipt for a dashboard whose effective output is not JSON', async () => {
+      const result = await runCLI(['dashboard', 'all-ideas', '--receipt'], vaultDir);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('--receipt requires JSON output');
+    });
+
+    it('returns a JSON error when receipt has no dashboard name', async () => {
+      const result = await runCLI(['dashboard', '--output', 'json', '--receipt'], vaultDir);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        success: false,
+        error: '--receipt requires a named dashboard.',
+      });
+      expect(result.stderr).toBe('');
+    });
+
+    it('allows an explicit JSON override for a receipt', async () => {
+      const result = await runCLI([
+        'dashboard', 'all-ideas', '--output', 'json', '--receipt',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const receipt = JSON.parse(result.stdout);
+      expect(receipt.dashboard.name).toBe('all-ideas');
+      expect(receipt.matched).toBe(2);
+      expect(receipt.returned).toBe(2);
+      expect(receipt.truncated).toBe(false);
+    });
+
+    it('rejects receipt for a count-only dashboard', async () => {
+      await createDashboards({
+        dashboards: {
+          'counted-ideas': { type: 'idea', count: true, output: 'json' },
+        },
+      });
+
+      const result = await runCLI(['dashboard', 'counted-ideas', '--receipt'], vaultDir);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(JSON.parse(result.stdout).error).toContain('--receipt cannot be combined');
+    });
   });
 
   describe('output format override', () => {

--- a/tests/ts/commands/hierarchical-scope.test.ts
+++ b/tests/ts/commands/hierarchical-scope.test.ts
@@ -215,14 +215,17 @@ describe('#554 hierarchical scope — contexts as notes + under()', () => {
     expect(derivable.stdout).toContain('Legacy double-entry.md');
 
     // Migration: drop the redundant field (dry-run first, then execute).
+    // Because `scope` is deliberately absent from the current task schema,
+    // target the legacy directory without a type boundary. Typed queries are
+    // strict; untyped migrations remain permissive for exactly this cleanup.
     const dryRun = await runCLI(
-      ['bulk', 'task', '--where', "!isEmpty(scope)", '--delete', 'scope'],
+      ['bulk', '--path', 'Tasks', '--where', "!isEmpty(scope)", '--delete', 'scope'],
       vaultDir
     );
     expect(dryRun.exitCode).toBe(0);
 
     const execute = await runCLI(
-      ['bulk', 'task', '--where', "!isEmpty(scope)", '--delete', 'scope', '--execute'],
+      ['bulk', '--path', 'Tasks', '--where', "!isEmpty(scope)", '--delete', 'scope', '--execute'],
       vaultDir
     );
     expect(execute.exitCode).toBe(0);
@@ -230,9 +233,10 @@ describe('#554 hierarchical scope — contexts as notes + under()', () => {
     // After migration: `scope` is gone, but the note is STILL reachable from
     // its domain via the context tree. Zero information lost.
     const afterScope = await runCLI(
-      ['list', 'task', '--where', "!isEmpty(scope)", '--output', 'paths'],
+      ['list', '--path', 'Tasks', '--where', "!isEmpty(scope)", '--output', 'paths'],
       vaultDir
     );
+    expect(afterScope.exitCode).toBe(0);
     expect(afterScope.stdout).not.toContain('Legacy double-entry.md');
 
     const afterDomain = await runCLI(

--- a/tests/ts/commands/list.test.ts
+++ b/tests/ts/commands/list.test.ts
@@ -442,6 +442,100 @@ describe('list command', () => {
       expect(result.stdout.trim()).toBe('2');
     });
 
+    it('returns an opt-in JSON receipt from the same filtered result set', async () => {
+      const result = await runCLI([
+        'list', 'idea', '--where', "status == 'raw'", '--fields', 'status',
+        '--sort', '_name', '--limit', '1', '--output', 'json', '--receipt',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const receipt = JSON.parse(result.stdout);
+      expect(receipt).toMatchObject({
+        query: {
+          type: 'idea',
+          path: null,
+          where: ["status == 'raw'"],
+          body: null,
+          id: null,
+          sort: '_name',
+          desc: false,
+          limit: 1,
+          fields: ['status'],
+        },
+        matched: 1,
+        returned: 1,
+        truncated: false,
+      });
+      expect(receipt.data).toHaveLength(1);
+      expect(receipt.data[0]).toMatchObject({ _name: 'Sample Idea', status: 'raw' });
+    });
+
+    it('reports a truncated receipt without changing ordinary limited JSON', async () => {
+      const receiptResult = await runCLI([
+        'list', 'idea', '--limit', '1', '--output', 'json', '--receipt',
+      ], vaultDir);
+
+      expect(receiptResult.exitCode).toBe(0);
+      const receipt = JSON.parse(receiptResult.stdout);
+      expect(receipt.matched).toBe(2);
+      expect(receipt.returned).toBe(1);
+      expect(receipt.truncated).toBe(true);
+      expect(receipt.data).toHaveLength(1);
+
+      const ordinaryResult = await runCLI(['list', 'idea', '--limit', '1', '--output', 'json'], vaultDir);
+      expect(JSON.parse(ordinaryResult.stdout)).toHaveLength(1);
+    });
+
+    it('reports an unbounded receipt as complete', async () => {
+      const result = await runCLI([
+        'list', 'idea', '--output', 'json', '--receipt',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      const receipt = JSON.parse(result.stdout);
+      expect(receipt.query.limit).toBeNull();
+      expect(receipt.matched).toBe(2);
+      expect(receipt.returned).toBe(2);
+      expect(receipt.truncated).toBe(false);
+      expect(receipt.data).toHaveLength(2);
+    });
+
+    it('returns an object receipt for empty JSON results', async () => {
+      const result = await runCLI([
+        'list', 'idea', '--where', "id == 'does-not-exist'", '--output', 'json', '--receipt',
+      ], vaultDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        matched: 0,
+        returned: 0,
+        truncated: false,
+        data: [],
+      });
+    });
+
+    it('rejects invalid receipt combinations', async () => {
+      const nonJson = await runCLI(['list', 'idea', '--receipt'], vaultDir);
+      expect(nonJson.exitCode).not.toBe(0);
+      expect(nonJson.stderr).toContain('--receipt requires --output json');
+
+      const count = await runCLI(['list', 'idea', '--count', '--output', 'json', '--receipt'], vaultDir);
+      expect(count.exitCode).not.toBe(0);
+      expect(JSON.parse(count.stdout).error).toContain('--receipt cannot be combined with --count');
+
+      const search = await runCLI(['list', '--name', 'Sample Idea', '--output', 'json', '--receipt'], vaultDir);
+      expect(search.exitCode).not.toBe(0);
+      expect(JSON.parse(search.stdout).error).toContain('cannot be combined');
+
+      const lineage = await runCLI(['list', '--lineage', 'Ideas/Sample Idea', '--output', 'json', '--receipt'], vaultDir);
+      expect(lineage.exitCode).not.toBe(0);
+      expect(JSON.parse(lineage.stdout).error).toContain('--lineage cannot be combined');
+
+      const open = await runCLI(['list', 'idea', '--open', '--output', 'json', '--receipt'], vaultDir);
+      expect(open.exitCode).not.toBe(0);
+      expect(JSON.parse(open.stdout).error).toContain('--receipt cannot be combined with --open');
+    });
+
     it('should reject invalid limit values', async () => {
       const result = await runCLI(['list', 'idea', '--limit', '0'], vaultDir);
 
@@ -1479,6 +1573,31 @@ status: done
       expect(dashboards.dashboards['json-tasks']).toEqual({
         type: 'task',
         output: 'json',
+      });
+    });
+
+    it('should not persist receipt mode when saving a dashboard', async () => {
+      const { join } = await import('path');
+
+      const result = await runCLI(
+        ['list', '--type', 'task', '--limit', '1', '--output', 'json', '--receipt', '--save-as', 'receipt-tasks'],
+        tempVaultDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        matched: 2,
+        returned: 1,
+        truncated: true,
+      });
+
+      const dashboardsPath = join(tempVaultDir, '.bwrb', 'dashboards.json');
+      const content = await import('fs/promises').then(fs => fs.readFile(dashboardsPath, 'utf-8'));
+      const dashboards = JSON.parse(content);
+      expect(dashboards.dashboards['receipt-tasks']).toEqual({
+        type: 'task',
+        output: 'json',
+        limit: 1,
       });
     });
 

--- a/tests/ts/lib/expression-validation.test.ts
+++ b/tests/ts/lib/expression-validation.test.ts
@@ -241,6 +241,62 @@ describe('expression-validation', () => {
       expect(result.errors[0]!.suggestion).toBe('status');
     });
 
+    it.each([
+      'statsu < 3',
+      'statsu >= 3',
+      "statsu =~ 'raw'",
+      'status == statsu',
+    ])('rejects an unknown field in non-select comparison expressions: %s', expression => {
+      const result = validateWhereExpressions([expression], schema, 'task');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        field: 'statsu',
+        message: "Unknown field 'statsu' for type 'task'",
+        suggestion: 'status',
+      });
+    });
+
+    it.each([
+      "startsWith(statsu, 'r')",
+      "endsWith(statsu, 'w')",
+      "lower(statsu) == 'raw'",
+      'isEmpty(statsu)',
+    ])('rejects an unknown field in function arguments: %s', expression => {
+      const result = validateWhereExpressions([expression], schema, 'task');
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        field: 'statsu',
+        message: "Unknown field 'statsu' for type 'task'",
+        suggestion: 'status',
+      });
+    });
+
+    it('preserves file metadata, function names, and this as non-frontmatter references', () => {
+      const result = validateWhereExpressions(
+        ["startsWith(file.name, 'Task') && file.folder == 'Tasks' && this == null && today() <= now()"],
+        schema,
+        'task'
+      );
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('validates normalized hyphenated fields inside function arguments', () => {
+      const result = validateWhereExpressions(
+        ['isEmpty(creation-date)'],
+        schema,
+        'task'
+      );
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
     it('validates multiple expressions', () => {
       const result = validateWhereExpressions(
         ["status == 'invalid1'", "status == 'invalid2'"],


### PR DESCRIPTION
## Summary

- add opt-in JSON query receipts for bounded list and saved-dashboard execution
- validate every typed where-expression field reference across operators and function arguments
- preserve existing raw-array and count JSON compatibility contracts
- document the contract and retain the shaping research artifact

## Verification

- pnpm build
- pnpm verify:pack
- pnpm typecheck
- pnpm lint
- pnpm knip
- pnpm test -- --exclude=**/*.pty.test.ts (2,972 passed, 3 skipped; one unrelated heartbeat timing test flaked under concurrent load and passed 4/4 immediately in isolation)
- independent human QA H1-H6 against rebuilt dist/index.js: PASS

## Human QA story

An agent can run a limited typed query, opt into a receipt that proves matched/returned/truncated cardinality, retain legacy raw-array and count shapes when receipt mode is absent, receive actionable JSON errors for misspelled typed fields, and execute the same receipt contract through a saved dashboard.