### PR TITLE
Harden preserve-first note repair

### DIFF
--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -96,6 +96,8 @@ Delete semantics in repair mode:
 
 | Type | Description |
 |------|-------------|
+| `missing-frontmatter` | Plain Markdown in a managed directory has no valid top frontmatter. Guided repair adopts it by adding only the minimal valid frontmatter and a UUID while preserving the body bytes; auto-repair runs only when type and required values are deterministic. Mapping-like prose is not relocated. |
+| `unsafe-filename` | The filename contains non-portable characters, a Windows device basename, a trailing dot/space, or exceeds Bowerbird's 192-byte Markdown filename budget. Repair deterministically renames it, preserves the full title in `name`, and updates backlinks; collisions fail without overwrite. |
 | `orphan-file` | File in managed directory but no `type` field |
 | `invalid-type` | Type field value not recognized in schema |
 | `missing-required` | Required field is missing |
@@ -111,6 +113,7 @@ Delete semantics in repair mode:
 | `duplicate-note-id` | Two or more notes use the same stable UUID `id` (error; flag-only) |
 | `missing-note-id` | A discovered parseable note has no `id` while the vault uses `frontmatter-v1` identity (error; flag-only) |
 | `invalid-note-id` | A discovered parseable note has a non-UUID `id` while the vault uses `frontmatter-v1` identity (error; flag-only) |
+| `frontmatter-not-at-top` | Exactly one displaced YAML block is repairable only when it resolves to a valid schema type, has no duplicate keys, contains a valid or absent UUID, and validates against that type. Multiple candidates or conflicting identity remain untouched for manual resolution. |
 | `fork-cycle` | Following immediate `forked-from` references forms a cycle (error; flag-only). Traversal is cycle-safe and always terminates |
 | `format-violation` | Field value doesn't match expected format (wikilink, etc.) |
 | `stale-reference` | Wikilink points to non-existent file |

--- a/docs-site/src/content/docs/reference/commands/new.md
+++ b/docs-site/src/content/docs/reference/commands/new.md
@@ -128,7 +128,7 @@ bwrb new project --json '{"name": "My Project"}' --template with-research
 
 The `_body` field accepts either a raw Markdown string or an object whose keys are schema body section names. Section-object values may be strings or string arrays. A raw string is written as the note body as-is and bypasses template/body-section generation.
 
-If the note name or resolved filename pattern contains characters that are not portable in filenames, `bwrb new` normalizes the filename by removing invalid characters, collapsing doubled whitespace, and trimming the result. Interactive creation prints a warning. JSON mode includes `nameTransformed` metadata:
+If the note name or resolved filename pattern is not filesystem-portable, `bwrb new` removes invalid characters, avoids Windows device basenames, trims trailing dots/spaces, and deterministically shortens long UTF-8 names to keep the complete Markdown filename at or below 192 bytes. Shortened names include a stable digest, so distinct long titles remain distinct. Interactive creation prints a warning. JSON mode includes `nameTransformed` metadata:
 
 ```json
 {
@@ -144,6 +144,8 @@ If the note name or resolved filename pattern contains characters that are not p
 
 The persisted `name` remains the original note identity. Only the physical
 filename is normalized.
+
+Creation uses an exclusive write for new paths: a concurrent collision is refused rather than overwriting the file that appeared.
 
 Paths longer than 200 characters include `pathLengthWarning` in JSON mode and print a warning in interactive mode. Paths longer than 260 characters are rejected.
 

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -605,13 +605,17 @@ on the named notes and retry—do not infer a replacement option.
 Audit resolves each file's type from its frontmatter `type` field. Understanding this is critical for automation:
 
 - **Type resolution**: Each file's `type` field is read and matched to the schema by short name (e.g., `task`, not `objective/task`)
-- **Early termination**: If `type` is missing or invalid, audit reports `orphan-file` or `invalid-type` and **skips all type-dependent checks**
+- **Plain Markdown adoption**: A managed Markdown file without valid top frontmatter reports `missing-frontmatter`. Auto-repair is available only when its path determines the type and all required values; otherwise use guided repair. The body is preserved byte-for-byte.
+- **Displaced YAML**: `frontmatter-not-at-top` is auto-repairable only for one schema-valid block with unambiguous identity. Multiple blocks, duplicate keys, or an invalid/conflicting UUID fail closed.
+- **Early termination**: If top frontmatter has a missing or invalid `type`, audit reports `orphan-file` or `invalid-type` and **skips all type-dependent checks**
 - **Filtering vs fixing**: `--type` filters which files to audit; it does not fix missing type fields
 
 **Check dependency table:**
 
 | Check | Requires Type Resolution |
 |-------|-------------------------|
+| `missing-frontmatter` | No (path inference may make adoption deterministic) |
+| `unsafe-filename` | Yes |
 | `orphan-file` | No (reports missing type) |
 | `invalid-type` | No (reports unrecognized type) |
 | `trailing-whitespace` | No (operates on raw frontmatter lines; schema/type not needed) |

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -104,6 +104,8 @@ export const auditCommand = new Command('audit')
   .description('Validate vault files against schema and report issues')
   .addHelpText('after', `
 Issue Types:
+  missing-frontmatter    Plain Markdown note has no valid top frontmatter block
+  unsafe-filename       Filename is not portable or exceeds Bowerbird's byte budget
   orphan-file           File in managed directory but no 'type' field
   invalid-type          Type field value not recognized
   missing-required      Required field is missing

--- a/src/commands/new/write-plan.ts
+++ b/src/commands/new/write-plan.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'fs';
 import { join, relative } from 'path';
 import {
   writeNote,
+  writeNoteExclusive,
 } from '../../lib/frontmatter.js';
 import {
   ensureIdInFieldOrder,
@@ -78,7 +79,8 @@ async function writeNotePlanWithinIdentityTransaction(
     }
   }
 
