### PR TITLE
Keep prose heuristics out of default audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Bounded default audit scope** — bare `bwrb audit` now runs core integrity
+  checks without the optional `unlinked-mention` or `frequent-unlinked-term`
+  prose heuristics. `--mentions` enables exact, alias, ambiguous, and frequent
+  term analysis; `--mention-fuzzy` (or a positive
+  `--mention-fuzzy-threshold`) additionally enables fuzzy suggestions. Exact
+  `--only unlinked-mention` and `--only frequent-unlinked-term` selectors remain
+  explicit opt-ins.
+
 ## [0.3.1] - 2026-08-05
 
 Patch release for distributed stable note identity, revision-safe file-backed

--- a/docs-site/src/content/docs/concepts/validation-and-audit.md
+++ b/docs-site/src/content/docs/concepts/validation-and-audit.md
@@ -18,6 +18,12 @@ Check your entire vault:
 bwrb audit
 ```
 
+The default profile checks structural and schema integrity without scanning
+body prose for link suggestions. Add `--mentions` for exact, alias, ambiguous,
+and frequent unlinked-term analysis; add `--mention-fuzzy` when you also want
+fuzzy "did you mean?" suggestions. Exact `--only unlinked-mention` and
+`--only frequent-unlinked-term` selectors remain direct opt-ins.
+
 Check specific types:
 
 ```bash

--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -4,6 +4,10 @@ description: Validate notes against schema
 ---
 
 Validate vault files against schema and report issues, with optional interactive repair.
+The default profile checks core structural and schema integrity. Prose-linking
+heuristics are opt-in because they are more expensive and more judgment-shaped:
+use `--mentions` for exact, alias, ambiguous, and frequent-term analysis, or
+`--mention-fuzzy` to include the fuzzy suggestion tier too.
 
 ## Synopsis
 
@@ -33,8 +37,10 @@ The target argument is auto-detected as type, path (contains `/`), or where expr
 | `--ignore <issue-type>` | Ignore specific issue type |
 | `--strict` | Treat unknown fields as errors instead of warnings |
 | `--allow-field <fields>` | Allow additional fields beyond schema (repeatable) |
-| `--mention-fuzzy-threshold <n>` | Max edit-distance cap (0–5) for the `unlinked-mention` fuzzy "did you mean?" tier (default: `config.mention_fuzzy_threshold` or `2`; candidate length also caps the effective distance) |
-| `--no-mention-fuzzy` | Disable the `unlinked-mention` fuzzy "did you mean?" tier entirely |
+| `--mentions` | Add exact, alias, and ambiguous `unlinked-mention` checks plus `frequent-unlinked-term`; fuzzy suggestions stay off |
+| `--mention-fuzzy` | Add mention analysis, including the fuzzy "did you mean?" tier |
+| `--mention-fuzzy-threshold <n>` | Set the fuzzy edit-distance cap (0–5); a positive value opts into fuzzy mention analysis, while `0` leaves it disabled |
+| `--no-mention-fuzzy` | Explicitly keep the optional fuzzy tier disabled |
 | `--mention-link-once` | With `--fix --auto`: link at most one `unlinked-mention` occurrence per note/target pair, overriding `config.mention_link_once` |
 | `--no-mention-link-once` | With `--fix --auto`: link every eligible `unlinked-mention` occurrence, overriding `config.mention_link_once` |
 | `--check-schema-docs` | Also report schema types/fields that have no `description` |
