### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,25 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-08-05
+
+Patch release for distributed stable note identity, revision-safe file-backed
+JSON writes, and bounded query receipts with strict typed validation.
+
 ### Added
 
 - **Distributed stable note identity** — new vaults keep the authoritative UUID
   with each note instead of mutating a shared registry. Existing vaults remain
   on the legacy registry until `bwrb identity migrate` validates every note and
   explicitly switches modes; reverse migration rebuilds the registry for safe
-  rollback.
+  rollback (#836).
+- **File-backed JSON writes** — `bwrb new --json-file` and
+  `bwrb edit --json-file` accept large private payloads without exposing them
+  through command-line arguments, while edit `_body` replacement remains
+  revision-guarded (#834).
+- **Bounded query receipts** — list and saved-dashboard JSON output can include
+  opt-in matched, returned, and truncated cardinality evidence without changing
+  legacy raw-array or count output (#835).
 
 ### Changed
 
@@ -18,7 +30,10 @@ All notable changes to Bowerbird are documented in this file.
   template scaffolding, lineage adoption, and deletion no longer take custody
   of `.bwrb/ids.jsonl` or a vault-wide identity-assignment lock. Audit reports
   missing, invalid, and copied duplicate IDs while stable targeting continues
-  across renames and moves.
+  across renames and moves (#836).
+- **Strict typed query validation** — typed `--where` expressions reject unknown
+  fields across supported operators and function arguments with actionable
+  errors instead of silently returning an empty result (#835).
 
 ## [0.3.0] - 2026-07-13
 

--- a/docs-site/src/content/docs/changelog.md
+++ b/docs-site/src/content/docs/changelog.md
@@ -11,6 +11,27 @@ For the complete changelog with all details, see [CHANGELOG.md](https://github.c
 
 ### Unreleased
 
+### 0.3.1
+
+- **Distributed stable note identity** — new vaults store their authoritative
+  UUID with each note, while existing vaults remain on the legacy registry
+  until an explicit whole-vault `identity migrate` preflight succeeds. The
+  migration is reversible and leaves a dirty legacy registry untouched when
+  moving forward.
+- **Independent Git transactions** — frontmatter-identity creation, forks,
+  templates, lineage adoption, and deletion no longer contend on a shared ID
+  registry. Audit reports missing, invalid, and duplicate copied IDs without
+  choosing an automatic winner.
+- **Revision-safe file-backed writes** — `new` and `edit` accept large private
+  JSON payloads from files, including guarded body replacement, without placing
+  those payloads in command-line arguments.
+- **Bounded query receipts** — list and saved-dashboard JSON output can prove
+  matched, returned, and truncated counts while preserving legacy output when
+  receipts are not requested.
+- **Strict typed query validation** — supported typed query operators and
+  functions reject unknown fields with actionable errors instead of silently
+  returning no rows.
+
 ### 0.3.0
 
 - **Removed deprecated CLI surfaces** — `search` and `open`, legacy `list`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bwrb",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Schema-driven note management for markdown vaults",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Problem

Bowerbird 0.3.0 was published to npm from `fe189765eb928bd5cf8985a0d8ba3453674b26cf`, but GitHub never received the matching tag/release and the source manifest remained at 0.3.0 while later capabilities accumulated on `main`. Rebuilding or publishing that moving source as 0.3.0 would misidentify an immutable npm version.

## Approach

Cut the current post-0.3.0 source as 0.3.1 without changing product code. Keep the historical GitHub v0.3.0 backfill separate and anchored to the npm artifact's exact `gitHead`.

## What changed

- bump the package version from 0.3.0 to 0.3.1;
- release the existing distributed note-identity and independent-transaction changelog entries;
- document revision-safe file-backed JSON writes and bounded query receipts with strict typed validation;
- add matching reader-facing highlights to the documentation changelog.

## Safety and operations

Existing vaults remain on `registry-v1` until an explicit whole-vault identity migration succeeds. Forward migration leaves the legacy ID registry byte-for-byte unchanged; missing, invalid, duplicate, or unreadable note identity still fails closed.

This PR does not create tags, publish GitHub releases, republish npm 0.3.0, publish npm 0.3.1, or modify any vault.

## Verification

Completed evidence on exact head `5e97ce683485bc70e304314857ac927696aafad7`:

- full GitHub CI passed: Test, Retry-zero reliability, PTY Tests, Windows Lock Tests, Docs Relevance, and Docs Site CI;
- build and npm package verification passed, proving the packed CLI reports 0.3.1 and exposes `identity`;
- typecheck, lint, and Knip passed;
- docs structure, links, doctor, and production build passed;
- focused identity migration and transaction tests passed against both source and built `dist` (10/10 in each mode);
- a fresh packed installation completed a frontmatter → registry → frontmatter round trip and preserved the legacy registry SHA-256 across preview and execute;
- independent real-PTY human QA passed the frozen H1–H6 script against the packed artifact, including fail-closed duplicate-ID audit behavior;
- all task-owned disposable fixtures were cleaned and absence was verified.

## Review focus

- Does the changelog account for every user-facing capability merged after npm 0.3.0?
- Is the boundary between the historical v0.3.0 GitHub backfill and the new v0.3.1 artifact unambiguous?
- Do the release notes preserve the opt-in, fail-closed migration contract for existing vaults?
