### PR TITLE
Add schema-derived virtual fields

### DIFF
--- a/docs-site/public/schema.json
+++ b/docs-site/public/schema.json
@@ -574,6 +574,31 @@
     "frontmatterField": {
       "type": "object",
       "properties": {
+        "derived": {
+          "type": "object",
+          "properties": {
+            "expression": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Expression evaluated for this record"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "string",
+                "number",
+                "boolean",
+                "date"
+              ],
+              "description": "Required result type for the derived expression"
+            }
+          },
+          "required": [
+            "expression",
+            "type"
+          ],
+          "additionalProperties": false
+        },
         "prompt": {
           "type": "string",
           "enum": [

--- a/docs-site/src/content/docs/reference/commands/dashboard.md
+++ b/docs-site/src/content/docs/reference/commands/dashboard.md
@@ -27,6 +27,7 @@ bwrb dashboard inbox --output json   # Override output format
 |--------|-------------|
 | `--output <format>` | Override output format: `text`, `paths`, `tree`, `link`, `json` |
 | `--receipt` | With JSON output, return dashboard identity, its saved definition, the applied query, counts, truncation, and data rows |
+| `--as-of <date>` | Evaluate `today()` against one full `YYYY-MM-DD` date for this run |
 
 ## Subcommands
 
@@ -51,6 +52,8 @@ bwrb list task --count --save-as "task-count"
 
 Dashboards saved from `bwrb list` preserve filters, default output settings,
 selected fields, `--sort`, `--desc`, `--limit`, and `--count`.
+The query's `--as-of` value is intentionally not saved; provide it when running
+the dashboard when reproducible temporal evaluation matters.
 
 ### With `dashboard new`
 

--- a/docs-site/src/content/docs/reference/commands/list.md
+++ b/docs-site/src/content/docs/reference/commands/list.md
@@ -56,6 +56,7 @@ rejected.
 | `--limit <n>` | Limit displayed results; never narrows name-mode selection |
 | `--count` | Print only the number of matching notes |
 | `--receipt` | With `--output json`, return query metadata, counts, truncation, and data rows |
+| `--as-of <date>` | Evaluate `today()` against one full `YYYY-MM-DD` date (defaults to local today captured once) |
 | `-L, --depth <n>` | Limit tree depth |
 
 ### Actions
@@ -94,6 +95,11 @@ array of note frontmatter objects used by existing scripts. Each row also has a
 Treat it only as an observation token—do not infer ordering or meaning from its
 format. Pass it unchanged to guarded JSON edits when a shared record must not
 silently overwrite a newer change.
+
+Schema-declared [derived fields](/reference/schema/#derived-fields) are projected
+before filtering, sorting, and rendering. They appear in JSON and `--fields`
+without being stored in Markdown. Use `--as-of` when a derived expression or
+filter uses `today()` and the result must be reproducible.
 
 With `--matches`, text output shows grep-style line details and JSON preserves
 structured match details. `paths` and `link` emit each matching note once, while

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -725,12 +725,51 @@ so declaring it on a base type (e.g. `entity`) applies to all descendants.
 
 ---
 
+## Derived Fields
+
+A derived field is a virtual scalar calculated from other fields on the same
+note. Declare its expression and result type instead of a prompt:
+
+```json
+{
+  "score": {
+    "derived": {
+      "expression": "importance * 4 + excitement",
+      "type": "number"
+    }
+  }
+}
+```
+
+Supported result types are `string`, `number`, `boolean`, and `date`. Date
+results must be valid full `YYYY-MM-DD` values. Derived fields participate in
+`list --output json`, `--fields`, `--where`, sorting, and dashboards, but are
+never prompted for or written to Markdown. `new`, `edit`, and `bulk` reject
+attempts to set them. If a note already stores a same-name value, query results
+use the calculated value and `bwrb audit` reports `derived-field-persisted`.
+
+Expressions use the ordinary Bowerbird expression language with a deliberately
+record-local subset. They may reference concrete or earlier derived fields on
+the effective inherited type and use pure scalar functions. Missing or `null`
+inputs produce `null` without evaluating the expression. Unknown fields,
+self-references, dependency cycles, `file.*`, hierarchy functions, `now()`, and
+relative-date dependencies are schema errors. Runtime evaluation or result-type
+errors fail the command and identify both the field and note path.
+
+`today()` uses one query snapshot date. Pass `--as-of YYYY-MM-DD` to `list` or
+`dashboard` for reproducible output; otherwise Bowerbird captures the local
+calendar date once when the command starts. Saved dashboards do not persist an
+as-of value.
+
+---
+
 ## Field Properties Reference
 
 Complete list of field properties:
 
 | Property | Type | Applies To | Description |
 |----------|------|------------|-------------|
+| `derived` | object | virtual | `{ expression, type }` query-time scalar derivation. Mutually exclusive with stored/prompted field behavior |
 | `value` | string | static | Fixed value (mutually exclusive with `prompt`) |
 | `prompt` | string | prompted | Prompt type: `text`, `number`, `boolean`, `date`, `relative-date`, `select`, `relation`, `list` |
 | `label` | string | prompted | Custom label shown during prompting (the imperative prompt text) |

--- a/docs/technical/expression-pipeline.md
+++ b/docs/technical/expression-pipeline.md
@@ -2,6 +2,13 @@
 
 > Developer reference for `--where` expressions and shared expression evaluation.
 
+Schema-declared derived fields reuse this parser and evaluator through
+`src/lib/derived-fields.ts`. Schema loading validates the resolved effective
+type, builds a dependency-first plan, and rejects impure or non-record-local
+access. Query surfaces project the virtual overlay before `--where`, sorting,
+and rendering. A command resolves `--as-of` once and threads that same day into
+both ordinary `today()` calls and derived projection.
+
 ---
 
 ## Purpose

--- a/schema.schema.json
+++ b/schema.schema.json
@@ -574,6 +574,31 @@
     "frontmatterField": {
       "type": "object",
       "properties": {
+        "derived": {
+          "type": "object",
+          "properties": {
+            "expression": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Expression evaluated for this record"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "string",
+                "number",
+                "boolean",
+                "date"
+              ],
+              "description": "Required result type for the derived expression"
+            }
+          },
+          "required": [
+            "expression",
+            "type"
+          ],
+          "additionalProperties": false
+        },
         "prompt": {
           "type": "string",
           "enum": [

--- a/src/commands/bulk.ts
+++ b/src/commands/bulk.ts
@@ -15,6 +15,8 @@ import {
   loadSchema,
   getType,
   getRootTypeNames,
+  getConcreteTypeNames,
+  getFieldsForType,
   getOptionsForField,
   resolveTypeFromFrontmatter,
   formatUnknownTypeError,
@@ -360,6 +362,21 @@ Hint: Bulk operations require explicit targeting to prevent accidents.
               isBwrbReservedFrontmatterField(operation.field) ? operation.field : operation.newField
             }' with bwrb bulk`
           );
+        }
+
+        const mutatedFields = [operation.field, operation.newField].filter(
+          (fieldName): fieldName is string => Boolean(fieldName)
+        );
+        const candidateTypes = typePath ? [typePath] : getConcreteTypeNames(schema);
+        for (const fieldName of mutatedFields) {
+          const derivedType = candidateTypes.find(
+            (candidateType) => getFieldsForType(schema, candidateType)[fieldName]?.derived
+          );
+          if (derivedType) {
+            validationErrors.push(
+              `Cannot mutate derived field '${fieldName}' for type '${derivedType}' with bwrb bulk`
+            );
+          }
         }
       }
 

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -34,6 +34,7 @@ import { UserCancelledError } from '../lib/errors.js';
 import type { DashboardDefinition, LoadedSchema } from '../types/schema.js';
 import { getTtyContext } from '../lib/tty/context.js';
 import { renderTable } from '../lib/tty/table.js';
+import { resolveAsOf } from '../lib/as-of.js';
 
 /**
  * Resolve output format from string, with validation.
@@ -54,6 +55,7 @@ function resolveOutputFormat(format?: string): ListOutputFormat {
 interface DashboardRunOptions {
   output?: string;
   receipt?: boolean;
+  asOf?: string;
 }
 
 interface DashboardListOptions {
@@ -65,6 +67,7 @@ export const dashboardCommand = new Command('dashboard')
   .argument('[name]', 'Dashboard name to run')
   .option('--output <format>', 'Output format: text (default), paths, tree, link, json')
   .option('--receipt', 'Return a JSON receipt with the dashboard definition and result cardinality')
+  .option('--as-of <date>', 'Evaluate temporal expressions against one YYYY-MM-DD date')
   .enablePositionalOptions()
   .addHelpText('after', `
 A dashboard is a saved list query. Running a dashboard executes the saved
@@ -154,6 +157,7 @@ async function runDashboard(
 
     // 3. Load schema
     const schema = await loadSchema(vaultDir);
+    const asOf = resolveAsOf(options.asOf);
 
     // 4. Convert DashboardDefinition to TargetingOptions
     const targeting: TargetingOptions = {};
@@ -161,6 +165,7 @@ async function runDashboard(
     if (dashboard.path) targeting.path = dashboard.path;
     if (dashboard.where) targeting.where = dashboard.where;
     if (dashboard.body) targeting.body = dashboard.body;
+    targeting.asOf = asOf;
 
     // 5. Resolve targets using shared targeting module
     const targetResult = await resolveTargets(targeting, schema, vaultDir);
@@ -192,6 +197,7 @@ async function runDashboard(
               desc: dashboard.desc === true,
               limit: dashboard.limit ?? null,
               fields: dashboard.fields ?? null,
+              asOf,
             },
             dashboard: {
               name,
@@ -201,6 +207,7 @@ async function runDashboard(
         : undefined,
       sortField: dashboard.sort,
       sortDesc: dashboard.desc,
+      asOf,
     };
 
     await listObjects(schema, vaultDir, targeting.type, targetResult.files, listOpts);

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -75,6 +75,8 @@ import {
 } from '../lib/lineage.js';
 import { isValidNoteId, normalizeNoteId } from '../lib/note-id.js';
 import { renderFlatNotePaths } from '../lib/flat-note-presenter.js';
+import { resolveAsOf } from '../lib/as-of.js';
+import { getDerivedFieldPlan, projectDerivedFields } from '../lib/derived-fields.js';
 
 /**
  * Resolve the output format from --output flag.
@@ -143,6 +145,7 @@ interface ListCommandOptions {
   // Dashboard save options
   saveAs?: string;
   force?: boolean;
+  asOf?: string;
 }
 
 function validateLineageMode(
@@ -180,6 +183,7 @@ function validateLineageMode(
   if (options.preview === true) conflicts.push('--preview');
   if (options.saveAs !== undefined) conflicts.push('--save-as');
   if (options.force === true) conflicts.push('--force');
+  if (options.asOf !== undefined) conflicts.push('--as-of');
 
   if (conflicts.length > 0) {
     return `--lineage cannot be combined with ${conflicts.join(', ')}.`;
@@ -225,7 +229,7 @@ function validateCanonicalSearchMode(
   if (hasCanonicalSearchMode(options) && (positional !== undefined || mode !== undefined)) {
     return 'Search modes do not accept positional filters or app modes; use targeting flags and --app instead.';
   }
-  if (hasCanonicalSearchMode(options) && (options.fields || options.count || options.receipt || options.sort || options.desc || options.depth || options.saveAs || options.force)) {
+  if (hasCanonicalSearchMode(options) && (options.fields || options.count || options.receipt || options.sort || options.desc || options.depth || options.saveAs || options.force || options.asOf)) {
     return '--name, --fuzzy, and --matches cannot be combined with table, hierarchy, sort, count, receipt, or dashboard options.';
   }
   if (hasCanonicalSearchMode(options) && options.id) {
@@ -539,6 +543,7 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
   .option('--limit <n>', 'Limit displayed results (never narrows --name selection)')
   .option('--count', 'Print only the number of matching notes')
   .option('--receipt', 'Return a JSON receipt with applied query settings and result cardinality (requires --output json)')
+  .option('--as-of <date>', 'Evaluate temporal expressions against one YYYY-MM-DD date')
   .option('--output <format>', 'Output format: text (default), paths, tree, link, content, json')
   // Open options
   .option('-o, --open', 'Open the first result (or pick from results interactively)')
@@ -660,6 +665,8 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
       if (options.where) targeting.where = options.where;
       if (options.id) targeting.id = options.id;
       if (options.body) targeting.body = options.body;
+      const asOf = resolveAsOf(options.asOf);
+      targeting.asOf = asOf;
 
       // Handle smart positional detection
       if (positional) {
@@ -768,11 +775,13 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
                 desc: options.desc === true,
                 limit: limit ?? null,
                 fields: fields ?? null,
+                asOf,
               },
             }
           : undefined,
         sortField: options.sort,
         sortDesc: options.desc,
+        asOf,
         ...(limit !== undefined && { limit }),
       });
 
@@ -845,6 +854,7 @@ export interface ListOptions {
   receipt?: QueryReceiptContext | undefined;
   sortField?: string | undefined;
   sortDesc?: boolean | undefined;
+  asOf?: string | undefined;
   // Open options
   open?: boolean | undefined;
   app?: string | undefined;
@@ -864,6 +874,7 @@ export interface QueryReceiptContext {
     desc: boolean;
     limit: number | null;
     fields: string[] | null;
+    asOf: string;
   };
   dashboard?: {
     name: string;
@@ -882,11 +893,21 @@ export async function listObjects(
   files: Array<{ path: string; relativePath: string; frontmatter: Record<string, unknown> }>,
   options: ListOptions
 ): Promise<void> {
+  const asOf = resolveAsOf(options.asOf);
   // Convert to the format expected by the rest of the function
-  let filteredFiles = files.map(f => ({
-    path: f.path,
-    frontmatter: f.frontmatter,
-  }));
+  let filteredFiles = files.map(f => {
+    const typePath = _typePath ?? resolveTypeFromFrontmatter(schema, f.frontmatter);
+    return {
+      path: f.path,
+      frontmatter: typePath
+        ? projectDerivedFields(
+            getDerivedFieldPlan(schema, typePath),
+            f.frontmatter,
+            { asOf, notePath: f.relativePath }
+          )
+        : { ...f.frontmatter },
+    };
+  });
 
   const jsonMode = options.outputFormat === 'json';
 
@@ -1005,9 +1026,17 @@ export async function listObjects(
         // The row and revision must describe one observation, not adjacent
         // reads of a note that an editor could change between them.
         const snapshot = await parseNote(path);
-        const frontmatter = snapshot.frontmatter;
+        const rawFrontmatter = snapshot.frontmatter;
         const notePath = relative(vaultDir, path);
         const noteName = basename(path, '.md');
+        const typePath = _typePath ?? resolveTypeFromFrontmatter(schema, rawFrontmatter);
+        const frontmatter = typePath
+          ? projectDerivedFields(
+              getDerivedFieldPlan(schema, typePath),
+              rawFrontmatter,
+              { asOf, notePath }
+            )
+          : rawFrontmatter;
         const base = {
           _path: notePath,
           _name: noteName,

--- a/src/commands/new/interactive.ts
+++ b/src/commands/new/interactive.ts
@@ -115,6 +115,7 @@ async function buildNoteContent(
     if (isBwrbReservedFrontmatterField(fieldName)) continue;
     const field = fields[fieldName];
     if (!field) continue;
+    if (field.derived) continue;
 
     const mergedDefault = mergedDefaults[fieldName];
     const hasDefault = mergedDefault !== undefined;

--- a/src/commands/new/json-mode.ts
+++ b/src/commands/new/json-mode.ts
@@ -179,6 +179,14 @@ async function validateJsonFrontmatter(
   mergedInput: Record<string, unknown>,
   template?: Template | null
 ): Promise<void> {
+  const fields = getFieldsForType(schema, typePath);
+  const derivedInput = Object.keys(mergedInput).find((fieldName) => fields[fieldName]?.derived);
+  if (derivedInput) {
+    throwJsonError(
+      jsonError(`Derived field '${derivedInput}' is virtual and cannot be set during note creation`),
+      ExitCodes.VALIDATION_ERROR
+    );
+  }
   const validation = validateFrontmatter(schema, typePath, mergedInput, { strictFields: true });
   if (!validation.valid) {
     throwJsonError({

--- a/src/lib/as-of.ts
+++ b/src/lib/as-of.ts
@@ -1,0 +1,11 @@
+import { formatLocalDate, parsePartialIsoDate } from './local-date.js';
+
+/** Resolve one stable local-calendar observation date for a command run. */
+export function resolveAsOf(value?: string): string {
+  const resolved = value ?? formatLocalDate();
+  const parsed = parsePartialIsoDate(resolved);
+  if (!parsed.valid || parsed.precision !== 'day') {
+    throw new Error(`Invalid --as-of date '${resolved}': expected a valid YYYY-MM-DD date`);
+  }
+  return parsed.value;
+}

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -664,6 +664,7 @@ export async function auditFile(
   );
   
   for (const [fieldName, field] of Object.entries(fields)) {
+    if (field.derived) continue;
     const value = frontmatter[fieldName];
     const hasKey = Object.prototype.hasOwnProperty.call(frontmatter, fieldName);
     const isEmptyValue = isEmptyRequiredValue(value);
@@ -712,6 +713,18 @@ export async function auditFile(
   for (const [fieldName, value] of Object.entries(frontmatter)) {
     const field = fields[fieldName];
     if (!field) continue;
+
+    if (field.derived) {
+      issues.push({
+        severity: 'error',
+        code: 'derived-field-persisted',
+        message: `Derived field '${fieldName}' is virtual and must not be stored in frontmatter`,
+        field: fieldName,
+        value,
+        autoFixable: false,
+      });
+      continue;
+    }
 
     if (field.prompt === 'relative-date') {
       const relativeDateError = validateRelativeDateValue(fieldName, value);

--- a/src/lib/audit/types.ts
+++ b/src/lib/audit/types.ts
@@ -26,6 +26,7 @@ export type IssueCode =
   | 'empty-string-required'
   | 'invalid-option'
   | 'unknown-field'
+  | 'derived-field-persisted'
   | 'wrong-directory'
   | 'type-mismatch'
   | 'format-violation'

--- a/src/lib/completion.ts
+++ b/src/lib/completion.ts
@@ -277,7 +277,7 @@ async function resolveVaultDirForCompletion(options: { vault?: string }): Promis
 const COMMAND_OPTIONS: Record<string, string[]> = {
   new: ['--type', '-t', '--vault', '-v', '--non-interactive', '--template', '--no-template', '--no-instances', '--owner', '--standalone', '--json', '--json-file', '--open', '-o', '--fork', '--label', '--name', '--output', '--help'],
   edit: ['--type', '-t', '--path', '-p', '--where', '-w', '--id', '--body', '-b', '--picker', '--json', '--json-file', '--output', '--open', '--app', '--vault', '-v', '--non-interactive', '--help'],
-  list: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--name', '--fuzzy', '--matches', '--threshold', '--context', '-C', '--no-context', '--case-sensitive', '-S', '--regex', '-E', '--id', '--lineage', '--fields', '--sort', '--desc', '--limit', '--count', '--output', '--open', '-o', '--app', '--picker', '--preview', '--vault', '-v', '--non-interactive', '--help'],
+  list: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--name', '--fuzzy', '--matches', '--threshold', '--context', '-C', '--no-context', '--case-sensitive', '-S', '--regex', '-E', '--id', '--lineage', '--fields', '--sort', '--desc', '--limit', '--count', '--as-of', '--output', '--open', '-o', '--app', '--picker', '--preview', '--vault', '-v', '--non-interactive', '--help'],
   recent: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--limit', '--output', '--open', '-o', '--app', '--save-as', '--force', '--vault', '-v', '--non-interactive', '--help'],
   audit: ['--type', '-t', '--path', '-p', '--where', '-w', '--body', '-b', '--all', '-a', '--strict', '--only', '--ignore', '--output', '--fix', '--auto', '--dry-run', '--execute', '--allow-field', '--vault', '-v', '--non-interactive', '--help'],
   bulk: [
@@ -323,7 +323,7 @@ const COMMAND_OPTIONS: Record<string, string[]> = {
   template: ['--vault', '-v', '--non-interactive', '--help'],
   lineage: ['--from', '--dry-run', '--execute', '-x', '--output', '--vault', '-v', '--non-interactive', '--help'],
   identity: ['--to', '--dry-run', '--execute', '-x', '--output', '--vault', '-v', '--non-interactive', '--help'],
-  dashboard: ['--output', '-o', '--vault', '-v', '--non-interactive', '--json', '--help'],
+  dashboard: ['--output', '--as-of', '-o', '--vault', '-v', '--non-interactive', '--json', '--help'],
   delete: [
     '--type', '-t',
     '--path', '-p',

--- a/src/lib/derived-fields.ts
+++ b/src/lib/derived-fields.ts
@@ -1,0 +1,289 @@
+import type { Expression, CallExpression, Identifier, MemberExpression } from 'jsep';
+import { evaluateExpression, parseExpression } from './expression.js';
+import { parsePartialIsoDate } from './local-date.js';
+import type { Field, LoadedSchema } from '../types/schema.js';
+
+export type DerivedValueType = 'string' | 'number' | 'boolean' | 'date';
+
+export interface DerivedFieldDefinition {
+  expression: string;
+  type: DerivedValueType;
+}
+
+export interface DerivedFieldPlanEntry extends DerivedFieldDefinition {
+  field: string;
+  dependencies: string[];
+  expressionAst: Expression;
+}
+
+/** A deterministic, dependency-first plan for one resolved effective type. */
+export interface DerivedFieldPlan {
+  fields: Map<string, DerivedFieldPlanEntry>;
+  order: string[];
+}
+
+export interface DerivedFieldPlans {
+  byType: Map<string, DerivedFieldPlan>;
+}
+
+export interface DerivedFieldProjectionOptions {
+  /** The query snapshot day, always YYYY-MM-DD. Required so today() is stable. */
+  asOf: string;
+  /** Optional note path included in runtime errors from a query projection. */
+  notePath?: string;
+}
+
+const plansBySchema = new WeakMap<LoadedSchema, DerivedFieldPlans>();
+
+const PURE_FUNCTIONS = new Set([
+  'contains', 'startsWith', 'endsWith', 'lower', 'upper', 'length', 'trim', 'replace',
+  'today', 'date', 'year', 'month', 'day', 'isEmpty', 'isNull', 'isDefined',
+]);
+const REJECTED_FUNCTIONS = new Set([
+  'now', 'inFolder', 'hasTag', 'isRoot', 'isChildOf', 'isDescendantOf', 'under',
+]);
+const DERIVED_INCOMPATIBLE_KEYS = [
+  'prompt', 'value', 'default', 'required', 'options', 'source', 'filter', 'multiple',
+  'list_format', 'reset_on_fork', 'owned', 'alias', 'minimum', 'maximum',
+] as const;
+
+/**
+ * Validate every resolved type's derived declarations and produce its
+ * dependency-first evaluation plan. Call this after schema inheritance and
+ * traits have been resolved.
+ */
+export function validateDerivedFields(schema: LoadedSchema): DerivedFieldPlans {
+  const byType = new Map<string, DerivedFieldPlan>();
+  for (const type of schema.types.values()) {
+    const plan = buildDerivedFieldPlan(type.fields, `types.${type.name}.fields`);
+    if (plan.order.length > 0) byType.set(type.name, plan);
+  }
+  const plans = { byType };
+  plansBySchema.set(schema, plans);
+  return plans;
+}
+
+/** Return the cached resolved-type plan, validating and caching on first use. */
+export function getDerivedFieldPlan(
+  schema: LoadedSchema,
+  typeName: string
+): DerivedFieldPlan | undefined {
+  return (plansBySchema.get(schema) ?? validateDerivedFields(schema)).byType.get(typeName);
+}
+
+/** Validate a single resolved effective field map and build its evaluation DAG. */
+export function buildDerivedFieldPlan(
+  fields: Record<string, Field>,
+  path = 'fields'
+): DerivedFieldPlan {
+  const entries = new Map<string, DerivedFieldPlanEntry>();
+
+  for (const [field, declaration] of Object.entries(fields)) {
+    if (!declaration.derived) continue;
+    const incompatible = DERIVED_INCOMPATIBLE_KEYS.find((key) =>
+      Object.hasOwn(declaration as object, key)
+    );
+    if (incompatible) {
+      throw new Error(
+        `${path}.${field}: derived fields cannot also declare ${incompatible}`
+      );
+    }
+    const derived = declaration.derived;
+    let expressionAst: Expression;
+    try {
+      expressionAst = parseExpression(derived.expression);
+    } catch (error) {
+      throw new Error(`${path}.${field}.derived.expression: ${(error as Error).message}`);
+    }
+    const dependencies = [...collectDependencies(expressionAst, field, path)];
+    for (const dependency of dependencies) {
+      if (!Object.hasOwn(fields, dependency)) {
+        throw new Error(
+          `${path}.${field}.derived.expression: unknown field reference "${dependency}"`
+        );
+      }
+      if (dependency === field) {
+        throw new Error(`${path}.${field}.derived.expression: field "${field}" cannot reference itself`);
+      }
+      if (fields[dependency]?.prompt === 'relative-date') {
+        throw new Error(
+          `${path}.${field}.derived.expression: relative-date field "${dependency}" is not record-local and cannot be referenced`
+        );
+      }
+    }
+    entries.set(field, { field, expression: derived.expression, type: derived.type, dependencies, expressionAst });
+  }
+
+  const order: string[] = [];
+  const states = new Map<string, 'visiting' | 'done'>();
+  const stack: string[] = [];
+  const visit = (field: string): void => {
+    const state = states.get(field);
+    if (state === 'done') return;
+    if (state === 'visiting') {
+      const start = stack.indexOf(field);
+      const chain = [...stack.slice(start), field].join(' -> ');
+      throw new Error(`${path}.${field}.derived.expression: derived-field cycle ${chain}`);
+    }
+    states.set(field, 'visiting');
+    stack.push(field);
+    const entry = entries.get(field);
+    if (entry) {
+      for (const dependency of entry.dependencies) {
+        if (entries.has(dependency)) visit(dependency);
+      }
+      order.push(field);
+    }
+    stack.pop();
+    states.set(field, 'done');
+  };
+  for (const field of entries.keys()) visit(field);
+  return { fields: entries, order };
+}
+
+/**
+ * Return a copy of record frontmatter with virtual values overlaid. Stored
+ * same-name values are intentionally overwritten, never consulted.
+ */
+export function projectDerivedFields(
+  plan: DerivedFieldPlan | undefined,
+  frontmatter: Record<string, unknown>,
+  options: DerivedFieldProjectionOptions
+): Record<string, unknown> {
+  if (!plan || plan.order.length === 0) return { ...frontmatter };
+  assertAsOf(options.asOf);
+  const projected = { ...frontmatter };
+  for (const field of plan.order) delete projected[field];
+
+  for (const field of plan.order) {
+    const entry = plan.fields.get(field);
+    if (!entry) continue;
+    if (entry.dependencies.some((dependency) => projected[dependency] == null)) {
+      projected[field] = null;
+      continue;
+    }
+    let value: unknown;
+    try {
+      value = evaluateExpression(bindToday(entry.expressionAst, options.asOf), { frontmatter: projected });
+    } catch (error) {
+      throw new Error(`${runtimeLabel(field, options.notePath)} evaluation failed: ${(error as Error).message}`);
+    }
+    assertResultType(field, entry.type, value, options.notePath);
+    projected[field] = value;
+  }
+  return projected;
+}
+
+function collectDependencies(expression: Expression, field: string, path: string): Set<string> {
+  const dependencies = new Set<string>();
+  const visit = (node: Expression, isCallCallee = false): void => {
+    switch (node.type) {
+      case 'Identifier': {
+        const name = (node as Identifier).name;
+        if (name === 'file' || name === '__frontmatter') {
+          throw new Error(`${path}.${field}.derived.expression: ${name} access is not supported for derived fields`);
+        }
+        if (!isCallCallee && !['true', 'false', 'null'].includes(name)) dependencies.add(name);
+        return;
+      }
+      case 'CallExpression': {
+        const call = node as CallExpression;
+        if (call.callee.type !== 'Identifier') {
+          throw new Error(`${path}.${field}.derived.expression: only named pure functions are supported`);
+        }
+        const name = (call.callee as Identifier).name;
+        if (REJECTED_FUNCTIONS.has(name)) {
+          throw new Error(`${path}.${field}.derived.expression: ${name}() is not supported for derived fields`);
+        }
+        if (!PURE_FUNCTIONS.has(name)) {
+          throw new Error(`${path}.${field}.derived.expression: unknown or impure function ${name}()`);
+        }
+        for (const arg of call.arguments) visit(arg);
+        return;
+      }
+      case 'MemberExpression': {
+        const member = node as MemberExpression;
+        visit(member.object);
+        if (member.computed) visit(member.property);
+        return;
+      }
+      case 'BinaryExpression':
+      case 'LogicalExpression': {
+        const binary = node as Expression & { left: Expression; right: Expression };
+        visit(binary.left);
+        visit(binary.right);
+        return;
+      }
+      case 'UnaryExpression':
+        visit((node as Expression & { argument: Expression }).argument);
+        return;
+      case 'Literal':
+      case 'ThisExpression':
+        if (node.type === 'ThisExpression') {
+          throw new Error(`${path}.${field}.derived.expression: this is not supported for derived fields`);
+        }
+        return;
+      default:
+        throw new Error(`${path}.${field}.derived.expression: unsupported expression node ${node.type}`);
+    }
+  };
+  visit(expression);
+  return dependencies;
+}
+
+function bindToday(expression: Expression, asOf: string): Expression {
+  if (expression.type === 'CallExpression') {
+    const call = expression as CallExpression;
+    if (call.callee.type === 'Identifier' && (call.callee as Identifier).name === 'today') {
+      return { type: 'Literal', value: asOf, raw: JSON.stringify(asOf) } as Expression;
+    }
+  }
+  const clone = { ...expression } as Expression & Record<string, unknown>;
+  if ('left' in clone) clone.left = bindToday(clone.left as Expression, asOf);
+  if ('right' in clone) clone.right = bindToday(clone.right as Expression, asOf);
+  if ('argument' in clone) clone.argument = bindToday(clone.argument as Expression, asOf);
+  if (expression.type === 'CallExpression') {
+    clone.arguments = (expression as CallExpression).arguments.map((arg) => bindToday(arg, asOf));
+  }
+  if (expression.type === 'MemberExpression') {
+    const member = expression as MemberExpression;
+    clone.object = bindToday(member.object, asOf);
+    if (member.computed) clone.property = bindToday(member.property, asOf);
+  }
+  return clone as Expression;
+}
+
+function assertAsOf(asOf: string): void {
+  const parsed = parsePartialIsoDate(asOf);
+  if (!parsed.valid || parsed.precision !== 'day') {
+    throw new Error(`Derived field projection requires asOf as YYYY-MM-DD; received "${asOf}"`);
+  }
+}
+
+function assertResultType(
+  field: string,
+  type: DerivedValueType,
+  value: unknown,
+  path: string | undefined
+): void {
+  const valid = value !== null && (
+    (type === 'string' && typeof value === 'string') ||
+    (type === 'number' && typeof value === 'number' && Number.isFinite(value)) ||
+    (type === 'boolean' && typeof value === 'boolean') ||
+    (type === 'date' && isFullCalendarDate(value))
+  );
+  if (!valid) {
+    const actual = value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value;
+    throw new Error(`${runtimeLabel(field, path)} result type mismatch: expected ${type}, received ${actual}`);
+  }
+}
+
+function isFullCalendarDate(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  const parsed = parsePartialIsoDate(value);
+  return parsed.valid && parsed.precision === 'day';
+}
+
+function runtimeLabel(field: string, path: string | undefined): string {
+  return path ? `Derived field "${field}" at ${path}` : `Derived field "${field}"`;
+}

--- a/src/lib/edit.ts
+++ b/src/lib/edit.ts
@@ -243,6 +243,17 @@ async function editNoteFromJsonAttempt(
     throw new Error(error);
   }
 
+  const fields = getFieldsForType(schema, typePath);
+  const derivedPatchField = Object.keys(patchData).find((fieldName) => fields[fieldName]?.derived);
+  if (derivedPatchField) {
+    const error = `Derived field '${derivedPatchField}' is virtual and cannot be edited`;
+    if (jsonMode) {
+      printJson(jsonError(error));
+      process.exit(ExitCodes.VALIDATION_ERROR);
+    }
+    throw new Error(error);
+  }
+
   const resolvedBody = typeof bodyInput === 'string'
     ? bodyInput
     : bodyInput
@@ -296,7 +307,6 @@ async function editNoteFromJsonAttempt(
   //
   // Keys the user blanked but whose field has NO default stay blank: optional →
   // unset (trim-everywhere preserved), required → still rejected at validation.
-  const fields = getFieldsForType(schema, typePath);
   const blankPatchKeys = new Set(
     Object.keys(patchData).filter((key) => {
       if (typeof patchData[key] !== 'string' || !isBlankScalar(patchData[key])) return false;
@@ -585,6 +595,7 @@ export async function editNoteInteractive(
     if (isBwrbReservedFrontmatterField(fieldName)) continue;
     const field = fields[fieldName];
     if (!field) continue;
+    if (field.derived) continue;
 
     const currentValue = frontmatter[fieldName];
     const newValue = await promptFieldEdit(

--- a/src/lib/expression.ts
+++ b/src/lib/expression.ts
@@ -110,6 +110,8 @@ export interface HierarchyData {
  */
 export interface EvalContext {
   frontmatter: Record<string, unknown>;
+  /** One immutable local-calendar observation date for the enclosing command. */
+  asOf?: string;
   file?: {
     name: string;
     path: string;
@@ -185,7 +187,8 @@ export function matchesExpression(exprString: string, context: EvalContext): boo
 export async function buildEvalContext(
   filePath: string,
   vaultDir: string,
-  frontmatter: Record<string, unknown>
+  frontmatter: Record<string, unknown>,
+  asOf?: string
 ): Promise<EvalContext> {
   const { stat } = await import('fs/promises');
   const { basename, dirname, relative } = await import('path');
@@ -216,6 +219,7 @@ export async function buildEvalContext(
 
   return {
     frontmatter,
+    ...(asOf ? { asOf } : {}),
     file: fileInfo,
   };
 }
@@ -372,8 +376,8 @@ const FUNCTIONS: Record<string, FunctionImpl> = {
   },
 
   // Date functions
-  today: () => {
-    return formatLocalDate();
+  today: (_args, context) => {
+    return context.asOf ?? formatLocalDate();
   },
 
   now: () => new Date(),

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -22,6 +22,8 @@ import {
   type RelativeDateFieldMap,
 } from './relative-date.js';
 import { calendarDateValue, parseCalendarDate } from './calendar-date.js';
+import { getDerivedFieldPlan, projectDerivedFields } from './derived-fields.js';
+import { resolveAsOf } from './as-of.js';
 
 /**
  * Validate that a field name is valid for a type.
@@ -58,6 +60,8 @@ export interface FrontmatterFilterOptions {
   schema?: LoadedSchema;
   /** Optional type path for type-aware hierarchy resolution */
   typePath?: string;
+  /** Stable date used by time-sensitive expressions for this query. */
+  asOf?: string;
 }
 
 // ============================================================================
@@ -554,7 +558,8 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
   files: T[],
   options: FrontmatterFilterOptions
 ): Promise<T[]> {
-  const { whereExpressions, vaultDir, knownKeys, schema, typePath } = options;
+  const { whereExpressions, vaultDir, knownKeys, schema, typePath, asOf } = options;
+  const effectiveAsOf = resolveAsOf(asOf);
   const result: T[] = [];
   const effectiveKnownKeys =
     knownKeys ?? collectFrontmatterKeys(files.map(file => file.frontmatter));
@@ -602,16 +607,23 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
   for (const file of files) {
     // Apply expression filters (--where style)
     if (expressionPairs.length > 0) {
-      const evalFrontmatter = frontmatterWithCalendarDates(
+      const baseFrontmatter = frontmatterWithCalendarDates(
         schema,
         file,
         frontmatterWithResolvedRelativeDates(schema, file, relativeDateFields)
       );
-      const context = await buildEvalContext(file.path, vaultDir, evalFrontmatter);
       const relationType = resolveHierarchyType(file.frontmatter, {
         ...(schema ? { schema } : {}),
         ...(typePath ? { typePath } : {}),
       });
+      const evalFrontmatter = schema
+        ? projectDerivedFields(
+            relationType ? getDerivedFieldPlan(schema, relationType) : undefined,
+            baseFrontmatter,
+            { asOf: effectiveAsOf, notePath: relative(vaultDir, file.path) }
+          )
+        : baseFrontmatter;
+      const context = await buildEvalContext(file.path, vaultDir, evalFrontmatter, effectiveAsOf);
       const relationSources = getRelationSourcesForType(schema, relationType, relationSourceCache);
       if (relationSources) {
         context.relationSourcesByField = relationSources;

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -22,6 +22,7 @@ import {
 } from '../types/schema.js';
 import { validateTransitionGuards } from './transition-guards.js';
 import { validateTransitionEffects } from './transition-effects.js';
+import { validateDerivedFields } from './derived-fields.js';
 
 const META_TYPE = 'meta';
 
@@ -210,6 +211,7 @@ export function resolveSchema(schema: Schema): LoadedSchema {
     throw new Error(`Invalid transition effects: ${transitionEffectErrors.join(' ')}`);
   }
   validateRetention(loaded);
+  validateDerivedFields(loaded);
   return loaded;
 }
 

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -47,6 +47,8 @@ export interface TargetingOptions {
   text?: string;
   /** Explicit flag to target all notes (required for destructive commands without other targeting) */
   all?: boolean;
+  /** Stable local-calendar date for query-time expression evaluation. */
+  asOf?: string;
 }
 
 /**
@@ -329,6 +331,7 @@ export async function resolveTargets(
       const filtered = await applyWhereExpressions(filteredFiles, {
         schema,
         ...(options.type ? { typePath: options.type } : {}),
+        ...(options.asOf ? { asOf: options.asOf } : {}),
         whereExpressions: options.where,
         vaultDir,
       });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -476,6 +476,13 @@ export function applyDefaults(
   for (const [fieldName, field] of Object.entries(fields)) {
     if (keyScope !== undefined && !keyScope.has(fieldName)) continue;
 
+    // Derived fields are a virtual read projection. Never materialize a
+    // template/default collision into Markdown.
+    if (field.derived) {
+      delete result[fieldName];
+      continue;
+    }
+
     // Lineage is provenance, not a user/schema default. Valid schemas reject
     // this declaration at load/write time; this guard protects creation paths
     // that receive a hand-built or otherwise unparsed LoadedSchema. Existing

--- a/src/lib/where-targeting.ts
+++ b/src/lib/where-targeting.ts
@@ -11,6 +11,7 @@ export interface WhereFilterOptions {
   vaultDir: string;
   schema: LoadedSchema;
   typePath?: string;
+  asOf?: string;
 }
 
 export type WhereFilterResult<T extends FileWithFrontmatter> =
@@ -21,7 +22,7 @@ export async function applyWhereExpressions<T extends FileWithFrontmatter>(
   files: T[],
   options: WhereFilterOptions
 ): Promise<WhereFilterResult<T>> {
-  const { whereExpressions, vaultDir, schema, typePath } = options;
+  const { whereExpressions, vaultDir, schema, typePath, asOf } = options;
 
   if (whereExpressions.length === 0) {
     return { ok: true, files };
@@ -44,6 +45,7 @@ export async function applyWhereExpressions<T extends FileWithFrontmatter>(
       whereExpressions,
       vaultDir,
       schema,
+      ...(asOf ? { asOf } : {}),
       ...(typePath ? { typePath } : {}),
       ...(knownKeys ? { knownKeys } : {}),
     });

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -85,10 +85,27 @@ export const FieldOptionSchema = z.union([
 ]);
 
 /**
+ * A virtual, record-local field calculated from other effective fields.
+ * Derived values are projected at query time and are never written to note
+ * frontmatter.
+ */
+export const DerivedFieldSchema = z.object({
+  expression: z.string().min(1).describe('Expression evaluated for this record'),
+  type: z
+    .enum(['string', 'number', 'boolean', 'date'])
+    .describe('Required result type for the derived expression'),
+});
+
+/**
  * Field definition for type frontmatter.
- * Fields can be static values, prompted inputs, or relation queries.
+ * Fields can be static values, prompted inputs, relation queries, or virtual
+ * record-local derivations.
  */
 export const FieldSchema = z.object({
+  // Virtual field calculated from the record's effective fields. The
+  // dependency graph and expression semantics are validated after inheritance
+  // and trait composition resolve the effective type.
+  derived: DerivedFieldSchema.optional(),
   // Prompt type (how the field is collected)
   prompt: z
     .enum(['text', 'select', 'list', 'date', 'relative-date', 'relation', 'boolean', 'number'])
@@ -694,6 +711,7 @@ export const BwrbSchema = z.object({
 // ============================================================================
 
 export type Field = z.infer<typeof FieldSchema>;
+export type DerivedField = z.infer<typeof DerivedFieldSchema>;
 export type FieldOption = z.infer<typeof FieldOptionSchema>;
 export type Calendar = z.infer<typeof CalendarSchema>;
 export type CalendarEra = z.infer<typeof CalendarEraSchema>;

--- a/tests/ts/commands/derived-fields.test.ts
+++ b/tests/ts/commands/derived-fields.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { cleanupTestVault, createTestVault, runCLI } from '../fixtures/setup.js';
+
+describe('schema-derived fields through the public CLI', () => {
+  let vaultDir: string;
+  let samplePath: string;
+  let sampleBefore: string;
+
+  beforeAll(async () => {
+    vaultDir = await createTestVault();
+    const schemaPath = join(vaultDir, '.bwrb', 'schema.json');
+    const schema = JSON.parse(await readFile(schemaPath, 'utf8')) as {
+      types: { idea: { fields: Record<string, unknown> } };
+    };
+    Object.assign(schema.types.idea.fields, {
+      importance: { prompt: 'number' },
+      excitement: { prompt: 'number' },
+      score: { derived: { expression: 'importance * 4 + excitement', type: 'number' } },
+      query_day: { derived: { expression: 'today()', type: 'date' } },
+    });
+    await writeFile(schemaPath, JSON.stringify(schema, null, 2));
+
+    samplePath = join(vaultDir, 'Ideas', 'Sample Idea.md');
+    sampleBefore = (await readFile(samplePath, 'utf8')).replace(
+      'status: raw\n',
+      'status: raw\nimportance: 4\nexcitement: 3\nscore: 999\n'
+    );
+    await writeFile(samplePath, sampleBefore);
+
+    const anotherPath = join(vaultDir, 'Ideas', 'Another Idea.md');
+    await writeFile(
+      anotherPath,
+      (await readFile(anotherPath, 'utf8')).replace('status: backlog\n', 'status: backlog\nimportance: 2\n')
+    );
+  });
+
+  afterAll(async () => cleanupTestVault(vaultDir));
+
+  it('projects values into JSON, overwrites stale stored collisions, and leaves Markdown unchanged', async () => {
+    const result = await runCLI(['list', '--type', 'idea', '--output', 'json', '--as-of', '2026-08-10'], vaultDir);
+    expect(result.exitCode).toBe(0);
+    const rows = JSON.parse(result.stdout) as Array<Record<string, unknown>>;
+    const sample = rows.find((row) => row._name === 'Sample Idea');
+    const another = rows.find((row) => row._name === 'Another Idea');
+    expect(sample).toMatchObject({ score: 19, query_day: '2026-08-10' });
+    expect(another).toMatchObject({ score: null, query_day: '2026-08-10' });
+    expect(await readFile(samplePath, 'utf8')).toBe(sampleBefore);
+  });
+
+  it('uses the same virtual values for filtering, sorting, fields, and dashboards', async () => {
+    const filtered = await runCLI([
+      'list', '--type', 'idea', '--where', 'score > 10', '--sort', 'score', '--fields', 'score',
+    ], vaultDir);
+    expect(filtered.exitCode).toBe(0);
+    expect(filtered.stdout).toContain('Sample Idea');
+    expect(filtered.stdout).toContain('19');
+    expect(filtered.stdout).not.toContain('Another Idea');
+
+    await writeFile(join(vaultDir, '.bwrb', 'dashboards.json'), JSON.stringify({
+      dashboards: { ranked: { type: 'idea', where: ['score > 10'], fields: ['score'] } },
+    }, null, 2));
+    const dashboard = await runCLI(['dashboard', 'ranked', '--as-of', '2026-08-10'], vaultDir);
+    expect(dashboard.exitCode).toBe(0);
+    expect(dashboard.stdout).toContain('Sample Idea');
+    expect(dashboard.stdout).toContain('19');
+    expect(dashboard.stdout).not.toContain('Another Idea');
+  });
+
+  it('rejects attempts to write or bulk-update a derived field', async () => {
+    const edit = await runCLI([
+      'edit', 'Sample Idea', '--json', '{"score":20}',
+    ], vaultDir);
+    expect(edit.exitCode).not.toBe(0);
+    expect(`${edit.stdout}${edit.stderr}`.toLowerCase()).toContain('derived field');
+
+    const bulk = await runCLI([
+      'bulk', '--type', 'idea', '--set', 'score=20', '--execute',
+    ], vaultDir);
+    expect(bulk.exitCode).not.toBe(0);
+    expect(`${bulk.stdout}${bulk.stderr}`.toLowerCase()).toContain('derived field');
+    expect(await readFile(samplePath, 'utf8')).toBe(sampleBefore);
+  });
+
+  it('reports invalid query dates and stored derived values', async () => {
+    const invalidDate = await runCLI([
+      'list', '--type', 'idea', '--output', 'json', '--as-of', '2026-02-30',
+    ], vaultDir);
+    expect(invalidDate.exitCode).not.toBe(0);
+    expect(`${invalidDate.stdout}${invalidDate.stderr}`).toContain('Invalid --as-of');
+
+    const audit = await runCLI(['audit', '--type', 'idea', '--output', 'json'], vaultDir);
+    expect(audit.exitCode).not.toBe(0);
+    expect(`${audit.stdout}${audit.stderr}`).toContain('derived-field-persisted');
+    expect(`${audit.stdout}${audit.stderr}`).toContain('score');
+  });
+});

--- a/tests/ts/lib/as-of.test.ts
+++ b/tests/ts/lib/as-of.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAsOf } from '../../../src/lib/as-of.js';
+
+describe('resolveAsOf', () => {
+  it('accepts a complete calendar-valid ISO date', () => {
+    expect(resolveAsOf('2026-08-10')).toBe('2026-08-10');
+  });
+
+  it('rejects partial and impossible dates', () => {
+    expect(() => resolveAsOf('2026-08')).toThrow('expected a valid YYYY-MM-DD');
+    expect(() => resolveAsOf('2026-02-30')).toThrow('expected a valid YYYY-MM-DD');
+  });
+});

--- a/tests/ts/lib/derived-fields.test.ts
+++ b/tests/ts/lib/derived-fields.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDerivedFieldPlan,
+  getDerivedFieldPlan,
+  projectDerivedFields,
+  validateDerivedFields,
+} from '../../../src/lib/derived-fields.js';
+import { resolveSchema } from '../../../src/lib/schema.js';
+import type { Field } from '../../../src/types/schema.js';
+
+function plan(fields: Record<string, Field>) {
+  return buildDerivedFieldPlan(fields, 'types.task.fields');
+}
+
+describe('derived fields', () => {
+  it('extracts dependencies and evaluates derived dependencies topologically', () => {
+    const derived = plan({
+      title: { prompt: 'text' },
+      slug: { derived: { expression: 'lower(title)', type: 'string' } },
+      labelled: { derived: { expression: 'upper(slug)', type: 'string' } },
+    });
+    expect(derived.fields.get('labelled')?.dependencies).toEqual(['slug']);
+    expect(derived.order).toEqual(['slug', 'labelled']);
+    expect(projectDerivedFields(derived, { title: 'HELLO' }, { asOf: '2026-08-10' })).toMatchObject({ slug: 'hello', labelled: 'HELLO' });
+  });
+
+  it('rejects unknown, self, and cyclic references with field chains', () => {
+    expect(() => plan({ x: { derived: { expression: 'missing + 1', type: 'number' } } })).toThrow('unknown field reference "missing"');
+    expect(() => plan({ x: { derived: { expression: 'x + 1', type: 'number' } } })).toThrow('cannot reference itself');
+    expect(() => plan({ a: { derived: { expression: 'b', type: 'string' } }, b: { derived: { expression: 'a', type: 'string' } } })).toThrow('a -> b -> a');
+  });
+
+  it('propagates null for absent inputs and overwrites stored collisions', () => {
+    const derived = plan({ input: { prompt: 'text' }, output: { derived: { expression: 'upper(input)', type: 'string' } } });
+    expect(projectDerivedFields(derived, { output: 'stale' }, { asOf: '2026-08-10' }).output).toBeNull();
+    expect(projectDerivedFields(derived, { input: 'fresh', output: 'stale' }, { asOf: '2026-08-10' }).output).toBe('FRESH');
+  });
+
+  it('binds today to asOf and rejects runtime-dependent or cross-note syntax', () => {
+    const derived = plan({ today: { derived: { expression: 'today()', type: 'date' } } });
+    expect(projectDerivedFields(derived, {}, { asOf: '2026-08-10' }).today).toBe('2026-08-10');
+    expect(() => plan({ x: { derived: { expression: 'now()', type: 'date' } } })).toThrow('now() is not supported');
+    expect(() => plan({ x: { derived: { expression: 'file.name', type: 'string' } } })).toThrow('file access is not supported');
+    expect(() => plan({ x: { derived: { expression: 'isRoot()', type: 'boolean' } } })).toThrow('isRoot() is not supported');
+  });
+
+  it('enforces declared scalar result types and finite numbers', () => {
+    const number = plan({ x: { derived: { expression: '1 / 0', type: 'number' } } });
+    expect(() => projectDerivedFields(number, {}, { asOf: '2026-08-10' })).toThrow('expected number');
+    const bool = plan({ x: { derived: { expression: "'yes'", type: 'boolean' } } });
+    expect(() => projectDerivedFields(bool, {}, { asOf: '2026-08-10' })).toThrow('expected boolean');
+  });
+
+  it('requires a full valid calendar date result and includes note paths in runtime errors', () => {
+    const invalid = plan({ x: { derived: { expression: "'2026-02-30'", type: 'date' } } });
+    expect(() => projectDerivedFields(invalid, {}, { asOf: '2026-08-10', notePath: 'Tasks/T.md' }))
+      .toThrow('Derived field "x" at Tasks/T.md result type mismatch');
+    const valid = plan({ x: { derived: { expression: "'2026-02-28'", type: 'date' } } });
+    expect(projectDerivedFields(valid, {}, { asOf: '2026-08-10' }).x).toBe('2026-02-28');
+  });
+
+  it('rejects prompt-like declarations and caches plans by loaded schema', () => {
+    expect(() => plan({ x: { prompt: 'text', derived: { expression: "'x'", type: 'string' } } }))
+      .toThrow('derived fields cannot also declare prompt');
+    const schema = resolveSchema({ version: 2, types: {
+      task: { fields: { x: { derived: { expression: "'x'", type: 'string' } } } },
+    } });
+    const plans = validateDerivedFields(schema);
+    expect(getDerivedFieldPlan(schema, 'task')).toBe(plans.byType.get('task'));
+  });
+});


### PR DESCRIPTION
## Problem

Bowerbird schemas can describe stored and prompted fields, but they cannot expose a value calculated from other fields as a first-class query field. Vault authors must either duplicate calculated values into Markdown or rebuild the calculation outside Bowerbird, which invites drift and makes filtering, sorting, and dashboards disagree.

## Approach

Add a vault-generic, query-time derived-field primitive that reuses the existing expression engine. A schema declares an expression and scalar result type; Bowerbird validates the dependency graph after inheritance and trait resolution, then projects the value into every relevant read surface without persisting it.

The primitive is deliberately record-local. It does not encode task, priority, triage, approval, queue, or vault-transaction policy. This is the smaller replacement direction for PR #840; that PR and branch remain open and unchanged pending a separate lifecycle decision.

## What changed

- Add derived field declarations for string, number, boolean, and full-date results, with static checks for unknown references, self-reference, cycles, incompatible field behavior, and unsupported cross-note or impure access.
- Project virtual values consistently into list JSON, selected fields, where expressions, sorting, and saved-dashboard execution. Missing or null inputs yield null.
- Add a command-level --as-of date for list and dashboard so today() uses one reproducible query snapshot. Saved dashboards never persist that date.
- Keep derived fields out of prompts and writes. New, edit, and bulk reject attempts to persist them; audit reports a stored same-name collision while queries use the calculated value.
- Regenerate the public JSON schema and document the public and internal contracts.

## Safety and operations

This change has no migration, backfill, network, credential, or production-data operation. Existing Markdown is not rewritten. Removing the schema declaration restores the previous read behavior; a pre-existing same-name stored value remains in the file and is surfaced by audit while the declaration exists.

## Verification

- Build and packaged-install verification passed against commit 42f5fff.
- Typecheck, ESLint, Knip, generated-schema drift, and diff checks passed.
- Focused derived-field and as-of suites passed: 13/13.
- Full non-PTY suite passed: 3,035 passed, 3 skipped, across 134 files.
- Independent packaged-CLI Human QA passed H1-H7 in a disposable vault: projection, null propagation, deterministic as-of, list/filter/sort/dashboard parity, write refusal, collision audit, invalid-schema failures, invalid-date failure, and byte-invariance checks.
- Independent bounded technical review found no P0/P1 correctness or data-integrity defect.

## Review focus

- Does the resolved-type dependency validation exclude every non-record-local or write-bearing field combination cleanly?
- Do list, where, sort, JSON, and dashboard all project the same virtual overlay at the correct point in their pipelines?
- Are stored-collision behavior and write refusal conservative enough for existing vaults?
- Is one command-scoped as-of date the right deterministic boundary for today()?

## Follow-ups

Closing or superseding PR #840 is intentionally not part of this PR and still requires an explicit decision.