@@ -120,8 +126,8 @@ Delete semantics in repair mode:
 | `trailing-whitespace` | Trailing spaces/tabs on raw frontmatter `key: value` lines (warning; auto-fixable) |
 | `wrong-scalar-type` | Scalar value has wrong type for schema |
 | `illegal-aliases` | An [`alias`-role field](/reference/schema/#alias) violates the Obsidian aliases format (array of **non-empty, unique** strings): an empty/whitespace entry, a **duplicate** entry, or a non-string entry (**error** — matching what `bwrb new`/`bwrb edit` reject on write; empty/whitespace + duplicate cases are **auto-fixable**, a non-string entry is **flag-only** — see below) |
-| `unlinked-mention` | A known entity's name or [registered alias](/reference/schema/#alias) appears in body prose as plain text but is not wikilinked (warning; exact/alias matches auto-fixable, fuzzy/ambiguous matches flag-only — see below) |
-| `frequent-unlinked-term` | A proper-noun-ish term mentioned frequently across the vault that has **no note yet** (warning; **advisory heuristic, never auto-fixable** — see below) |
+| `unlinked-mention` | **Opt-in.** A known entity's name or [registered alias](/reference/schema/#alias) appears in body prose as plain text but is not wikilinked (warning; exact/alias matches auto-fixable, fuzzy/ambiguous matches flag-only — see below) |
+| `frequent-unlinked-term` | **Opt-in.** A proper-noun-ish term mentioned frequently across the vault that has **no note yet** (warning; **advisory heuristic, never auto-fixable** — see below) |
 | `missing-body-section` | A heading section declared in the type's [`body_sections`](/reference/schema/) is missing from the note body, or present at the wrong heading level (warning; **auto-fixable** — `--fix` appends the canonical heading scaffold — see below) |
 | `broken-body-wikilink` | A well-formed `[[wikilink]]` in the note **body** whose target resolves to **no note** via the alias-aware, case-insensitive note index (warning; **flag-only** — offers a "did you mean?" hint but never auto-links — see below) |
 | `malformed-body-wikilink` | Wikilink bracket syntax in the body that is broken — an empty target (`[[]]`/`[[ ]]`) or an unclosed `[[` (warning; **flag-only**) |
@@ -270,6 +276,11 @@ after:  status: "raw"
 
 `unlinked-mention` is the closed-world web-integrity check: bwrb knows every note (by name) and, via the [`alias`-role field](/reference/schema/#alias), every registered alias. It scans note **bodies** for any known name or alias that appears as plain text but is **not** wikilinked, so the vault stays a connected graph instead of islands.
 
+This check is optional. `--mentions` enables exact, alias, and ambiguous matches
+without fuzzy suggestions. `--mention-fuzzy` enables the same profile plus the
+fuzzy tier. An exact `--only unlinked-mention` selector is also an explicit
+opt-in, but remains non-fuzzy unless one of the fuzzy flags enables that tier.
+
 It enforces a strict **trust line** — only matches bwrb can be certain about are auto-linked; everything uncertain becomes a visible review item that is never silently resolved:
 
 | Tier | What it matches | Behavior |
@@ -301,24 +312,30 @@ False-positive guards (none of these are scanned or rewritten):
 - Single-word note-name matches with capitalized canonical casing are skipped at positions where capitalization carries no signal: the start of the body, sentence starts after `.`, `!`, or `?`, line starts, markdown list starts, headings, and blockquotes. Multi-word names, aliases, and lowercase canonical names are unaffected.
 - Corpus calibration catches vault-local common words that the static list cannot know. During an audit run, bwrb counts single-token word casing across the full vault snapshot's prose (with code, links, URLs, and wikilinks masked for prose matching), and separately counts wikilink targets/display text as entity evidence. A single-word note name is dropped for that run when it appears in at least `mention_corpus_min_notes` distinct non-self notes and the non-canonical-case occurrence share is strictly greater than `mention_corpus_noncanonical_ratio`. Dropped names are also removed from fuzzy suggestions and `frequent-unlinked-term` nudges; declared aliases remain linkable.
 
-Only frontmatter is exempt from scanning — this detection looks at body prose only. Surfaces shorter than three characters are ignored to avoid noise. The entity index is built once per run and each body is scanned in a single pass, so cost scales with body size rather than notes × entities. Scoped audits such as `--path` still build the mention index and corpus calibration from the full vault snapshot, then scan only the targeted files for issues.
+Only frontmatter is exempt from scanning — this detection looks at body prose only. Surfaces shorter than three characters are ignored to avoid noise. When mention analysis is selected, the entity index is built once per run and exact/alias matching scans each body in a single pass. Fuzzy candidate comparison is a separate, more expensive opt-in tier. Scoped mention audits such as `--path` still build the mention index and corpus calibration from the full vault snapshot, then scan only the targeted files for issues. Bare audit runs build neither mention corpus.
 
 ```bash
 # Report unlinked mentions only
 bwrb audit --only unlinked-mention
 
+# Include exact/alias/ambiguous mentions and frequent terms, without fuzzy matching
+bwrb audit --mentions
+
+# Add fuzzy "did you mean?" suggestions
+bwrb audit --mention-fuzzy
+
 # Auto-link trusted (exact/alias) mentions across the Notes directory
-bwrb audit --path "Notes/**" --fix --auto --execute
+bwrb audit --path "Notes/**" --mentions --fix --auto --execute
 ```
 
 Fuzzy and ambiguous mentions are **never** modified by `--fix --auto`. Fuzzy matches are always flag-only (resolve them with interactive `--fix`, which skips them with the suggestion, or by editing manually). Ambiguous matches can be resolved in an interactive `--fix` session — see below.
 
 #### Tuning the fuzzy tier (#622)
 
-The fuzzy "did you mean?" tier is deliberately conservative. The configured threshold is a **cap** (default **2**), and bwrb also scales the effective distance by candidate length: `min(configured threshold, floor(candidate length / 4))`. In practice, 4–7 character candidates allow distance 1, 8–11 allow distance 2, and short sentence-initial words like `This` or `What` do not get a loose edit budget.
+The fuzzy "did you mean?" tier is deliberately conservative and always opt-in. The configured threshold is a **cap** (default **2**), and bwrb also scales the effective distance by candidate length: `min(configured threshold, floor(candidate length / 4))`. In practice, 4–7 character candidates allow distance 1, 8–11 allow distance 2, and short sentence-initial words like `This` or `What` do not get a loose edit budget.
 
-- **Per run (flag):** `--mention-fuzzy-threshold <n>` sets the max edit-distance cap, where `n` is an integer in `0`–`5`. Raising it can surface looser matches only when candidate length also permits that distance; lowering it surfaces fewer. `0` (or `--no-mention-fuzzy`) disables the fuzzy tier entirely. Out-of-range or non-integer values produce a clear validation error.
-- **Persistent (config):** set `mention_fuzzy_threshold` in your vault `config` (integer `0`–`5`). The flag, when present, overrides the config value for that run.
+- **Per run (flag):** `--mention-fuzzy` opts in with the configured cap. `--mention-fuzzy-threshold <n>` sets the cap, where `n` is an integer in `0`–`5`; a positive value also opts in. Raising it can surface looser matches only when candidate length permits that distance. `0` does not opt in, and `--no-mention-fuzzy` explicitly disables the tier. Contradictory positive/negative selectors produce a validation error regardless of flag order.
+- **Persistent (config):** `mention_fuzzy_threshold` tunes the cap used after fuzzy analysis is selected; it does **not** opt bare audit runs into fuzzy matching. Edit the schema config with an integer `0`–`5`.
 
 ```bash
 # Raise the fuzzy cap for one run (candidate length still applies)
@@ -329,7 +346,7 @@ bwrb audit --only unlinked-mention --no-mention-fuzzy
 ```
 
 ```json
-// .bwrb/schema.json — persist a higher cap for every run
+// .bwrb/schema.json — persist the cap used by opt-in fuzzy runs
 {
   "config": { "mention_fuzzy_threshold": 3 }
 }
@@ -407,6 +424,9 @@ This is **interactive-only**. In `--auto` / `--fix --auto` and any non-TTY (head
 
 `frequent-unlinked-term` is the **open-world** counterpart to `unlinked-mention`. Where `unlinked-mention` keeps *known* entities linked, this detection points at entities that probably *should* exist but don't yet — it surfaces proper-noun-ish terms mentioned a lot across the vault that have **no note**. It attacks the failure mode where the AI agent (or you) never links something because it doesn't know the entity exists in the first place. Create the note, and `unlinked-mention` keeps it wired up forever after.
 
+This heuristic is opt-in through `--mentions` or an exact
+`--only frequent-unlinked-term` selector; bare audits do not run it.
+
 **Advisory only — this detection NEVER takes action.** It is always reported as a warning and is **never auto-fixable**: there is no `--fix` path for it, `--fix --auto` ignores it, and interactive `--fix` lists it as a manual item only. Because it never acts, it is *allowed* to be a little noisy; the thresholds exist purely to keep the report readable, not for correctness. Just ignore any suggestion that isn't a real entity.
 
 **The heuristic (and its honest limits).** Discovering an unknown "thing" in prose without an LLM is inherently fuzzy. The detection approximates proper nouns with **runs of Capitalized words** (1–3 words: `Rust`, `Steve Yegge`, `New York Times`), counted only in prose. Known limits, stated plainly:
@@ -428,8 +448,8 @@ Because the threshold is vault-wide, this detection aggregates across all scanne
 # Report frequent unlinked terms only
 bwrb audit --only frequent-unlinked-term
 
-# Suppress them (e.g. while focusing on fixable issues)
-bwrb audit --ignore frequent-unlinked-term
+# Include both optional mention heuristics (with fuzzy matching still off)
+bwrb audit --mentions
 ```
 
 ### Missing-body-section semantics (body structure)

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -871,7 +871,7 @@ Vault-wide settings:
 | `date_format` | string | `"YYYY-MM-DD"` | Generated full-date and parsing pattern (`YYYY`, `MM`, `DD` tokens); Gregorian date fields are stored canonically as ISO |
 | `date_granularity` | string | `"day"` | Default coarsest date precision for all date fields: `day`, `month`, or `year`. Per-field [`granularity`](#partial-dates-and-granularity) overrides it |
 | `calendars` | object | `{}` | Named custom-calendar definitions available to type `calendar_default` and field `calendar`; see [Custom Calendars](/concepts/custom-calendars/) |
-| `mention_fuzzy_threshold` | integer | `2` | Maximum fuzzy edit distance for `unlinked-mention` suggestions (`0` disables fuzzy matching; range `0`–`5`) |
+| `mention_fuzzy_threshold` | integer | `2` | Maximum fuzzy edit distance after mention fuzzy analysis is explicitly selected (`0` disables fuzzy matching; range `0`–`5`; config alone does not opt in) |
 | `mention_corpus_calibration` | boolean | `true` | Damp vault-common single-word mention targets using corpus casing statistics |
 | `mention_corpus_min_notes` | integer | `3` | Minimum distinct non-self notes required before corpus damping can apply |
 | `mention_corpus_noncanonical_ratio` | number | `0.5` | Strict non-canonical-case share threshold for corpus damping (`0`–`1`) |

--- a/docs/product/audit-default-scope.md
+++ b/docs/product/audit-default-scope.md
@@ -1,0 +1,367 @@
+# Default `bwrb audit` scope
+
+Status: shaped for Work
+Date: 2026-08-09
+Canonical behavior docs to update during Work: [`docs-site/src/content/docs/reference/commands/audit.md`](../../docs-site/src/content/docs/reference/commands/audit.md)
+
+## Summary
+
+`bwrb audit` should validate explicit schema, structure, identity, ownership, lineage, and link-integrity contracts by default. It should not run prose-connectivity heuristics unless the caller asks for them.
+
+The first slice will remove both `unlinked-mention` and `frequent-unlinked-term` from the default audit profile. A new `--mentions` flag will opt into those two analyses. Fuzzy near-match analysis will require a further explicit opt-in through `--mention-fuzzy` or a positive `--mention-fuzzy-threshold`.
+
+This preserves the mention safety net while restoring a fast, predictable default audit. The bird may still inspect every noun, but only after being invited.
+
+## Context
+
+Bowerbird's product vision places schema enforcement at the core and the AI safety net, including unlinked-mention analysis, in the outermost circle. The current default audit crosses those layers invisibly: a command described as validating notes against a schema also performs multiple whole-vault prose analyses.
+
+The behavior is especially costly in a large real-world vault. Read-only measurements against an installed Bowerbird CLI showed a routine no-fuzzy audit taking tens of seconds, while the fuzzy mention pass could run for minutes.
+
+The main cost is not schema validation. Exact mention analysis builds a full-vault corpus and scans every selected body against a large combined surface pattern. Fuzzy analysis then compares each eligible capitalized phrase against every known entity name with Levenshtein distance. The frequent-term post-pass rereads every selected body.
+
+## Problem
+
+The default command currently violates three useful expectations:
+
+1. **Scope:** `audit` sounds like enforcement of explicit vault contracts, while unlinked prose and candidate entities are editorial suggestions.
+2. **Cost:** callers cannot predict that a routine audit may become a minutes-long corpus analysis.
+3. **Automation:** default text and JSON output can acquire heuristic warnings and latency unrelated to schema validity.
+
+`unlinked-mention` remains valuable as deterministic graph-maintenance assistance, and `frequent-unlinked-term` remains useful as an advisory discovery pass. Their value does not require default execution.
+
+## Desired outcome
+
+A user can run `bwrb audit` frequently and trust that it checks declared vault integrity without performing optional prose analysis. A user or agent can deliberately request mention analysis, including fuzzy suggestions when desired, using discoverable CLI flags. Existing mention detection and repair capabilities remain available.
+
+## Options considered
+
+### 1. Disable fuzzy matching only
+
+This removes the worst unbounded nested comparison but leaves exact mention analysis and the frequent-term pass in every audit. The measured full audit still took 40.1 seconds with fuzzy disabled. This is insufficient.
+
+### 2. Exclude mention issues by default and rely only on existing `--only`
+
+This is the smallest runtime change: callers could run `--only unlinked-mention` and `--only frequent-unlinked-term` separately. It lacks an ergonomic way to request the complete mention safety net in one run.
+
+### 3. Add an explicit mention profile at the existing command boundary
+
+Add `--mentions` for the two prose heuristics and `--mention-fuzzy` for the expensive fuzzy tier. Preserve `--only` for issue-specific runs. This makes cost and intent visible without adding a top-level command or moving detector ownership.
+
+**Recommended.**
+
+### 4. Create a separate command such as `bwrb mentions`
+
+This produces the strongest conceptual separation but expands the command surface, duplicates audit targeting/output/fix behavior, and creates a migration larger than the demonstrated problem requires. Defer unless the explicit audit profile later proves awkward.
+
+## Recommended direction
+
+### Default profile
+
+`bwrb audit` and `bwrb audit --fix` exclude:
+
+- `unlinked-mention`
+- `frequent-unlinked-term`
+- every corpus/index/post-pass cost used exclusively by those issue families
+
+Broken or malformed body links remain in the default audit because they are integrity defects. Schema-declared body sections remain because they are explicit contracts.
+
+### Explicit mention profile
+
+```sh
+bwrb audit --mentions
+```
+
+This enables:
+
+- exact known-name and registered-alias detection;
+- ambiguous exact-surface review items; and
+- `frequent-unlinked-term` advisory findings.
+
+It does not enable fuzzy near-match analysis.
+
+`--mentions` composes with existing targeting, output, and repair flags. In repair mode it explicitly permits the existing trusted exact/alias mention fixes; the frequent-term detector remains non-fixable.
+
+### Explicit fuzzy tier
+
+```sh
+bwrb audit --mentions --mention-fuzzy
+bwrb audit --mention-fuzzy
+bwrb audit --mention-fuzzy-threshold 3
+```
+
+`--mention-fuzzy` implies `--mentions`. A positive `--mention-fuzzy-threshold` also implies fuzzy analysis and the mention profile. The configured threshold continues to tune distance once fuzzy analysis is enabled; it does not enable fuzzy analysis by itself.
+
+`--no-mention-fuzzy` remains as a compatibility flag and is harmless with `--mentions`. Combining it with `--mention-fuzzy` or a positive `--mention-fuzzy-threshold` is a command-boundary validation error independent of flag order. A threshold of `0` disables fuzzy analysis and does not independently opt into mention analysis.
+
+### Existing issue filters
+
+- `--only unlinked-mention` opts into that detector without requiring `--mentions`; fuzzy remains off unless explicitly enabled.
+- `--only frequent-unlinked-term` opts into that detector without requiring `--mentions`.
+- `--mentions --only <mention-code>` is accepted as a redundant but coherent narrowing.
+- `--mention-fuzzy --only frequent-unlinked-term` is rejected because fuzzy findings belong to `unlinked-mention`, which `--only` excluded.
+- Existing `--ignore` semantics remain unchanged.
+
+### Configuration
+
+No new persistent `audit_mentions` or `mention_fuzzy` schema keys are in the first slice. The existing `mention_fuzzy_threshold` remains a tuning value with default `2`, but fuzzy work is dormant until the caller opts in. Persistent default-profile customization can be shaped later if real usage demands it.
+
+### Compatibility and communication
+
+This is an intentional default-behavior change:
+
+- scripts depending on mention findings from bare `bwrb audit` must add `--mentions`;
+- scripts depending on fuzzy findings must also add `--mention-fuzzy` or a positive threshold;
+- JSON shape and issue objects do not change, but default results omit the two advisory issue families;
+- the changelog, command help, canonical audit reference, validation concept page where relevant, and `docs/skill/SKILL.md` must describe the new opt-in contract in the same change.
+
+## Architecture grounding and fit
+
+Architecture grounding is **not required** for this bounded local CLI policy change. The owning boundary is already explicit and does not alter a shared service, schema protocol, or cross-repository contract.
+
+- **Demonstrated caller:** a maintainer running bare `bwrb audit` in a large vault expects a routine integrity check and encounters minutes-long prose analysis.
+- **Existing primitives:** `--only`, `--ignore`, Commander command-boundary options, `AuditRunOptions`, and the existing detector gates in `runAuditDetailed` already control issue selection.
+- **Ownership boundaries:** the `audit` command owns CLI intent and validation; audit detection owns execution of selected detectors; individual mention detectors retain their current matching and repair semantics.
+- **Legacy contracts to preserve:** explicit `--only unlinked-mention`, explicit `--only frequent-unlinked-term`, targeting, text/JSON result shapes, exit codes, and safe mention-fix behavior.
+- **Shared vocabulary:** `core audit` means declared integrity checks; `mention profile` means the two prose-connectivity heuristics; `fuzzy tier` means flag-only near-match suggestions within `unlinked-mention`.
+- **Smallest compatible delta:** resolve mention inclusion once at the command/audit-run boundary and skip all mention-only setup and passes when disabled. Do not rewrite matching algorithms in this slice.
+- **Deferred capabilities:** detector performance optimization, parsed-body caching, generic named audit profiles, repeatable `--include`/`--ignore`, persistent profile configuration, and a separate mentions command.
+- **Reversibility:** the detectors and issue codes remain intact; the behavior can be restored by changing selection defaults, while users can opt in immediately.
+- **Direct evidence:** current command registration and detector gates; issues #600, #601, #622, and #783; canonical audit documentation; the measurements above.
+- **Inference:** users generally interpret bare audit as contract enforcement rather than editorial review. This aligns with the product vision and the observed caller but has not been surveyed broadly.
+- **Unresolved owner questions:** none.
+
+Bowerbird's product-boundary gate passes: this change selects deterministic validation and advisory checks. It owns no agent, retry, scheduling, deployment, or process policy.
+
+## Constraints
+
+- Preserve the current issue codes and explicit workflows.
+- Do not weaken schema, identity, ownership, lineage, relative-date, body-link, or schema-declared body-section checks.
+- Do not make fuzzy matching automatic merely because a vault has a nonzero configured threshold.
+- Resolve positive/negated flag conflicts at the command boundary and test both flag orders, consistent with Commander's `--no-*` contract.
+- Keep user-facing behavior canonical in `docs-site`; this product brief records rationale and links to that contract.
+- Update the automation skill because bare `bwrb audit` will no longer inspect unlinked prose.
+- Do not introduce a CI timing threshold tied to a shared machine. Use the existing benchmark machinery or a recorded manual measurement for real-vault performance evidence.
+
+## Risks and assumptions
+
+- **Silent coverage reduction:** existing users may assume bare audit still checks mentions. Mitigate with help text, changelog/migration guidance, and explicit examples.
+- **Flag complexity:** `--mentions`, `--mention-fuzzy`, threshold, `--only`, and `--no-mention-fuzzy` need one centralized option-resolution matrix rather than scattered conditionals.
+- **Performance remains imperfect:** the explicit mention profile will still be slow. This slice makes the cost intentional; it does not optimize it.
+- **Default audit may still have other scale costs:** acceptance must measure the complete new default rather than infer its speed from one detector benchmark.
+
+## Acceptance story
+
+Acceptance story ID: `audit-core-default-v1`
+
+**Successful-user story:** In a vault containing schema errors, broken links, exact unlinked names, a repeated unknown proper noun, and a fuzzy near-match, a maintainer can run bare `bwrb audit` and quickly receive only declared integrity findings. They can add `--mentions` to receive exact/alias and frequent-term findings, then explicitly add `--mention-fuzzy` to receive fuzzy suggestions. Existing safe repair and JSON contracts continue to work.
+
+Required assertions:
+
+1. Bare text and JSON audits do not report either mention issue code and do not build the mention corpus/index or execute either mention body pass.
+2. Bare audit still reports representative schema, identity, ownership, body-section, and broken-body-link findings.
+3. `--mentions` reports exact/alias, ambiguous, and frequent-term findings but no fuzzy near-match.
+4. `--mention-fuzzy` and a positive `--mention-fuzzy-threshold` imply mention analysis and report fuzzy near-matches.
+5. Each explicit `--only` mention code still works without `--mentions`; incompatible flag combinations fail clearly and identically in either order.
+6. Bare `audit --fix` does not propose or apply mention rewrites; `--mentions --fix` and `--only unlinked-mention --fix` preserve current preview, execute, ambiguity, and safety behavior.
+7. Text/JSON shapes, exit codes, targeting semantics, and all non-mention audit behavior remain compatible.
+8. Canonical docs, help, changelog, and `docs/skill/SKILL.md` explain the opt-in and migration contract.
+9. A built-CLI read-only benchmark against a large real-world vault records before/after wall time and content checksums. The new bare default must avoid all mention-only work and materially improve over the no-fuzzy baseline; the evidence packet must report the actual ratio rather than inventing a portable CI budget.
+10. Full local CI parity passes in repository order.
+
+Independent real-interface acceptance: **required**, interface class **CLI**. An independent tester must run the built CLI against a disposable representative vault and verify the default, `--mentions`, fuzzy opt-in, JSON, and repair-preview stories. The large-vault benchmark is read-only performance evidence, not the tester's mutation surface.
+
+Execution placement: **local**. The implementation and ordinary test suite do not require Framework compute or persistent servers. Any generated benchmark fixture must remain disposable and local; no relocatability requirement applies.
+
+## Architecture fingerprint
+
+```yaml
+authoritySchemaVersion: 2
+outcome: Make bare bwrb audit a fast contract-integrity check while preserving mention analysis as an explicit opt-in.
+shipping-surfaces:
+  - id: bwrb-audit-cli-contract
+    repository: 3mdistal/bwrb
+    product-surface: bwrb audit text, JSON, and fix CLI behavior plus its canonical docs and agent skill
+    constituency: human CLI users and automation or agents operating Markdown vaults
+    durable-destination: Bowerbird mainline product and bwrb.dev command documentation
+    integration-action: merge
+governing-architecture: Resolve optional audit profiles once at the audit command/run boundary; keep detector and repair ownership unchanged and skip all mention-only work unless selected.
+acceptance-story:
+  id: audit-core-default-v1
+  summary: Bare audit reports explicit vault-contract defects quickly; mention and fuzzy analyses appear only through deliberate flags while explicit legacy workflows remain available.
+  required-assertions: 10 assertions in the Acceptance story section, including independent CLI acceptance.
+risk-strategy:
+  kind: system-ready
+  production-validation-after-merge: false
+```
+
+## Shape authority envelope
+
+```yaml
+stage: shape
+authority-source: "$shape this fix."
+authorized-scope:
+  repositories:
+    - 3mdistal/bwrb
+  product-surfaces:
+    - bwrb audit default and explicit mention-selection contract
+  outcome: Freeze an implementation-ready decision brief for the audit default-scope correction.
+allowed-mutations:
+  - artifact-write
+write-targets:
+  artifacts:
+    - docs/product/audit-default-scope.md
+governing-artifact:
+  path: docs/product/audit-default-scope.md
+  revision: shape-audit-default-scope-r1
+delegation-ceiling: []
+acceptance-state:
+  status: pending
+  summary: Shape is complete when the brief freezes the destination; no production implementation or acceptance evidence exists yet.
+  blockers: []
+ledger-revision: shape-audit-default-scope-r1
+status: active
+```
+
+## Next steps
+
+Work should implement the centralized option-resolution matrix, preserve the detector internals, update tests and canonical documentation, run full CI parity, benchmark the built CLI, and obtain independent CLI acceptance. Work should produce a draft pull request for maintainer review; readiness does not transfer review custody or authorize merge.
+
+No material product question remains. Future detector optimization should be shaped separately after the default-scope correction is proven.
+
+## Work execution record
+
+```yaml
+stage: work
+authority-source: "$work"
+authorized-scope:
+  repositories:
+    - 3mdistal/bwrb
+  product-surfaces:
+    - bwrb audit default and explicit mention-selection contract
+  outcome: Implement and prove the frozen audit default-scope correction on a draft pull request.
+allowed-mutations:
+  - artifact-write
+  - ephemeral-test-resource
+  - branch
+  - commit
+  - push
+  - pull-request
+write-targets:
+  artifacts:
+    - task-owned branch files required by the frozen implementation and evidence
+test-resources:
+  - id: focused-vitest-vaults
+    kind: file
+    surface: OS temporary directories created by the focused and full Bowerbird test suites
+    ownership-marker: suite-generated bwrb-* mkdtemp basenames returned to this task's test processes
+    baseline: no task-created pathname exists before each mkdtemp call
+    allowed-actions: [create, update, exercise, delete]
+    cleanup-trigger: each test afterEach or global teardown, with final residue check before Work completion
+    cleanup-method: suite-owned recursive removal of the exact returned mkdtemp path
+    cleanup-proof: successful suite teardown plus absence of this run's returned paths
+    shared-impact: none
+    isolation: local-runtime
+    ownership: task-created
+    production-data: false
+    customer-data: false
+    cost: none
+    boundary-evidence:
+      - tests use mkdtemp under the operating-system temporary directory and retain the returned exact path for teardown
+      - final suite teardown passed and a Land absence scan found no matching task test directories
+    max-lifetime-minutes: 1440
+    declared-at: 2026-08-09T00:00:00-04:00
+    expires-at: 2026-08-10T00:00:00-04:00
+    status: cleaned
+    phase: work
+  - id: independent-cli-qa-vault
+    kind: file
+    surface: OS temporary directory matching /tmp/bwrb-audit-qa.* plus its suite-owned transcript
+    ownership-marker: .bwrb-audit-qa-owned marker containing this task revision
+    baseline: no task-created pathname exists before the tester's mktemp call
+    allowed-actions: [create, update, exercise, delete]
+    cleanup-trigger: completion or blockage of the frozen H1-H6 CLI story
+    cleanup-method: recursive removal of the exact mktemp path after the tester returns transcript evidence
+    cleanup-proof: tester reports the exact path removed and root confirms it no longer exists
+    shared-impact: none
+    isolation: local-runtime
+    ownership: task-created
+    production-data: false
+    customer-data: false
+    cost: none
+    boundary-evidence:
+      - the tester may mutate only the disposable fixture it creates under the returned mktemp path
+      - the repository checkout and large real-world benchmark vault remain read-only to the tester
+      - both tester reports recorded exact-path removal and Land rechecked those paths as absent
+    max-lifetime-minutes: 120
+    declared-at: 2026-08-09T15:35:00-04:00
+    expires-at: 2026-08-09T17:35:00-04:00
+    status: cleaned
+    phase: work
+governing-artifact:
+  path: docs/product/audit-default-scope.md
+  revision: work-audit-default-scope-r2
+architecture-fingerprint: unchanged from the Architecture fingerprint section
+architecture-grounding:
+  applicability: not-required
+  reason: bounded local CLI selection policy with an already-evidenced command and detector boundary
+  status: grounded
+delegation-ceiling:
+  - read-only repository inventory
+acceptance-state:
+  status: pending
+  summary: Implementation, technical gates, benchmark, independent CLI acceptance, draft PR, and CI evidence remain pending.
+  blockers: []
+ledger-revision: work-audit-default-scope-r2
+status: active
+```
+
+## Work verification evidence
+
+- Focused audit profile suite: 350 tests passed, followed by the expanded
+  threshold-zero slice with 8 passing profile tests.
+- Full local CI parity passed in the repository-mandated order: build,
+  package verification, typecheck, lint, knip, then 3,022 passing non-PTY
+  tests (3 skipped).
+- A read-only built-CLI benchmark against a large real-world vault more than
+  halved bare-audit wall time while continuing to report core issues. Aggregate
+  Markdown checksums were identical before and after.
+
+## Frozen independent CLI acceptance story
+
+Persona: a vault maintainer who wants a fast integrity audit and chooses prose
+link advice only when useful.
+
+Starting state: the exact committed artifact is built locally; the tester owns
+a fresh disposable vault carrying the `independent-cli-qa-vault` marker.
+
+H1. Inspect `bwrb audit --help` through the built CLI.
+    Expect the default/mention distinction and all three positive selectors to
+    be readable and discoverable.
+
+H2. Run bare text and JSON audits on a fixture containing one core schema
+    defect, one broken body link, one exact unlinked name, one fuzzy near-match,
+    and a frequent unknown proper-noun phrase.
+    Expect core findings, with neither mention issue code or prose suggestion.
+
+H3. Run `audit --mentions` on the same fixture.
+    Expect exact/alias/ambiguous and frequent-term analysis, with no fuzzy
+    suggestion.
+
+H4. Run `audit --mention-fuzzy` and a positive threshold selector.
+    Expect both selectors to imply the mention profile and surface the fuzzy
+    suggestion.
+
+H5. Exercise threshold zero and conflicting positive/negative fuzzy selectors.
+    Expect zero not to opt in, and conflicts to fail clearly regardless of flag
+    order.
+
+H6. Run default and explicit mention auto-fix flows on fresh disposable copies.
+    Expect default auto-fix not to rewrite prose; expect explicit mention
+    selection to link the trusted exact occurrence while leaving fuzzy and
+    frequent-term findings untouched.
+
+Regression checks: existing exact `--only` selectors remain sufficient;
+stdout/stderr, exits, and remediation text remain legible in a real terminal.
+
+Cleanup: remove the tester's exact disposable vault path and report proof.

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -130,7 +130,7 @@ bwrb supports vault-wide configuration in `.bwrb/schema.json` under the `config`
 | `obsidian_vault` | String | auto | Obsidian vault name for URI opening |
 | `default_dashboard` | String | none | Dashboard run with no name |
 | `excluded_directories` | `string[]` | `[]` | Directory prefixes to exclude from discovery/targeting |
-| `mention_fuzzy_threshold` | Integer `0`–`5` | `2` | Fuzzy edit-distance cap for mention suggestions |
+| `mention_fuzzy_threshold` | Integer `0`–`5` | `2` | Fuzzy edit-distance cap after an audit run explicitly selects fuzzy mention analysis; config alone does not opt in |
 | `mention_corpus_calibration` | Boolean | `true` | Dampen vault-common single-word targets |
 | `mention_corpus_min_notes` | Integer | `3` | Corpus damping minimum note count |
 | `mention_corpus_noncanonical_ratio` | Number `0`–`1` | `0.5` | Corpus damping casing threshold |
@@ -534,6 +534,13 @@ bwrb list --id "<uuid>" --open --app print --picker none
 # Audit all notes against schema
 bwrb audit
 
+# Optional prose-linking analysis (exact/alias/ambiguous + frequent terms;
+# fuzzy suggestions remain off)
+bwrb audit --mentions
+
+# Include the optional fuzzy "did you mean?" tier too
+bwrb audit --mention-fuzzy
+
 # Audit specific type
 bwrb audit --type task
 
@@ -568,6 +575,10 @@ bwrb audit --path "Ideas/**" --fix --auto
 #       and capitalized single-word names are ignored at sentence/list/heading
 #       starts where capitalization carries no signal. Declared aliases remain
 #       explicit link intent.
+# Note: bare audit runs core integrity checks only. Unlinked mentions and
+#       frequent unlinked terms require --mentions or an exact --only selector;
+#       fuzzy matching additionally requires --mention-fuzzy or a positive
+#       --mention-fuzzy-threshold. Config only tunes an opted-in fuzzy run.
 # Note: to link each mention target at most once per note (dense repeats read
 #       poorly), enable link-once: pass --mention-link-once (or set config
 #       mention_link_once: true; --no-mention-link-once overrides it off).

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -72,6 +72,12 @@ const FIX_TARGETING_ERROR_MESSAGE = [
   '  bwrb audit --path "Ideas/**" --fix --dry-run --auto',
 ].join('\n');
 
+const BUILT_IN_MENTION_FUZZY_THRESHOLD = 2;
+
+function commandHasRawFlag(flag: string): boolean {
+  return process.argv.includes(flag);
+}
+
 /**
  * Print the schema documentation coverage report (opt-in --check-schema-docs).
  */
@@ -135,9 +141,9 @@ Issue Types:
   frontmatter-not-at-top Frontmatter block is not at top
   duplicate-frontmatter-keys Duplicate YAML keys in frontmatter
   malformed-wikilink    Near-wikilink bracket typo (frontmatter only)
-  unlinked-mention      Known entity name/alias in body prose, not wikilinked
+  unlinked-mention      Optional: known entity name/alias in body prose, not wikilinked
                         (exact/alias auto-fixable; fuzzy/ambiguous flag-only)
-  frequent-unlinked-term Proper-noun-ish term mentioned often across the vault
+  frequent-unlinked-term Optional: proper-noun-ish term mentioned often across the vault
                         with no note yet (advisory heuristic; never auto-fixed)
   missing-body-section  Heading section declared in the type's body_sections is
                         missing from the note body (auto-fixable: appends it)
@@ -184,8 +190,10 @@ Examples:
   bwrb audit --ignore unknown-field
   bwrb audit --output json        # JSON output for CI
   bwrb audit --allow-field custom # Allow specific extra field
-  bwrb audit --only unlinked-mention --mention-fuzzy-threshold 3 # Raise fuzzy "did you mean?" cap
-  bwrb audit --only unlinked-mention --no-mention-fuzzy          # Disable fuzzy tier
+  bwrb audit --mentions                  # Include exact/alias and frequent-term prose analysis
+  bwrb audit --mention-fuzzy             # Include mentions plus fuzzy "did you mean?" suggestions
+  bwrb audit --only unlinked-mention      # Run only exact/alias mention analysis (fuzzy off)
+  bwrb audit --only unlinked-mention --mention-fuzzy-threshold 3 # Opt into fuzzy with cap 3
   bwrb audit --all --fix                  # Interactive guided fixes across vault (writes)
   bwrb audit --fix --path "Ideas/**"      # Interactive guided fixes (writes)
   bwrb audit --fix --dry-run --path "Ideas/**"    # Preview guided fixes (no writes)
@@ -208,11 +216,13 @@ Examples:
   .option('--execute', 'With --fix --auto: apply fixes (omit to preview)')
   .option('--retention-action <kind>', 'Explicit retention action: archive, tombstone, or delete (requires --only retention-due --fix)')
   .option('--allow-field <fields...>', 'Allow additional fields beyond schema (repeatable)')
+  .option('--mentions', 'Include optional unlinked-mention and frequent-term prose analysis')
   .option(
     '--mention-fuzzy-threshold <n>',
-    'unlinked-mention fuzzy "did you mean?" max edit-distance cap (0-5; default from config or 2)'
+    'Opt into fuzzy unlinked-mention suggestions with max edit-distance cap (0-5)'
   )
-  .option('--no-mention-fuzzy', 'Disable the unlinked-mention fuzzy "did you mean?" tier')
+  .option('--mention-fuzzy', 'Include mention analysis and fuzzy "did you mean?" suggestions')
+  .option('--no-mention-fuzzy', 'Explicitly keep the optional fuzzy mention tier disabled')
   .option(
     '--mention-link-once',
     'With --fix --auto: link at most one unlinked mention per note/target pair'
@@ -234,6 +244,8 @@ Examples:
     const dryRunMode = options.dryRun ?? false;
     const executeMode = options.execute ?? false;
     const retentionAction = options.retentionAction as 'archive' | 'tombstone' | 'delete' | undefined;
+    const mentionFuzzyRequested = commandHasRawFlag('--mention-fuzzy');
+    const mentionFuzzyDisabled = commandHasRawFlag('--no-mention-fuzzy');
     const exitWithValidationError = (
       message: string,
       {
@@ -288,6 +300,11 @@ Examples:
     if (retentionAction && autoMode) {
       exitWithValidationError('--retention-action cannot be combined with --auto');
     }
+    if (mentionFuzzyRequested && mentionFuzzyDisabled) {
+      exitWithValidationError(
+        '--mention-fuzzy cannot be combined with --no-mention-fuzzy. Remove one of the two flags and rerun.'
+      );
+    }
 
     try {
       const globalOpts = getGlobalOpts(cmd);
@@ -300,19 +317,42 @@ Examples:
       const vaultDir = await resolveVaultDirWithSelection(vaultOptions);
       const schema = await loadSchema(vaultDir);
 
-      // Resolve the unlinked-mention fuzzy tuning (#622). Precedence: CLI flag
-      // > schema config > built-in default. `--no-mention-fuzzy` disables the
-      // tier outright. The CLI threshold is validated to a sensible range.
-      const mentionFuzzyEnabled = options.mentionFuzzy !== false;
+      // Mention analysis is an explicit profile. Fuzzy suggestions require a
+      // second opt-in; the configured threshold tunes that tier but does not
+      // enable it by itself.
       let mentionFuzzyThreshold = schema.config.mentionFuzzyThreshold;
+      let explicitMentionFuzzyThreshold: number | undefined;
       if (options.mentionFuzzyThreshold !== undefined) {
         const parsed = parseFuzzyThreshold(options.mentionFuzzyThreshold);
         if (!parsed.ok) {
           exitWithValidationError(parsed.error);
         } else {
           mentionFuzzyThreshold = parsed.value;
+          explicitMentionFuzzyThreshold = parsed.value;
         }
       }
+      const thresholdEnablesMentionFuzzy =
+        explicitMentionFuzzyThreshold !== undefined && explicitMentionFuzzyThreshold > 0;
+      if (mentionFuzzyDisabled && thresholdEnablesMentionFuzzy) {
+        exitWithValidationError(
+          '--mention-fuzzy-threshold greater than 0 cannot be combined with --no-mention-fuzzy. Use threshold 0 or remove --no-mention-fuzzy.'
+        );
+      }
+      if (mentionFuzzyRequested && explicitMentionFuzzyThreshold === 0) {
+        exitWithValidationError(
+          '--mention-fuzzy cannot be combined with --mention-fuzzy-threshold 0. Remove --mention-fuzzy or choose a threshold from 1 to 5.'
+        );
+      }
+      const mentionFuzzyEnabled = mentionFuzzyRequested || thresholdEnablesMentionFuzzy;
+      if (mentionFuzzyRequested && mentionFuzzyThreshold === 0) {
+        mentionFuzzyThreshold = BUILT_IN_MENTION_FUZZY_THRESHOLD;
+      }
+      if (mentionFuzzyEnabled && options.only && options.only !== 'unlinked-mention') {
+        exitWithValidationError(
+          '--mention-fuzzy requires --only unlinked-mention when --only is used'
+        );
+      }
+      const includeMentions = options.mentions === true || mentionFuzzyEnabled;
       const mentionLinkOnce = options.mentionLinkOnce ?? schema.config.mentionLinkOnce;
 
       if (globalOpts.nonInteractive && fixMode && !autoMode && !retentionAction) {
@@ -401,6 +441,7 @@ Examples:
         allowedFields,
         vaultDir,
         schema,
+        includeMentions,
         mentionFuzzyThreshold,
         mentionFuzzyEnabled,
       });

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -221,10 +221,12 @@ export async function runAuditDetailed(
 
   const wantUnlinkedMention =
     options.ignoreIssue !== 'unlinked-mention' &&
-    (options.onlyIssue === undefined || options.onlyIssue === 'unlinked-mention');
+    (options.onlyIssue === 'unlinked-mention' ||
+      (options.onlyIssue === undefined && options.includeMentions === true));
   const wantFrequentTerm =
     options.ignoreIssue !== 'frequent-unlinked-term' &&
-    (options.onlyIssue === undefined || options.onlyIssue === 'frequent-unlinked-term');
+    (options.onlyIssue === 'frequent-unlinked-term' ||
+      (options.onlyIssue === undefined && options.includeMentions === true));
   const wantsMentionSafetyNet = wantUnlinkedMention || wantFrequentTerm;
 
   // Build the entity-mention index once for the whole run (#600), but only when
@@ -1124,9 +1126,7 @@ export async function auditFile(
             ...(options.mentionFuzzyThreshold !== undefined
               ? { fuzzyThreshold: options.mentionFuzzyThreshold }
               : {}),
-            ...(options.mentionFuzzyEnabled !== undefined
-              ? { fuzzyEnabled: options.mentionFuzzyEnabled }
-              : {}),
+            fuzzyEnabled: options.mentionFuzzyEnabled === true,
           })
         );
       }

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -250,14 +250,16 @@ export interface AuditOptions {
   retentionAction?: 'archive' | 'tombstone' | 'delete';
   all?: boolean;
   allowField?: string[];
+  /** Include the optional prose-connectivity audit profile. */
+  mentions?: boolean;
   /**
    * Max Levenshtein distance for the unlinked-mention fuzzy tier (#622). Raw
    * string as parsed by commander from `--mention-fuzzy-threshold <n>`.
    */
   mentionFuzzyThreshold?: string;
   /**
-   * False when `--no-mention-fuzzy` is passed, disabling the fuzzy "did you
-   * mean?" tier. Commander stores the negatable boolean here.
+   * True for `--mention-fuzzy`, false for `--no-mention-fuzzy`, and undefined
+   * when neither is passed. Commander stores both forms on this positive key.
    */
   mentionFuzzy?: boolean;
   /**
@@ -285,14 +287,16 @@ export interface AuditRunOptions {
   vaultDir?: string | undefined;
   /** Schema for looking up field formats */
   schema?: LoadedSchema | undefined;
+  /** Include unlinked-mention and frequent-unlinked-term in an unfiltered run. */
+  includeMentions?: boolean | undefined;
   /**
    * Resolved max Levenshtein distance for the unlinked-mention fuzzy tier
    * (#622). Undefined means use the built-in default. Already validated.
    */
   mentionFuzzyThreshold?: number | undefined;
   /**
-   * When false, the unlinked-mention fuzzy "did you mean?" tier is disabled
-   * (#622). Undefined means enabled (default).
+   * When true, enable the unlinked-mention fuzzy "did you mean?" tier (#622).
+   * Undefined and false both mean disabled at the audit-run boundary.
    */
   mentionFuzzyEnabled?: boolean | undefined;
   /** One local day snapshot shared by every retention finding in this run. */

--- a/tests/bench/generate-fixtures.test.ts
+++ b/tests/bench/generate-fixtures.test.ts
@@ -56,7 +56,11 @@ describe('benchmark fixtures', () => {
   it('has the recorded advisory-only audit state in the built CLI', async () => {
     const dir = await fixtureDir('audit');
     await generateFixture('realistic', dir);
-    const result = await execFileAsync(process.execPath, ['dist/index.js', '--vault', dir, 'audit', '--output', 'json'], { cwd: process.cwd() });
+    const result = await execFileAsync(
+      process.execPath,
+      ['dist/index.js', '--vault', dir, 'audit', '--mentions', '--output', 'json'],
+      { cwd: process.cwd() }
+    );
     const parsed = JSON.parse(result.stdout) as { files: Array<{ issues: unknown[] }> };
     expect(parsed.files.flatMap(file => file.issues)).toHaveLength(3);
   }, 20_000);

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -91,6 +91,169 @@ describe('audit command', () => {
     });
   });
 
+  describe('optional mention analysis profile', () => {
+    let tempVaultDir: string;
+
+    beforeEach(async () => {
+      tempVaultDir = await mkdtemp(join(tmpdir(), 'bwrb-audit-mentions-'));
+      await mkdir(join(tempVaultDir, '.bwrb'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, '.bwrb', 'schema.json'),
+        JSON.stringify(TEST_SCHEMA, null, 2)
+      );
+      await mkdir(join(tempVaultDir, 'Ideas'), { recursive: true });
+      await writeFile(
+        join(tempVaultDir, 'Ideas', 'Steve Yegge.md'),
+        `---
+type: idea
+status: raw
+priority: medium
+---
+`
+      );
+      await writeFile(
+        join(tempVaultDir, 'Ideas', 'Mentions A.md'),
+        `---
+type: idea
+status: invalid-status
+priority: medium
+---
+Met Steve Yegge. Reading Steve Yeg today.
+Project Phoenix matters. Project Phoenix grows.
+See [[Missing Target]].
+`
+      );
+      await writeFile(
+        join(tempVaultDir, 'Ideas', 'Mentions B.md'),
+        `---
+type: idea
+status: raw
+priority: medium
+---
+Project Phoenix returns. Project Phoenix persists.
+`
+      );
+    });
+
+    afterEach(async () => {
+      await rm(tempVaultDir, { recursive: true, force: true });
+    });
+
+    it('keeps prose heuristics out of the default text and JSON audit', async () => {
+      const textResult = await runCLI(['audit'], tempVaultDir);
+      expect(textResult.stdout).toContain('Invalid status value');
+      expect(textResult.stdout).toContain('Broken wikilink');
+      expect(textResult.stdout).not.toContain('Unlinked mention');
+      expect(textResult.stdout).not.toContain('Project Phoenix');
+
+      const jsonResult = await runCLI(['audit', '--output', 'json'], tempVaultDir);
+      const json = JSON.parse(jsonResult.stdout);
+      const codes = json.files.flatMap((file: { issues: Array<{ code: string }> }) =>
+        file.issues.map((issue) => issue.code)
+      );
+      expect(codes).toContain('invalid-option');
+      expect(codes).toContain('broken-body-wikilink');
+      expect(codes).not.toContain('unlinked-mention');
+      expect(codes).not.toContain('frequent-unlinked-term');
+    });
+
+    it('--mentions enables exact and frequent-term findings but not fuzzy suggestions', async () => {
+      const result = await runCLI(['audit', '--mentions'], tempVaultDir);
+      expect(result.stdout).toContain("Unlinked mention on line 1: 'Steve Yegge'");
+      expect(result.stdout).toContain('Project Phoenix');
+      expect(result.stdout).not.toContain("Possible unlinked mention on line 1: 'Steve Yeg'");
+    });
+
+    it('positive fuzzy selectors imply mention analysis', async () => {
+      const flagResult = await runCLI(['audit', '--mention-fuzzy'], tempVaultDir);
+      expect(flagResult.stdout).toContain("Possible unlinked mention on line 1: 'Steve Yeg'");
+      expect(flagResult.stdout).toContain('Project Phoenix');
+
+      const thresholdResult = await runCLI(
+        ['audit', '--mention-fuzzy-threshold', '2'],
+        tempVaultDir
+      );
+      expect(thresholdResult.stdout).toContain("Possible unlinked mention on line 1: 'Steve Yeg'");
+    });
+
+    it('treats a zero fuzzy threshold as disabled rather than as mention opt-in', async () => {
+      const zeroOnly = await runCLI(
+        ['audit', '--mention-fuzzy-threshold', '0'],
+        tempVaultDir
+      );
+      expect(zeroOnly.stdout).not.toContain('Unlinked mention');
+      expect(zeroOnly.stdout).not.toContain('Project Phoenix');
+
+      const mentionsWithZero = await runCLI(
+        ['audit', '--mentions', '--mention-fuzzy-threshold', '0'],
+        tempVaultDir
+      );
+      expect(mentionsWithZero.stdout).toContain("Unlinked mention on line 1: 'Steve Yegge'");
+      expect(mentionsWithZero.stdout).toContain('Project Phoenix');
+      expect(mentionsWithZero.stdout).not.toContain('Possible unlinked mention');
+    });
+
+    it('keeps explicit mention issue selectors working without --mentions', async () => {
+      const exactResult = await runCLI(
+        ['audit', '--only', 'unlinked-mention'],
+        tempVaultDir
+      );
+      expect(exactResult.stdout).toContain("Unlinked mention on line 1: 'Steve Yegge'");
+      expect(exactResult.stdout).not.toContain('Possible unlinked mention');
+      expect(exactResult.stdout).not.toContain('Project Phoenix');
+
+      const frequentResult = await runCLI(
+        ['audit', '--only', 'frequent-unlinked-term'],
+        tempVaultDir
+      );
+      expect(frequentResult.stdout).toContain('Project Phoenix');
+      expect(frequentResult.stdout).not.toContain('Steve Yegge');
+    });
+
+    it('rejects incompatible fuzzy selectors independent of flag order', async () => {
+      for (const args of [
+        ['audit', '--mention-fuzzy', '--no-mention-fuzzy'],
+        ['audit', '--no-mention-fuzzy', '--mention-fuzzy'],
+        ['audit', '--mention-fuzzy-threshold', '2', '--no-mention-fuzzy'],
+        ['audit', '--no-mention-fuzzy', '--mention-fuzzy-threshold', '2'],
+        ['audit', '--mention-fuzzy', '--mention-fuzzy-threshold', '0'],
+        ['audit', '--mention-fuzzy-threshold', '0', '--mention-fuzzy'],
+      ]) {
+        const result = await runCLI(args, tempVaultDir);
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain('cannot be combined');
+        expect(result.stderr).toMatch(/Remove|Use/);
+      }
+    });
+
+    it('rejects fuzzy analysis when --only excludes unlinked-mention', async () => {
+      for (const args of [
+        ['audit', '--mention-fuzzy', '--only', 'frequent-unlinked-term'],
+        ['audit', '--only', 'frequent-unlinked-term', '--mention-fuzzy'],
+      ]) {
+        const result = await runCLI(args, tempVaultDir);
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain(
+          '--mention-fuzzy requires --only unlinked-mention when --only is used'
+        );
+      }
+    });
+
+    it('requires explicit mention selection before auto-fixing prose', async () => {
+      const notePath = join(tempVaultDir, 'Ideas', 'Mentions A.md');
+      const before = await readFile(notePath, 'utf-8');
+
+      await runCLI(['audit', '--all', '--fix', '--auto', '--execute'], tempVaultDir);
+      expect(await readFile(notePath, 'utf-8')).toBe(before);
+
+      await runCLI(
+        ['audit', '--mentions', '--all', '--fix', '--auto', '--execute'],
+        tempVaultDir
+      );
+      expect(await readFile(notePath, 'utf-8')).toContain('Met [[Steve Yegge]].');
+    });
+  });
+
   describe('relation field integrity', () => {
     let tempVaultDir: string;
 

--- a/tests/ts/lib/audit-unlinked-mention-interactive.test.ts
+++ b/tests/ts/lib/audit-unlinked-mention-interactive.test.ts
@@ -75,7 +75,7 @@ describe('unlinked-mention: interactive ambiguous resolution (#622)', () => {
   it('rewrites the mention to [[Chosen]] when a candidate is picked', async () => {
     await writeDaily('Talking about Mercury.');
     const schema = await loadSchema(vaultDir);
-    const results = await runAudit(schema, vaultDir, { strict: false });
+    const results = await runAudit(schema, vaultDir, { strict: false, onlyIssue: 'unlinked-mention' });
 
     // Pick the planet "Mercury" (the surface equals the canonical name).
     promptSelectionMock.mockResolvedValueOnce('Mercury');
@@ -92,7 +92,7 @@ describe('unlinked-mention: interactive ambiguous resolution (#622)', () => {
   it('uses the display form [[Chosen|surface]] when surface differs from the note', async () => {
     await writeDaily('Talking about Mercury.');
     const schema = await loadSchema(vaultDir);
-    const results = await runAudit(schema, vaultDir, { strict: false });
+    const results = await runAudit(schema, vaultDir, { strict: false, onlyIssue: 'unlinked-mention' });
 
     // Pick "Freddie" — the surface "Mercury" differs from the note name.
     promptSelectionMock.mockResolvedValueOnce('Freddie');
@@ -106,7 +106,7 @@ describe('unlinked-mention: interactive ambiguous resolution (#622)', () => {
   it('leaves the mention untouched when the user skips', async () => {
     await writeDaily('Talking about Mercury.');
     const schema = await loadSchema(vaultDir);
-    const results = await runAudit(schema, vaultDir, { strict: false });
+    const results = await runAudit(schema, vaultDir, { strict: false, onlyIssue: 'unlinked-mention' });
 
     promptSelectionMock.mockResolvedValueOnce('[skip]');
 
@@ -120,7 +120,7 @@ describe('unlinked-mention: interactive ambiguous resolution (#622)', () => {
   it('--auto (runAutoFix) never resolves an ambiguous mention', async () => {
     await writeDaily('Talking about Mercury.');
     const schema = await loadSchema(vaultDir);
-    const results = await runAudit(schema, vaultDir, { strict: false });
+    const results = await runAudit(schema, vaultDir, { strict: false, onlyIssue: 'unlinked-mention' });
 
     await runAutoFix(results, schema, vaultDir, { dryRun: false });
 
@@ -134,7 +134,7 @@ describe('unlinked-mention: interactive ambiguous resolution (#622)', () => {
   it('offers the candidate entities (plus skip/quit) in the prompt', async () => {
     await writeDaily('Talking about Mercury.');
     const schema = await loadSchema(vaultDir);
-    const results = await runAudit(schema, vaultDir, { strict: false });
+    const results = await runAudit(schema, vaultDir, { strict: false, onlyIssue: 'unlinked-mention' });
 
     promptSelectionMock.mockResolvedValueOnce('[skip]');
     await runInteractiveFix(results, schema, vaultDir, { dryRun: false });

--- a/tests/ts/lib/audit-unlinked-mention.test.ts
+++ b/tests/ts/lib/audit-unlinked-mention.test.ts
@@ -1236,7 +1236,7 @@ describe('unlinked-mention: end-to-end audit + fix', () => {
     );
     const schema = await loadSchema(vaultDir);
 
-    const results = await runAudit(schema, vaultDir, { strict: false });
+    const results = await runAudit(schema, vaultDir, { strict: false, includeMentions: true });
     const daily = results.find((r) => r.relativePath === 'Notes/Daily.md');
     expect(daily?.issues.some((i) => i.code === 'unlinked-mention' && i.autoFixable)).toBe(true);
 
@@ -1252,7 +1252,7 @@ describe('unlinked-mention: end-to-end audit + fix', () => {
       `---\ntype: note\n---\nNotes from Stevey.\n`
     );
     const schema = await loadSchema(vaultDir);
-    const results = await runAudit(schema, vaultDir, { strict: false });
+    const results = await runAudit(schema, vaultDir, { strict: false, includeMentions: true });
     await runAutoFix(results, schema, vaultDir, { dryRun: false });
     const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
     expect(after).toContain('[[Steve Yegge|Stevey]]');
@@ -1262,7 +1262,7 @@ describe('unlinked-mention: end-to-end audit + fix', () => {
     const original = `---\ntype: note\n---\nI spoke with [[Steve Yegge]] today.\n`;
     await writeFile(join(vaultDir, 'Notes', 'Daily.md'), original);
     const schema = await loadSchema(vaultDir);
-    const results = await runAudit(schema, vaultDir, { strict: false });
+    const results = await runAudit(schema, vaultDir, { strict: false, includeMentions: true });
     const daily = results.find((r) => r.relativePath === 'Notes/Daily.md');
     expect(daily?.issues.some((i) => i.code === 'unlinked-mention')).toBeFalsy();
   });
@@ -1273,7 +1273,11 @@ describe('unlinked-mention: end-to-end audit + fix', () => {
       `---\ntype: note\n---\nReading Steve Yeg today.\n`
     );
     const schema = await loadSchema(vaultDir);
-    const results = await runAudit(schema, vaultDir, { strict: false });
+    const results = await runAudit(schema, vaultDir, {
+      strict: false,
+      includeMentions: true,
+      mentionFuzzyEnabled: true,
+    });
     await runAutoFix(results, schema, vaultDir, { dryRun: false });
     const after = await readFile(join(vaultDir, 'Notes', 'Daily.md'), 'utf-8');
     // The fuzzy mention is left untouched.


### PR DESCRIPTION
## Problem

Bare `bwrb audit` currently performs whole-vault prose analysis in addition to
validating declared vault contracts. On a large real-world vault, even
disabling fuzzy matching left routine audits taking tens of seconds, while the
default fuzzy pass could run for minutes. These editorial heuristics also add
warnings to automation that asked only for integrity validation.

## Approach

Make core structural, schema, identity, ownership, lineage, and link-integrity
checks the default audit profile. Keep prose-connectivity analysis available as
an explicit profile, with fuzzy near-match suggestions behind a second opt-in.
Broken body links and schema-declared body sections remain default integrity
checks.

## What changed

- Added `--mentions` for exact, alias, ambiguous, and frequent unlinked-term
  analysis without fuzzy matching.
- Added `--mention-fuzzy`; it and a positive
  `--mention-fuzzy-threshold` imply the mention profile. Threshold `0` remains
  disabled and does not opt in.
- Preserved exact `--only unlinked-mention` and
  `--only frequent-unlinked-term` selectors, including existing safe fix
  behavior.
- Skip mention indexes, corpus calibration, and frequent-term passes entirely
  when the profile is not selected.
- Added order-independent validation with actionable recovery for contradictory
  fuzzy selectors, plus aligned CLI help, canonical docs, changelog, and agent
  skill guidance.

## Safety and compatibility

This intentionally changes bare-audit results: scripts that rely on mention
findings must add `--mentions`, and scripts that rely on fuzzy findings must add
`--mention-fuzzy` or a positive threshold. JSON structures, issue codes, exit
semantics, matching algorithms, and fix implementations are unchanged. Bare
auto-fix no longer rewrites mention prose; explicit mention selection retains
the previous trusted exact/alias fix path.

## Verification

- GitHub CI passed across source and packaged-CLI tests, deterministic
  benchmarks, retry-zero reliability, PTY, Windows lock, docs-site, and Vercel
  checks.
- Full local CI parity passed: build, package verification, typecheck, lint,
  knip, and 3,022 non-PTY tests (3 skipped). The dedicated built-CLI benchmark
  suite passes all 12 tests.
- Focused command and library coverage proves bare text/JSON scope, opt-in
  profiles, threshold zero, flag-order conflicts, legacy `--only` behavior,
  and default-versus-explicit fix safety.
- A read-only benchmark on a large real-world vault more than halved bare-audit
  wall time, with content checksums unchanged.
- Independent real-PTY QA passed the complete CLI story, including help,
  default and opt-in profiles, conflict recovery, and fix safety.

## Review focus

- Does the command-boundary matrix make every opt-in, zero, conflict, and
  `--only` combination unsurprising?
- Do the detector gates guarantee that bare audit avoids all mention-only index
  and corpus work without suppressing broken-body-link or body-section checks?
- Is the compatibility notice prominent enough for scripts that consumed
  heuristic findings from bare JSON audits?