-  if (existsSync(filePath)) {
+  const overwriteExisting = existsSync(filePath);
+  if (overwriteExisting) {
     await fileExistsStrategy.onExists(filePath, args.vaultDir);
   }
 
@@ -102,7 +104,11 @@ async function writeNotePlanWithinIdentityTransaction(
   }
   const orderedFields = ensureIdInFieldOrder(args.content.orderedFields);
 
-  await writeNote(filePath, args.content.frontmatter, args.content.body, orderedFields);
+  if (overwriteExisting) {
+    await writeNote(filePath, args.content.frontmatter, args.content.body, orderedFields);
+  } else {
+    await writeNoteExclusive(filePath, args.content.frontmatter, args.content.body, orderedFields);
+  }
   await registerIssuedNoteId(
     args.vaultDir,
     noteId,

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -412,6 +412,7 @@ export async function auditFile(
     }
   }
   const topMappingLooksLikeProse = Boolean(
+    file.expectedType &&
     structural.primaryBlock &&
     structural.atTop &&
     !Object.prototype.hasOwnProperty.call(structural.frontmatter, 'type') &&

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -42,7 +42,7 @@ import { isBlankScalar } from '../emptiness.js';
 import { isMap } from 'yaml';
 import type { Pair, Scalar, YAMLMap } from 'yaml';
 import { isDeepStrictEqual } from 'node:util';
-import { suggestOptionValue, suggestFieldName } from '../validation.js';
+import { suggestOptionValue, suggestFieldName, validateFrontmatter } from '../validation.js';
 import { searchContent } from '../content-search.js';
 import { applyWhereExpressions } from '../where-targeting.js';
 import { type LoadedSchema, type Field, getOptionValues } from '../../types/schema.js';
@@ -86,6 +86,8 @@ import { parseCalendarDate } from '../calendar-date.js';
 import { formatLocalDate } from '../local-date.js';
 import { collectLineageIssues } from './lineage.js';
 import { collectRequiredNoteIdentityIssues } from './identity.js';
+import { isValidNoteId } from '../note-id.js';
+import { sanitizeFilenameBase } from '../filename.js';
 
 // Import ownership tracking
 import {
@@ -245,11 +247,24 @@ export async function runAuditDetailed(
   const results: FileAuditResult[] = [];
 
   for (const file of filteredFiles) {
+    const fileIssues = await auditFile(schema, vaultDir, file, { ...options, retentionToday }, noteIndex, ownershipIndex, parentMap, entityMentionIndex);
+    const isPlainMarkdown = fileIssues.some(issue => issue.code === 'missing-frontmatter');
     const issues = [
-      ...(await auditFile(schema, vaultDir, file, { ...options, retentionToday }, noteIndex, ownershipIndex, parentMap, entityMentionIndex)),
+      ...fileIssues,
       ...(lineageIssuesByPath.get(file.relativePath) ?? []),
-      ...(identityIssuesByPath.get(file.relativePath) ?? []),
+      ...(isPlainMarkdown
+        ? (identityIssuesByPath.get(file.relativePath) ?? []).filter(issue => issue.code !== 'missing-note-id')
+        : (identityIssuesByPath.get(file.relativePath) ?? [])),
     ];
+
+    if (issues.some(issue => issue.code === 'duplicate-note-id')) {
+      for (const issue of issues) {
+        if (issue.code === 'frontmatter-not-at-top') {
+          issue.autoFixable = false;
+          issue.message = 'Frontmatter is not at the top of the file (conflicting identity; not auto-fixable)';
+        }
+      }
+    }
 
     // Apply issue filters
     let filteredIssues = issues;
@@ -386,6 +401,26 @@ export async function auditFile(
     return issues;
   }
 
+  const displacedType = structural.primaryBlock && !structural.atTop
+    ? resolveTypeFromFrontmatter(schema, structural.frontmatter)
+    : undefined;
+  if (!structural.primaryBlock || (structural.primaryBlock && !structural.atTop && !displacedType)) {
+    const inferredType = file.expectedType;
+    const autoFixable = Boolean(
+      inferredType && hasDeterministicAdoptionFields(schema, inferredType)
+    );
+    issues.push({
+      severity: 'error',
+      code: 'missing-frontmatter',
+      message: structural.primaryBlock
+        ? 'No valid top frontmatter; YAML-like body content was left as prose'
+        : 'No frontmatter block; plain Markdown can be adopted explicitly',
+      autoFixable,
+      ...(inferredType ? { inferredType } : {}),
+    });
+    return issues;
+  }
+
   const frontmatter: Record<string, unknown> = structural.frontmatter;
 
   const getDeleteRecommendationMeta = (
@@ -400,7 +435,7 @@ export async function auditFile(
   });
 
   // Phase 4: Structural integrity issues
-  issues.push(...collectStructuralIssues(structural, frontmatter));
+  issues.push(...collectStructuralIssues(schema, structural, frontmatter));
 
   // Raw-level hygiene: detect trailing whitespace before YAML parsing
   issues.push(...detectTrailingWhitespaceInRawFrontmatter(structural));
@@ -450,6 +485,24 @@ export async function auditFile(
       meta: getDeleteRecommendationMeta('invalid-type'),
     });
     return issues;
+  }
+
+  const filenameBase = basename(file.path, '.md');
+  const filenameSafety = sanitizeFilenameBase(filenameBase);
+  if (filenameSafety.transformation) {
+    issues.push({
+      severity: 'error',
+      code: 'unsafe-filename',
+      message: `Filename component is not portable; repair to '${filenameSafety.transformation.filename}'`,
+      autoFixable: filenameSafety.sanitized.length > 0,
+      fixedValue: filenameSafety.sanitized,
+      meta: {
+        originalFilename: `${filenameBase}.md`,
+        safeFilename: filenameSafety.transformation.filename,
+        originalBytes: Buffer.byteLength(`${filenameBase}.md`, 'utf8'),
+        safeBytes: Buffer.byteLength(filenameSafety.transformation.filename, 'utf8'),
+      },
+    });
   }
 
   // Check wrong directory
@@ -1501,7 +1554,20 @@ function repairNearWikilink(trimmed: string): string | null {
   return null;
 }
 
+function hasDeterministicAdoptionFields(schema: LoadedSchema, typePath: string): boolean {
+  const typeDef = getType(schema, typePath);
+  if (!typeDef) return false;
+  const fields = getFieldsForType(schema, typePath);
+  return Object.entries(fields).every(([fieldName, field]) =>
+    isBwrbBuiltinFrontmatterField(fieldName) ||
+    !field.required ||
+    field.default !== undefined ||
+    field.value !== undefined
+  );
+}
+
 function collectStructuralIssues(
+  schema: LoadedSchema,
   structural: Awaited<ReturnType<typeof readStructuralFrontmatter>>,
   frontmatter: Record<string, unknown>
 ): AuditIssue[] {
@@ -1509,10 +1575,18 @@ function collectStructuralIssues(
 
   // frontmatter-not-at-top
   if (structural.primaryBlock && !structural.atTop) {
+    const resolvedType = resolveTypeFromFrontmatter(schema, frontmatter);
+    const id = frontmatter.id;
+    const validIdentity = id === undefined || isValidNoteId(id);
+    const validSchema = resolvedType
+      ? validateFrontmatter(schema, resolvedType, frontmatter).valid
+      : false;
     const autoFixable =
       structural.frontmatterBlocks.length === 1 &&
       !structural.unterminated &&
-      structural.yamlErrors.length === 0;
+      structural.yamlErrors.length === 0 &&
+      validIdentity &&
+      validSchema;
 
     issues.push({
       severity: 'error',

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -13,6 +13,7 @@ import {
   resolveTypeFromFrontmatter,
   getOutputDir,
   getRootTypeNames,
+  getConcreteTypeNames,
   getDescendants,
   getOwnedFields,
   resolveDateCalendar,
@@ -404,7 +405,24 @@ export async function auditFile(
   const displacedType = structural.primaryBlock && !structural.atTop
     ? resolveTypeFromFrontmatter(schema, structural.frontmatter)
     : undefined;
-  if (!structural.primaryBlock || (structural.primaryBlock && !structural.atTop && !displacedType)) {
+  const knownFrontmatterKeys = new Set(['type', 'id', 'name', 'forked-from']);
+  for (const typeName of getConcreteTypeNames(schema)) {
+    for (const fieldName of Object.keys(getFieldsForType(schema, typeName))) {
+      knownFrontmatterKeys.add(fieldName);
+    }
+  }
+  const topMappingLooksLikeProse = Boolean(
+    structural.primaryBlock &&
+    structural.atTop &&
+    !Object.prototype.hasOwnProperty.call(structural.frontmatter, 'type') &&
+    Object.keys(structural.frontmatter).length > 0 &&
+    Object.keys(structural.frontmatter).every(key => !knownFrontmatterKeys.has(key))
+  );
+  if (
+    !structural.primaryBlock ||
+    (structural.primaryBlock && !structural.atTop && !displacedType) ||
+    topMappingLooksLikeProse
+  ) {
     const inferredType = file.expectedType;
     const autoFixable = Boolean(
       inferredType && hasDeterministicAdoptionFields(schema, inferredType)

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -60,7 +60,7 @@ import {
 } from '../note-id.js';
 import { withNoteIdentityTransaction } from '../identity-transaction.js';
 import { withLineageMutationLocks } from '../lineage-lock.js';
-import { rollbackNoteIfUnchanged } from '../note-write-concurrency.js';
+import { assertNoteBytesUnchanged, rollbackNoteIfUnchanged } from '../note-write-concurrency.js';
 import { normalizeDateFields, validateFrontmatter } from '../validation.js';
 import { expandStaticValue } from '../local-date.js';
 import { promptField } from '../field-prompt.js';
@@ -646,10 +646,10 @@ async function applyMissingFrontmatterFix(
         withNoteIdAssignmentLock(vaultDir, async () => {
           const raw = await readFile(filePath, 'utf-8');
           const structural = readStructuralFrontmatterFromRaw(raw);
-          const displacedType = structural.primaryBlock && !structural.atTop
+          const recognizableType = structural.primaryBlock
             ? resolveTypeFromFrontmatter(schema, structural.frontmatter)
             : undefined;
-          if (structural.primaryBlock && (structural.atTop || displacedType)) {
+          if (structural.primaryBlock && recognizableType) {
             return {
               file: filePath,
               issue,
@@ -725,6 +725,16 @@ async function applyUnsafeFilenameFix(
   filePath: string,
   issue: AuditIssue
 ): Promise<FixResult> {
+  return withLineageMutationLocks(vaultDir, [filePath], () =>
+    applyUnsafeFilenameFixLocked(vaultDir, filePath, issue)
+  );
+}
+
+async function applyUnsafeFilenameFixLocked(
+  vaultDir: string,
+  filePath: string,
+  issue: AuditIssue
+): Promise<FixResult> {
   const originalBase = basename(filePath, '.md');
   const safe = sanitizeFilenameBase(originalBase);
   if (!safe.transformation || !safe.sanitized) {
@@ -756,6 +766,7 @@ async function applyUnsafeFilenameFix(
       if (parseNoteContent(updated).body !== parsed.body) {
         throw new Error('Filename title preservation changed note body');
       }
+      await assertNoteBytesUnchanged(filePath, raw);
       await writeFileAtomic(filePath, updated);
       titleUpdatedRaw = updated;
     }

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -5,7 +5,7 @@
  */
 
 import chalk from 'chalk';
-import { readFile, writeFile, unlink } from 'fs/promises';
+import { readFile, writeFile, unlink, stat } from 'fs/promises';
 import { join, dirname, basename } from 'path';
 import { parseDocument, isMap, isSeq, isScalar } from 'yaml';
 import type { YAMLSeq } from 'yaml';
@@ -30,7 +30,15 @@ import {
   getUnambiguousDateNormalization,
   isCanonicalIsoDate,
 } from './fix-policy.js';
-import { parseNote, writeNote, generateBodySections } from '../frontmatter.js';
+import {
+  buildNoteContent,
+  parseNote,
+  parseNoteContent,
+  serializeFrontmatter,
+  writeFileAtomic,
+  writeNote,
+  generateBodySections,
+} from '../frontmatter.js';
 import { levenshteinDistance } from '../levenshtein.js';
 import { promptSelection, promptConfirm, promptInput } from '../prompt.js';
 import type { LoadedSchema, Field, BodySection } from '../../types/schema.js';
@@ -44,6 +52,19 @@ import { formatValue } from '../vault.js';
 import { buildNoteTargetIndex, type NoteTargetIndex } from '../discovery.js';
 import { BacklinkScanner } from './backlink-index.js';
 import { isBwrbBuiltinFrontmatterField } from '../frontmatter/systemFields.js';
+import {
+  generateUniqueNoteId,
+  isValidNoteId,
+  registerIssuedNoteId,
+  withNoteIdAssignmentLock,
+} from '../note-id.js';
+import { withNoteIdentityTransaction } from '../identity-transaction.js';
+import { withLineageMutationLocks } from '../lineage-lock.js';
+import { rollbackNoteIfUnchanged } from '../note-write-concurrency.js';
+import { normalizeDateFields, validateFrontmatter } from '../validation.js';
+import { expandStaticValue } from '../local-date.js';
+import { promptField } from '../field-prompt.js';
+import { sanitizeFilenameBase } from '../filename.js';
 
 import {
   type AuditIssue,
@@ -73,7 +94,7 @@ import {
   parseSimpleYamlKeyValueLine,
   isBlockScalarHeader,
 } from './raw.js';
-import { extractYamlNodeValue, isEffectivelyEmpty } from './value-utils.js';
+import { detectEol, extractYamlNodeValue, isEffectivelyEmpty } from './value-utils.js';
 import {
   getAutoUnknownFieldMigrationTarget,
   getSimilarFieldCandidates,
@@ -569,6 +590,185 @@ async function applyFrontmatterKeyRenameFix(
 // Fix Application
 // ============================================================================
 
+function deterministicAdoptionFields(
+  schema: LoadedSchema,
+  typePath: string,
+  explicitFields: Record<string, unknown> = {}
+): { frontmatter: Record<string, unknown>; missing: string[] } {
+  const typeDef = getType(schema, typePath);
+  if (!typeDef) return { frontmatter: {}, missing: [`unknown type '${typePath}'`] };
+
+  const fields = getFieldsForType(schema, typePath);
+  const frontmatter: Record<string, unknown> = { type: typeDef.name };
+  const missing: string[] = [];
+  const now = new Date();
+
+  const fieldNames = [...new Set([...typeDef.fieldOrder, ...Object.keys(fields)])];
+  for (const fieldName of fieldNames) {
+    if (isBwrbBuiltinFrontmatterField(fieldName)) continue;
+    const field = fields[fieldName];
+    if (!field) continue;
+
+    if (Object.prototype.hasOwnProperty.call(explicitFields, fieldName)) {
+      frontmatter[fieldName] = explicitFields[fieldName];
+    } else if (field.value !== undefined) {
+      frontmatter[fieldName] = expandStaticValue(
+        field.value,
+        now,
+        schema.config.dateFormat
+      );
+    } else if (field.required && field.default !== undefined) {
+      frontmatter[fieldName] = field.default;
+    } else if (field.required) {
+      missing.push(fieldName);
+    }
+  }
+
+  return {
+    frontmatter: normalizeDateFields(schema, typePath, frontmatter),
+    missing,
+  };
+}
+
+async function applyMissingFrontmatterFix(
+  schema: LoadedSchema,
+  vaultDir: string,
+  filePath: string,
+  issue: AuditIssue,
+  typePath: string,
+  explicitFields: Record<string, unknown> = {}
+): Promise<FixResult> {
+  if (isDryRunEnabled()) return { file: filePath, issue, action: 'fixed' };
+
+  try {
+    return await withNoteIdentityTransaction(vaultDir, schema.config.identityStore, () =>
+      withLineageMutationLocks(vaultDir, [filePath], () =>
+        withNoteIdAssignmentLock(vaultDir, async () => {
+          const raw = await readFile(filePath, 'utf-8');
+          const structural = readStructuralFrontmatterFromRaw(raw);
+          const displacedType = structural.primaryBlock && !structural.atTop
+            ? resolveTypeFromFrontmatter(schema, structural.frontmatter)
+            : undefined;
+          if (structural.primaryBlock && (structural.atTop || displacedType)) {
+            return {
+              file: filePath,
+              issue,
+              action: 'skipped' as const,
+              message: 'File gained recognizable frontmatter; re-run audit',
+            };
+          }
+
+          const prepared = deterministicAdoptionFields(schema, typePath, explicitFields);
+          if (prepared.missing.length > 0) {
+            return {
+              file: filePath,
+              issue,
+              action: 'skipped' as const,
+              message: `Required fields need explicit values: ${prepared.missing.join(', ')}`,
+            };
+          }
+
+          const id = await generateUniqueNoteId(vaultDir, schema);
+          const frontmatter = { ...prepared.frontmatter, id };
+          const validation = validateFrontmatter(schema, typePath, frontmatter);
+          if (!validation.valid) {
+            return {
+              file: filePath,
+              issue,
+              action: 'skipped' as const,
+              message: `Adoption would not produce valid frontmatter: ${validation.errors.map(error => error.message).join('; ')}`,
+            };
+          }
+
+          const bom = raw.startsWith('\uFEFF') ? '\uFEFF' : '';
+          const body = bom ? raw.slice(1) : raw;
+          const eol = detectEol(raw);
+          const order = ['type', 'id', ...getType(schema, typePath)!.fieldOrder];
+          const yaml = serializeFrontmatter(frontmatter, order).replace(/\n/g, eol);
+          const nextRaw = `${bom}---${eol}${yaml}${eol}---${eol}${body}`;
+          const parsedNext = parseNoteContent(nextRaw);
+          if (parsedNext.body !== body) {
+            throw new Error('Adoption body-preservation check failed');
+          }
+
+          let written = false;
+          try {
+            await writeFileAtomic(filePath, nextRaw);
+            written = true;
+            await registerIssuedNoteId(vaultDir, id, filePath, schema.config.identityStore);
+          } catch (error) {
+            if (written) {
+              const rolledBack = await rollbackNoteIfUnchanged(filePath, nextRaw, raw);
+              if (!rolledBack) {
+                throw new Error(`Adoption failed and rollback was blocked by newer file bytes: ${String(error)}`);
+              }
+            }
+            throw error;
+          }
+
+          return { file: filePath, issue, action: 'fixed' as const };
+        }, {}, schema.config.identityStore)
+      )
+    );
+  } catch (error) {
+    return {
+      file: filePath,
+      issue,
+      action: 'failed',
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function applyUnsafeFilenameFix(
+  schema: LoadedSchema,
+  vaultDir: string,
+  filePath: string,
+  issue: AuditIssue
+): Promise<FixResult> {
+  const originalBase = basename(filePath, '.md');
+  const safe = sanitizeFilenameBase(originalBase);
+  if (!safe.transformation || !safe.sanitized) {
+    return { file: filePath, issue, action: 'skipped', message: 'Filename is already safe' };
+  }
+
+  const targetBasename = `${safe.sanitized}.md`;
+  if (!isDryRunEnabled()) {
+    const targetPath = join(dirname(filePath), targetBasename);
+    try {
+      await stat(targetPath);
+      return {
+        file: filePath,
+        issue,
+        action: 'failed',
+        message: `Destination already exists, left source untouched: ${targetBasename}`,
+      };
+    } catch (error) {
+      if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) throw error;
+    }
+
+    const parsed = await parseNote(filePath);
+    if (parsed.frontmatter.name === undefined) {
+      const nextFrontmatter = { ...parsed.frontmatter, name: originalBase };
+      const typePath = resolveTypeFromFrontmatter(schema, nextFrontmatter);
+      const order = typePath ? getType(schema, typePath)?.fieldOrder : undefined;
+      await writeFileAtomic(filePath, buildNoteContent(nextFrontmatter, parsed.body, order));
+    }
+  }
+
+  const moveResult = await executeBulkMove({
+    vaultDir,
+    targetDir: dirname(filePath),
+    filesToMove: [filePath],
+    execute: !isDryRunEnabled(),
+    targetBasenames: new Map([[filePath, targetBasename]]),
+  });
+  if (moveResult.errors.length > 0) {
+    return { file: filePath, issue, action: 'failed', message: moveResult.errors[0] ?? 'Rename failed' };
+  }
+  return { file: filePath, issue, action: 'fixed' };
+}
+
 /**
  * Apply a single fix to a file.
  */
@@ -581,7 +781,7 @@ async function applyFix(
   try {
     // Phase 4 structural fixes operate on raw content.
     if (issue.code === 'frontmatter-not-at-top' || issue.code === 'duplicate-frontmatter-keys' || issue.code === 'malformed-wikilink') {
-      return await applyStructuralFix(filePath, issue, newValue);
+      return await applyStructuralFix(schema, filePath, issue, newValue);
     }
 
     if (issue.code === 'trailing-whitespace') {
@@ -828,6 +1028,7 @@ async function applyFix(
 }
 
 async function applyStructuralFix(
+  schema: LoadedSchema,
   filePath: string,
   issue: AuditIssue,
   newValue?: unknown
@@ -842,11 +1043,16 @@ async function applyStructuralFix(
 
   switch (issue.code) {
     case 'frontmatter-not-at-top': {
+      const resolvedType = resolveTypeFromFrontmatter(schema, structural.frontmatter);
+      const identityValid = structural.frontmatter.id === undefined || isValidNoteId(structural.frontmatter.id);
       const eligible =
         !structural.atTop &&
         structural.frontmatterBlocks.length === 1 &&
         !structural.unterminated &&
-        structural.yamlErrors.length === 0;
+        structural.yamlErrors.length === 0 &&
+        Boolean(resolvedType) &&
+        identityValid &&
+        Boolean(resolvedType && validateFrontmatter(schema, resolvedType, structural.frontmatter).valid);
 
       if (!eligible) {
         return { file: filePath, issue, action: 'skipped', message: 'Ambiguous frontmatter; manual fix required' };
@@ -854,7 +1060,7 @@ async function applyStructuralFix(
 
       const updated = movePrimaryBlockToTop(raw, block);
       if (!isDryRunEnabled()) {
-        await writeFile(filePath, updated, 'utf-8');
+        await writeFileAtomic(filePath, updated);
       }
       return { file: filePath, issue, action: 'fixed' };
     }
@@ -1329,7 +1535,40 @@ export async function runAutoFix(
 
     // Apply auto-fixes
     for (const issue of fixableIssues) {
-      if (issue.code === 'orphan-file' && issue.inferredType) {
+      if (issue.code === 'missing-frontmatter' && issue.inferredType) {
+        const fixResult = await applyMissingFrontmatterFix(
+          schema,
+          vaultDir,
+          result.path,
+          issue,
+          issue.inferredType
+        );
+        console.log(chalk.cyan(`  ${result.relativePath}`));
+        if (fixResult.action === 'fixed') {
+          console.log(chalk.green(`    ✓ Adopted plain Markdown as ${issue.inferredType} with a stable id`));
+          fixed++;
+        } else if (fixResult.action === 'skipped') {
+          console.log(chalk.yellow(`    ⚠ ${fixResult.message}`));
+          skipped++;
+          registerManualReview(manualReviewNeeded, result.relativePath, issue);
+        } else {
+          console.log(chalk.red(`    ✗ Failed to adopt note: ${fixResult.message}`));
+          failed++;
+        }
+      } else if (issue.code === 'unsafe-filename') {
+        const fixResult = await applyUnsafeFilenameFix(schema, vaultDir, result.path, issue);
+        console.log(chalk.cyan(`  ${result.relativePath}`));
+        if (fixResult.action === 'fixed') {
+          console.log(chalk.green(`    ✓ Repaired filename to ${String(issue.meta?.safeFilename ?? issue.fixedValue)}`));
+          fixed++;
+        } else if (fixResult.action === 'skipped') {
+          console.log(chalk.yellow(`    ⚠ ${fixResult.message}`));
+          skipped++;
+        } else {
+          console.log(chalk.red(`    ✗ Failed to repair filename: ${fixResult.message}`));
+          failed++;
+        }
+      } else if (issue.code === 'orphan-file' && issue.inferredType) {
         // Auto-fix orphan-file when we have inferred type from directory
         const fixResult = await applyFix(schema, result.path, issue, issue.inferredType);
         if (fixResult.action === 'fixed') {
@@ -1983,6 +2222,8 @@ async function handleInteractiveFix(
   const { schema } = context;
   
   switch (issue.code) {
+    case 'missing-frontmatter':
+      return handleMissingFrontmatterFix(context, result, issue);
     case 'orphan-file':
       return handleOrphanFileFix(schema, result, issue, context);
     case 'missing-required':
@@ -2018,6 +2259,8 @@ async function handleInteractiveFix(
     // Phase 4: Structural integrity issues
     case 'frontmatter-not-at-top':
       return handleFrontmatterNotAtTopFix(schema, result, issue);
+    case 'unsafe-filename':
+      return handleUnsafeFilenameFix(context, result, issue);
     case 'duplicate-frontmatter-keys':
       return handleDuplicateFrontmatterKeysFix(schema, result, issue);
     case 'malformed-wikilink':
@@ -2254,6 +2497,83 @@ async function deleteNoteWithSafety(
     console.log(chalk.red(`    ✗ Failed to delete note: ${message}`));
     return 'failed';
   }
+}
+
+async function handleMissingFrontmatterFix(
+  context: FixContext,
+  result: FileAuditResult,
+  issue: AuditIssue
+): Promise<'fixed' | 'skipped' | 'failed' | 'quit'> {
+  const { schema, vaultDir } = context;
+  if (!issue.inferredType) {
+    console.log(chalk.dim('    → Type and destination are ambiguous; target a managed type directory first'));
+    return 'skipped';
+  }
+
+  const selected = await promptSelection('    Adopt plain Markdown?', [
+    `[adopt as ${issue.inferredType}]`,
+    '[skip]',
+    '[quit]',
+  ]);
+  if (selected === null || selected === '[quit]') return 'quit';
+  if (selected === '[skip]') return 'skipped';
+
+  const typePath = issue.inferredType;
+  const fields = getFieldsForType(schema, typePath);
+  const explicitFields: Record<string, unknown> = {};
+  const deterministic = deterministicAdoptionFields(schema, typePath);
+  for (const fieldName of deterministic.missing) {
+    const field = fields[fieldName];
+    if (!field) continue;
+    const value = await promptField(schema, vaultDir, fieldName, field, { mode: 'create' });
+    if (value === undefined || value === '') {
+      console.log(chalk.dim(`    → Required field '${fieldName}' was not supplied`));
+      return 'skipped';
+    }
+    explicitFields[fieldName] = value;
+  }
+
+  const fixResult = await applyMissingFrontmatterFix(
+    schema,
+    vaultDir,
+    result.path,
+    issue,
+    typePath,
+    explicitFields
+  );
+  if (fixResult.action === 'fixed') {
+    console.log(chalk.green(`    ✓ Adopted as ${typePath} with a stable id`));
+    return 'fixed';
+  }
+  console.log(chalk.red(`    ✗ Failed: ${fixResult.message}`));
+  return fixResult.action === 'skipped' ? 'skipped' : 'failed';
+}
+
+async function handleUnsafeFilenameFix(
+  context: FixContext,
+  result: FileAuditResult,
+  issue: AuditIssue
+): Promise<'fixed' | 'skipped' | 'failed' | 'quit'> {
+  const safeFilename = String(issue.meta?.safeFilename ?? `${issue.fixedValue ?? ''}.md`);
+  const selected = await promptSelection(`    Repair filename to ${safeFilename}?`, [
+    '[repair filename]',
+    '[skip]',
+    '[quit]',
+  ]);
+  if (selected === null || selected === '[quit]') return 'quit';
+  if (selected === '[skip]') return 'skipped';
+  const fixResult = await applyUnsafeFilenameFix(
+    context.schema,
+    context.vaultDir,
+    result.path,
+    issue
+  );
+  if (fixResult.action === 'fixed') {
+    console.log(chalk.green(`    ✓ Renamed to ${safeFilename}`));
+    return 'fixed';
+  }
+  console.log(chalk.red(`    ✗ Failed: ${fixResult.message}`));
+  return fixResult.action === 'skipped' ? 'skipped' : 'failed';
 }
 
 async function handleOrphanFileFix(

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -693,6 +693,7 @@ async function applyMissingFrontmatterFix(
 
           let written = false;
           try {
+            await assertNoteBytesUnchanged(filePath, raw);
             await writeFileAtomic(filePath, nextRaw);
             written = true;
             await registerIssuedNoteId(vaultDir, id, filePath, schema.config.identityStore);

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -732,6 +732,8 @@ async function applyUnsafeFilenameFix(
   }
 
   const targetBasename = `${safe.sanitized}.md`;
+  let originalRaw: string | undefined;
+  let titleUpdatedRaw: string | undefined;
   if (!isDryRunEnabled()) {
     const targetPath = join(dirname(filePath), targetBasename);
     try {
@@ -747,6 +749,7 @@ async function applyUnsafeFilenameFix(
     }
 
     const raw = await readFile(filePath, 'utf8');
+    originalRaw = raw;
     const parsed = parseNoteContent(raw);
     if (parsed.frontmatter.name === undefined) {
       const updated = insertFrontmatterStringPreservingBytes(raw, 'name', originalBase);
@@ -754,6 +757,7 @@ async function applyUnsafeFilenameFix(
         throw new Error('Filename title preservation changed note body');
       }
       await writeFileAtomic(filePath, updated);
+      titleUpdatedRaw = updated;
     }
   }
 
@@ -765,6 +769,17 @@ async function applyUnsafeFilenameFix(
     targetBasenames: new Map([[filePath, targetBasename]]),
   });
   if (moveResult.errors.length > 0) {
+    if (originalRaw !== undefined && titleUpdatedRaw !== undefined) {
+      const rolledBack = await rollbackNoteIfUnchanged(filePath, titleUpdatedRaw, originalRaw);
+      if (!rolledBack) {
+        return {
+          file: filePath,
+          issue,
+          action: 'failed',
+          message: `${moveResult.errors[0]}; title insertion rollback was blocked by newer source bytes`,
+        };
+      }
+    }
     return { file: filePath, issue, action: 'failed', message: moveResult.errors[0] ?? 'Rename failed' };
   }
   return { file: filePath, issue, action: 'fixed' };

--- a/src/lib/audit/fix.ts
+++ b/src/lib/audit/fix.ts
@@ -31,9 +31,9 @@ import {
   isCanonicalIsoDate,
 } from './fix-policy.js';
 import {
-  buildNoteContent,
   parseNote,
   parseNoteContent,
+  insertFrontmatterStringPreservingBytes,
   serializeFrontmatter,
   writeFileAtomic,
   writeNote,
@@ -721,7 +721,6 @@ async function applyMissingFrontmatterFix(
 }
 
 async function applyUnsafeFilenameFix(
-  schema: LoadedSchema,
   vaultDir: string,
   filePath: string,
   issue: AuditIssue
@@ -747,12 +746,14 @@ async function applyUnsafeFilenameFix(
       if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) throw error;
     }
 
-    const parsed = await parseNote(filePath);
+    const raw = await readFile(filePath, 'utf8');
+    const parsed = parseNoteContent(raw);
     if (parsed.frontmatter.name === undefined) {
-      const nextFrontmatter = { ...parsed.frontmatter, name: originalBase };
-      const typePath = resolveTypeFromFrontmatter(schema, nextFrontmatter);
-      const order = typePath ? getType(schema, typePath)?.fieldOrder : undefined;
-      await writeFileAtomic(filePath, buildNoteContent(nextFrontmatter, parsed.body, order));
+      const updated = insertFrontmatterStringPreservingBytes(raw, 'name', originalBase);
+      if (parseNoteContent(updated).body !== parsed.body) {
+        throw new Error('Filename title preservation changed note body');
+      }
+      await writeFileAtomic(filePath, updated);
     }
   }
 
@@ -1556,7 +1557,7 @@ export async function runAutoFix(
           failed++;
         }
       } else if (issue.code === 'unsafe-filename') {
-        const fixResult = await applyUnsafeFilenameFix(schema, vaultDir, result.path, issue);
+        const fixResult = await applyUnsafeFilenameFix(vaultDir, result.path, issue);
         console.log(chalk.cyan(`  ${result.relativePath}`));
         if (fixResult.action === 'fixed') {
           console.log(chalk.green(`    ✓ Repaired filename to ${String(issue.meta?.safeFilename ?? issue.fixedValue)}`));
@@ -2563,7 +2564,6 @@ async function handleUnsafeFilenameFix(
   if (selected === null || selected === '[quit]') return 'quit';
   if (selected === '[skip]') return 'skipped';
   const fixResult = await applyUnsafeFilenameFix(
-    context.schema,
     context.vaultDir,
     result.path,
     issue

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -19,6 +19,7 @@ export type IssueSeverity = 'error' | 'warning';
  * Issue codes for audit findings.
  */
 export type IssueCode =
+  | 'missing-frontmatter'
   | 'orphan-file'
   | 'invalid-type'
   | 'missing-required'
@@ -62,6 +63,7 @@ export type IssueCode =
   | 'invalid-date-format'
   // Phase 4: Structural integrity fixes
   | 'frontmatter-not-at-top'
+  | 'unsafe-filename'
   | 'duplicate-frontmatter-keys'
   | 'malformed-wikilink'
   // Ingest safety net (#600): a known entity name/alias mentioned in body prose

--- a/src/lib/bulk/move.ts
+++ b/src/lib/bulk/move.ts
@@ -441,7 +441,18 @@ async function moveFile(
     try {
       await unlink(filePath);
     } catch (error) {
-      await unlink(newPath).catch(() => undefined);
+      const [sourceInfo, destinationInfo] = await Promise.all([
+        stat(filePath).catch(() => undefined),
+        stat(newPath).catch(() => undefined),
+      ]);
+      if (
+        sourceInfo &&
+        destinationInfo &&
+        sourceInfo.dev === destinationInfo.dev &&
+        sourceInfo.ino === destinationInfo.ino
+      ) {
+        await unlink(newPath).catch(() => undefined);
+      }
       throw error;
     }
     result.applied = true;

--- a/src/lib/bulk/move.ts
+++ b/src/lib/bulk/move.ts
@@ -7,8 +7,8 @@
  * - Updating wikilinks to point to new locations
  */
 
-import { readFile, writeFile, rename, mkdir, readdir, stat } from 'fs/promises';
-import { join, relative, basename, extname } from 'path';
+import { readFile, writeFile, link, unlink, mkdir, readdir, stat } from 'fs/promises';
+import { join, relative, basename, extname, resolve } from 'path';
 
 // ============================================================================
 // Types
@@ -417,6 +417,11 @@ async function moveFile(
     return result;
   }
 
+  if (resolve(filePath) === resolve(newPath)) {
+    result.applied = true;
+    return result;
+  }
+
   try {
     // Ensure target directory exists
     await mkdir(targetDir, { recursive: true });
@@ -429,8 +434,16 @@ async function moveFile(
       return result;
     }
 
-    // Move the file
-    await rename(filePath, newPath);
+    // Claim the destination atomically without replacement, then remove the
+    // source link. Unlike rename(), link() fails with EEXIST if a concurrent
+    // writer wins the destination path after our preflight check.
+    await link(filePath, newPath);
+    try {
+      await unlink(filePath);
+    } catch (error) {
+      await unlink(newPath).catch(() => undefined);
+      throw error;
+    }
     result.applied = true;
   } catch (err) {
     result.error = err instanceof Error ? err.message : String(err);

--- a/src/lib/bulk/move.ts
+++ b/src/lib/bulk/move.ts
@@ -438,23 +438,9 @@ async function moveFile(
     // source link. Unlike rename(), link() fails with EEXIST if a concurrent
     // writer wins the destination path after our preflight check.
     await link(filePath, newPath);
-    try {
-      await unlink(filePath);
-    } catch (error) {
-      const [sourceInfo, destinationInfo] = await Promise.all([
-        stat(filePath).catch(() => undefined),
-        stat(newPath).catch(() => undefined),
-      ]);
-      if (
-        sourceInfo &&
-        destinationInfo &&
-        sourceInfo.dev === destinationInfo.dev &&
-        sourceInfo.ino === destinationInfo.ino
-      ) {
-        await unlink(newPath).catch(() => undefined);
-      }
-      throw error;
-    }
+    // On unlink failure preserve both names. Duplicate hardlinks are
+    // recoverable; cleanup could race and delete another writer's file.
+    await unlink(filePath);
     result.applied = true;
   } catch (err) {
     result.error = err instanceof Error ? err.message : String(err);

--- a/src/lib/bulk/move.ts
+++ b/src/lib/bulk/move.ts
@@ -397,9 +397,10 @@ async function moveFile(
   filePath: string,
   targetDir: string,
   vaultDir: string,
-  execute: boolean
+  execute: boolean,
+  targetBasename?: string
 ): Promise<MoveResult> {
-  const fileName = basename(filePath);
+  const fileName = targetBasename ?? basename(filePath);
   const newPath = join(targetDir, fileName);
   const oldRelativePath = relative(vaultDir, filePath);
   const newRelativePath = relative(vaultDir, newPath);
@@ -447,6 +448,8 @@ export async function executeBulkMove(options: {
   filesToMove: string[];
   execute: boolean;
   allVaultFiles?: string[];
+  /** Optional exact destination basenames, keyed by source path, for safe renames. */
+  targetBasenames?: ReadonlyMap<string, string>;
 }): Promise<BulkMoveResult> {
   const { vaultDir, targetDir, filesToMove, execute } = options;
   
@@ -479,7 +482,10 @@ export async function executeBulkMove(options: {
     allReferences.set(filePath, refs);
     
     // Calculate new path
-    const newPath = join(absoluteTargetDir, basename(filePath));
+    const newPath = join(
+      absoluteTargetDir,
+      options.targetBasenames?.get(filePath) ?? basename(filePath)
+    );
     
     // Group by source file
     for (const ref of refs) {
@@ -503,7 +509,13 @@ export async function executeBulkMove(options: {
   // as "moved" to preserve the existing preview behaviour (link-update counts).
   const movedFiles = new Set<string>();
   for (const filePath of filesToMove) {
-    const moveResult = await moveFile(filePath, absoluteTargetDir, vaultDir, execute);
+    const moveResult = await moveFile(
+      filePath,
+      absoluteTargetDir,
+      vaultDir,
+      execute,
+      options.targetBasenames?.get(filePath)
+    );
     result.moveResults.push(moveResult);
 
     if (moveResult.error) {
@@ -518,7 +530,7 @@ export async function executeBulkMove(options: {
   // its original path so links to it stay valid.
   const newFilePaths = allVaultFiles.map(f => {
     if (movedFiles.has(f)) {
-      return join(absoluteTargetDir, basename(f));
+      return join(absoluteTargetDir, options.targetBasenames?.get(f) ?? basename(f));
     }
     return f;
   });

--- a/src/lib/filename.ts
+++ b/src/lib/filename.ts
@@ -2,8 +2,26 @@
  * Filename safety helpers shared by note creation and filename patterns.
  */
 
+import { createHash } from 'crypto';
+
 // eslint-disable-next-line no-control-regex
 const INVALID_FILENAME_CHARS = /[/\\:*?"<>|\x00-\x1F]/g;
+
+/**
+ * Maximum UTF-8 byte length of a Bowerbird markdown filename component.
+ *
+ * This deliberately leaves 63 bytes below the common 255-byte component limit:
+ * `.md` is included here, and the remaining space accommodates the longest
+ * same-directory temporary name produced by `writeFileAtomic`.
+ */
+export const FILENAME_COMPONENT_MAX_BYTES = 192;
+
+/** Maximum UTF-8 byte length available to a filename base before `.md`. */
+export const FILENAME_BASE_MAX_BYTES = FILENAME_COMPONENT_MAX_BYTES - '.md'.length;
+
+const LONG_FILENAME_DIGEST_LENGTH = 16;
+const LONG_FILENAME_DIGEST_SEPARATOR = '--';
+const WINDOWS_RESERVED_BASENAME = /^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\..*)?$/i;
 
 export interface FilenameTransformation {
   original: string;
@@ -16,11 +34,61 @@ export interface FilenameSanitizationResult {
   transformation?: FilenameTransformation;
 }
 
+/** Whether a basename is illegal on Windows, including device-name extensions. */
+export function isWindowsReservedBasename(name: string): boolean {
+  return WINDOWS_RESERVED_BASENAME.test(name.replace(/[. ]+$/, ''));
+}
+
+/**
+ * Whether a filename base can be used unchanged as a Bowerbird markdown name.
+ * This is intentionally based on the shared normalizer so audit classification
+ * and creation cannot disagree about what needs repair.
+ */
+export function isFilenameBaseSafe(name: string): boolean {
+  return sanitizeFilenameBase(name).transformation === undefined;
+}
+
+function truncateUtf8AtCodePointBoundary(value: string, maxBytes: number): string {
+  let result = '';
+  let bytes = 0;
+
+  for (const codePoint of value) {
+    const codePointBytes = Buffer.byteLength(codePoint, 'utf8');
+    if (bytes + codePointBytes > maxBytes) break;
+    result += codePoint;
+    bytes += codePointBytes;
+  }
+
+  return result;
+}
+
+function shortenFilenameBase(value: string, original: string): string {
+  if (Buffer.byteLength(value, 'utf8') <= FILENAME_BASE_MAX_BYTES) return value;
+
+  const digest = createHash('sha256')
+    .update(original, 'utf8')
+    .digest('hex')
+    .slice(0, LONG_FILENAME_DIGEST_LENGTH);
+  const suffix = `${LONG_FILENAME_DIGEST_SEPARATOR}${digest}`;
+  const prefix = truncateUtf8AtCodePointBoundary(
+    value,
+    FILENAME_BASE_MAX_BYTES - Buffer.byteLength(suffix, 'utf8')
+  );
+  return `${prefix}${suffix}`;
+}
+
 export function sanitizeFilenameBase(name: string): FilenameSanitizationResult {
-  const sanitized = name
+  let sanitized = name
     .replace(INVALID_FILENAME_CHARS, '')
     .replace(/\s+/g, ' ')
-    .trim();
+    .trim()
+    .replace(/[. ]+$/, '');
+
+  if (isWindowsReservedBasename(sanitized)) {
+    sanitized = `_${sanitized}`;
+  }
+
+  sanitized = shortenFilenameBase(sanitized, name);
 
   if (sanitized === name) {
     return { sanitized };

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -132,6 +132,37 @@ export function insertFrontmatterScalarPreservingBytes(
   return `${before}${separator}${key}: ${value}${eol}${content.slice(insertionPoint)}`;
 }
 
+/** Insert an arbitrary YAML-safe string while preserving every unrelated note byte. */
+export function insertFrontmatterStringPreservingBytes(
+  content: string,
+  key: string,
+  value: string
+): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(key)) {
+    throw new Error(`Cannot insert unsafe frontmatter key: ${key}`);
+  }
+  const structural = readStructuralFrontmatterFromRaw(content);
+  const block = structural.primaryBlock;
+  const doc = structural.doc;
+  if (!block || !structural.atTop || !doc || structural.yamlErrors.length > 0 || !isMap(doc.contents)) {
+    throw new Error('Cannot insert field: note does not have valid top-level mapping frontmatter');
+  }
+  const pairs = (doc.contents as YAMLMap).items as Pair[];
+  if (pairs.some(pair => String((pair.key as Scalar | null | undefined)?.value ?? '') === key)) {
+    throw new Error(`Cannot insert field: frontmatter already contains '${key}'`);
+  }
+  const yaml = structural.yaml ?? '';
+  const typePair = pairs.find(pair => String((pair.key as Scalar | null | undefined)?.value ?? '') === 'type');
+  const typeEnd = (typePair?.value as { range?: [number, number, number] } | null | undefined)?.range?.[2];
+  const insertionOffset = typeof typeEnd === 'number' ? typeEnd : yaml.length;
+  const insertionPoint = block.yamlStart + insertionOffset;
+  const eol = detectEol(content);
+  const before = content.slice(0, insertionPoint);
+  const separator = before.endsWith('\n') ? '' : eol;
+  const serialized = stringify({ [key]: value }).trimEnd().replace(/\n/g, eol);
+  return `${before}${separator}${serialized}${eol}${content.slice(insertionPoint)}`;
+}
+
 /** Replace a UTF-8 file atomically via a same-directory temporary file. */
 export async function writeFileAtomic(filePath: string, content: string): Promise<void> {
   await mkdir(dirname(filePath), { recursive: true });

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -2,7 +2,7 @@ import matter from 'gray-matter';
 import { isMap, stringify } from 'yaml';
 import type { Pair, Scalar, YAMLMap } from 'yaml';
 import { readFile, writeFile, mkdir, open, unlink, rename, stat } from 'fs/promises';
-import { basename, dirname, join } from 'path';
+import { dirname, join } from 'path';
 import { randomUUID } from 'crypto';
 import type { BodySection } from '../types/schema.js';
 import { readStructuralFrontmatterFromRaw } from './audit/structural.js';
@@ -138,7 +138,7 @@ export async function writeFileAtomic(filePath: string, content: string): Promis
   const mode = await stat(filePath).then(info => info.mode).catch(() => undefined);
   const tempPath = join(
     dirname(filePath),
-    `.${basename(filePath)}.bwrb-${process.pid}-${randomUUID()}.tmp`
+    `.bwrb-${process.pid}-${randomUUID()}.tmp`
   );
   const handle = await open(tempPath, 'wx', mode);
   let renamed = false;

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, mkdir, writeFile, readFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { createTestVault, cleanupTestVault, runCLI, TEST_SCHEMA } from '../fixtures/setup.js';
+import { parseFrontmatter } from '../../../src/lib/frontmatter.js';
 
 describe('audit command', () => {
   let vaultDir: string;
@@ -6969,6 +6970,156 @@ priority: medium
       const trigger = await runCLI(['audit', '--only', 'retention-due'], tempVaultDir);
       expect(trigger.exitCode).toBe(1);
       expect(trigger.stderr).toContain('cannot modify transition trigger field "status"');
+    });
+  });
+
+  describe('preserve-first note repair', () => {
+    let tempVaultDir: string;
+
+    beforeEach(async () => {
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-preserve-repair-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      const schema = structuredClone(TEST_SCHEMA) as typeof TEST_SCHEMA & {
+        config?: Record<string, unknown>;
+      };
+      schema.config = { ...(schema.config ?? {}), identity_store: 'frontmatter-v1' };
+      await writeFile(join(tempVaultDir, '.bwrb', 'schema.json'), JSON.stringify(schema, null, 2));
+      await mkdir(join(tempVaultDir, 'Ideas'), { recursive: true });
+    });
+
+    afterEach(async () => {
+      await rm(tempVaultDir, { recursive: true, force: true });
+    });
+
+    it('adopts plain Markdown with minimal valid frontmatter and preserves every body byte', async () => {
+      const notePath = join(tempVaultDir, 'Ideas', 'Plain.md');
+      const body = '# Plain\r\n\r\nParagraph with  trailing spaces.  \r\n';
+      await writeFile(notePath, body);
+
+      const report = await runCLI(['audit', '--path', 'Plain.md', '--output', 'json'], tempVaultDir);
+      const reportJson = JSON.parse(report.stdout);
+      expect(reportJson.files[0].issues.map((issue: { code: string }) => issue.code)).toContain('missing-frontmatter');
+      expect(reportJson.files[0].issues.map((issue: { code: string }) => issue.code)).not.toContain('orphan-file');
+
+      const repair = await runCLI(
+        ['audit', '--fix', '--auto', '--execute', '--path', 'Plain.md'],
+        tempVaultDir
+      );
+      expect(repair.stdout).toContain('Adopted plain Markdown as idea with a stable id');
+
+      const repaired = await readFile(notePath, 'utf8');
+      const closing = repaired.indexOf('---\r\n', 4);
+      expect(closing).toBeGreaterThan(0);
+      expect(repaired.slice(closing + 5)).toBe(body);
+      expect(repaired).toMatch(/^---\r\ntype: idea\r\nid: [0-9a-f-]{36}\r\nstatus: raw\r\n---\r\n/);
+
+      const rerun = await runCLI(['audit', '--path', 'Plain.md', '--output', 'json'], tempVaultDir);
+      const rerunJson = JSON.parse(rerun.stdout);
+      expect(rerunJson.files.flatMap((file: { issues: Array<{ code: string }> }) => file.issues))
+        .not.toContainEqual(expect.objectContaining({ code: 'missing-frontmatter' }));
+    });
+
+    it('leaves mapping-like thematic body content as prose while adopting the note', async () => {
+      const notePath = join(tempVaultDir, 'Ideas', 'Body YAML.md');
+      const body = 'Intro paragraph\n---\nexample: prose, not metadata\n---\nTail\n';
+      await writeFile(notePath, body);
+
+      const report = await runCLI(['audit', '--path', 'Body YAML.md', '--output', 'json'], tempVaultDir);
+      const reportJson = JSON.parse(report.stdout);
+      expect(reportJson.files[0].issues).toContainEqual(expect.objectContaining({ code: 'missing-frontmatter' }));
+      expect(reportJson.files[0].issues).not.toContainEqual(expect.objectContaining({ code: 'frontmatter-not-at-top' }));
+
+      await runCLI(['audit', '--fix', '--auto', '--execute', '--path', 'Body YAML.md'], tempVaultDir);
+      const repaired = await readFile(notePath, 'utf8');
+      expect(repaired.endsWith(body)).toBe(true);
+      expect(repaired.match(/example: prose, not metadata/g)).toHaveLength(1);
+    });
+
+    it('moves only one schema-valid displaced block and preserves the UUID and prose bytes', async () => {
+      const id = '123e4567-e89b-42d3-a456-426614174000';
+      const notePath = join(tempVaultDir, 'Ideas', 'Misplaced.md');
+      const original = `Leading prose\n---\ntype: idea\nid: ${id}\nstatus: raw\n---\nTrailing prose\n`;
+      await writeFile(notePath, original);
+
+      const repair = await runCLI(
+        ['audit', '--fix', '--auto', '--execute', '--path', 'Misplaced.md'],
+        tempVaultDir
+      );
+      expect(repair.stdout).toContain('Moved frontmatter to top');
+      const repaired = await readFile(notePath, 'utf8');
+      expect(repaired.startsWith(`---\ntype: idea\nid: ${id}\nstatus: raw\n---\n`)).toBe(true);
+      expect(repaired.slice(repaired.indexOf('Leading prose'))).toBe('Leading prose\nTrailing prose\n');
+
+      const rerun = await runCLI(['audit', '--path', 'Misplaced.md', '--output', 'json'], tempVaultDir);
+      expect(JSON.parse(rerun.stdout).files).toEqual([]);
+    });
+
+    it('fails closed for multiple candidates, duplicate keys, and invalid displaced identity', async () => {
+      const cases = [
+        ['Multiple.md', 'Lead\n---\ntype: idea\nid: 123e4567-e89b-42d3-a456-426614174000\nstatus: raw\n---\nMid\n---\ntype: idea\nid: 123e4567-e89b-42d3-a456-426614174001\nstatus: raw\n---\n'],
+        ['Duplicate.md', 'Lead\n---\ntype: idea\nid: 123e4567-e89b-42d3-a456-426614174000\nstatus: raw\nstatus: backlog\n---\n'],
+        ['Bad Id.md', 'Lead\n---\ntype: idea\nid: not-a-uuid\nstatus: raw\n---\n'],
+      ] as const;
+      for (const [name, content] of cases) {
+        await writeFile(join(tempVaultDir, 'Ideas', name), content);
+      }
+
+      for (const [name, content] of cases) {
+        const report = await runCLI(['audit', '--path', name, '--output', 'json'], tempVaultDir);
+        const issue = JSON.parse(report.stdout).files[0].issues.find(
+          (candidate: { code: string }) => candidate.code === 'frontmatter-not-at-top'
+        );
+        expect(issue?.autoFixable).toBe(false);
+        await runCLI(['audit', '--fix', '--auto', '--execute', '--path', name], tempVaultDir);
+        expect(await readFile(join(tempVaultDir, 'Ideas', name), 'utf8')).toBe(content);
+      }
+    });
+
+    it('repairs an over-budget filename, preserves title and UUID, and updates backlinks', async () => {
+      const originalBase = `A ${'very-long-title-'.repeat(14)}ending`;
+      const originalPath = join(tempVaultDir, 'Ideas', `${originalBase}.md`);
+      const id = '123e4567-e89b-42d3-a456-426614174000';
+      await writeFile(originalPath, `---\ntype: idea\nid: ${id}\nstatus: raw\n---\nBody\n`);
+      const backlinkPath = join(tempVaultDir, 'Ideas', 'Backlink.md');
+      await writeFile(backlinkPath, `---\ntype: idea\nid: 123e4567-e89b-42d3-a456-426614174001\nstatus: raw\n---\n[[${originalBase}]]\n`);
+
+      const report = await runCLI(['audit', '--path', `${originalBase}.md`, '--output', 'json'], tempVaultDir);
+      const unsafe = JSON.parse(report.stdout).files[0].issues.find(
+        (issue: { code: string }) => issue.code === 'unsafe-filename'
+      );
+      expect(unsafe.autoFixable).toBe(true);
+      expect(unsafe.meta.safeBytes).toBeLessThanOrEqual(192);
+
+      const repair = await runCLI(
+        ['audit', '--fix', '--auto', '--execute', '--path', `${originalBase}.md`],
+        tempVaultDir
+      );
+      expect(repair.stdout).toContain('Repaired filename');
+      const files = await import('fs/promises').then(fs => fs.readdir(join(tempVaultDir, 'Ideas')));
+      const repairedName = files.find(name => name.includes('--') && name.endsWith('.md'));
+      expect(repairedName).toBeDefined();
+      expect(Buffer.byteLength(repairedName!, 'utf8')).toBeLessThanOrEqual(192);
+      const repaired = await readFile(join(tempVaultDir, 'Ideas', repairedName!), 'utf8');
+      expect(repaired).toContain(`id: ${id}`);
+      expect(parseFrontmatter(repaired).name).toBe(originalBase);
+      expect(await readFile(backlinkPath, 'utf8')).toContain(`[[${repairedName!.slice(0, -3)}]]`);
+    });
+
+    it('leaves the source and destination untouched when a repaired filename collides', async () => {
+      const sourcePath = join(tempVaultDir, 'Ideas', 'Bad?.md');
+      const destinationPath = join(tempVaultDir, 'Ideas', 'Bad.md');
+      const source = '---\ntype: idea\nid: 123e4567-e89b-42d3-a456-426614174010\nstatus: raw\n---\nSource\n';
+      const destination = '---\ntype: idea\nid: 123e4567-e89b-42d3-a456-426614174011\nstatus: raw\n---\nDestination\n';
+      await writeFile(sourcePath, source);
+      await writeFile(destinationPath, destination);
+
+      const repair = await runCLI(
+        ['audit', '--fix', '--auto', '--execute', '--path', 'Bad?.md'],
+        tempVaultDir
+      );
+      expect(repair.stdout).toContain('Destination already exists, left source untouched');
+      expect(await readFile(sourcePath, 'utf8')).toBe(source);
+      expect(await readFile(destinationPath, 'utf8')).toBe(destination);
     });
   });
 });

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -7079,7 +7079,7 @@ priority: medium
       const originalBase = `A ${'very-long-title-'.repeat(14)}ending`;
       const originalPath = join(tempVaultDir, 'Ideas', `${originalBase}.md`);
       const id = '123e4567-e89b-42d3-a456-426614174000';
-      await writeFile(originalPath, `---\ntype: idea\nid: ${id}\nstatus: raw\n---\nBody\n`);
+      await writeFile(originalPath, `---\ntype: idea\n# preserve this comment\nid: ${id}\nstatus: "raw"\n---\nBody\n`);
       const backlinkPath = join(tempVaultDir, 'Ideas', 'Backlink.md');
       await writeFile(backlinkPath, `---\ntype: idea\nid: 123e4567-e89b-42d3-a456-426614174001\nstatus: raw\n---\n[[${originalBase}]]\n`);
 
@@ -7102,6 +7102,8 @@ priority: medium
       const repaired = await readFile(join(tempVaultDir, 'Ideas', repairedName!), 'utf8');
       expect(repaired).toContain(`id: ${id}`);
       expect(parseFrontmatter(repaired).name).toBe(originalBase);
+      expect(repaired).toContain('# preserve this comment');
+      expect(repaired).toContain('status: "raw"');
       expect(await readFile(backlinkPath, 'utf8')).toContain(`[[${repairedName!.slice(0, -3)}]]`);
     });
 

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -7021,7 +7021,7 @@ priority: medium
 
     it('leaves mapping-like thematic body content as prose while adopting the note', async () => {
       const notePath = join(tempVaultDir, 'Ideas', 'Body YAML.md');
-      const body = 'Intro paragraph\n---\nexample: prose, not metadata\n---\nTail\n';
+      const body = '---\nexample: prose, not metadata\nimage: rain\n---\nTail\n';
       await writeFile(notePath, body);
 
       const report = await runCLI(['audit', '--path', 'Body YAML.md', '--output', 'json'], tempVaultDir);

--- a/tests/ts/commands/json-io.test.ts
+++ b/tests/ts/commands/json-io.test.ts
@@ -24,6 +24,13 @@ describe('JSON I/O', () => {
     await writeFile(schemaPath, JSON.stringify(schema, null, 2), 'utf-8');
   }
 
+  async function setIdeaOutputDir(outputDir: string): Promise<void> {
+    const schemaPath = join(vaultDir, '.bwrb', 'schema.json');
+    const schema = JSON.parse(await readFile(schemaPath, 'utf-8'));
+    schema.types.idea.output_dir = outputDir;
+    await writeFile(schemaPath, JSON.stringify(schema, null, 2), 'utf-8');
+  }
+
   describe('bwrb new --json', () => {
     it('should create a note with JSON frontmatter', async () => {
       const result = await runCLI(
@@ -118,6 +125,7 @@ describe('JSON I/O', () => {
     });
 
     it('should include a path length warning for long portable paths', async () => {
+      await setIdeaOutputDir('Ideas/LongerFolder');
       const longName = 'L'.repeat(196);
       const result = await runCLI(
         ['new', 'idea', '--json', JSON.stringify({ name: longName, status: 'raw' })],
@@ -138,6 +146,7 @@ describe('JSON I/O', () => {
     });
 
     it('should reject paths above the portable path limit', async () => {
+      await setIdeaOutputDir(`Ideas/${'D'.repeat(70)}`);
       const tooLongName = 'L'.repeat(252);
       const result = await runCLI(
         ['new', 'idea', '--json', JSON.stringify({ name: tooLongName, status: 'raw' })],

--- a/tests/ts/lib/filename.test.ts
+++ b/tests/ts/lib/filename.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FILENAME_BASE_MAX_BYTES,
+  FILENAME_COMPONENT_MAX_BYTES,
+  isFilenameBaseSafe,
+  isWindowsReservedBasename,
+  sanitizeFilenameBase,
+} from '../../../src/lib/filename.js';
+
+describe('filename safety', () => {
+  it('leaves an already safe basename untouched', () => {
+    expect(sanitizeFilenameBase('Project notes')).toEqual({ sanitized: 'Project notes' });
+    expect(isFilenameBaseSafe('Project notes')).toBe(true);
+  });
+
+  it('normalizes invalid characters and records the complete original title', () => {
+    const result = sanitizeFilenameBase('  A/B: C?  ');
+
+    expect(result).toEqual({
+      sanitized: 'AB C',
+      transformation: {
+        original: '  A/B: C?  ',
+        sanitized: 'AB C',
+        filename: 'AB C.md',
+      },
+    });
+  });
+
+  it('normalizes Windows reserved basenames and trailing dots or spaces', () => {
+    expect(sanitizeFilenameBase('CON. ')).toMatchObject({ sanitized: '_CON' });
+    expect(sanitizeFilenameBase('notes.  ')).toMatchObject({ sanitized: 'notes' });
+    expect(isWindowsReservedBasename('LPT1.md')).toBe(true);
+    expect(isWindowsReservedBasename('ordinary.md')).toBe(false);
+    expect(isFilenameBaseSafe('CON')).toBe(false);
+  });
+
+  it('keeps an ASCII filename and its extension inside the component budget', () => {
+    const result = sanitizeFilenameBase('a'.repeat(FILENAME_BASE_MAX_BYTES + 40));
+
+    expect(Buffer.byteLength(result.sanitized, 'utf8')).toBe(FILENAME_BASE_MAX_BYTES);
+    expect(Buffer.byteLength(`${result.sanitized}.md`, 'utf8')).toBe(FILENAME_COMPONENT_MAX_BYTES);
+    expect(result.transformation?.original).toBe('a'.repeat(FILENAME_BASE_MAX_BYTES + 40));
+  });
+
+  it('truncates multibyte text at code-point boundaries', () => {
+    const original = '🙂'.repeat(100);
+    const result = sanitizeFilenameBase(original);
+
+    expect(Buffer.byteLength(result.sanitized, 'utf8')).toBeLessThanOrEqual(FILENAME_BASE_MAX_BYTES);
+    expect(Buffer.byteLength(`${result.sanitized}.md`, 'utf8')).toBeLessThanOrEqual(FILENAME_COMPONENT_MAX_BYTES);
+    expect(result.sanitized).toBe(`${'🙂'.repeat(42)}--${result.sanitized.slice(-16)}`);
+    expect(result.transformation?.original).toBe(original);
+  });
+
+  it('uses a stable digest suffix that distinguishes different long titles', () => {
+    const first = `${'a'.repeat(FILENAME_BASE_MAX_BYTES + 30)} one`;
+    const second = `${'a'.repeat(FILENAME_BASE_MAX_BYTES + 30)} two`;
+
+    const firstResult = sanitizeFilenameBase(first);
+    const repeatedFirstResult = sanitizeFilenameBase(first);
+    const secondResult = sanitizeFilenameBase(second);
+
+    expect(firstResult.sanitized).toBe(repeatedFirstResult.sanitized);
+    expect(firstResult.sanitized).not.toBe(secondResult.sanitized);
+    expect(firstResult.sanitized).toMatch(/--[a-f0-9]{16}$/);
+    expect(firstResult.transformation?.filename).toBe(`${firstResult.sanitized}.md`);
+  });
+});


### PR DESCRIPTION
## Problem

Bowerbird could create filename components that exceed common filesystem limits, treat mapping-like prose between `---` delimiters as misplaced frontmatter, and could not safely adopt plain Markdown into a managed vault. Those failure modes risk failed writes, swallowed prose, or incomplete identity metadata.

## Approach

Use one preserve-first repair contract at the existing filename and audit seams: normalize filenames deterministically within a conservative byte budget while retaining the full title in frontmatter; relocate YAML only when one block is unambiguously valid for the live schema; and adopt plain Markdown by prepending only the minimum valid top frontmatter without rewriting its body.

## What changed

- Limit complete Markdown filename components to 192 UTF-8 bytes, avoid cross-platform-invalid names, and shorten long names with a stable SHA-256-derived suffix.
- Use exclusive creation for previously absent paths so concurrent collisions cannot overwrite a newly appeared file.
- Add `missing-frontmatter` and `unsafe-filename` audit findings and guided/execute-gated repairs.
- Preserve full titles, UUIDs, raw note bodies, and backlinks during repair; refuse occupied destinations before any source mutation.
- Require exactly one schema-valid displaced YAML mapping with valid identity before relocation; ambiguous, duplicate-key, or invalid-identity cases remain manual.
- Document the behavior in CLI help, canonical command docs, and the automation skill.

## Safety and operations

Repairs remain explicitly targeted and execute-gated. Plain-note adoption uses identity transactions, assignment locks, atomic writes, registration, and guarded rollback. Filename repair reuses the existing collision-aware mover and backlink updater; it does not claim whole-vault transactional atomicity. No schema migration or network service change is involved.

## Verification

- Focused adversarial tests pass for CRLF body preservation, mapping-like prose, idempotent valid relocation, ambiguous/duplicate/invalid refusal, long multibyte filenames, backlink updates, and collision non-mutation.
- `pnpm typecheck`, `pnpm lint`, and `pnpm knip` pass; packaging and build gates pass locally.
- Independent review drove fixes for concurrent destination claims, source-byte races, rollback deletion, and frontmatter representation loss; final review reports no P0/P1 preserve-first blocker at `1fa1922`.
- Frozen independent PTY QA passed H1-H6 against packaged artifact `1fa1922` (SHA-256 `fd88c938…99d7`), covering all three repair stories and collision refusal.
- The complete 238-test audit command suite passes locally. Exact-head GitHub CI is fully green, including source/dist, retry-zero, PTY, Windows lock, docs, and packaging gates.

## Review focus

- Is the 192-byte component budget conservative enough for atomic sibling files across supported filesystems?
- Are the displaced-frontmatter predicates strict enough to avoid interpreting prose as metadata?
- Does adoption preserve identity-store and raw-body invariants across failure paths?
- Can any filename collision path mutate the source or backlinks before refusal?
