### PR TITLE
Distribute stable note identity into note frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Distributed stable note identity** — new vaults keep the authoritative UUID
+  with each note instead of mutating a shared registry. Existing vaults remain
+  on the legacy registry until `bwrb identity migrate` validates every note and
+  explicitly switches modes; reverse migration rebuilds the registry for safe
+  rollback.
+
+### Changed
+
+- **Independent Git transactions** — frontmatter-identity creation, fork,
+  template scaffolding, lineage adoption, and deletion no longer take custody
+  of `.bwrb/ids.jsonl` or a vault-wide identity-assignment lock. Audit reports
+  missing, invalid, and copied duplicate IDs while stable targeting continues
+  across renames and moves.
+
 ## [0.3.0] - 2026-07-13
 
 ### Breaking changes

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -82,6 +82,7 @@ export default defineConfig({
 								{ slug: 'reference/commands/bulk' },
 								{ slug: 'reference/commands/template' },
 								{ slug: 'reference/commands/lineage' },
+								{ slug: 'reference/commands/identity' },
 								{ slug: 'reference/commands/dashboard' },
 								{ slug: 'reference/commands/init' },
 								{ slug: 'reference/commands/config' },

--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -47,6 +47,14 @@
     "config": {
       "type": "object",
       "properties": {
+        "identity_store": {
+          "type": "string",
+          "enum": [
+            "registry-v1",
+            "frontmatter-v1"
+          ],
+          "description": "Stable note identity storage: legacy shared registry or authoritative per-note frontmatter"
+        },
         "link_format": {
           "type": "string",
           "enum": [

--- a/docs-site/src/content/docs/concepts/validation-and-audit.md
+++ b/docs-site/src/content/docs/concepts/validation-and-audit.md
@@ -38,6 +38,11 @@ allowed and never reported as `unknown-field`. Ordinary interactive and JSON
 creation writes `id` and `name`; the name remains the note identity even when
 the physical filename is normalized or pattern-derived.
 
+In a `frontmatter-v1` vault, audit also enforces that every discovered,
+parseable note has one valid UUID `id`, and reports copied notes that duplicate
+an existing ID. Missing and invalid IDs are never repaired automatically:
+choose the surviving identity explicitly, then rerun audit.
+
 ## Fixing Issues
 
 `bwrb audit --fix` applies fixes by default, but requires explicit targeting (use `--all` to target the full vault).

--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -109,6 +109,8 @@ Delete semantics in repair mode:
 | `missing-lineage-id` | A note declares `forked-from` but lacks its own valid UUID `id` (error; flag-only) |
 | `dangling-forked-from` | `forked-from` references a UUID not present on any discovered note (warning; flag-only). Provenance is retained because the source may be restored later; this is also the deliberate result of deleting a fork parent with `bwrb delete --force` |
 | `duplicate-note-id` | Two or more notes use the same stable UUID `id` (error; flag-only) |
+| `missing-note-id` | A discovered parseable note has no `id` while the vault uses `frontmatter-v1` identity (error; flag-only) |
+| `invalid-note-id` | A discovered parseable note has a non-UUID `id` while the vault uses `frontmatter-v1` identity (error; flag-only) |
 | `fork-cycle` | Following immediate `forked-from` references forms a cycle (error; flag-only). Traversal is cycle-safe and always terminates |
 | `format-violation` | Field value doesn't match expected format (wikilink, etc.) |
 | `stale-reference` | Wikilink points to non-existent file |

--- a/docs-site/src/content/docs/reference/commands/delete.md
+++ b/docs-site/src/content/docs/reference/commands/delete.md
@@ -153,7 +153,9 @@ bwrb delete "My Note" --force --backup
 bwrb delete "My Note" --dry-run --output json
 ```
 
-When a note is actually deleted, bwrb also removes the matching path from `.bwrb/ids.jsonl`.
+In legacy `registry-v1` vaults, deleting a note also removes its matching path
+from `.bwrb/ids.jsonl`. In `frontmatter-v1` vaults, deletion owns only the note
+path; the optional registry is inert and unchanged.
 
 ### Bulk Mode
 

--- a/docs-site/src/content/docs/reference/commands/identity.md
+++ b/docs-site/src/content/docs/reference/commands/identity.md
@@ -1,0 +1,80 @@
+---
+title: bwrb identity
+description: Safely migrate stable note identity storage
+---
+
+`identity migrate` switches a vault between the legacy shared ID registry and
+distributed note-owned identity. It is dry-run by default and validates the
+whole discoverable note set before any write.
+
+## Synopsis
+
+```bash
+bwrb identity migrate --to <frontmatter-v1|registry-v1> [--dry-run | --execute] [--output text|json]
+```
+
+## Governing model
+
+In `frontmatter-v1`, the reserved UUID `id` in each note's frontmatter is
+authoritative. It survives a rename or move because it travels with the note.
+There is no authoritative global index: discovery reads note frontmatter, and
+any future index must be disposable and rebuildable.
+
+In legacy `registry-v1`, `.bwrb/ids.jsonl` remains part of completed creation
+and deletion writes. A schema with no `config.identity_store` uses this legacy
+mode, preserving existing vault behavior until migration is explicit. New
+vaults created by `bwrb init` explicitly use `frontmatter-v1`.
+
+## Guarded migration
+
+```bash
+# Preview; writes nothing
+bwrb identity migrate --to frontmatter-v1 --output json
+
+# Apply after reviewing blockers and planned changes
+bwrb identity migrate --to frontmatter-v1 --execute --output json
+
+# Rebuild the legacy registry and switch back
+bwrb identity migrate --to registry-v1 --execute --output json
+```
+
+Both directions fail closed when a discovered note is unreadable, lacks `id`,
+has a non-UUID `id`, or shares an ID with another note. Repair is deliberately
+manual: for a copied note, decide whether it is the same logical note or a new
+one before changing identity. Bowerbird will not crown a winner merely because
+one path sorts first.
+
+Forward migration changes only `.bwrb/schema.json`; it leaves an existing or
+dirty `.bwrb/ids.jsonl` byte-for-byte untouched. Reverse migration first
+atomically rebuilds `.bwrb/ids.jsonl` from current note frontmatter, preserving
+known `createdAt` values where possible, then switches the schema mode. If the
+schema mode changes concurrently, migration stops and asks for a retry.
+
+## Git workflow
+
+With `frontmatter-v1`, unrelated note creates modify unrelated Markdown files,
+so separate branches or autonomous transactions do not contend on a shared
+registry. Normal Git rename detection is sufficient: no registry path needs to
+be updated. A copied note preserves its source ID and is therefore reported by
+`bwrb audit --only duplicate-note-id`; resolve that conflict before merging.
+
+Use audit after external-editor or merge activity:
+
+```bash
+bwrb audit --only missing-note-id --output json
+bwrb audit --only invalid-note-id --output json
+bwrb audit --only duplicate-note-id --output json
+```
+
+## JSON output
+
+JSON reports `from`, `to`, note counts, exact blockers, and planned or applied
+changes. A blocked execute exits non-zero and writes neither schema nor
+registry. Dry-run may return blockers with a successful command so automation
+can inspect the complete plan before deciding whether repair is required.
+
+## See also
+
+- [bwrb audit](/reference/commands/audit/)
+- [bwrb init](/reference/commands/init/)
+- [Schema configuration](/reference/schema/#config)

--- a/docs-site/src/content/docs/reference/commands/identity.md
+++ b/docs-site/src/content/docs/reference/commands/identity.md
@@ -50,6 +50,13 @@ atomically rebuilds `.bwrb/ids.jsonl` from current note frontmatter, preserving
 known `createdAt` values where possible, then switches the schema mode. If the
 schema mode changes concurrently, migration stops and asks for a retry.
 
+Execute mode briefly fences Bowerbird operations that can create, remove, move,
+or backfill note identity. Operations already in flight finish first; new ones
+fail with a retryable error until the mode switch completes. Unrelated ordinary
+operations remain concurrent at every other time. External editors and raw Git
+filesystem changes cannot participate in this fence, so pause them between the
+final preview and execute command.
+
 ## Git workflow
 
 With `frontmatter-v1`, unrelated note creates modify unrelated Markdown files,

--- a/docs-site/src/content/docs/reference/commands/init.md
+++ b/docs-site/src/content/docs/reference/commands/init.md
@@ -4,6 +4,8 @@ description: Initialize a new Bowerbird vault
 ---
 
 Create a `.bwrb/` directory and a version 2 `.bwrb/schema.json` in a new vault.
+New vaults use distributed `frontmatter-v1` note identity: each note carries
+its stable UUID in `id`, and no shared identity registry is authoritative.
 
 ## Synopsis
 

--- a/docs-site/src/content/docs/reference/commands/lineage.md
+++ b/docs-site/src/content/docs/reference/commands/lineage.md
@@ -48,11 +48,12 @@ Before previewing or writing, adoption refuses:
 - a proposed edge that would create a cycle.
 
 Valid existing IDs are preserved. If either target is an older note without an
-ID, execute mode assigns a fresh UUID and records it in `.bwrb/ids.jsonl` as
-part of the guarded operation. Parent and child paths are locked together, the
-notes and graph are re-read under those locks, and ID assignment shares the
-same lock used by `new --fork`. Concurrent fork, non-force delete, and adoption
-operations therefore serialize on every path they share. Ordinary `bwrb edit`
+ID, execute mode assigns a fresh UUID. Legacy `registry-v1` vaults also record
+that UUID in `.bwrb/ids.jsonl`; `frontmatter-v1` vaults do not. Parent and child
+paths are locked together, and the notes and graph are re-read under those
+locks. Concurrent fork, non-force delete, and adoption operations therefore
+serialize only on paths they share in `frontmatter-v1`; legacy vaults retain
+their vault-wide ID-assignment lock. Ordinary `bwrb edit`
 now joins those path locks for its short commit phase and replays a stale JSON
 patch from fresh bytes, preventing an edit from erasing a newly assigned ID or
 provenance edge.
@@ -61,7 +62,7 @@ Only the missing `id` fields and the child's new `forked-from` field may change.
 The writer inserts plain scalars without reserializing YAML, and verifies that
 the parsed bodies and all ordinary frontmatter remain unchanged. Filenames,
 aliases, provider metadata, bodies, and other frontmatter are not rewritten.
-If the two-note write or registry update fails, changed note bytes are rolled
+If the two-note write or any required legacy registry update fails, changed note bytes are rolled
 back before the command reports failure. Rollback restores a note only when it
 still contains adoption's own write; bytes from a newer writer are left intact.
 A pre-write byte conflict is retryable and uses numeric JSON `code: 2` with

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -845,6 +845,7 @@ Vault-wide settings:
 ```json
 {
   "config": {
+    "identity_store": "frontmatter-v1",
     "link_format": "wikilink",
     "open_with": "obsidian",
     "editor": "nvim",
@@ -859,6 +860,7 @@ Vault-wide settings:
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
+| `identity_store` | string | `"registry-v1"` when omitted | Stable identity authority: legacy `registry-v1`, or distributed `frontmatter-v1`. New vaults explicitly use `frontmatter-v1`; change modes only with [`bwrb identity migrate`](/reference/commands/identity/) |
 | `link_format` | string | `"wikilink"` | Link format for relations: `wikilink` (`[[Note]]`) or `markdown` (`[Note](Note.md)`) |
 | `open_with` | string | `"system"` | Default for `--open`: `system`, `editor`, `visual`, or `obsidian` |
 | `editor` | string | `$EDITOR` | Terminal editor command |

--- a/docs/product/system-frontmatter.md
+++ b/docs/product/system-frontmatter.md
@@ -18,6 +18,9 @@ Audit/validation behavior:
 - `forked-from` cannot be declared as a type or trait schema field. Schema load,
   validation, and field creation reject the reserved name.
 - Existing `id` schema declarations retain their current behavior.
+- In `frontmatter-v1`, each parseable discovered note must have one valid,
+  vault-unique UUID `id`. The note is authoritative; any global index is a
+  rebuildable cache, never identity state.
 
 ## Reserved (immutable) fields
 
@@ -34,6 +37,22 @@ The only in-place exception is `bwrb lineage adopt`, which revalidates two exact
 existing notes under lineage locks, refuses reparenting, cycles, and unsafe
 graph state, and can add only missing `id` fields plus the child's
 `forked-from` value.
+
+## Identity storage modes
+
+- `registry-v1` preserves the legacy `.bwrb/ids.jsonl` issuance registry and
+  its registry/assignment locks. Omitted `config.identity_store` resolves to
+  this mode for compatibility with existing vaults.
+- `frontmatter-v1` derives identity from live note frontmatter. Creation,
+  deletion, fork, template scaffolding, and lineage adoption never mutate
+  `.bwrb/ids.jsonl` and take no vault-wide identity-assignment lock. Path-level
+  mutation locks remain authoritative for writes to the same note.
+
+`bwrb identity migrate` is the only supported mode switch. Forward migration
+requires every discovered parseable note to have a valid unique UUID and then
+changes only `schema.json`. Reverse migration atomically rebuilds the legacy
+registry from live notes before changing the schema mode. Both directions fail
+closed on unreadable, missing, invalid, or duplicate identity.
 
 ## Policy
 

--- a/docs/product/system-frontmatter.md
+++ b/docs/product/system-frontmatter.md
@@ -54,6 +54,13 @@ changes only `schema.json`. Reverse migration atomically rebuilds the legacy
 registry from live notes before changing the schema mode. Both directions fail
 closed on unreadable, missing, invalid, or duplicate identity.
 
+Execute mode raises a short-lived migration fence. Identity-relevant Bowerbird
+transactions already in flight drain before the snapshot; newcomers fail with
+a retryable error until the schema mode has changed. Independent transactions
+otherwise keep separate leases and do not serialize with each other. Because
+external editors and raw Git moves do not honor Bowerbird's fence, the operator
+must keep those writers quiescent between the final preview and execution.
+
 ## Policy
 
 - Keep the system-managed allowlist small and explicit.

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -420,6 +420,22 @@ bwrb template validate --output json
 
 Notes created via `bwrb new` always include a system-managed frontmatter `id` (UUIDv4). The `id` is reserved: you cannot set it in `bwrb new --json`, and you cannot modify it via `bwrb edit`.
 
+New vaults use `config.identity_store: frontmatter-v1`, where note frontmatter
+is the identity authority and `.bwrb/ids.jsonl` is not mutated. Existing vaults
+without the setting remain in legacy `registry-v1` mode. Never edit the setting
+directly; preview and execute the guarded migration:
+
+```bash
+bwrb identity migrate --to frontmatter-v1 --output json
+bwrb identity migrate --to frontmatter-v1 --execute --output json
+# Roll back only after previewing the reverse rebuild
+bwrb identity migrate --to registry-v1 --execute --output json
+```
+
+Migration fails closed on unreadable notes, missing or invalid IDs, and copied
+notes with duplicate IDs. Resolve exact paths deliberately; Bowerbird does not
+guess which copy owns an identity.
+
 `forked-from` is also reserved. If an agent encounters it, treat the value as an
 immediate source note UUID and leave it unchanged. `bwrb audit --output json`
 reports malformed, dangling, duplicate-ID, and cyclic lineage metadata.

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -434,7 +434,10 @@ bwrb identity migrate --to registry-v1 --execute --output json
 
 Migration fails closed on unreadable notes, missing or invalid IDs, and copied
 notes with duplicate IDs. Resolve exact paths deliberately; Bowerbird does not
-guess which copy owns an identity.
+guess which copy owns an identity. Pause external editors and raw Git moves
+between the final preview and execute command. Bowerbird drains its own
+identity-relevant transactions and asks newcomers to retry during the brief
+mode switch, but it cannot fence writers that bypass the CLI.
 
 `forked-from` is also reserved. If an agent encounters it, treat the value as an
 immediate source note UUID and leave it unchanged. `bwrb audit --output json`

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -47,6 +47,14 @@
     "config": {
       "type": "object",
       "properties": {
+        "identity_store": {
+          "type": "string",
+          "enum": [
+            "registry-v1",
+            "frontmatter-v1"
+          ],
+          "description": "Stable note identity storage: legacy shared registry or authoritative per-note frontmatter"
+        },
         "link_format": {
           "type": "string",
           "enum": [

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -120,6 +120,8 @@ Issue Types:
   invalid-forked-from   forked-from is not a UUID string
   missing-lineage-id    Note with forked-from lacks a valid note id
   dangling-forked-from  forked-from references a missing note id (warning)
+  missing-note-id       Frontmatter-v1 note has no stable id
+  invalid-note-id       Frontmatter-v1 note id is not a UUID
   duplicate-note-id     Stable note id is used by multiple notes
   self-reference        Relation field references the same note
   ambiguous-link-target Relation target matches multiple files

--- a/src/commands/bulk.ts
+++ b/src/commands/bulk.ts
@@ -26,6 +26,7 @@ import { resolveVaultDirWithSelection } from '../lib/vaultSelection.js';
 import { getGlobalOpts } from '../lib/command.js';
 import { configurePromptMode, printError, promptConfirm } from '../lib/prompt.js';
 import { UserCancelledError } from '../lib/errors.js';
+import { isBwrbReservedFrontmatterField } from '../lib/frontmatter/systemFields.js';
 import {
   printJson,
   jsonError,
@@ -349,6 +350,18 @@ Hint: Bulk operations require explicit targeting to prevent accidents.
       // (--set, --delete, --append, --remove). Users may want to set arbitrary
       // custom fields not defined in the schema. Field validation is enforced
       // for --where expressions (filtering) where typos cause silent bugs.
+      for (const operation of operations) {
+        if (
+          isBwrbReservedFrontmatterField(operation.field) ||
+          (operation.newField !== undefined && isBwrbReservedFrontmatterField(operation.newField))
+        ) {
+          validationErrors.push(
+            `Cannot mutate reserved system-managed field '${
+              isBwrbReservedFrontmatterField(operation.field) ? operation.field : operation.newField
+            }' with bwrb bulk`
+          );
+        }
+      }
 
       // Check for validation errors
       if (validationErrors.length > 0) {

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -48,6 +48,7 @@ import {
 } from '../lib/delete-lineage-guard.js';
 import { withLineageMutationLocks } from '../lib/lineage-lock.js';
 import { createBackup } from '../lib/bulk/backup.js';
+import { withNoteIdentityTransaction } from '../lib/identity-transaction.js';
 
 // ============================================================================
 // Types
@@ -680,28 +681,30 @@ async function handleBulkDelete(
     }
   };
 
-  if (options.force) {
-    if (options.backup) {
-      backupPath = await createBackup(vaultDir, files.map(file => file.path), `delete ${files.length} file(s)`);
-    }
-    await deleteFiles();
-  } else {
-    try {
-      await withLineageMutationLocks(vaultDir, files.map(file => file.path), async () => {
-        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, files, true);
-        if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
+  try {
+    await withNoteIdentityTransaction(vaultDir, schema.config.identityStore, async () => {
+      if (options.force) {
         if (options.backup) {
           backupPath = await createBackup(vaultDir, files.map(file => file.path), `delete ${files.length} file(s)`);
         }
         await deleteFiles();
-      });
-    } catch (error) {
-      if (error instanceof LineageDeleteRefusalError) {
-        reportLineageRefusal(error.blocked, jsonMode, true);
-        return;
+      } else {
+        await withLineageMutationLocks(vaultDir, files.map(file => file.path), async () => {
+          const assessment = await assessCurrentDeleteLineage(schema, vaultDir, files, true);
+          if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
+          if (options.backup) {
+            backupPath = await createBackup(vaultDir, files.map(file => file.path), `delete ${files.length} file(s)`);
+          }
+          await deleteFiles();
+        });
       }
-      throw error;
+    });
+  } catch (error) {
+    if (error instanceof LineageDeleteRefusalError) {
+      reportLineageRefusal(error.blocked, jsonMode, true);
+      return;
     }
+    throw error;
   }
 
   // Output results
@@ -874,30 +877,32 @@ async function deleteResolvedFile({
   // Delete the file. Non-force deletion rechecks under the same path-keyed
   // lock used by `new --fork`, after every prompt and backlink scan has ended.
   let backupPath: string | undefined;
-  if (options.force) {
-    if (options.backup) {
-      backupPath = await createBackup(vaultDir, [fullPath], `delete ${relativePath}`);
-    }
-    await unlink(fullPath);
-    await unregisterIssuedNotePath(vaultDir, relativePath, schema.config.identityStore);
-  } else {
-    try {
-      await withLineageMutationLocks(vaultDir, [fullPath], async () => {
-        const assessment = await assessCurrentDeleteLineage(schema, vaultDir, [file], true);
-        if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
+  try {
+    await withNoteIdentityTransaction(vaultDir, schema.config.identityStore, async () => {
+      if (options.force) {
         if (options.backup) {
           backupPath = await createBackup(vaultDir, [fullPath], `delete ${relativePath}`);
         }
         await unlink(fullPath);
         await unregisterIssuedNotePath(vaultDir, relativePath, schema.config.identityStore);
-      });
-    } catch (error) {
-      if (error instanceof LineageDeleteRefusalError) {
-        reportLineageRefusal(error.blocked, jsonMode, false);
-        return;
+      } else {
+        await withLineageMutationLocks(vaultDir, [fullPath], async () => {
+          const assessment = await assessCurrentDeleteLineage(schema, vaultDir, [file], true);
+          if (assessment.length > 0) throw new LineageDeleteRefusalError(assessment);
+          if (options.backup) {
+            backupPath = await createBackup(vaultDir, [fullPath], `delete ${relativePath}`);
+          }
+          await unlink(fullPath);
+          await unregisterIssuedNotePath(vaultDir, relativePath, schema.config.identityStore);
+        });
       }
-      throw error;
+    });
+  } catch (error) {
+    if (error instanceof LineageDeleteRefusalError) {
+      reportLineageRefusal(error.blocked, jsonMode, false);
+      return;
     }
+    throw error;
   }
 
   // Success output

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -667,7 +667,11 @@ async function handleBulkDelete(
     for (const file of files) {
       try {
         await unlink(file.path);
-        await unregisterIssuedNotePath(vaultDir, file.relativePath);
+        await unregisterIssuedNotePath(
+          vaultDir,
+          file.relativePath,
+          schema.config.identityStore
+        );
         deleted.push(file.relativePath);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -875,7 +879,7 @@ async function deleteResolvedFile({
       backupPath = await createBackup(vaultDir, [fullPath], `delete ${relativePath}`);
     }
     await unlink(fullPath);
-    await unregisterIssuedNotePath(vaultDir, relativePath);
+    await unregisterIssuedNotePath(vaultDir, relativePath, schema.config.identityStore);
   } else {
     try {
       await withLineageMutationLocks(vaultDir, [fullPath], async () => {
@@ -885,7 +889,7 @@ async function deleteResolvedFile({
           backupPath = await createBackup(vaultDir, [fullPath], `delete ${relativePath}`);
         }
         await unlink(fullPath);
-        await unregisterIssuedNotePath(vaultDir, relativePath);
+        await unregisterIssuedNotePath(vaultDir, relativePath, schema.config.identityStore);
       });
     } catch (error) {
       if (error instanceof LineageDeleteRefusalError) {

--- a/src/commands/identity/index.ts
+++ b/src/commands/identity/index.ts
@@ -1,0 +1,90 @@
+import { Command } from 'commander';
+import { getGlobalOpts } from '../../lib/command.js';
+import {
+  IdentityMigrationBlockedError,
+  migrateIdentityStore,
+} from '../../lib/identity-migration.js';
+import { ExitCodes, jsonError, printJson } from '../../lib/output.js';
+import { printError, printInfo, printSuccess } from '../../lib/prompt.js';
+import { loadSchema } from '../../lib/schema.js';
+import type { NoteIdentityStore } from '../../lib/note-id.js';
+import { resolveVaultDirWithSelection } from '../../lib/vaultSelection.js';
+
+interface IdentityMigrateOptions {
+  to?: string;
+  dryRun?: boolean;
+  execute?: boolean;
+  output?: string;
+}
+
+const migrateCommand = new Command('migrate')
+  .description('Migrate stable note identity storage after a guarded vault preflight')
+  .requiredOption('--to <store>', 'Target store: frontmatter-v1 or registry-v1')
+  .option('--dry-run', 'Preview the migration (default)')
+  .option('-x, --execute', 'Apply the migration after revalidation')
+  .option('--output <format>', 'Output format: text or json', 'text')
+  .addHelpText('after', `
+Examples:
+  bwrb identity migrate --to frontmatter-v1 --dry-run --output json
+  bwrb identity migrate --to frontmatter-v1 --execute --output json
+  bwrb identity migrate --to registry-v1 --execute --output json
+`)
+  .action(async (options: IdentityMigrateOptions, command: Command) => {
+    const jsonMode = options.output === 'json';
+    try {
+      if (options.output !== 'text' && options.output !== 'json') {
+        throw new Error('--output must be text or json.');
+      }
+      if (options.execute === true && options.dryRun === true) {
+        throw new Error('--execute cannot be combined with --dry-run.');
+      }
+      if (options.to !== 'frontmatter-v1' && options.to !== 'registry-v1') {
+        throw new Error('--to must be frontmatter-v1 or registry-v1.');
+      }
+
+      const globalOpts = getGlobalOpts(command);
+      const vaultDir = await resolveVaultDirWithSelection({
+        ...(globalOpts.vault ? { vault: globalOpts.vault } : {}),
+        allowFindDown: true,
+        jsonMode,
+      });
+      const schema = await loadSchema(vaultDir);
+      const result = await migrateIdentityStore(
+        schema,
+        vaultDir,
+        options.to as NoteIdentityStore,
+        options.execute === true
+      );
+
+      if (jsonMode) {
+        printJson({ success: true, ...result });
+        return;
+      }
+      const verb = result.mode === 'execute' ? 'Migrated' : 'Dry run: would migrate';
+      const message = `${verb} identity storage ${result.from} -> ${result.to}`;
+      if (result.mode === 'execute') printSuccess(message);
+      else printInfo(message);
+      printInfo(
+        `Notes: ${result.notes.total} total, ${result.notes.valid} valid, ` +
+        `${result.blockers.length} blocker(s)`
+      );
+      for (const blocker of result.blockers) {
+        printInfo(`  ${blocker.code}: ${blocker.path}`);
+      }
+      if (result.mode === 'dry-run' && result.blockers.length === 0 && result.changes.length > 0) {
+        printInfo('Run again with --execute to apply these changes.');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const data = error instanceof IdentityMigrationBlockedError
+        ? { blockers: error.blockers }
+        : undefined;
+      if (jsonMode) printJson(jsonError(message, { code: ExitCodes.VALIDATION_ERROR, data }));
+      else printError(message);
+      process.exitCode = ExitCodes.VALIDATION_ERROR;
+    }
+  });
+
+export const identityCommand = new Command('identity')
+  .description('Inspect and migrate stable note identity storage')
+  .addCommand(migrateCommand);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -46,6 +46,7 @@ interface InitResult {
   vault: string;
   schema_path: string;
   config: {
+    identity_store: 'frontmatter-v1';
     link_format: string;
     obsidian_vault?: string;
     editor?: string;
@@ -168,6 +169,7 @@ Examples:
 
       // Build config
       const config: Config = {
+        identity_store: 'frontmatter-v1',
         link_format: linkFormat,
       };
 
@@ -198,6 +200,7 @@ Examples:
         vault: vaultDir,
         schema_path: schemaPath,
         config: {
+          identity_store: 'frontmatter-v1',
           link_format: linkFormat,
           ...(obsidianVault && { obsidian_vault: obsidianVault }),
           ...(editor && { editor }),

--- a/src/commands/lineage/adopt.ts
+++ b/src/commands/lineage/adopt.ts
@@ -3,6 +3,7 @@ import { isDeepStrictEqual } from 'util';
 import { readFile } from 'fs/promises';
 import { resolve } from 'path';
 import type { LoadedSchema } from '../../types/schema.js';
+import { withNoteIdentityTransaction } from '../../lib/identity-transaction.js';
 import {
   insertFrontmatterScalarPreservingBytes,
   parseNoteContent,
@@ -99,25 +100,27 @@ export async function adoptLineage(
   }
 
   const lockedPaths = [initial.child.file.path, initial.parent.file.path];
-  return withLineageMutationLocks(vaultDir, lockedPaths, async () =>
-    withNoteIdAssignmentLock(vaultDir, async () => {
-      const current = await resolveTargets(schema, vaultDir, options.child, options.parent);
-      assertTargetsStayedLocked(vaultDir, initial, current);
-      const prepared = await prepareAdoption(
-        schema,
-        vaultDir,
-        current.child,
-        current.parent,
-        'execute'
-      );
-      await applyPreparedAdoption(
-        vaultDir,
-        prepared,
-        dependencies.registerIds ?? registerIssuedNoteIds,
-        schema.config.identityStore
-      );
-      return prepared.result;
-    }, {}, schema.config.identityStore)
+  return withNoteIdentityTransaction(vaultDir, schema.config.identityStore, () =>
+    withLineageMutationLocks(vaultDir, lockedPaths, async () =>
+      withNoteIdAssignmentLock(vaultDir, async () => {
+        const current = await resolveTargets(schema, vaultDir, options.child, options.parent);
+        assertTargetsStayedLocked(vaultDir, initial, current);
+        const prepared = await prepareAdoption(
+          schema,
+          vaultDir,
+          current.child,
+          current.parent,
+          'execute'
+        );
+        await applyPreparedAdoption(
+          vaultDir,
+          prepared,
+          dependencies.registerIds ?? registerIssuedNoteIds,
+          schema.config.identityStore
+        );
+        return prepared.result;
+      }, {}, schema.config.identityStore)
+    )
   );
 }
 

--- a/src/commands/lineage/adopt.ts
+++ b/src/commands/lineage/adopt.ts
@@ -113,10 +113,11 @@ export async function adoptLineage(
       await applyPreparedAdoption(
         vaultDir,
         prepared,
-        dependencies.registerIds ?? registerIssuedNoteIds
+        dependencies.registerIds ?? registerIssuedNoteIds,
+        schema.config.identityStore
       );
       return prepared.result;
-    })
+    }, {}, schema.config.identityStore)
   );
 }
 
@@ -166,13 +167,13 @@ async function prepareAdoption(
   const parentExistingId = parent.frontmatter.id;
   const parentId = isValidNoteId(parentExistingId)
     ? parentExistingId
-    : await generateProspectiveId(vaultDir, usedIds);
+    : await generateProspectiveId(schema, vaultDir, usedIds);
   usedIds.add(normalizeNoteId(parentId));
 
   const childExistingId = child.frontmatter.id;
   const childId = isValidNoteId(childExistingId)
     ? childExistingId
-    : await generateProspectiveId(vaultDir, usedIds);
+    : await generateProspectiveId(schema, vaultDir, usedIds);
   usedIds.add(normalizeNoteId(childId));
 
   if (normalizeNoteId(childId) === normalizeNoteId(parentId)) {
@@ -264,7 +265,8 @@ async function prepareAdoption(
 async function applyPreparedAdoption(
   vaultDir: string,
   prepared: PreparedAdoption,
-  registerIds: typeof registerIssuedNoteIds
+  registerIds: typeof registerIssuedNoteIds,
+  identityStore: LoadedSchema['config']['identityStore']
 ): Promise<void> {
   let parentWritten = false;
   let childWritten = false;
@@ -283,7 +285,7 @@ async function applyPreparedAdoption(
     );
     await writeFileAtomic(prepared.child.file.path, prepared.childNextRaw);
     childWritten = true;
-    await registerIds(vaultDir, prepared.registrations);
+    await registerIds(vaultDir, prepared.registrations, identityStore);
   } catch (error) {
     const rollbackErrors: string[] = [];
     if (childWritten) {
@@ -411,9 +413,13 @@ function withProspectiveEdge(
   return { notes };
 }
 
-async function generateProspectiveId(vaultDir: string, usedIds: Set<string>): Promise<string> {
+async function generateProspectiveId(
+  schema: LoadedSchema,
+  vaultDir: string,
+  usedIds: Set<string>
+): Promise<string> {
   for (let attempt = 0; attempt < 100; attempt++) {
-    const id = await generateUniqueNoteId(vaultDir);
+    const id = await generateUniqueNoteId(vaultDir, schema);
     if (!usedIds.has(normalizeNoteId(id))) return id;
   }
   throw new Error('Could not assign a unique note ID; retry the command.');

--- a/src/commands/new/fork.ts
+++ b/src/commands/new/fork.ts
@@ -1,6 +1,7 @@
 import { unlink } from 'fs/promises';
 import { basename, dirname, relative, resolve } from 'path';
 import type { LoadedSchema } from '../../types/schema.js';
+import { withNoteIdentityTransaction } from '../../lib/identity-transaction.js';
 import type { ManagedFile } from '../../lib/navigation.js';
 import { buildNoteIndex } from '../../lib/navigation.js';
 import {
@@ -70,6 +71,16 @@ interface ResolvedForkSource {
 }
 
 export async function forkNote(
+  schema: LoadedSchema,
+  vaultDir: string,
+  options: ForkNoteOptions
+): Promise<ForkNoteResult> {
+  return withNoteIdentityTransaction(vaultDir, schema.config.identityStore, () =>
+    forkNoteWithinIdentityTransaction(schema, vaultDir, options)
+  );
+}
+
+async function forkNoteWithinIdentityTransaction(
   schema: LoadedSchema,
   vaultDir: string,
   options: ForkNoteOptions

--- a/src/commands/new/fork.ts
+++ b/src/commands/new/fork.ts
@@ -109,7 +109,7 @@ export async function forkNote(
         sourceId
       )
     );
-    const childId = await generateUniqueNoteId(vaultDir);
+    const childId = await generateUniqueNoteId(vaultDir, schema);
     frontmatter.id = childId;
 
     const pathResult = buildNotePath(dirname(source.file.path), childName, 'interactive');
@@ -140,7 +140,12 @@ export async function forkNote(
     }
 
     try {
-      await registerIssuedNoteId(vaultDir, childId, pathResult.path);
+      await registerIssuedNoteId(
+        vaultDir,
+        childId,
+        pathResult.path,
+        schema.config.identityStore
+      );
     } catch (error) {
       // A note without a registry row is not a completed creation. Roll it
       // back; the source ID backfill intentionally remains durable.
@@ -207,7 +212,7 @@ async function ensureSourceId(
       return existing;
     }
 
-    const id = await generateUniqueNoteId(vaultDir);
+    const id = await generateUniqueNoteId(vaultDir, schema);
     const collisions = await findNotesWithId(schema, vaultDir, id);
     if (collisions.length > 0) {
       throw new Error('Generated source ID collides with an existing note; retry the command.');
@@ -216,7 +221,7 @@ async function ensureSourceId(
     await assertNoteBytesUnchanged(sourcePath, parsed.raw);
     await writeFileAtomic(sourcePath, nextRaw);
     try {
-      await registerIssuedNoteId(vaultDir, id, sourcePath);
+      await registerIssuedNoteId(vaultDir, id, sourcePath, schema.config.identityStore);
     } catch (error) {
       const rolledBack = await rollbackNoteIfUnchanged(sourcePath, nextRaw, parsed.raw);
       if (!rolledBack) {
@@ -228,7 +233,7 @@ async function ensureSourceId(
       throw error;
     }
     return id;
-  });
+  }, {}, schema.config.identityStore);
 }
 
 function formatError(error: unknown): string {

--- a/src/commands/new/write-plan.ts
+++ b/src/commands/new/write-plan.ts
@@ -84,7 +84,7 @@ export async function writeNotePlan(
     args.content.frontmatter
   );
 
-  const noteId = await generateUniqueNoteId(args.vaultDir);
+  const noteId = await generateUniqueNoteId(args.vaultDir, args.schema);
   args.content.frontmatter.id = noteId;
   if (args.ownership.kind === 'owned') {
     args.content.frontmatter.owner = cleanRelationLink(args.ownership.owner.ownerName, args.schema.config.linkFormat);
@@ -92,7 +92,12 @@ export async function writeNotePlan(
   const orderedFields = ensureIdInFieldOrder(args.content.orderedFields);
 
   await writeNote(filePath, args.content.frontmatter, args.content.body, orderedFields);
-  await registerIssuedNoteId(args.vaultDir, noteId, filePath);
+  await registerIssuedNoteId(
+    args.vaultDir,
+    noteId,
+    filePath,
+    args.schema.config.identityStore
+  );
 
   let scaffoldResult = null;
   if (args.template) {

--- a/src/commands/new/write-plan.ts
+++ b/src/commands/new/write-plan.ts
@@ -18,6 +18,7 @@ import { buildNotePath } from './paths.js';
 import { throwJsonError } from './errors.js';
 import { handleInstanceScaffolding } from './scaffolding.js';
 import type { LoadedSchema } from '../../types/schema.js';
+import { withNoteIdentityTransaction } from '../../lib/identity-transaction.js';
 
 const PORTABLE_PATH_WARNING_LENGTH = 200;
 const PORTABLE_PATH_MAX_LENGTH = 260;
@@ -36,6 +37,16 @@ async function resolveOutputDir(
 }
 
 export async function writeNotePlan(
+  args: WritePlanArgs,
+  fileExistsStrategy: FileExistsStrategy,
+  skipInstances: boolean
+): Promise<NoteCreationResult> {
+  return withNoteIdentityTransaction(args.vaultDir, args.schema.config.identityStore, () =>
+    writeNotePlanWithinIdentityTransaction(args, fileExistsStrategy, skipInstances)
+  );
+}
+
+async function writeNotePlanWithinIdentityTransaction(
   args: WritePlanArgs,
   fileExistsStrategy: FileExistsStrategy,
   skipInstances: boolean

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { bulkCommand } from './commands/bulk.js';
 import { templateCommand } from './commands/template.js';
 import { completionCommand } from './commands/completion.js';
 import { lineageCommand } from './commands/lineage/index.js';
+import { identityCommand } from './commands/identity/index.js';
 import { configCommand } from './commands/config.js';
 import { dashboardCommand } from './commands/dashboard.js';
 import { initCommand } from './commands/init.js';
@@ -84,6 +85,7 @@ if (completionsIndex !== -1) {
   program.addCommand(bulkCommand);
   program.addCommand(templateCommand);
   program.addCommand(lineageCommand);
+  program.addCommand(identityCommand);
 
   // Saved queries
   program.addCommand(dashboardCommand);

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -85,6 +85,7 @@ import { buildRelativeDateFieldMap, validateRelativeDateValue } from '../relativ
 import { parseCalendarDate } from '../calendar-date.js';
 import { formatLocalDate } from '../local-date.js';
 import { collectLineageIssues } from './lineage.js';
+import { collectRequiredNoteIdentityIssues } from './identity.js';
 
 // Import ownership tracking
 import {
@@ -211,6 +212,9 @@ export async function runAuditDetailed(
   // Build parent map for cycle detection on recursive types
   const parentMap = await buildParentMap(schema, filteredFiles, noteIndex);
   const lineageIssuesByPath = collectLineageIssues(noteIndex.snapshot);
+  const identityIssuesByPath = schema.config.identityStore === 'frontmatter-v1'
+    ? collectRequiredNoteIdentityIssues(noteIndex.snapshot)
+    : new Map<string, AuditIssue[]>();
 
   const wantUnlinkedMention =
     options.ignoreIssue !== 'unlinked-mention' &&
@@ -244,6 +248,7 @@ export async function runAuditDetailed(
     const issues = [
       ...(await auditFile(schema, vaultDir, file, { ...options, retentionToday }, noteIndex, ownershipIndex, parentMap, entityMentionIndex)),
       ...(lineageIssuesByPath.get(file.relativePath) ?? []),
+      ...(identityIssuesByPath.get(file.relativePath) ?? []),
     ];
 
     // Apply issue filters

--- a/src/lib/audit/identity.ts
+++ b/src/lib/audit/identity.ts
@@ -1,0 +1,36 @@
+import type { VaultNoteSnapshot } from '../discovery.js';
+import { isValidNoteId } from '../note-id.js';
+import type { AuditIssue } from './types.js';
+
+/** Validate the frontmatter-v1 invariant for every parseable discovered note. */
+export function collectRequiredNoteIdentityIssues(
+  snapshot: VaultNoteSnapshot
+): Map<string, AuditIssue[]> {
+  const issuesByPath = new Map<string, AuditIssue[]>();
+  for (const note of snapshot.notes) {
+    if (!note.frontmatter) continue;
+    const hasId = Object.prototype.hasOwnProperty.call(note.frontmatter, 'id');
+    if (!hasId) {
+      issuesByPath.set(note.relativePath, [{
+        severity: 'error',
+        code: 'missing-note-id',
+        message: "Frontmatter-v1 notes must have a stable UUID 'id'",
+        field: 'id',
+        autoFixable: false,
+      }]);
+      continue;
+    }
+    const id = note.frontmatter.id;
+    if (!isValidNoteId(id)) {
+      issuesByPath.set(note.relativePath, [{
+        severity: 'error',
+        code: 'invalid-note-id',
+        message: "Frontmatter-v1 note 'id' must be a UUID string",
+        field: 'id',
+        value: id,
+        autoFixable: false,
+      }]);
+    }
+  }
+  return issuesByPath;
+}

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -42,6 +42,8 @@ export type IssueCode =
   | 'invalid-forked-from'
   | 'missing-lineage-id'
   | 'dangling-forked-from'
+  | 'missing-note-id'
+  | 'invalid-note-id'
   | 'duplicate-note-id'
   | 'self-reference'
   | 'ambiguous-link-target'

--- a/src/lib/bulk/execute.ts
+++ b/src/lib/bulk/execute.ts
@@ -22,6 +22,7 @@ import type {
   FileChange,
   BulkOperation,
 } from './types.js';
+import { withNoteIdentityTransaction } from '../identity-transaction.js';
 
 /**
  * Check if operations include a move operation.
@@ -34,6 +35,17 @@ function hasMoveOperation(operations: BulkOperation[]): BulkOperation | undefine
  * Execute bulk operations on matching files.
  */
 export async function executeBulk(options: BulkOptions): Promise<BulkResult> {
+  if (options.execute) {
+    return withNoteIdentityTransaction(
+      options.vaultDir,
+      options.schema.config.identityStore,
+      () => executeBulkWithinTransaction(options)
+    );
+  }
+  return executeBulkWithinTransaction(options);
+}
+
+async function executeBulkWithinTransaction(options: BulkOptions): Promise<BulkResult> {
   const {
     typePath,
     pathGlob,

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -54,7 +54,7 @@ export interface CompletionContext {
 /**
  * Commands that have subcommands.
  */
-const COMMANDS_WITH_SUBCOMMANDS = ['schema', 'template', 'dashboard', 'lineage', 'completion'];
+const COMMANDS_WITH_SUBCOMMANDS = ['schema', 'template', 'dashboard', 'lineage', 'identity', 'completion'];
 
 /**
  * Subcommands for each parent command.
@@ -64,6 +64,7 @@ const SUBCOMMANDS: Record<string, string[]> = {
   template: ['list', 'validate', 'new', 'edit', 'delete'],
   dashboard: ['list', 'new', 'edit', 'delete'],
   lineage: ['adopt'],
+  identity: ['migrate'],
   completion: ['bash', 'zsh', 'fish'],
 };
 
@@ -256,6 +257,7 @@ const COMMANDS = [
   'bulk',
   'template',
   'lineage',
+  'identity',
   'dashboard',
   'init',
   'config',
@@ -320,6 +322,7 @@ const COMMAND_OPTIONS: Record<string, string[]> = {
   ],
   template: ['--vault', '-v', '--non-interactive', '--help'],
   lineage: ['--from', '--dry-run', '--execute', '-x', '--output', '--vault', '-v', '--non-interactive', '--help'],
+  identity: ['--to', '--dry-run', '--execute', '-x', '--output', '--vault', '-v', '--non-interactive', '--help'],
   dashboard: ['--output', '-o', '--vault', '-v', '--non-interactive', '--json', '--help'],
   delete: [
     '--type', '-t',
@@ -599,6 +602,14 @@ export async function handleCompletionRequest(
   if (ctx.command === 'lineage') {
     if (!ctx.subcommand && ctx.positionalIndex === 0) {
       return filterByPrefix(SUBCOMMANDS['lineage'] ?? [], ctx.current);
+    }
+    return [];
+  }
+
+  // === Identity command ===
+  if (ctx.command === 'identity') {
+    if (!ctx.subcommand && ctx.positionalIndex === 0) {
+      return filterByPrefix(SUBCOMMANDS['identity'] ?? [], ctx.current);
     }
     return [];
   }

--- a/src/lib/identity-migration.ts
+++ b/src/lib/identity-migration.ts
@@ -6,8 +6,10 @@ import {
   type NoteIdentityStore,
   type NoteIdRegistration,
 } from './note-id.js';
-import { loadRawSchemaJson, writeSchema } from './schema-writer.js';
+import { withSchemaMutation } from './schema-writer.js';
 import type { LoadedSchema } from '../types/schema.js';
+import { loadSchema } from './schema.js';
+import { withIdentityMigrationFence } from './identity-transaction.js';
 
 export interface IdentityMigrationBlocker {
   code: 'unreadable-note' | 'missing-note-id' | 'invalid-note-id' | 'duplicate-note-id';
@@ -47,6 +49,36 @@ export async function migrateIdentityStore(
   target: NoteIdentityStore,
   execute: boolean
 ): Promise<IdentityMigrationResult> {
+  if (!execute) {
+    return planIdentityMigration(schema, vaultDir, target, false);
+  }
+
+  return withIdentityMigrationFence(vaultDir, () =>
+    withSchemaMutation(vaultDir, async raw => {
+      const liveSchema = await loadSchema(vaultDir);
+      if (liveSchema.config.identityStore !== schema.config.identityStore) {
+        throw new Error(
+          `Identity storage changed during migration (${schema.config.identityStore} -> ` +
+          `${liveSchema.config.identityStore}); retry the command.`
+        );
+      }
+      const result = await planIdentityMigration(liveSchema, vaultDir, target, true);
+      const write = liveSchema.config.identityStore !== target;
+      if (write) {
+        raw.config ??= {};
+        raw.config.identity_store = target;
+      }
+      return { result, write };
+    })
+  );
+}
+
+async function planIdentityMigration(
+  schema: LoadedSchema,
+  vaultDir: string,
+  target: NoteIdentityStore,
+  execute: boolean
+): Promise<IdentityMigrationResult> {
   const current = schema.config.identityStore;
   const snapshot = await buildVaultNoteSnapshot(schema, vaultDir);
   const preflight = preflightIdentity(snapshot);
@@ -60,7 +92,7 @@ export async function migrateIdentityStore(
     changes.push({ path: '.bwrb/schema.json', action: 'set-identity-store', status });
   }
 
-  if (execute && preflight.blockers.length > 0) {
+  if (execute && current !== target && preflight.blockers.length > 0) {
     throw new IdentityMigrationBlockedError(preflight.blockers);
   }
 
@@ -71,17 +103,6 @@ export async function migrateIdentityStore(
       // inert, so retry is safe.
       await rebuildIssuedNoteRegistry(vaultDir, preflight.registrations);
     }
-
-    const raw = await loadRawSchemaJson(vaultDir);
-    const liveMode = raw.config?.identity_store ?? 'registry-v1';
-    if (liveMode !== current) {
-      throw new Error(
-        `Identity storage changed during migration (${current} -> ${liveMode}); retry the command.`
-      );
-    }
-    raw.config ??= {};
-    raw.config.identity_store = target;
-    await writeSchema(vaultDir, raw);
   }
 
   return {

--- a/src/lib/identity-migration.ts
+++ b/src/lib/identity-migration.ts
@@ -1,0 +1,173 @@
+import { buildVaultNoteSnapshot, type VaultNoteSnapshot } from './discovery.js';
+import {
+  isValidNoteId,
+  normalizeNoteId,
+  rebuildIssuedNoteRegistry,
+  type NoteIdentityStore,
+  type NoteIdRegistration,
+} from './note-id.js';
+import { loadRawSchemaJson, writeSchema } from './schema-writer.js';
+import type { LoadedSchema } from '../types/schema.js';
+
+export interface IdentityMigrationBlocker {
+  code: 'unreadable-note' | 'missing-note-id' | 'invalid-note-id' | 'duplicate-note-id';
+  path: string;
+  id?: unknown;
+  paths?: string[];
+}
+
+export interface IdentityMigrationResult {
+  mode: 'dry-run' | 'execute';
+  from: NoteIdentityStore;
+  to: NoteIdentityStore;
+  notes: {
+    total: number;
+    valid: number;
+    missing: number;
+    invalid: number;
+    duplicate: number;
+  };
+  blockers: IdentityMigrationBlocker[];
+  changes: Array<{
+    path: string;
+    action: 'set-identity-store' | 'rebuild-registry';
+    status: 'planned' | 'applied';
+  }>;
+}
+
+interface IdentityPreflight {
+  blockers: IdentityMigrationBlocker[];
+  registrations: NoteIdRegistration[];
+  counts: IdentityMigrationResult['notes'];
+}
+
+export async function migrateIdentityStore(
+  schema: LoadedSchema,
+  vaultDir: string,
+  target: NoteIdentityStore,
+  execute: boolean
+): Promise<IdentityMigrationResult> {
+  const current = schema.config.identityStore;
+  const snapshot = await buildVaultNoteSnapshot(schema, vaultDir);
+  const preflight = preflightIdentity(snapshot);
+  const status = execute ? 'applied' : 'planned';
+  const changes: IdentityMigrationResult['changes'] = [];
+
+  if (current !== target) {
+    if (target === 'registry-v1') {
+      changes.push({ path: '.bwrb/ids.jsonl', action: 'rebuild-registry', status });
+    }
+    changes.push({ path: '.bwrb/schema.json', action: 'set-identity-store', status });
+  }
+
+  if (execute && preflight.blockers.length > 0) {
+    throw new IdentityMigrationBlockedError(preflight.blockers);
+  }
+
+  if (execute && current !== target) {
+    if (target === 'registry-v1') {
+      // Build the legacy completion record before switching modes. If the
+      // schema write fails, frontmatter remains authoritative and this file is
+      // inert, so retry is safe.
+      await rebuildIssuedNoteRegistry(vaultDir, preflight.registrations);
+    }
+
+    const raw = await loadRawSchemaJson(vaultDir);
+    const liveMode = raw.config?.identity_store ?? 'registry-v1';
+    if (liveMode !== current) {
+      throw new Error(
+        `Identity storage changed during migration (${current} -> ${liveMode}); retry the command.`
+      );
+    }
+    raw.config ??= {};
+    raw.config.identity_store = target;
+    await writeSchema(vaultDir, raw);
+  }
+
+  return {
+    mode: execute ? 'execute' : 'dry-run',
+    from: current,
+    to: target,
+    notes: preflight.counts,
+    blockers: preflight.blockers,
+    changes,
+  };
+}
+
+export class IdentityMigrationBlockedError extends Error {
+  constructor(readonly blockers: IdentityMigrationBlocker[]) {
+    super(
+      `Identity migration blocked by ${blockers.length} note identity issue(s); ` +
+      'run the dry-run with --output json for exact paths.'
+    );
+    this.name = 'IdentityMigrationBlockedError';
+  }
+}
+
+function preflightIdentity(snapshot: VaultNoteSnapshot): IdentityPreflight {
+  const blockers: IdentityMigrationBlocker[] = [];
+  const registrations: NoteIdRegistration[] = [];
+  const notesById = new Map<string, Array<{ path: string; absolutePath: string; id: string }>>();
+  let valid = 0;
+  let missing = 0;
+  let invalid = 0;
+
+  for (const note of snapshot.notes) {
+    if (!note.frontmatter) {
+      blockers.push({ code: 'unreadable-note', path: note.relativePath });
+      invalid++;
+      continue;
+    }
+    if (!Object.prototype.hasOwnProperty.call(note.frontmatter, 'id')) {
+      blockers.push({ code: 'missing-note-id', path: note.relativePath });
+      missing++;
+      continue;
+    }
+    const id = note.frontmatter.id;
+    if (!isValidNoteId(id)) {
+      blockers.push({ code: 'invalid-note-id', path: note.relativePath, id });
+      invalid++;
+      continue;
+    }
+    valid++;
+    const key = normalizeNoteId(id);
+    const matches = notesById.get(key) ?? [];
+    matches.push({ path: note.relativePath, absolutePath: note.path, id });
+    notesById.set(key, matches);
+  }
+
+  let duplicate = 0;
+  for (const matches of notesById.values()) {
+    if (matches.length > 1) {
+      const paths = matches.map(match => match.path).sort((a, b) => a.localeCompare(b, 'en'));
+      duplicate += matches.length;
+      for (const match of matches) {
+        blockers.push({
+          code: 'duplicate-note-id',
+          path: match.path,
+          id: match.id,
+          paths,
+        });
+      }
+      continue;
+    }
+    const match = matches[0]!;
+    registrations.push({ id: match.id, notePath: match.absolutePath });
+  }
+
+  blockers.sort((a, b) =>
+    a.path.localeCompare(b.path, 'en') || a.code.localeCompare(b.code, 'en')
+  );
+
+  return {
+    blockers,
+    registrations,
+    counts: {
+      total: snapshot.notes.length,
+      valid,
+      missing,
+      invalid,
+      duplicate,
+    },
+  };
+}

--- a/src/lib/identity-transaction.ts
+++ b/src/lib/identity-transaction.ts
@@ -1,0 +1,103 @@
+import { randomUUID } from 'crypto';
+import { mkdir, readFile, readdir } from 'fs/promises';
+import { dirname, join, resolve } from 'path';
+import {
+  ownershipFileLockIsLive,
+  withOwnershipFileLock,
+} from './lineage-lock.js';
+import type { NoteIdentityStore } from './note-id.js';
+
+const MIGRATION_LOCK = '.bwrb/locks/identity-migration.lock';
+const TRANSACTION_DIR = '.bwrb/locks/identity-transactions';
+const RETRY_MS = 20;
+const ATTEMPTS = 250;
+const STALE_MS = 30_000;
+const HEARTBEAT_MS = 10_000;
+const LOCK_OPTIONS = {
+  retryMs: RETRY_MS,
+  attempts: ATTEMPTS,
+  staleMs: STALE_MS,
+  heartbeatMs: HEARTBEAT_MS,
+};
+
+/**
+ * Register one identity-relevant vault mutation without serializing it with
+ * unrelated mutations. A migration raises an exclusive fence, then waits for
+ * these independent leases to drain before changing identity authority.
+ */
+export async function withNoteIdentityTransaction<T>(
+  vaultDir: string,
+  expectedStore: NoteIdentityStore,
+  task: () => Promise<T>
+): Promise<T> {
+  const transactionDir = resolve(vaultDir, TRANSACTION_DIR);
+  const migrationLock = resolve(vaultDir, MIGRATION_LOCK);
+  await mkdir(transactionDir, { recursive: true });
+  const leasePath = join(transactionDir, `${process.pid}-${randomUUID()}.lease`);
+
+  return withOwnershipFileLock(
+    leasePath,
+    async () => {
+      if (await ownershipFileLockIsLive(migrationLock, LOCK_OPTIONS)) {
+        throw new Error('Note identity migration is in progress; retry the command.');
+      }
+      const liveStore = await readLiveIdentityStore(vaultDir);
+      if (liveStore !== expectedStore) {
+        throw new Error(
+          `Note identity storage changed (${expectedStore} -> ${liveStore}); retry the command.`
+        );
+      }
+      return task();
+    },
+    LOCK_OPTIONS,
+    'Timed out starting a note identity transaction; retry the command.'
+  );
+}
+
+/** Exclusively fence identity-relevant Bowerbird mutations for a mode switch. */
+export async function withIdentityMigrationFence<T>(
+  vaultDir: string,
+  task: () => Promise<T>
+): Promise<T> {
+  const migrationLock = resolve(vaultDir, MIGRATION_LOCK);
+  await mkdir(dirname(migrationLock), { recursive: true });
+  return withOwnershipFileLock(
+    migrationLock,
+    async () => {
+      await waitForTransactionsToDrain(resolve(vaultDir, TRANSACTION_DIR));
+      return task();
+    },
+    LOCK_OPTIONS,
+    'Timed out waiting to migrate note identity; retry the command.'
+  );
+}
+
+async function readLiveIdentityStore(vaultDir: string): Promise<NoteIdentityStore> {
+  const raw = JSON.parse(await readFile(resolve(vaultDir, '.bwrb/schema.json'), 'utf-8')) as {
+    config?: { identity_store?: unknown };
+  };
+  const store = raw.config?.identity_store ?? 'registry-v1';
+  if (store !== 'registry-v1' && store !== 'frontmatter-v1') {
+    throw new Error(`Unsupported note identity store '${String(store)}'.`);
+  }
+  return store;
+}
+
+async function waitForTransactionsToDrain(transactionDir: string): Promise<void> {
+  for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+    const entries = await readdir(transactionDir).catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [] as string[];
+      throw error;
+    });
+    let live = 0;
+    for (const entry of entries) {
+      if (!entry.endsWith('.lease')) continue;
+      if (await ownershipFileLockIsLive(join(transactionDir, entry), LOCK_OPTIONS)) {
+        live++;
+      }
+    }
+    if (live === 0) return;
+    await new Promise(resolveDelay => setTimeout(resolveDelay, RETRY_MS));
+  }
+  throw new Error('Timed out waiting for active note transactions; retry identity migration.');
+}

--- a/src/lib/lineage-lock.ts
+++ b/src/lib/lineage-lock.ts
@@ -102,6 +102,28 @@ export async function withOwnershipFileLock<T>(
   }
 }
 
+/**
+ * Report whether an ownership-safe lock is live, recovering it only when the
+ * same PID-aware rules used by lock acquisition prove the owner is gone.
+ */
+export async function ownershipFileLockIsLive(
+  lockPath: string,
+  optionOverrides: Partial<OwnershipFileLockOptions> = {}
+): Promise<boolean> {
+  const resolvedLockPath = resolve(lockPath);
+  const recoveryPath = `${resolvedLockPath}.recovery`;
+  const options = { ...DEFAULT_OPTIONS, ...optionOverrides };
+  if (await recoveryIsInProgress(recoveryPath, options)) return true;
+
+  const snapshotRead = await readLockSnapshot(resolvedLockPath);
+  if (snapshotRead.kind === 'missing') return false;
+  if (snapshotRead.kind === 'busy') return true;
+  if (!await isRecoverable(snapshotRead.snapshot, options.staleMs)) return true;
+
+  await recoverStaleLock(resolvedLockPath, recoveryPath, options);
+  return pathExists(resolvedLockPath) || pathExists(recoveryPath);
+}
+
 export function getLineageMutationLockPath(vaultDir: string, sourcePath: string): string {
   const vaultRoot = resolve(vaultDir);
   const absoluteSource = resolve(sourcePath);

--- a/src/lib/note-id.ts
+++ b/src/lib/note-id.ts
@@ -6,6 +6,10 @@ import {
   type OwnershipFileLockOptions,
   withOwnershipFileLock,
 } from './lineage-lock.js';
+import { buildVaultNoteSnapshot } from './discovery.js';
+import type { LoadedSchema } from '../types/schema.js';
+
+export type NoteIdentityStore = 'registry-v1' | 'frontmatter-v1';
 
 const ID_REGISTRY_RELATIVE_PATH = '.bwrb/ids.jsonl';
 const ID_ASSIGNMENT_LOCK = '.bwrb/locks/fork-source-id.lock';
@@ -84,8 +88,13 @@ async function readIssuedIds(vaultDir: string): Promise<Set<string>> {
   return ids;
 }
 
-export async function generateUniqueNoteId(vaultDir: string): Promise<string> {
-  const issued = await readIssuedIds(vaultDir);
+export async function generateUniqueNoteId(
+  vaultDir: string,
+  schema?: LoadedSchema
+): Promise<string> {
+  const issued = schema?.config.identityStore === 'frontmatter-v1'
+    ? await readFrontmatterIds(schema, vaultDir)
+    : await readIssuedIds(vaultDir);
 
   for (let attempt = 0; attempt < MAX_ID_GENERATION_ATTEMPTS; attempt++) {
     const id = randomUUID();
@@ -100,17 +109,19 @@ export async function generateUniqueNoteId(vaultDir: string): Promise<string> {
 export async function registerIssuedNoteId(
   vaultDir: string,
   id: string,
-  notePath: string
+  notePath: string,
+  identityStore: NoteIdentityStore = 'registry-v1'
 ): Promise<void> {
-  await registerIssuedNoteIds(vaultDir, [{ id, notePath }]);
+  await registerIssuedNoteIds(vaultDir, [{ id, notePath }], identityStore);
 }
 
 /** Register several newly assigned IDs as one atomic registry mutation. */
 export async function registerIssuedNoteIds(
   vaultDir: string,
-  registrations: NoteIdRegistration[]
+  registrations: NoteIdRegistration[],
+  identityStore: NoteIdentityStore = 'registry-v1'
 ): Promise<void> {
-  if (registrations.length === 0) return;
+  if (identityStore === 'frontmatter-v1' || registrations.length === 0) return;
   await withNoteIdRegistryLock(vaultDir, async () => {
     const registryPath = getIdRegistryPath(vaultDir);
     const current = await readFile(registryPath, 'utf-8').catch(error => {
@@ -130,8 +141,10 @@ export async function registerIssuedNoteIds(
 
 export async function unregisterIssuedNotePath(
   vaultDir: string,
-  relativePath: string
+  relativePath: string,
+  identityStore: NoteIdentityStore = 'registry-v1'
 ): Promise<void> {
+  if (identityStore === 'frontmatter-v1') return;
   await withNoteIdRegistryLock(vaultDir, async () => {
     const registryPath = getIdRegistryPath(vaultDir);
     if (!existsSync(registryPath)) return;
@@ -162,14 +175,35 @@ export async function unregisterIssuedNotePath(
 export async function withNoteIdAssignmentLock<T>(
   vaultDir: string,
   task: () => Promise<T>,
-  optionOverrides: Partial<OwnershipFileLockOptions> = {}
+  optionOverrides: Partial<OwnershipFileLockOptions> = {},
+  identityStore: NoteIdentityStore = 'registry-v1'
 ): Promise<T> {
+  if (identityStore === 'frontmatter-v1') return task();
   return withOwnershipFileLock(
     resolve(vaultDir, ID_ASSIGNMENT_LOCK),
     task,
     { ...NOTE_ID_LOCK_OPTIONS, ...optionOverrides },
     'Timed out waiting to assign a note ID; retry the command.'
   );
+}
+
+/** Rebuild the legacy registry from authoritative live-note frontmatter. */
+export async function rebuildIssuedNoteRegistry(
+  vaultDir: string,
+  registrations: NoteIdRegistration[],
+  rebuiltAt = new Date().toISOString()
+): Promise<void> {
+  await withNoteIdRegistryLock(vaultDir, async () => {
+    const existingCreatedAt = await readRegistryCreatedAtById(vaultDir);
+    const rows = [...registrations]
+      .sort((a, b) => relative(vaultDir, a.notePath).localeCompare(relative(vaultDir, b.notePath), 'en'))
+      .map(({ id, notePath }) => JSON.stringify({
+        id,
+        createdAt: existingCreatedAt.get(normalizeNoteId(id)) ?? rebuiltAt,
+        path: relative(vaultDir, notePath),
+      } satisfies IdRegistryEntry));
+    await writeRegistryAtomic(getIdRegistryPath(vaultDir), rows.length > 0 ? `${rows.join('\n')}\n` : '');
+  });
 }
 
 export function ensureIdInFieldOrder(order: string[]): string[] {
@@ -213,4 +247,35 @@ async function writeRegistryAtomic(registryPath: string, content: string): Promi
 
 function isFileMissingError(error: unknown): boolean {
   return error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+async function readFrontmatterIds(schema: LoadedSchema, vaultDir: string): Promise<Set<string>> {
+  const snapshot = await buildVaultNoteSnapshot(schema, vaultDir);
+  const ids = new Set<string>();
+  for (const note of snapshot.notes) {
+    const id = note.frontmatter?.id;
+    if (isValidNoteId(id)) ids.add(normalizeNoteId(id));
+  }
+  return ids;
+}
+
+async function readRegistryCreatedAtById(vaultDir: string): Promise<Map<string, string>> {
+  const registryPath = getIdRegistryPath(vaultDir);
+  const content = await readFile(registryPath, 'utf-8').catch(error => {
+    if (isFileMissingError(error)) return '';
+    throw error;
+  });
+  const values = new Map<string, string>();
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as Partial<IdRegistryEntry>;
+      if (isValidNoteId(parsed.id) && typeof parsed.createdAt === 'string') {
+        values.set(normalizeNoteId(parsed.id), parsed.createdAt);
+      }
+    } catch {
+      // Malformed legacy rows carry no trustworthy timestamp to preserve.
+    }
+  }
+  return values;
 }

--- a/src/lib/schema-writer.ts
+++ b/src/lib/schema-writer.ts
@@ -10,6 +10,10 @@ import { readFile, writeFile, rename } from 'fs/promises';
 import { join } from 'path';
 import { BwrbSchema, type Schema } from '../types/schema.js';
 import { SCHEMA_RELATIVE_PATH } from './bwrb-paths.js';
+import { withOwnershipFileLock } from './lineage-lock.js';
+
+const SCHEMA_LOCK_RELATIVE_PATH = '.bwrb/locks/schema.lock';
+const schemaSources = new WeakMap<object, string>();
 
 /**
  * Load the raw schema JSON from a vault directory.
@@ -19,7 +23,9 @@ export async function loadRawSchemaJson(vaultDir: string): Promise<Schema> {
   const schemaPath = join(vaultDir, SCHEMA_RELATIVE_PATH);
   const content = await readFile(schemaPath, 'utf-8');
   const json = JSON.parse(content) as unknown;
-  return BwrbSchema.parse(json);
+  const schema = BwrbSchema.parse(json);
+  schemaSources.set(schema, content);
+  return schema;
 }
 
 /**
@@ -27,6 +33,39 @@ export async function loadRawSchemaJson(vaultDir: string): Promise<Schema> {
  * Uses atomic write (temp file + rename) for safety.
  */
 export async function writeSchema(vaultDir: string, schema: Schema): Promise<void> {
+  await withSchemaLock(vaultDir, async () => {
+    const expected = schemaSources.get(schema);
+    if (expected !== undefined) {
+      const current = await readFile(join(vaultDir, SCHEMA_RELATIVE_PATH), 'utf-8');
+      if (current !== expected) {
+        throw new Error('Schema changed concurrently; retry the command.');
+      }
+    }
+    await writeSchemaUnlocked(vaultDir, schema);
+  });
+}
+
+/** Hold the schema read-modify-write lock for one guarded mutation. */
+export async function withSchemaMutation<T>(
+  vaultDir: string,
+  task: (schema: Schema) => Promise<{ result: T; write: boolean }>
+): Promise<T> {
+  return withSchemaLock(vaultDir, async () => {
+    const schema = await loadRawSchemaJson(vaultDir);
+    const expected = schemaSources.get(schema)!;
+    const outcome = await task(schema);
+    if (outcome.write) {
+      const current = await readFile(join(vaultDir, SCHEMA_RELATIVE_PATH), 'utf-8');
+      if (current !== expected) {
+        throw new Error('Schema changed concurrently; retry the command.');
+      }
+      await writeSchemaUnlocked(vaultDir, schema);
+    }
+    return outcome.result;
+  });
+}
+
+async function writeSchemaUnlocked(vaultDir: string, schema: Schema): Promise<void> {
   const schemaPath = join(vaultDir, SCHEMA_RELATIVE_PATH);
   const tempPath = join(vaultDir, SCHEMA_RELATIVE_PATH + '.tmp');
   
@@ -39,6 +78,16 @@ export async function writeSchema(vaultDir: string, schema: Schema): Promise<voi
   
   // Atomic rename
   await rename(tempPath, schemaPath);
+  schemaSources.set(schema, content);
+}
+
+async function withSchemaLock<T>(vaultDir: string, task: () => Promise<T>): Promise<T> {
+  return withOwnershipFileLock(
+    join(vaultDir, SCHEMA_LOCK_RELATIVE_PATH),
+    task,
+    {},
+    'Timed out waiting to update the schema; retry the command.'
+  );
 }
 
 /**

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -679,6 +679,7 @@ function resolveConfig(
   types: Map<string, ResolvedType>
 ): ResolvedConfig {
   return {
+    identityStore: config?.identity_store ?? 'registry-v1',
     linkFormat: config?.link_format ?? 'wikilink',
     editor: config?.editor ?? process.env.EDITOR,
     visual: config?.visual ?? process.env.VISUAL,

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -1570,7 +1570,7 @@ export async function createScaffoldedInstances(
       }
 
       // System-managed stable note id (v1.0)
-      const noteId = await generateUniqueNoteId(vaultDir);
+      const noteId = await generateUniqueNoteId(vaultDir, schema);
       frontmatter['id'] = noteId;
 
       // Generate body
@@ -1598,7 +1598,12 @@ export async function createScaffoldedInstances(
 
       // Write file
       await writeNote(filePath, frontmatter, body, orderedFields);
-      await registerIssuedNoteId(vaultDir, noteId, filePath);
+      await registerIssuedNoteId(
+        vaultDir,
+        noteId,
+        filePath,
+        schema.config.identityStore
+      );
       created.push(filePath);
 
     } catch (e) {

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -499,6 +499,12 @@ export const AuditConfigSchema = z.object({
  * These settings apply to the entire vault and control CLI behavior.
  */
 export const ConfigSchema = z.object({
+  identity_store: z
+    .enum(['registry-v1', 'frontmatter-v1'])
+    .optional()
+    .describe(
+      'Stable note identity storage: legacy shared registry or authoritative per-note frontmatter'
+    ),
   // Link format for relation fields in frontmatter
   // wikilink: "[[Note Name]]" (default, Obsidian-compatible)
   // markdown: "[Note Name](Note Name.md)"
@@ -783,6 +789,8 @@ export interface ResolvedType {
  * Resolved configuration with defaults applied.
  */
 export interface ResolvedConfig {
+  /** Stable note identity storage (omitted legacy vaults remain registry-v1). */
+  identityStore: 'registry-v1' | 'frontmatter-v1';
   /** Link format for relation fields: 'wikilink' or 'markdown' */
   linkFormat: 'wikilink' | 'markdown';
   /** Terminal editor command (from config or $EDITOR) */

--- a/tests/ts/commands/audit-lineage.test.ts
+++ b/tests/ts/commands/audit-lineage.test.ts
@@ -102,4 +102,47 @@ describe('audit command lineage UUID identity', () => {
     expect(result.stdout).toContain('Ideas/A.md');
     expect(result.stdout).toContain('Ideas/B.md');
   });
+
+  it('enforces required note identity only after frontmatter-v1 migration', async () => {
+    await writeFile(
+      join(vaultDir, 'Ideas', 'Missing.md'),
+      `---\ntype: idea\nstatus: raw\npriority: medium\n---\n`
+    );
+    await writeFile(
+      join(vaultDir, 'Ideas', 'Invalid.md'),
+      `---\ntype: idea\nid: definitely-not-a-uuid\nstatus: raw\npriority: medium\n---\n`
+    );
+
+    const legacy = await runCLI(
+      ['audit', 'idea', '--only', 'missing-note-id', '--output', 'json'],
+      vaultDir
+    );
+    expect(legacy.exitCode).toBe(0);
+
+    await writeFile(
+      join(vaultDir, '.bwrb', 'schema.json'),
+      JSON.stringify({
+        ...TEST_SCHEMA,
+        config: { ...TEST_SCHEMA.config, identity_store: 'frontmatter-v1' },
+      }, null, 2)
+    );
+
+    const missing = await runCLI(
+      ['audit', 'idea', '--only', 'missing-note-id', '--output', 'json'],
+      vaultDir
+    );
+    expect(missing.exitCode).toBe(1);
+    expect(JSON.parse(missing.stdout).files).toMatchObject([
+      { path: 'Ideas/Missing.md', issues: [{ code: 'missing-note-id' }] },
+    ]);
+
+    const invalid = await runCLI(
+      ['audit', 'idea', '--only', 'invalid-note-id', '--output', 'json'],
+      vaultDir
+    );
+    expect(invalid.exitCode).toBe(1);
+    expect(JSON.parse(invalid.stdout).files).toMatchObject([
+      { path: 'Ideas/Invalid.md', issues: [{ code: 'invalid-note-id' }] },
+    ]);
+  });
 });

--- a/tests/ts/commands/bulk.test.ts
+++ b/tests/ts/commands/bulk.test.ts
@@ -45,6 +45,19 @@ describe('bulk command', () => {
       // Error goes to stderr via printError
       expect(result.stderr).toContain("Invalid value 'invalid' for field 'status'");
     });
+
+    it.each([
+      ['--set', 'id=11111111-1111-4111-8111-111111111111'],
+      ['--delete', 'id'],
+      ['--append', 'id=value'],
+      ['--remove', 'id=value'],
+      ['--rename', 'id=legacy-id'],
+      ['--rename', 'status=id'],
+    ])('rejects reserved identity mutation through %s', async (flag, value) => {
+      const result = await runCLI(['bulk', 'idea', '--all', flag, value], vaultDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Cannot mutate reserved system-managed field 'id'");
+    });
   });
 
   describe('targeting gate (--all flag)', () => {

--- a/tests/ts/commands/completion.test.ts
+++ b/tests/ts/commands/completion.test.ts
@@ -219,6 +219,21 @@ describe('bwrb completion command', () => {
       expect(options).not.toContain('--force');
     });
 
+    it('completes identity migrate and its guarded migration options', async () => {
+      const subcommands = (await runCliOutput([
+        '--completions', 'bwrb', 'identity', '',
+      ], { vault: VAULT_DIR })).split('\n').filter(Boolean);
+      expect(subcommands).toEqual(['migrate']);
+
+      const options = (await runCliOutput([
+        '--completions', 'bwrb', 'identity', 'migrate', '--',
+      ], { vault: VAULT_DIR })).split('\n').filter(Boolean);
+      expect(options).toEqual(expect.arrayContaining([
+        '--to', '--dry-run', '--execute', '--output', '--vault', '--help',
+      ]));
+      expect(options).not.toContain('--force');
+    });
+
     it('should return option completions when current word starts with -', async () => {
       const output = await runCliOutput(['--completions', 'bwrb', 'list', '--'], {
         vault: VAULT_DIR,

--- a/tests/ts/commands/config.test.ts
+++ b/tests/ts/commands/config.test.ts
@@ -8,6 +8,8 @@ import { CONFIG_OPTION_KEYS } from '../../../src/commands/config.js';
 import { ConfigSchema, type Config } from '../../../src/types/schema.js';
 
 const INTENTIONALLY_UNEXPOSED_CONFIG_KEYS = [
+  // Identity mode changes require guarded `bwrb identity migrate`, never a flat edit.
+  'identity_store',
   // Calendar objects need guided authoring rather than a flat config editor (#790).
   'calendars',
   // Advanced mention tuning remains schema-only; dedicated command UX has not been designed.

--- a/tests/ts/commands/delete.test.ts
+++ b/tests/ts/commands/delete.test.ts
@@ -210,6 +210,23 @@ describe('delete command', () => {
       expect(await readFile(registryPath, 'utf-8')).not.toContain(created.path);
     });
 
+    it('should leave a dirty legacy registry untouched in frontmatter-v1', async () => {
+      const schemaPath = join(vaultDir, '.bwrb/schema.json');
+      const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as any;
+      schema.config = { ...schema.config, identity_store: 'frontmatter-v1' };
+      await writeFile(schemaPath, JSON.stringify(schema, null, 2));
+      const registryPath = join(vaultDir, '.bwrb/ids.jsonl');
+      const dirtyRegistry = '{"id":"unfinished","path":"Elsewhere.md"}\n';
+      await writeFile(registryPath, dirtyRegistry);
+
+      const result = await runCLI([
+        'delete', 'Ideas/Sample Idea.md', '--force', '--output', 'json',
+      ], vaultDir);
+
+      expect(result.exitCode, result.stderr || result.stdout).toBe(0);
+      expect(await readFile(registryPath, 'utf-8')).toBe(dirtyRegistry);
+    });
+
     it('should output JSON error on no match', async () => {
       const result = await runCLI(['delete', 'nonexistent-xyz', '--force', '--output', 'json'], vaultDir);
 

--- a/tests/ts/commands/help.contract.test.ts
+++ b/tests/ts/commands/help.contract.test.ts
@@ -35,6 +35,7 @@ describe('help output contract snapshots', () => {
       'bulk',
       'template',
       'lineage',
+      'identity',
       'dashboard',
       'init',
       'config',

--- a/tests/ts/commands/identity-migrate.test.ts
+++ b/tests/ts/commands/identity-migrate.test.ts
@@ -5,6 +5,9 @@ import { join } from 'path';
 import { promisify } from 'util';
 import { afterEach, describe, expect, it } from 'vitest';
 import { runCLI } from '../fixtures/setup.js';
+import { loadSchema } from '../../../src/lib/schema.js';
+import { migrateIdentityStore } from '../../../src/lib/identity-migration.js';
+import { withNoteIdentityTransaction } from '../../../src/lib/identity-transaction.js';
 
 const execFile = promisify(execFileCallback);
 const IDS = [
@@ -190,6 +193,45 @@ describe('identity migrate', () => {
     }));
     expect(new Set(ids).size).toBe(8);
     expect(await readFile(registryPath, 'utf-8')).toBe(dirtyRegistry);
+  });
+
+  it('waits for an active create before rebuilding and activating the legacy registry', async () => {
+    const vault = await makeVault({ identityStore: 'frontmatter-v1' });
+    const schema = await loadSchema(vault);
+    let release!: () => void;
+    const held = new Promise<void>(resolve => { release = resolve; });
+    let entered!: () => void;
+    const active = new Promise<void>(resolve => { entered = resolve; });
+
+    const create = withNoteIdentityTransaction(vault, 'frontmatter-v1', async () => {
+      await writeFile(join(vault, 'Notes/Late.md'), note('Late', IDS[1]));
+      entered();
+      await held;
+    });
+    await active;
+    let migrationSettled = false;
+    const migration = migrateIdentityStore(schema, vault, 'registry-v1', true)
+      .finally(() => { migrationSettled = true; });
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(migrationSettled).toBe(false);
+
+    release();
+    await create;
+    await migration;
+    const registry = await readFile(join(vault, '.bwrb/ids.jsonl'), 'utf-8');
+    expect(registry).toContain('Notes/One.md');
+    expect(registry).toContain('Notes/Late.md');
+  });
+
+  it('treats an already-selected identity store as an idempotent no-op', async () => {
+    const vault = await makeVault({ identityStore: 'frontmatter-v1', notes: [{ name: 'Missing' }] });
+    const schemaBefore = await readFile(join(vault, '.bwrb/schema.json'), 'utf-8');
+    const result = await runCLI([
+      'identity', 'migrate', '--to', 'frontmatter-v1', '--execute', '--output', 'json',
+    ], vault);
+    expect(result.exitCode, result.stderr || result.stdout).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({ changes: [], from: 'frontmatter-v1' });
+    expect(await readFile(join(vault, '.bwrb/schema.json'), 'utf-8')).toBe(schemaBefore);
   });
 });
 

--- a/tests/ts/commands/identity-migrate.test.ts
+++ b/tests/ts/commands/identity-migrate.test.ts
@@ -1,0 +1,224 @@
+import { execFile as execFileCallback } from 'child_process';
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { promisify } from 'util';
+import { afterEach, describe, expect, it } from 'vitest';
+import { runCLI } from '../fixtures/setup.js';
+
+const execFile = promisify(execFileCallback);
+const IDS = [
+  '11111111-1111-4111-8111-111111111111',
+  '22222222-2222-4222-8222-222222222222',
+  '33333333-3333-4333-8333-333333333333',
+  '44444444-4444-4444-8444-444444444444',
+];
+
+const createdVaults: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(createdVaults.splice(0).map(vault => rm(vault, { recursive: true, force: true })));
+});
+
+describe('identity migrate', () => {
+  it('defaults old vaults to registry-v1 and forward migration changes only schema mode', async () => {
+    const vault = await makeVault();
+    const registryPath = join(vault, '.bwrb/ids.jsonl');
+    const dirtyRegistry = `${JSON.stringify({ id: IDS[0], createdAt: '2026-01-01T00:00:00.000Z', path: 'Notes/One.md' })}\n` +
+      '{ deliberately malformed unfinished row\n';
+    await writeFile(registryPath, dirtyRegistry);
+
+    const preview = await runCLI([
+      'identity', 'migrate', '--to', 'frontmatter-v1', '--output', 'json',
+    ], vault);
+    expect(preview.exitCode, preview.stderr || preview.stdout).toBe(0);
+    expect(JSON.parse(preview.stdout)).toMatchObject({
+      success: true,
+      mode: 'dry-run',
+      from: 'registry-v1',
+      to: 'frontmatter-v1',
+      blockers: [],
+    });
+    expect(await readFile(registryPath, 'utf-8')).toBe(dirtyRegistry);
+    expect(JSON.parse(await readFile(join(vault, '.bwrb/schema.json'), 'utf-8')).config.identity_store)
+      .toBeUndefined();
+
+    const execute = await runCLI([
+      'identity', 'migrate', '--to', 'frontmatter-v1', '--execute', '--output', 'json',
+    ], vault);
+    expect(execute.exitCode, execute.stderr || execute.stdout).toBe(0);
+    expect(JSON.parse(execute.stdout).mode).toBe('execute');
+    expect(await readFile(registryPath, 'utf-8')).toBe(dirtyRegistry);
+    expect(JSON.parse(await readFile(join(vault, '.bwrb/schema.json'), 'utf-8')).config.identity_store)
+      .toBe('frontmatter-v1');
+  });
+
+  it('fails closed on missing, invalid, and duplicate frontmatter identity', async () => {
+    const vault = await makeVault({
+      notes: [
+        { name: 'Missing' },
+        { name: 'Invalid', id: 'not-a-uuid' },
+        { name: 'Duplicate A', id: IDS[0] },
+        { name: 'Duplicate B', id: IDS[0].toUpperCase() },
+      ],
+    });
+    const schemaBefore = await readFile(join(vault, '.bwrb/schema.json'), 'utf-8');
+
+    const preview = await runCLI([
+      'identity', 'migrate', '--to', 'frontmatter-v1', '--output', 'json',
+    ], vault);
+    expect(preview.exitCode).toBe(0);
+    const previewJson = JSON.parse(preview.stdout);
+    expect(previewJson.blockers.map((blocker: { code: string }) => blocker.code)).toEqual([
+      'duplicate-note-id',
+      'duplicate-note-id',
+      'invalid-note-id',
+      'missing-note-id',
+    ]);
+
+    const execute = await runCLI([
+      'identity', 'migrate', '--to', 'frontmatter-v1', '--execute', '--output', 'json',
+    ], vault);
+    expect(execute.exitCode).toBe(1);
+    expect(JSON.parse(execute.stdout).data.blockers).toHaveLength(4);
+    expect(await readFile(join(vault, '.bwrb/schema.json'), 'utf-8')).toBe(schemaBefore);
+  });
+
+  it('rebuilds the legacy registry before reverse migration and preserves known timestamps', async () => {
+    const vault = await makeVault({ identityStore: 'frontmatter-v1' });
+    const registryPath = join(vault, '.bwrb/ids.jsonl');
+    await writeFile(
+      registryPath,
+      `${JSON.stringify({ id: IDS[0], createdAt: '2025-05-04T03:02:01.000Z', path: 'Old/Path.md' })}\n`
+    );
+
+    const result = await runCLI([
+      'identity', 'migrate', '--to', 'registry-v1', '--execute', '--output', 'json',
+    ], vault);
+    expect(result.exitCode, result.stderr || result.stdout).toBe(0);
+    const rows = (await readFile(registryPath, 'utf-8')).trim().split('\n').map(line => JSON.parse(line));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({
+      id: IDS[0],
+      createdAt: '2025-05-04T03:02:01.000Z',
+      path: 'Notes/One.md',
+    });
+    expect(JSON.parse(await readFile(join(vault, '.bwrb/schema.json'), 'utf-8')).config.identity_store)
+      .toBe('registry-v1');
+  });
+
+  it('reproduces the Plaud dirty-registry collision without taking registry custody', async () => {
+    const vault = await makeVault({ notes: [] });
+    await execFile('git', ['init', '-q'], { cwd: vault });
+    await execFile('git', ['config', 'user.email', 'fixture@example.com'], { cwd: vault });
+    await execFile('git', ['config', 'user.name', 'Bowerbird Fixture'], { cwd: vault });
+    await execFile('git', ['add', '.'], { cwd: vault });
+    await execFile('git', ['commit', '-qm', 'fixture baseline'], { cwd: vault });
+
+    const registryPath = join(vault, '.bwrb/ids.jsonl');
+    const dirtyRows: string[] = [];
+    for (let index = 0; index < 4; index++) {
+      const path = `Notes/Unfinished ${index + 1}.md`;
+      await writeFile(join(vault, path), note(`Unfinished ${index + 1}`, IDS[index]!));
+      dirtyRows.push(JSON.stringify({
+        id: IDS[index],
+        createdAt: '2026-08-03T12:00:00.000Z',
+        path,
+      }));
+    }
+    await writeFile(registryPath, `${dirtyRows.join('\n')}\n`);
+
+    const migrate = await runCLI([
+      'identity', 'migrate', '--to', 'frontmatter-v1', '--execute', '--output', 'json',
+    ], vault);
+    expect(migrate.exitCode, migrate.stderr || migrate.stdout).toBe(0);
+    const registryBeforeImport = await readFile(registryPath, 'utf-8');
+
+    const created: Array<{ path: string; id: string }> = [];
+    for (let index = 0; index < 11; index++) {
+      const result = await runCLI([
+        'new', 'note', '--json', JSON.stringify({ name: `Plaud Transcript ${index + 1}` }),
+      ], vault);
+      expect(result.exitCode, result.stderr || result.stdout).toBe(0);
+      const output = JSON.parse(result.stdout) as { path: string };
+      const raw = await readFile(join(vault, output.path), 'utf-8');
+      created.push({ path: output.path, id: raw.match(/^id:\s*([^\s]+)$/m)![1]! });
+    }
+
+    expect(new Set(created.map(item => item.id)).size).toBe(11);
+    expect(await readFile(registryPath, 'utf-8')).toBe(registryBeforeImport);
+
+    const moved = created[0]!;
+    const movedPath = 'Notes/Renamed Plaud Transcript.md';
+    await execFile('git', ['add', moved.path], { cwd: vault });
+    await execFile('git', ['mv', moved.path, movedPath], { cwd: vault });
+    const resolved = await runCLI(['list', '--id', moved.id, '--output', 'json'], vault);
+    expect(resolved.exitCode, resolved.stderr || resolved.stdout).toBe(0);
+    expect(resolved.stdout).toContain(movedPath);
+
+    const copiedPath = join(vault, 'Notes/Copied Plaud Transcript.md');
+    await copyFile(join(vault, movedPath), copiedPath);
+    const duplicate = await runCLI([
+      'audit', '--only', 'duplicate-note-id', '--output', 'json',
+    ], vault);
+    expect(duplicate.exitCode).not.toBe(0);
+    expect(duplicate.stdout).toContain('duplicate-note-id');
+    expect(duplicate.stdout).toContain('Copied Plaud Transcript.md');
+    expect(duplicate.stdout).toContain('Renamed Plaud Transcript.md');
+    expect(await readFile(registryPath, 'utf-8')).toBe(registryBeforeImport);
+  });
+
+  it('lets unrelated frontmatter-v1 creates complete concurrently without registry custody', async () => {
+    const vault = await makeVault({ identityStore: 'frontmatter-v1', notes: [] });
+    const registryPath = join(vault, '.bwrb/ids.jsonl');
+    const dirtyRegistry = '{"unfinished":"belongs-to-another-transaction"}\n';
+    await writeFile(registryPath, dirtyRegistry);
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, (_, index) => runCLI([
+        'new', 'note', '--json', JSON.stringify({ name: `Concurrent ${index + 1}` }),
+      ], vault))
+    );
+
+    for (const result of results) {
+      expect(result.exitCode, result.stderr || result.stdout).toBe(0);
+    }
+    const paths = results.map(result => (JSON.parse(result.stdout) as { path: string }).path);
+    const ids = await Promise.all(paths.map(async path => {
+      const raw = await readFile(join(vault, path), 'utf-8');
+      return raw.match(/^id:\s*([^\s]+)$/m)![1]!;
+    }));
+    expect(new Set(ids).size).toBe(8);
+    expect(await readFile(registryPath, 'utf-8')).toBe(dirtyRegistry);
+  });
+});
+
+async function makeVault(options: {
+  identityStore?: 'registry-v1' | 'frontmatter-v1';
+  notes?: Array<{ name: string; id?: string }>;
+} = {}): Promise<string> {
+  const vault = await mkdtemp(join(tmpdir(), 'bwrb-identity-'));
+  createdVaults.push(vault);
+  await mkdir(join(vault, '.bwrb'), { recursive: true });
+  await mkdir(join(vault, 'Notes'), { recursive: true });
+  const config = options.identityStore ? { identity_store: options.identityStore } : {};
+  await writeFile(join(vault, '.bwrb/schema.json'), JSON.stringify({
+    version: 2,
+    config,
+    types: {
+      note: {
+        fields: {},
+        output_dir: 'Notes',
+      },
+    },
+  }, null, 2));
+  const notes = options.notes ?? [{ name: 'One', id: IDS[0] }];
+  for (const entry of notes) {
+    await writeFile(join(vault, `Notes/${entry.name}.md`), note(entry.name, entry.id));
+  }
+  return vault;
+}
+
+function note(name: string, id?: string): string {
+  return `---\ntype: note\n${id === undefined ? '' : `id: ${id}\n`}name: ${name}\n---\n`;
+}

--- a/tests/ts/commands/init.test.ts
+++ b/tests/ts/commands/init.test.ts
@@ -49,6 +49,7 @@ describe('init command', () => {
       const schema = JSON.parse(schemaContent);
 
       expect(schema.config.link_format).toBe('wikilink');
+      expect(schema.config.identity_store).toBe('frontmatter-v1');
     });
 
     it('should output success message', async () => {
@@ -69,6 +70,7 @@ describe('init command', () => {
       expect(json.data.vault).toBe(tempDir);
       expect(json.data.schema_path).toContain('.bwrb/schema.json');
       expect(json.data.config.link_format).toBe('wikilink');
+      expect(json.data.config.identity_store).toBe('frontmatter-v1');
     });
   });
 

--- a/tests/ts/commands/init.test.ts
+++ b/tests/ts/commands/init.test.ts
@@ -215,9 +215,11 @@ describe('init command', () => {
 
       await runCLI(['init', tempDir, '--force', '--yes']);
 
-      // Only schema.json should exist
+      // Reinitialization removes user/config state. The schema writer may leave
+      // its empty coordination directory after releasing the schema lock.
       const contents = await readdir(join(tempDir, '.bwrb'));
-      expect(contents).toEqual(['schema.json']);
+      expect(contents).toEqual(['locks', 'schema.json']);
+      expect(await readdir(join(tempDir, '.bwrb', 'locks'))).toEqual([]);
     });
   });
 

--- a/tests/ts/commands/lineage-adopt.test.ts
+++ b/tests/ts/commands/lineage-adopt.test.ts
@@ -118,6 +118,28 @@ describe('lineage adopt', () => {
       .toEqual([]);
   });
 
+  it('adopts lineage in frontmatter-v1 without taking custody of the legacy registry', async () => {
+    const schemaPath = join(vaultDir, '.bwrb/schema.json');
+    const rawSchema = JSON.parse(await readFile(schemaPath, 'utf-8')) as any;
+    rawSchema.config = { ...rawSchema.config, identity_store: 'frontmatter-v1' };
+    await writeFile(schemaPath, JSON.stringify(rawSchema, null, 2));
+    const registryPath = join(vaultDir, '.bwrb/ids.jsonl');
+    const dirtyRegistry = '{"id":"unfinished","path":"Elsewhere.md"}\n';
+    await writeFile(registryPath, dirtyRegistry);
+    await writeFile(join(vaultDir, 'Ideas/Frontmatter Parent.md'), noteRaw({ id: A }));
+    await writeFile(join(vaultDir, 'Ideas/Frontmatter Child.md'), noteRaw({ id: B }));
+
+    const result = await runCLI([
+      'lineage', 'adopt', 'Frontmatter Child', '--from', 'Frontmatter Parent',
+      '--execute', '--output', 'json',
+    ], vaultDir);
+
+    expect(result.exitCode, result.stderr || result.stdout).toBe(0);
+    expect(await readFile(registryPath, 'utf-8')).toBe(dirtyRegistry);
+    expect((await parseNote(join(vaultDir, 'Ideas/Frontmatter Child.md'))).frontmatter['forked-from'])
+      .toBe(A);
+  });
+
   it('resolves child and parent by exact UUID, path, basename, name, and schema alias', async () => {
     const schemaPath = join(vaultDir, '.bwrb/schema.json');
     const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as any;

--- a/tests/ts/commands/new-fork.test.ts
+++ b/tests/ts/commands/new-fork.test.ts
@@ -83,6 +83,29 @@ Words worth keeping.
     expect(fork.body).toBe('## Draft\n\nWords worth keeping.\n');
   });
 
+  it('forks in frontmatter-v1 without taking custody of the legacy registry', async () => {
+    const schemaPath = join(vaultDir, '.bwrb/schema.json');
+    const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as any;
+    schema.config = { ...schema.config, identity_store: 'frontmatter-v1' };
+    await writeFile(schemaPath, JSON.stringify(schema, null, 2));
+    const registryPath = join(vaultDir, '.bwrb/ids.jsonl');
+    const dirtyRegistry = '{"id":"unfinished","path":"Elsewhere.md"}\n';
+    await writeFile(registryPath, dirtyRegistry);
+    await writeFile(
+      join(vaultDir, 'Ideas/Frontmatter Source.md'),
+      `---\ntype: idea\nid: ${SOURCE_ID}\nname: Frontmatter Source\nstatus: raw\n---\nBody\n`
+    );
+
+    const result = await runCLI([
+      'new', '--fork', 'Frontmatter Source', '--name', 'Frontmatter Child', '--output', 'json',
+    ], vaultDir);
+
+    expect(result.exitCode, result.stderr || result.stdout).toBe(0);
+    expect(await readFile(registryPath, 'utf-8')).toBe(dirtyRegistry);
+    expect((await parseNote(join(vaultDir, 'Ideas/Frontmatter Child.md'))).frontmatter.id)
+      .toBe(JSON.parse(result.stdout).id);
+  });
+
   it('evaluates dynamic schema date defaults for new, edit restoration, and fork, and stays audit-clean', async () => {
     const schemaPath = join(vaultDir, '.bwrb/schema.json');
     const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as any;

--- a/tests/ts/contracts/command-byte-contracts.test.ts
+++ b/tests/ts/contracts/command-byte-contracts.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'crypto';
 import { spawn } from 'child_process';
-import { readdir, readFile } from 'fs/promises';
+import { readdir, readFile, writeFile } from 'fs/promises';
 import { join, relative } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { cleanupTestVault, createTestVault, PROJECT_ROOT } from '../fixtures/setup.js';
@@ -138,6 +138,33 @@ describe('P1 command contracts: JSON output and vault-byte invariance', () => {
       '.bwrb/ids.jsonl',
       'Ideas/Contract Created.md',
     ]);
+    expect(changed).toEqual([]);
+    expect(removed).toEqual([]);
+  });
+
+  it('P1 write isolation: frontmatter-v1 new owns only the new note bytes', async () => {
+    const schemaPath = join(vaultDir, '.bwrb/schema.json');
+    const schema = JSON.parse(await readFile(schemaPath, 'utf-8')) as {
+      config?: Record<string, unknown>;
+    };
+    schema.config = { ...schema.config, identity_store: 'frontmatter-v1' };
+    await writeFile(schemaPath, JSON.stringify(schema, null, 2));
+    const before = await vaultFileHashes(vaultDir);
+
+    const result = await runRawCli([
+      'new', 'idea', '--json', '{"name":"Isolated Contract","status":"raw"}',
+    ], vaultDir);
+    const json = expectOneJsonValue(result) as { path: string; success: boolean };
+    const after = await vaultFileHashes(vaultDir);
+    const added = after.filter((file) => !before.some((prior) => prior.path === file.path));
+    const changed = after.filter((file) => {
+      const prior = before.find((candidate) => candidate.path === file.path);
+      return prior !== undefined && prior.sha256 !== file.sha256;
+    });
+    const removed = before.filter((file) => !after.some((later) => later.path === file.path));
+
+    expect(json.success).toBe(true);
+    expect(added.map((file) => file.path)).toEqual(['Ideas/Isolated Contract.md']);
     expect(changed).toEqual([]);
     expect(removed).toEqual([]);
   });

--- a/tests/ts/helpers/help.ts
+++ b/tests/ts/helpers/help.ts
@@ -10,6 +10,7 @@ const CANONICAL_HELP_COMMAND_ORDER = [
   'bulk',
   'template',
   'lineage',
+  'identity',
   'dashboard',
   'init',
   'config',

--- a/tests/ts/lib/identity-transaction.test.ts
+++ b/tests/ts/lib/identity-transaction.test.ts
@@ -1,0 +1,96 @@
+import { mkdir, mkdtemp, readdir, rm, utimes, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  withIdentityMigrationFence,
+  withNoteIdentityTransaction,
+} from '../../../src/lib/identity-transaction.js';
+
+const vaults: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(vaults.splice(0).map(path => rm(path, { recursive: true, force: true })));
+});
+
+describe('identity migration fence', () => {
+  it('drains active transactions, blocks newcomers, and never serializes peer transactions', async () => {
+    const vault = await mkdtemp(join(tmpdir(), 'bwrb-identity-fence-'));
+    vaults.push(vault);
+    await mkdir(join(vault, '.bwrb'), { recursive: true });
+    await writeIdentitySchema(vault, 'frontmatter-v1');
+
+    let releasePeers!: () => void;
+    const holdPeers = new Promise<void>(resolve => { releasePeers = resolve; });
+    let peerCount = 0;
+    let peersEntered!: () => void;
+    const bothPeersEntered = new Promise<void>(resolve => { peersEntered = resolve; });
+    const peer = () => withNoteIdentityTransaction(vault, 'frontmatter-v1', async () => {
+      peerCount++;
+      if (peerCount === 2) peersEntered();
+      await holdPeers;
+    });
+    const peers = Promise.all([peer(), peer()]);
+    await bothPeersEntered;
+    const leaseDir = join(vault, '.bwrb/locks/identity-transactions');
+    const old = new Date(Date.now() - 60_000);
+    for (const entry of await readdir(leaseDir)) {
+      await utimes(join(leaseDir, entry), old, old);
+    }
+
+    let fenceEntered!: () => void;
+    const insideFence = new Promise<void>(resolve => { fenceEntered = resolve; });
+    let releaseFence!: () => void;
+    const holdFence = new Promise<void>(resolve => { releaseFence = resolve; });
+    const fence = withIdentityMigrationFence(vault, async () => {
+      fenceEntered();
+      await holdFence;
+    });
+    await new Promise(resolve => setTimeout(resolve, 50));
+    let didFenceEnter = false;
+    void insideFence.then(() => { didFenceEnter = true; });
+    await Promise.resolve();
+    expect(didFenceEnter).toBe(false);
+
+    releasePeers();
+    await peers;
+    await insideFence;
+    await expect(withNoteIdentityTransaction(vault, 'frontmatter-v1', async () => undefined))
+      .rejects.toThrow('migration is in progress');
+    releaseFence();
+    await fence;
+  });
+
+  it('rejects a transaction whose loaded identity mode became stale', async () => {
+    const vault = await mkdtemp(join(tmpdir(), 'bwrb-identity-mode-'));
+    vaults.push(vault);
+    await mkdir(join(vault, '.bwrb'), { recursive: true });
+    await writeIdentitySchema(vault, 'registry-v1');
+
+    await expect(withNoteIdentityTransaction(
+      vault,
+      'frontmatter-v1',
+      async () => undefined
+    )).rejects.toThrow('frontmatter-v1 -> registry-v1');
+  });
+
+  it('fails closed when the transaction lease directory is unreadable as a directory', async () => {
+    const vault = await mkdtemp(join(tmpdir(), 'bwrb-identity-unreadable-'));
+    vaults.push(vault);
+    await mkdir(join(vault, '.bwrb/locks'), { recursive: true });
+    await writeFile(join(vault, '.bwrb/locks/identity-transactions'), 'not a directory');
+
+    await expect(withIdentityMigrationFence(vault, async () => undefined))
+      .rejects.toMatchObject({ code: 'ENOTDIR' });
+  });
+});
+
+async function writeIdentitySchema(
+  vault: string,
+  identityStore: 'registry-v1' | 'frontmatter-v1'
+): Promise<void> {
+  await writeFile(
+    join(vault, '.bwrb/schema.json'),
+    JSON.stringify({ version: 2, config: { identity_store: identityStore }, types: {} }, null, 2)
+  );
+}

--- a/tests/ts/lib/schema-writer-concurrency.test.ts
+++ b/tests/ts/lib/schema-writer-concurrency.test.ts
@@ -1,0 +1,30 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { loadRawSchemaJson, writeSchema } from '../../../src/lib/schema-writer.js';
+
+const vaults: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(vaults.splice(0).map(path => rm(path, { recursive: true, force: true })));
+});
+
+describe('schema writer concurrency', () => {
+  it('refuses a stale whole-schema write instead of losing a concurrent change', async () => {
+    const vault = await mkdtemp(join(tmpdir(), 'bwrb-schema-cas-'));
+    vaults.push(vault);
+    await mkdir(join(vault, '.bwrb'), { recursive: true });
+    const schemaPath = join(vault, '.bwrb/schema.json');
+    await writeFile(schemaPath, JSON.stringify({ version: 2, config: {}, types: {} }, null, 2));
+    const first = await loadRawSchemaJson(vault);
+    const stale = await loadRawSchemaJson(vault);
+    first.config = { ...first.config, identity_store: 'frontmatter-v1' };
+    await writeSchema(vault, first);
+    stale.config = { ...stale.config, link_format: 'markdown' };
+
+    await expect(writeSchema(vault, stale)).rejects.toThrow('Schema changed concurrently');
+    expect(JSON.parse(await readFile(schemaPath, 'utf-8')).config.identity_store)
+      .toBe('frontmatter-v1');
+  });
+});

--- a/tests/ts/lib/transition-effects.test.ts
+++ b/tests/ts/lib/transition-effects.test.ts
@@ -12,6 +12,11 @@ afterEach(async () => { await Promise.all(dirs.splice(0).map((dir) => rm(dir, { 
 
 async function fixture() {
   const vault = await mkdtemp(join(tmpdir(), 'bwrb-effects-')); dirs.push(vault);
+  await mkdir(join(vault, '.bwrb'), { recursive: true });
+  await writeFile(
+    join(vault, '.bwrb/schema.json'),
+    JSON.stringify({ version: 2, config: {}, types: {} })
+  );
   await mkdir(join(vault, 'Candidates'), { recursive: true });
   await mkdir(join(vault, 'Tasks'), { recursive: true });
   const schema = resolveSchema({ version: 2, traits: { advancing: { transition_effects: [{ on: 'status = accepted', relation: 'task', set: { status: 'done' } }] } }, types: {

--- a/tests/ts/lib/transition-guards.test.ts
+++ b/tests/ts/lib/transition-guards.test.ts
@@ -12,6 +12,11 @@ afterEach(async () => { await Promise.all(dirs.splice(0).map((dir) => rm(dir, { 
 
 async function fixture(requirementStatus: string) {
   const vault = await mkdtemp(join(tmpdir(), 'bwrb-transition-')); dirs.push(vault);
+  await mkdir(join(vault, '.bwrb'), { recursive: true });
+  await writeFile(
+    join(vault, '.bwrb/schema.json'),
+    JSON.stringify({ version: 2, config: {}, types: {} })
+  );
   await mkdir(join(vault, 'Candidates'), { recursive: true });
   await mkdir(join(vault, 'Requirements'), { recursive: true });
   const schema = resolveSchema({ version: 2, traits: { guarded: { transition_guards: [{ on: 'status = accepted', requires: [{ relation: 'requirements', all: { field: 'status', equals: 'satisfied' }, failed_when: { field: 'status', in: ['failed'] }, stale_when: { field: 'status', in: ['stale'] } }] }] } }, types: {


### PR DESCRIPTION
## Problem

Bowerbird currently treats `.bwrb/ids.jsonl` as the authoritative identity registry for existing vaults. That preserves stable identity, but every note creation and deletion mutates one shared file. In a Git-backed vault, unfinished changes for one group of notes can therefore block unrelated imports; the August 3 Plaud import reproduced this when eleven otherwise independent transcript writes collided with four unfinished registrations.

## Approach

Make each note own its stable UUID in reserved frontmatter and treat discovery plus validation as the source of truth. New vaults select `frontmatter-v1`; existing vaults remain on the legacy `registry-v1` behavior until an explicit, whole-vault migration succeeds. No global index is authoritative in frontmatter mode, and any future index must be disposable and rebuildable.

## What changed

- Add `bwrb identity migrate`, dry-run by default, for validated forward migration and registry-rebuilding rollback.
- Make create, fork, lineage adoption, deletion, templates, and bulk operations identity-mode aware.
- Preserve stable targeting across renames and moves by resolving the note-owned ID during discovery.
- Audit missing, invalid, and copied duplicate IDs without choosing an automatic winner.
- Fence only mode-changing migration while allowing unrelated frontmatter-mode note transactions to proceed concurrently.
- Protect schema mode changes with lock-and-compare semantics, and reject stale callers before they mutate a note.
- Document the governing model, Git workflow, migration requirements, rollback, and automation-facing CLI surface.

## Safety and operations

Existing vaults with an omitted `config.identity_store` continue to use the legacy registry. Forward migration validates all discoverable notes and changes only the schema; even a dirty legacy registry remains byte-for-byte unchanged. Reverse migration validates identities, atomically rebuilds the registry, and then returns the schema to `registry-v1`.

Migration fails closed on unreadable notes, missing or malformed IDs, duplicates, live transactions, stale mode observations, and non-ENOENT lease-read errors. Bowerbird writers are fenced during the brief mode switch. External editors and raw Git operations cannot join that fence, so operators must quiesce them between final preview and execute. Mixed writer versions should not be used after migration.

## Verification

- Full CI-parity sequence passed at `929bc6f72362db170bf852764beae34949c18dc1`: build, package verification, typecheck, lint, knip, and 3,002 non-PTY tests across 130 files.
- Schema and documentation checks passed: schema check, docs check, docs lint, docs doctor, and docs build.
- Independent technical review found no remaining blocking findings after concurrency, lease recovery, stale-mode, and fail-closed repairs.
- Independent real-CLI acceptance passed all six horizons on the exact commit: forward preview and execute, eleven concurrent Plaud transcript creates against a dirty legacy registry, stable lookup after `git mv`, duplicate-copy detection, missing/invalid-ID audit, and reverse migration to a 15-row registry with unique IDs and paths.
- The tester did not capture a standalone lock-directory listing immediately after the concurrent creates. The eleven writes all exited zero, later migration completed, and fixture cleanup passed; this is an evidence granularity gap, not an observed functional failure.

## Review focus

- Does the migration fence cover every operation that can create, remove, move, or backfill identity without becoming a steady-state global lock?
- Are schema lock-and-compare and live-owner lease recovery conservative enough across process crashes and filesystem errors?
- Is legacy compatibility truly inert until explicit migration, including dirty-registry preservation?
- Are duplicate-copy handling and manual repair boundaries sufficiently fail-closed for external-editor and Git workflows?
- Is reverse migration ordering safe if rebuilding the registry succeeds but switching schema mode encounters a concurrent change?

## Follow-ups

- A generated identity index remains an optional later performance capability. It must be rebuildable and non-authoritative.