### PR TITLE
Add typed one-hop relation quantifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Bowerbird are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Typed one-hop relation quantifiers** — `--where` and schema-derived boolean
+  fields can use `all(relation, target.predicate)` and `any(...)`. Target
+  resolution is source-aware, alias/path-aware, snapshot-based, and read-only;
+  malformed, missing, ambiguous, or wrong-source edges fail explicitly.
+
 ### Changed
 
 - **Bounded default audit scope** — bare `bwrb audit` now runs core integrity

--- a/docs-site/src/content/docs/reference/commands/list.md
+++ b/docs-site/src/content/docs/reference/commands/list.md
@@ -99,7 +99,10 @@ silently overwrite a newer change.
 Schema-declared [derived fields](/reference/schema/#derived-fields) are projected
 before filtering, sorting, and rendering. They appear in JSON and `--fields`
 without being stored in Markdown. Use `--as-of` when a derived expression or
-filter uses `today()` and the result must be reproducible.
+filter uses `today()` and the result must be reproducible. `--where` and boolean
+derived fields may use typed one-hop relation quantifiers such as
+`all(depends-on, target.status == 'done')`; see
+[Targeting](/reference/targeting/#query--w---where-expression).
 
 With `--matches`, text output shows grep-style line details and JSON preserves
 structured match details. `paths` and `link` emit each matching note once, while

--- a/docs-site/src/content/docs/reference/schema.md
+++ b/docs-site/src/content/docs/reference/schema.md
@@ -727,8 +727,10 @@ so declaring it on a base type (e.g. `entity`) applies to all descendants.
 
 ## Derived Fields
 
-A derived field is a virtual scalar calculated from other fields on the same
-note. Declare its expression and result type instead of a prompt:
+A derived field is a virtual scalar calculated at query time. Most expressions
+read fields on the same note; boolean fields may also inspect one hop across a
+declared relation with `all()` or `any()`. Declare its expression and result
+type instead of a prompt:
 
 ```json
 {
@@ -749,12 +751,34 @@ attempts to set them. If a note already stores a same-name value, query results
 use the calculated value and `bwrb audit` reports `derived-field-persisted`.
 
 Expressions use the ordinary Bowerbird expression language with a deliberately
-record-local subset. They may reference concrete or earlier derived fields on
-the effective inherited type and use pure scalar functions. Missing or `null`
-inputs produce `null` without evaluating the expression. Unknown fields,
+bounded subset. They may reference concrete or earlier derived fields on the
+effective inherited type and use pure scalar functions. A boolean derived field
+may use `all(relation, target.predicate)` or `any(...)` over directly related
+notes. Target predicates may read stored fields only; nested quantifiers and
+additional graph traversal are not supported. Missing or `null` local inputs
+produce `null` without evaluating the expression. Unknown fields,
 self-references, dependency cycles, `file.*`, hierarchy functions, `now()`, and
-relative-date dependencies are schema errors. Runtime evaluation or result-type
-errors fail the command and identify both the field and note path.
+relative-date dependencies are schema errors. Runtime evaluation, relation
+resolution, or result-type errors fail the command and identify both the field
+and note path.
+
+For example, a task schema can own readiness without teaching Bowerbird any
+workflow policy:
+
+```json
+{
+  "depends-on": { "prompt": "relation", "source": "task", "multiple": true },
+  "ready": {
+    "derived": {
+      "expression": "all(depends-on, target.status == 'done' || target.status == 'cancelled')",
+      "type": "boolean"
+    }
+  }
+}
+```
+
+The terminal statuses remain schema policy. Bowerbird supplies only typed,
+read-only, one-hop quantification.
 
 `today()` uses one query snapshot date. Pass `--as-of YYYY-MM-DD` to `list` or
 `dashboard` for reproducible output; otherwise Bowerbird captures the local

--- a/docs-site/src/content/docs/reference/targeting.md
+++ b/docs-site/src/content/docs/reference/targeting.md
@@ -59,7 +59,8 @@ bwrb audit --where "isEmpty(tags)"
 - Supports comparison operators: `==`, `!=`, `<`, `>`, `<=`, `>=`
 - Supports regex match operator: `=~` (e.g., `name =~ '^\\[ERROR\\]'`)
 - Supports boolean operators: `&&`, `||`, `!`
-- Supports functions: `isEmpty()`, `contains()`, `startsWith()`
+- Supports functions: `isEmpty()`, `contains()`, `startsWith()`, and the typed
+  one-hop relation quantifiers `all()` and `any()`
 - Multiple `--where` flags are ANDed together
 - Field names may include hyphens and are treated literally in `--where` (e.g., `creation-date == '2026-01-28'`).
 - System fields are always available: `name` (falls back to filename) and `id`.
@@ -68,6 +69,33 @@ bwrb audit --where "isEmpty(tags)"
 - With `--type`: every field reference is validated against the type's schema, including function arguments such as the relation field passed to `under()`; unknown fields and invalid select values are errors
 - Without `--type`: unknown fields are permissive (no unknown-field validation)
 - In all modes: invalid expression syntax and runtime expression errors are hard errors
+
+**Relation quantifiers** inspect stored fields on each directly related note:
+
+```bash
+# Ready means every dependency is in a terminal state. Empty is ready.
+bwrb list --type task --where \
+  "all(depends-on, target.status == 'done' || target.status == 'cancelled')"
+
+# A book linked to at least one currently available edition.
+bwrb list --type book --where "any(editions, target.available == true)"
+```
+
+The grammar is `all(relation-field, target-predicate)` or
+`any(relation-field, target-predicate)`. The first argument must be a direct
+relation field. Predicate fields must be explicitly qualified as
+`target.field` or `target['hyphenated-field']`; bare source fields, `file.*`,
+hierarchy functions, and nested quantifiers are rejected. The predicate must
+return a boolean. `all()` returns true for an empty relation and `any()` returns
+false.
+
+Bowerbird resolves every target before evaluating the predicate, using the
+relation's declared source type plus ordinary path, name, and alias rules.
+Malformed values, dangling or ambiguous links, source-type mismatches, and
+unreadable targets are hard errors that identify the source note, field, raw
+target, and candidates. The operation is read-only and one hop only: it does
+not compute reverse edges, transitive closure, topological order, or a critical
+path.
 
 **Hierarchy functions** (for parent-child note relationships):
 - `isRoot()` — note has no parent-like note link of any kind (for example `parent`, `owner`, or a singular relation like `milestone`)

--- a/docs/skill/SKILL.md
+++ b/docs/skill/SKILL.md
@@ -281,6 +281,11 @@ bwrb list task --where "status == 'active'" --output json
 bwrb list task --limit 10 --receipt --output json  # selectors, counts, and rows
 bwrb list task --where "priority == 'high' && status != 'done'" --output json
 
+# Inspect directly related notes with typed, read-only one-hop quantifiers.
+# all([]) is true; any([]) is false. Resolution failures are hard errors.
+bwrb list task --where "all(depends-on, target.status == 'done' || target.status == 'cancelled')" --output json
+bwrb list book --where "any(editions, target.available == true)" --output json
+
 # Include specific fields in output
 bwrb list task --fields status,priority --output json
 

--- a/docs/technical/expression-pipeline.md
+++ b/docs/technical/expression-pipeline.md
@@ -4,10 +4,12 @@
 
 Schema-declared derived fields reuse this parser and evaluator through
 `src/lib/derived-fields.ts`. Schema loading validates the resolved effective
-type, builds a dependency-first plan, and rejects impure or non-record-local
-access. Query surfaces project the virtual overlay before `--where`, sorting,
-and rendering. A command resolves `--as-of` once and threads that same day into
-both ordinary `today()` calls and derived projection.
+type, builds a dependency-first plan, and rejects impure access. Query surfaces
+project the virtual overlay before `--where`, sorting, and rendering. A command
+resolves `--as-of` once and threads that same day into both ordinary `today()`
+calls and derived projection. Boolean expressions may use one-hop relation
+quantifiers; the command shell owns the single immutable vault index used to
+resolve their targets.
 
 ---
 
@@ -83,6 +85,9 @@ This reuses the same parser/evaluator, but not targeting policy.
 5. Runtime context construction
    - `buildEvalContext()` in `src/lib/expression.ts` builds `frontmatter` + `file.*` values.
    - `query.ts` computes hierarchy maps once per filter pass when expressions use hierarchy functions.
+   - When `all()` or `any()` is present directly or in a derived-field plan,
+     `query.ts` builds one vault note index and pre-resolves every referenced
+     target before predicate evaluation.
 
 6. Runtime evaluation
    - `matchesExpression()` parses + evaluates and coerces to boolean.
@@ -118,11 +123,11 @@ Rule: keep policy decisions at command/targeting boundaries. Keep lower-level he
 
 | Layer | Owns | Does Not Own |
 |-------|------|--------------|
-| `src/lib/expression.ts` | Parse/eval semantics, built-ins, operator behavior, context property lookup | CLI mode policy, warning formatting, command exits |
+| `src/lib/expression.ts` | Parse/eval semantics, built-ins, quantifier predicate grammar and empty-set behavior, context property lookup | Vault reads, relation resolution, CLI mode policy, command exits |
 | `src/lib/where-normalize.ts` | String rewrite for hyphenated keys in expressions | Schema/type validation, output rendering |
 | `src/lib/expression-validation.ts` | Static analysis for known type context; unknown-field/select-option findings | Runtime file filtering, printing, process exit |
 | `src/lib/where-targeting.ts` | Apply strict-vs-permissive `--where` policy (typed early validation when available), then delegate runtime filtering | Expression language semantics; command output rendering |
-| `src/lib/query.ts` | Apply expressions to file sets; hierarchy precomputation for hierarchy functions | Strict/permissive policy decisions; JSON envelope rendering |
+| `src/lib/query.ts` | Apply expressions to file sets; hierarchy precomputation; one-snapshot, source-aware relation-target resolution | Graph algorithms beyond one hop; scheduling policy; JSON envelope rendering |
 | `src/lib/targeting.ts` + commands | Orchestrate selector order and route failures to text/JSON output flows | Low-level parse/eval semantics |
 | `src/lib/output.ts` | JSON envelope helpers and exit-code constants | Expression semantics |
 
@@ -141,6 +146,13 @@ Rule: keep policy decisions at command/targeting boundaries. Keep lower-level he
   - Command behavior stays permissive to support migration workflows described in product docs.
 
 This mirrors current product policy; do not tighten permissive mode in docs-only changes.
+
+Relation quantifiers are deliberately stricter at runtime in both modes because
+silently dropping a corrupt edge changes the truth of `all()` and `any()`.
+Constrained relations are target-field checked against every allowed schema
+type up front. Unconstrained relations validate stored target fields against
+each resolved target's concrete type. Resolution and predicate failures are
+hard errors.
 
 ---
 

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -208,6 +208,7 @@ async function runDashboard(
       sortField: dashboard.sort,
       sortDesc: dashboard.desc,
       asOf,
+      queryContext: targetResult.queryContext,
     };
 
     await listObjects(schema, vaultDir, targeting.type, targetResult.files, listOpts);

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -84,6 +84,7 @@ import {
 import {
   buildRelationQuantifierContext,
   createRelationQuantifierIndexContext,
+  type QueryExecutionContext,
 } from '../lib/query.js';
 
 /**
@@ -763,6 +764,7 @@ Note: In zsh, use single quotes for expressions with '!' to avoid history expans
 
       await listObjects(schema, vaultDir, targeting.type, targetResult.files, {
         outputFormat,
+        queryContext: targetResult.queryContext,
         ...(fields !== undefined && { fields }),
         // Open options
         open: options.open,
@@ -863,6 +865,7 @@ export interface ListOptions {
   sortField?: string | undefined;
   sortDesc?: boolean | undefined;
   asOf?: string | undefined;
+  queryContext?: QueryExecutionContext | undefined;
   // Open options
   open?: boolean | undefined;
   app?: string | undefined;
@@ -909,7 +912,10 @@ export async function listObjects(
       : false;
   });
   const needsVaultIndex = needsRelationQuantifiers || schemaHasRelativeDateFields(schema);
-  const vaultIndex = needsVaultIndex ? await buildVaultNoteIndex(schema, vaultDir) : undefined;
+  const vaultIndex = needsVaultIndex
+    ? (options.queryContext?.vaultIndex ?? await buildVaultNoteIndex(schema, vaultDir))
+    : undefined;
+  if (vaultIndex && options.queryContext) options.queryContext.vaultIndex = vaultIndex;
   const relationIndex = needsRelationQuantifiers && vaultIndex
     ? createRelationQuantifierIndexContext(vaultIndex)
     : undefined;

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -55,7 +55,7 @@ import { createDashboard, updateDashboard, getDashboard } from '../lib/dashboard
 import { suggestFieldName } from '../lib/validation.js';
 import { getTtyContext } from '../lib/tty/context.js';
 import { renderTable } from '../lib/tty/table.js';
-import { buildVaultNoteIndex } from '../lib/discovery.js';
+import { buildVaultNoteIndex, type VaultNoteIndex } from '../lib/discovery.js';
 import {
   buildRelativeDateFieldMap,
   type RelativeDateFieldMap,
@@ -76,7 +76,15 @@ import {
 import { isValidNoteId, normalizeNoteId } from '../lib/note-id.js';
 import { renderFlatNotePaths } from '../lib/flat-note-presenter.js';
 import { resolveAsOf } from '../lib/as-of.js';
-import { getDerivedFieldPlan, projectDerivedFields } from '../lib/derived-fields.js';
+import {
+  getDerivedFieldPlan,
+  getDerivedRelationQuantifierExpressions,
+  projectDerivedFields,
+} from '../lib/derived-fields.js';
+import {
+  buildRelationQuantifierContext,
+  createRelationQuantifierIndexContext,
+} from '../lib/query.js';
 
 /**
  * Resolve the output format from --output flag.
@@ -894,18 +902,51 @@ export async function listObjects(
   options: ListOptions
 ): Promise<void> {
   const asOf = resolveAsOf(options.asOf);
+  const needsRelationQuantifiers = files.some((file) => {
+    const typePath = _typePath ?? resolveTypeFromFrontmatter(schema, file.frontmatter);
+    return typePath
+      ? getDerivedRelationQuantifierExpressions(getDerivedFieldPlan(schema, typePath)).length > 0
+      : false;
+  });
+  const needsVaultIndex = needsRelationQuantifiers || schemaHasRelativeDateFields(schema);
+  const vaultIndex = needsVaultIndex ? await buildVaultNoteIndex(schema, vaultDir) : undefined;
+  const relationIndex = needsRelationQuantifiers && vaultIndex
+    ? createRelationQuantifierIndexContext(vaultIndex)
+    : undefined;
+  const projectListFields = (
+    frontmatter: Record<string, unknown>,
+    notePath: string,
+    typePath: string | undefined
+  ): Record<string, unknown> => {
+    if (!typePath) return { ...frontmatter };
+    const plan = getDerivedFieldPlan(schema, typePath);
+    const expressions = getDerivedRelationQuantifierExpressions(plan);
+    const relationQuantifiers = expressions.length > 0 && relationIndex
+      ? buildRelationQuantifierContext(
+          frontmatter,
+          notePath,
+          expressions,
+          schema,
+          relationIndex,
+          new Map(
+            Object.entries(getFieldsForType(schema, typePath))
+              .filter(([, field]) => field.prompt === 'relation')
+              .map(([field, definition]) => [field, definition.source])
+          )
+        )
+      : undefined;
+    return projectDerivedFields(plan, frontmatter, {
+      asOf,
+      notePath,
+      ...(relationQuantifiers ? { relationQuantifiers } : {}),
+    });
+  };
   // Convert to the format expected by the rest of the function
   let filteredFiles = files.map(f => {
     const typePath = _typePath ?? resolveTypeFromFrontmatter(schema, f.frontmatter);
     return {
       path: f.path,
-      frontmatter: typePath
-        ? projectDerivedFields(
-            getDerivedFieldPlan(schema, typePath),
-            f.frontmatter,
-            { asOf, notePath: f.relativePath }
-          )
-        : { ...f.frontmatter },
+      frontmatter: projectListFields(f.frontmatter, f.relativePath, typePath),
     };
   });
 
@@ -923,7 +964,7 @@ export async function listObjects(
     ? await collectFileStats(filteredFiles.map(f => f.path))
     : undefined;
 
-  const relativeDateFields = await resolveRelativeDateFieldsForList(schema, vaultDir);
+  const relativeDateFields = await resolveRelativeDateFieldsForList(schema, vaultDir, vaultIndex);
   const fileComparator = createFileComparator(
     vaultDir,
     options.sortField,
@@ -1030,13 +1071,7 @@ export async function listObjects(
         const notePath = relative(vaultDir, path);
         const noteName = basename(path, '.md');
         const typePath = _typePath ?? resolveTypeFromFrontmatter(schema, rawFrontmatter);
-        const frontmatter = typePath
-          ? projectDerivedFields(
-              getDerivedFieldPlan(schema, typePath),
-              rawFrontmatter,
-              { asOf, notePath }
-            )
-          : rawFrontmatter;
+        const frontmatter = projectListFields(rawFrontmatter, notePath, typePath);
         const base = {
           _path: notePath,
           _name: noteName,
@@ -1278,11 +1313,12 @@ function printTable(
 
 async function resolveRelativeDateFieldsForList(
   schema: LoadedSchema,
-  vaultDir: string
+  vaultDir: string,
+  existingIndex?: VaultNoteIndex
 ): Promise<RelativeDateFieldMap> {
   if (!schemaHasRelativeDateFields(schema)) return new Map();
 
-  const index = await buildVaultNoteIndex(schema, vaultDir);
+  const index = existingIndex ?? await buildVaultNoteIndex(schema, vaultDir);
   const result = buildRelativeDateFieldMap(
     schema,
     vaultDir,

--- a/src/lib/derived-fields.ts
+++ b/src/lib/derived-fields.ts
@@ -1,7 +1,13 @@
 import type { Expression, CallExpression, Identifier, MemberExpression } from 'jsep';
-import { evaluateExpression, parseExpression } from './expression.js';
+import {
+  evaluateExpression, parseExpression, getRelationQuantifierField,
+  collectRelationQuantifierFields,
+  type RelationQuantifierContext,
+} from './expression.js';
 import { parsePartialIsoDate } from './local-date.js';
 import type { Field, LoadedSchema } from '../types/schema.js';
+import { validateRelationQuantifierTyping } from './expression-validation.js';
+import { normalizeWhereExpression } from './where-normalize.js';
 
 export type DerivedValueType = 'string' | 'number' | 'boolean' | 'date';
 
@@ -31,6 +37,8 @@ export interface DerivedFieldProjectionOptions {
   asOf: string;
   /** Optional note path included in runtime errors from a query projection. */
   notePath?: string;
+  /** Pre-resolved target context supplied by the query/list snapshot owner. */
+  relationQuantifiers?: RelationQuantifierContext;
 }
 
 const plansBySchema = new WeakMap<LoadedSchema, DerivedFieldPlans>();
@@ -56,6 +64,12 @@ export function validateDerivedFields(schema: LoadedSchema): DerivedFieldPlans {
   const byType = new Map<string, DerivedFieldPlan>();
   for (const type of schema.types.values()) {
     const plan = buildDerivedFieldPlan(type.fields, `types.${type.name}.fields`);
+    for (const entry of plan.fields.values()) {
+      const errors = validateRelationQuantifierTyping(entry.expressionAst, schema, type.name);
+      if (errors.length > 0) {
+        throw new Error(`types.${type.name}.fields.${entry.field}.derived.expression: ${errors[0]}`);
+      }
+    }
     if (plan.order.length > 0) byType.set(type.name, plan);
   }
   const plans = { byType };
@@ -91,11 +105,18 @@ export function buildDerivedFieldPlan(
     const derived = declaration.derived;
     let expressionAst: Expression;
     try {
-      expressionAst = parseExpression(derived.expression);
+      expressionAst = parseExpression(
+        normalizeWhereExpression(derived.expression, new Set(Object.keys(fields)))
+      );
     } catch (error) {
       throw new Error(`${path}.${field}.derived.expression: ${(error as Error).message}`);
     }
     const dependencies = [...collectDependencies(expressionAst, field, path)];
+    if (collectRelationQuantifierFields(expressionAst).length > 0 && derived.type !== 'boolean') {
+      throw new Error(
+        `${path}.${field}.derived: all()/any() expressions must declare type "boolean"`
+      );
+    }
     for (const dependency of dependencies) {
       if (!Object.hasOwn(fields, dependency)) {
         throw new Error(
@@ -141,6 +162,16 @@ export function buildDerivedFieldPlan(
   return { fields: entries, order };
 }
 
+/** Quantifier expressions needed to pre-resolve one-hop targets for a plan. */
+export function getDerivedRelationQuantifierExpressions(
+  plan: DerivedFieldPlan | undefined
+): Expression[] {
+  if (!plan) return [];
+  return [...plan.fields.values()]
+    .map((entry) => entry.expressionAst)
+    .filter((expression) => collectRelationQuantifierFields(expression).length > 0);
+}
+
 /**
  * Return a copy of record frontmatter with virtual values overlaid. Stored
  * same-name values are intentionally overwritten, never consulted.
@@ -158,13 +189,19 @@ export function projectDerivedFields(
   for (const field of plan.order) {
     const entry = plan.fields.get(field);
     if (!entry) continue;
-    if (entry.dependencies.some((dependency) => projected[dependency] == null)) {
+    const relationDependencies = new Set(collectRelationQuantifierFields(entry.expressionAst));
+    if (entry.dependencies.some((dependency) =>
+      projected[dependency] == null && !relationDependencies.has(dependency)
+    )) {
       projected[field] = null;
       continue;
     }
     let value: unknown;
     try {
-      value = evaluateExpression(bindToday(entry.expressionAst, options.asOf), { frontmatter: projected });
+      value = evaluateExpression(bindToday(entry.expressionAst, options.asOf), {
+        frontmatter: projected,
+        ...(options.relationQuantifiers ? { relationQuantifiers: options.relationQuantifiers } : {}),
+      });
     } catch (error) {
       throw new Error(`${runtimeLabel(field, options.notePath)} evaluation failed: ${(error as Error).message}`);
     }
@@ -192,6 +229,11 @@ function collectDependencies(expression: Expression, field: string, path: string
           throw new Error(`${path}.${field}.derived.expression: only named pure functions are supported`);
         }
         const name = (call.callee as Identifier).name;
+        if (name === 'all' || name === 'any') {
+          const relationField = getRelationQuantifierField(call);
+          dependencies.add(relationField);
+          return;
+        }
         if (REJECTED_FUNCTIONS.has(name)) {
           throw new Error(`${path}.${field}.derived.expression: ${name}() is not supported for derived fields`);
         }

--- a/src/lib/expression-validation.ts
+++ b/src/lib/expression-validation.ts
@@ -14,6 +14,8 @@ import type { Field } from '../types/schema.js';
 import { validateSelectOptionValue, suggestFieldName } from './validation.js';
 import { normalizeWhereExpression } from './where-normalize.js';
 import { FRONTMATTER_IDENTIFIER } from './where-constants.js';
+import { getRelationSourceTypes } from './discovery.js';
+import { getRelationQuantifierField } from './expression.js';
 
 // ============================================================================
 // Types
@@ -57,6 +59,110 @@ export interface WhereValidationResult {
   valid: boolean;
   /** List of validation errors */
   errors: WhereValidationError[];
+}
+
+/** Schema-only validation shared by --where and schema-derived booleans. */
+export function validateRelationQuantifierTyping(
+  expr: Expression,
+  schema: LoadedSchema,
+  typeName: string
+): string[] {
+  const errors: string[] = [];
+  const sourceFields = getFieldsForType(schema, typeName);
+  const visit = (node: Expression): void => {
+    if (node.type === 'CallExpression') {
+      const call = node as CallExpression;
+      const name = call.callee.type === 'Identifier' ? (call.callee as Identifier).name : '';
+      if (name === 'all' || name === 'any') {
+        let relationField: string;
+        try { relationField = getRelationQuantifierField(call); } catch (error) { errors.push((error as Error).message); return; }
+        const definition = sourceFields[relationField];
+        if (!definition) errors.push(`Unknown field '${relationField}' for type '${typeName}' in ${name}()`);
+        else if (definition.prompt !== 'relation') errors.push(`${name}() expects a relation field, but '${relationField}' is a '${definition.prompt ?? 'non-relation'}' field on type '${typeName}'`);
+        else {
+          const targetTypes = getRelationSourceTypes(schema, definition.source);
+          // Unconstrained relations are checked against each target's resolved
+          // runtime type. A declared source can be checked completely here.
+          for (const targetField of collectTargetFields(call.arguments[1]!)) {
+            const missing = [...targetTypes].filter(targetType => {
+              const targetDefinition = getFieldsForType(schema, targetType)[targetField];
+              return !targetDefinition || Boolean(targetDefinition.derived);
+            });
+            if (missing.length > 0) errors.push(`${name}() target field '${targetField}' must be a stored field on every allowed target type (${missing.join(', ')})`);
+          }
+          for (const comparison of collectTargetComparisons(call.arguments[1]!)) {
+            for (const targetType of targetTypes) {
+              const targetDefinition = getFieldsForType(schema, targetType)[comparison.field];
+              if (!targetDefinition) continue;
+              const options = getFieldOptions(targetDefinition);
+              if (options.length === 0) continue;
+              const invalid = validateSelectOptionValue(comparison.value, options);
+              if (invalid) {
+                errors.push(`${name}() target value '${comparison.value}' is invalid for field '${comparison.field}' on type '${targetType}'; valid options: ${options.join(', ')}`);
+              }
+            }
+          }
+        }
+      }
+      for (const arg of call.arguments) visit(arg);
+    } else if (node.type === 'BinaryExpression' || node.type === 'LogicalExpression') {
+      const binary = node as Expression & { left: Expression; right: Expression }; visit(binary.left); visit(binary.right);
+    } else if (node.type === 'UnaryExpression') visit((node as Expression & { argument: Expression }).argument);
+  };
+  visit(expr);
+  return errors;
+}
+
+function collectTargetFields(node: Expression): string[] {
+  const result: string[] = [];
+  const visit = (current: Expression): void => {
+    if (current.type === 'MemberExpression') {
+      const member = current as MemberExpression;
+      if (member.object.type === 'Identifier' && (member.object as Identifier).name === 'target') {
+        const property = member.computed ? (member.property as Literal).value : (member.property as Identifier).name;
+        if (typeof property === 'string') result.push(property);
+        return;
+      }
+    }
+    if (current.type === 'CallExpression') for (const arg of (current as CallExpression).arguments) visit(arg);
+    else if (current.type === 'BinaryExpression' || current.type === 'LogicalExpression') { const binary = current as Expression & { left: Expression; right: Expression }; visit(binary.left); visit(binary.right); }
+    else if (current.type === 'UnaryExpression') visit((current as Expression & { argument: Expression }).argument);
+  };
+  visit(node); return result;
+}
+
+function collectTargetComparisons(node: Expression): Array<{ field: string; value: string }> {
+  const result: Array<{ field: string; value: string }> = [];
+  const targetField = (candidate: Expression): string | undefined => {
+    if (candidate.type !== 'MemberExpression') return undefined;
+    const member = candidate as MemberExpression;
+    if (member.object.type !== 'Identifier' || (member.object as Identifier).name !== 'target') return undefined;
+    const property = member.computed ? (member.property as Literal).value : (member.property as Identifier).name;
+    return typeof property === 'string' ? property : undefined;
+  };
+  const literal = (candidate: Expression): string | undefined => {
+    if (candidate.type !== 'Literal') return undefined;
+    const value = (candidate as Literal).value;
+    return typeof value === 'string' ? value : undefined;
+  };
+  const visit = (current: Expression): void => {
+    if (current.type === 'BinaryExpression') {
+      const binary = current as BinaryExpression;
+      const leftField = targetField(binary.left);
+      const rightField = targetField(binary.right);
+      const leftValue = literal(binary.left);
+      const rightValue = literal(binary.right);
+      if (leftField && rightValue !== undefined) result.push({ field: leftField, value: rightValue });
+      if (rightField && leftValue !== undefined) result.push({ field: rightField, value: leftValue });
+      visit(binary.left); visit(binary.right);
+    } else if (current.type === 'CallExpression') {
+      for (const argument of (current as CallExpression).arguments) visit(argument);
+    } else if (current.type === 'UnaryExpression') {
+      visit((current as UnaryExpression).argument);
+    }
+  };
+  visit(node);
+  return result;
 }
 
 // ============================================================================
@@ -194,6 +300,11 @@ function extractFrontmatterFieldRefs(expr: Expression): string[] {
 
       case 'MemberExpression': {
         const member = node as MemberExpression;
+        // all()/any() predicates have their own target-type validation below;
+        // `target` is never a source-note frontmatter field.
+        if (member.object.type === 'Identifier' && (member.object as Identifier).name === 'target') {
+          break;
+        }
         const fieldName = getFieldName(member);
         if (fieldName) {
           fields.push(fieldName);
@@ -386,6 +497,10 @@ export function validateWhereExpressions(
     try {
       const normalized = normalizeWhereExpression(exprString, allFieldNames);
       const expr = parseExpression(normalized);
+
+      for (const message of validateRelationQuantifierTyping(expr, schema, typeName)) {
+        errors.push({ expression: exprString, field: '', value: '', message, validOptions: [] });
+      }
 
       // Validate the FIRST argument of any `under(field, '[[Node]]')` call: it
       // must be a known field on the type, and a relation-typed field (since

--- a/src/lib/expression.ts
+++ b/src/lib/expression.ts
@@ -125,7 +125,23 @@ export interface EvalContext {
   hierarchyData?: HierarchyData;
   /** Source constraints for relation fields on the current note's resolved type. */
   relationSourcesByField?: Map<string, string | string[] | undefined>;
+  /** Pre-resolved one-hop targets for all()/any(). Built once by the query layer. */
+  relationQuantifiers?: RelationQuantifierContext;
 }
+
+export interface RelationQuantifierTarget {
+  path: string;
+  frontmatter: Record<string, unknown>;
+}
+
+export interface RelationQuantifierContext {
+  targetsByField: Map<string, RelationQuantifierTarget[]>;
+}
+
+const RELATION_PREDICATE_FUNCTIONS = new Set([
+  'contains', 'startsWith', 'endsWith', 'lower', 'upper', 'length', 'trim', 'replace',
+  'today', 'date', 'year', 'month', 'day', 'isEmpty', 'isNull', 'isDefined',
+]);
 
 /**
  * Parse an expression string into an AST.
@@ -284,6 +300,9 @@ function evaluateUnary(expr: UnaryExpression, context: EvalContext): unknown {
 function evaluateCall(expr: CallExpression, context: EvalContext): unknown {
   const callee = expr.callee as Identifier;
   const fnName = callee.name;
+  if (fnName === 'all' || fnName === 'any') {
+    return evaluateRelationQuantifier(fnName, expr, context);
+  }
   const args = expr.arguments.map(arg => evaluateExpression(arg, context));
 
   const fn = FUNCTIONS[fnName];
@@ -292,6 +311,95 @@ function evaluateCall(expr: CallExpression, context: EvalContext): unknown {
   }
 
   return fn(args, context, expr);
+}
+
+/** Validate the intentionally narrow predicate grammar used by all()/any(). */
+export function getRelationQuantifierField(call: CallExpression): string {
+  if (call.arguments.length !== 2) throw new Error('all()/any() expects exactly two arguments');
+  const field = call.arguments[0] ? getRelationFieldNameFromExpression(call.arguments[0]) : null;
+  if (!field) throw new Error('all()/any() expects a direct relation field as its first argument');
+  validateRelationQuantifierPredicate(call.arguments[1]!);
+  return field;
+}
+
+export function collectRelationQuantifierFields(expr: Expression): string[] {
+  const fields: string[] = [];
+  const visit = (node: Expression): void => {
+    if (node.type === 'CallExpression') {
+      const call = node as CallExpression;
+      const name = call.callee.type === 'Identifier' ? (call.callee as Identifier).name : '';
+      if (name === 'all' || name === 'any') fields.push(getRelationQuantifierField(call));
+      for (const arg of call.arguments) visit(arg);
+      return;
+    }
+    if (node.type === 'BinaryExpression' || node.type === 'LogicalExpression') {
+      const binary = node as Expression & { left: Expression; right: Expression };
+      visit(binary.left); visit(binary.right);
+    } else if (node.type === 'UnaryExpression') visit((node as Expression & { argument: Expression }).argument);
+    else if (node.type === 'MemberExpression') {
+      const member = node as MemberExpression;
+      visit(member.object); if (member.computed) visit(member.property);
+    }
+  };
+  visit(expr);
+  return fields;
+}
+
+function validateRelationQuantifierPredicate(predicate: Expression): void {
+  const visit = (node: Expression, isCallee = false): void => {
+    if (node.type === 'Identifier') {
+      const name = (node as Identifier).name;
+      if (!isCallee && !['true', 'false', 'null'].includes(name)) {
+        throw new Error(`all()/any() predicate fields must use target.<field>; found "${name}"`);
+      }
+      return;
+    }
+    if (node.type === 'MemberExpression') {
+      const member = node as MemberExpression;
+      if (member.object.type !== 'Identifier' || (member.object as Identifier).name !== 'target') {
+        throw new Error('all()/any() predicate only permits target.field access');
+      }
+      if (member.computed && (
+        member.property.type !== 'Literal' ||
+        typeof (member.property as Literal).value !== 'string'
+      )) {
+        throw new Error('all()/any() predicate computed target access requires a string literal');
+      }
+      return;
+    }
+    if (node.type === 'CallExpression') {
+      const call = node as CallExpression;
+      if (call.callee.type !== 'Identifier') throw new Error('all()/any() predicate only permits named functions');
+      const name = (call.callee as Identifier).name;
+      if (name === 'all' || name === 'any') throw new Error('nested all()/any() predicates are not supported');
+      if (!RELATION_PREDICATE_FUNCTIONS.has(name)) {
+        throw new Error(`all()/any() predicate does not permit ${name}()`);
+      }
+      for (const arg of call.arguments) visit(arg);
+      return;
+    }
+    if (node.type === 'BinaryExpression' || node.type === 'LogicalExpression') {
+      const binary = node as Expression & { left: Expression; right: Expression };
+      visit(binary.left); visit(binary.right); return;
+    }
+    if (node.type === 'UnaryExpression') { visit((node as Expression & { argument: Expression }).argument); return; }
+    if (node.type === 'ThisExpression') throw new Error('all()/any() predicate only permits target fields');
+  };
+  visit(predicate);
+}
+
+function evaluateRelationQuantifier(kind: 'all' | 'any', call: CallExpression, context: EvalContext): boolean {
+  const field = getRelationQuantifierField(call);
+  const targets = context.relationQuantifiers?.targetsByField.get(field);
+  if (!targets) throw new Error(`all()/any() relation context is unavailable for field "${field}"`);
+  if (targets.length === 0) return kind === 'all';
+  for (const target of targets) {
+    const value = evaluateExpression(call.arguments[1]!, { ...context, frontmatter: { target: target.frontmatter } });
+    if (typeof value !== 'boolean') throw new Error(`all()/any() predicate for "${field}" must return boolean`);
+    if (kind === 'all' && !value) return false;
+    if (kind === 'any' && value) return true;
+  }
+  return kind === 'all';
 }
 
 function evaluateIdentifier(expr: Identifier, context: EvalContext): unknown {

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -23,7 +23,6 @@ import {
   type VaultNoteSnapshot,
   type VaultNoteIndex,
 } from './discovery.js';
-import { extractLinkTargets } from './links.js';
 import {
   buildRelativeDateFieldMap,
   type RelativeDateFieldMap,
@@ -69,6 +68,12 @@ export interface FrontmatterFilterOptions {
   typePath?: string;
   /** Stable date used by time-sensitive expressions for this query. */
   asOf?: string;
+  /** Mutable command-scoped holder used only to share one immutable vault index. */
+  queryContext?: QueryExecutionContext;
+}
+
+export interface QueryExecutionContext {
+  vaultIndex?: VaultNoteIndex;
 }
 
 // ============================================================================
@@ -695,9 +700,15 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
     }
   });
   const directExpressionAsts = expressionPairs.map(pair => pair.ast);
+  const candidateTypes = schema
+    ? new Set(files.map(file => resolveHierarchyType(file.frontmatter, {
+        schema,
+        ...(typePath ? { typePath } : {}),
+      })).filter((name): name is string => Boolean(name)))
+    : new Set<string>();
   const schemaDerivedQuantifierAsts = schema
-    ? [...schema.types.values()].flatMap(type => {
-        const plan = getDerivedFieldPlan(schema, type.name);
+    ? [...candidateTypes].flatMap(typeName => {
+        const plan = getDerivedFieldPlan(schema, typeName);
         return plan ? plan.order.map(field => plan.fields.get(field)!.expressionAst) : [];
       })
     : [];
@@ -706,8 +717,9 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
   // A quantifier needs every target frontmatter record, and hierarchy augmentation
   // may need the same snapshot. Build it once for this command.
   const vaultIndex = (schema && usesRelationQuantifiers)
-    ? await buildVaultNoteIndex(schema, vaultDir)
+    ? (options.queryContext?.vaultIndex ?? await buildVaultNoteIndex(schema, vaultDir))
     : undefined;
+  if (vaultIndex && options.queryContext) options.queryContext.vaultIndex = vaultIndex;
   const vaultSnapshot = (schema && !usesRelationQuantifiers && expressionsNeedVaultAugmentation(normalizedExpressions))
     ? await buildVaultNoteSnapshot(schema, vaultDir)
     : vaultIndex?.snapshot;
@@ -763,6 +775,14 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
         ? (getDerivedFieldPlan(schema, relationType)?.order.map(field => getDerivedFieldPlan(schema, relationType)!.fields.get(field)!.expressionAst) ?? [])
         : [];
       const quantifierExpressions = [...directExpressionAsts, ...derivedExpressionAsts];
+      if (quantifierExpressions.some(expression => collectRelationQuantifierFields(expression).length > 0)) {
+        assertRelationQuantifierFields(
+          quantifierExpressions,
+          relationSources,
+          relationType,
+          relative(vaultDir, file.path)
+        );
+      }
       const relationQuantifiers = usesRelationQuantifiers && schema && relationQuantifierIndex
         ? buildRelationQuantifierContext(
             baseFrontmatter,
@@ -815,6 +835,27 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
   }
 
   return result;
+}
+
+function assertRelationQuantifierFields(
+  expressions: Expression[],
+  relationSources: Map<string, string | string[] | undefined> | undefined,
+  relationType: string | undefined,
+  sourcePath: string
+): void {
+  if (!relationType || !relationSources) {
+    throw new Error(`Relation quantifier source at ${sourcePath} has no resolved schema type`);
+  }
+  for (const expression of expressions) {
+    for (const field of collectRelationQuantifierFields(expression)) {
+      if (!relationSources.has(field)) {
+        throw new Error(
+          `Relation quantifier at ${sourcePath} expects a relation field, but "${field}" ` +
+          `is not a relation field on type "${relationType}"`
+        );
+      }
+    }
+  }
 }
 
 async function resolveRelativeDateFieldsForQuery(

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -8,15 +8,22 @@ import {
   resolveDateCalendar,
   resolveTypeFromFrontmatter,
 } from './schema.js';
-import { matchesExpression, buildEvalContext, type HierarchyData } from './expression.js';
+import {
+  matchesExpression, buildEvalContext, collectRelationQuantifierFields,
+  parseExpression, type HierarchyData, type RelationQuantifierContext,
+} from './expression.js';
+import type { Expression, CallExpression, Identifier, Literal, MemberExpression } from 'jsep';
 import { collectFrontmatterKeys, normalizeWhereExpressions } from './where-normalize.js';
 import { extractLinkTarget } from './links.js';
 import {
   buildVaultNoteSnapshot,
   buildVaultNoteIndex,
   deriveNoteTargetIndex,
+  resolveRelationTarget,
   type VaultNoteSnapshot,
+  type VaultNoteIndex,
 } from './discovery.js';
+import { extractLinkTargets } from './links.js';
 import {
   buildRelativeDateFieldMap,
   type RelativeDateFieldMap,
@@ -79,6 +86,118 @@ function expressionsUseHierarchyFunctions(expressions: string[]): boolean {
   return expressions.some(expr =>
     HIERARCHY_FUNCTIONS.some(fn => expr.includes(fn + '('))
   );
+}
+
+export interface RelationQuantifierIndexContext {
+  snapshot: VaultNoteSnapshot;
+  noteTargetIndex: VaultNoteIndex['noteTargetIndex'];
+  notesByPath: Map<string, VaultNoteSnapshot['notes'][number]>;
+}
+
+/** Derive immutable per-command lookup data from the canonical vault index. */
+export function createRelationQuantifierIndexContext(index: VaultNoteIndex): RelationQuantifierIndexContext {
+  return {
+    snapshot: index.snapshot,
+    noteTargetIndex: index.noteTargetIndex,
+    notesByPath: new Map(index.snapshot.notes.map(note => [note.relativePath, note])),
+  };
+}
+
+/**
+ * Build the read-only, one-snapshot context consumed by expression all()/any().
+ * Exported for list projections that evaluate derived fields after filtering.
+ */
+export function buildRelationQuantifierContext(
+  frontmatter: Record<string, unknown>,
+  sourcePath: string,
+  expressions: Expression[],
+  schema: LoadedSchema,
+  indexContext: RelationQuantifierIndexContext,
+  relationSourcesByField: Map<string, string | string[] | undefined>
+): RelationQuantifierContext {
+  const fields = new Set<string>();
+  for (const expression of expressions) for (const field of collectRelationQuantifierFields(expression)) fields.add(field);
+  const targetsByField = new Map<string, { path: string; frontmatter: Record<string, unknown> }[]>();
+  for (const field of fields) {
+    const targets = [] as { path: string; frontmatter: Record<string, unknown> }[];
+    for (const rawTarget of normalizedRelationTargets(frontmatter[field], sourcePath, field)) {
+      const resolved = resolveRelationTarget(indexContext.noteTargetIndex, rawTarget, { schema, source: relationSourcesByField.get(field) });
+      const note = resolved.resolvedPath ? indexContext.notesByPath.get(resolved.resolvedPath) : undefined;
+      if (!note?.frontmatter) {
+        const unreadable = resolved.resolvedPath && note ? '; target frontmatter is unreadable or malformed' : '';
+        throw new Error(
+          `Relation quantifier resolution failed at ${sourcePath}, field "${field}", target "${rawTarget}": ` +
+          `${resolved.resolution}; candidates: ${resolved.candidates.join(', ') || '(none)'}; ` +
+          `source candidates: ${resolved.sourceCandidates.join(', ') || '(none)'}${unreadable}`
+        );
+      }
+      if (resolved.resolution !== 'unique') {
+        throw new Error(`Relation quantifier resolution failed at ${sourcePath}, field "${field}", target "${rawTarget}": ${resolved.resolution}; candidates: ${resolved.candidates.join(', ') || '(none)'}; source candidates: ${resolved.sourceCandidates.join(', ') || '(none)'}`);
+      }
+      validateResolvedTargetFields(expressions, schema, note.resolvedType, sourcePath, field, rawTarget);
+      targets.push({ path: resolved.resolvedPath!, frontmatter: note.frontmatter });
+    }
+    targetsByField.set(field, targets);
+  }
+  return { targetsByField };
+}
+
+function normalizedRelationTargets(value: unknown, sourcePath: string, field: string): string[] {
+  if (value === undefined || value === null || value === '') return [];
+  const values = Array.isArray(value) ? value : [value];
+  if (values.some(value => typeof value !== 'string')) {
+    throw new Error(`Relation quantifier resolution failed at ${sourcePath}, field "${field}": malformed relation value (expected string or array of strings)`);
+  }
+  const targets: string[] = [];
+  for (const relationValue of values) {
+    const trimmed = relationValue.trim();
+    if (trimmed === '') continue;
+    const target = extractLinkTarget(trimmed);
+    if (!target) {
+      throw new Error(
+        `Relation quantifier resolution failed at ${sourcePath}, field "${field}", ` +
+        `target "${relationValue}": malformed relation value (expected one wikilink or Markdown link)`
+      );
+    }
+    targets.push(target);
+  }
+  return targets;
+}
+
+function validateResolvedTargetFields(expressions: Expression[], schema: LoadedSchema, targetType: string | undefined, sourcePath: string, relationField: string, rawTarget: string): void {
+  if (!targetType) throw new Error(`Relation quantifier resolution failed at ${sourcePath}, field "${relationField}", target "${rawTarget}": target has no resolved schema type`);
+  const fields = getFieldsForType(schema, targetType);
+  for (const expression of expressions) {
+    for (const [quantifierField, targetField] of collectQuantifierTargetFields(expression)) {
+      if (quantifierField !== relationField) continue;
+      const definition = fields[targetField];
+      if (!definition) throw new Error(`Relation quantifier resolution failed at ${sourcePath}, field "${relationField}", target "${rawTarget}": target field "${targetField}" is not defined on type "${targetType}"`);
+      if (definition.derived) throw new Error(`Relation quantifier resolution failed at ${sourcePath}, field "${relationField}", target "${rawTarget}": target derived field "${targetField}" is not supported`);
+    }
+  }
+}
+
+function collectQuantifierTargetFields(expression: Expression): Array<[string, string]> {
+  const result: Array<[string, string]> = [];
+  const visit = (node: Expression, activeField?: string): void => {
+    if (node.type === 'CallExpression') {
+      const call = node as CallExpression;
+      const name = call.callee.type === 'Identifier' ? (call.callee as Identifier).name : '';
+      if (name === 'all' || name === 'any') {
+        const field = collectRelationQuantifierFields(call)[0];
+        visit(call.arguments[1]!, field);
+      } else for (const arg of call.arguments) visit(arg, activeField);
+    } else if (node.type === 'MemberExpression' && activeField) {
+      const member = node as MemberExpression;
+      if (member.object.type === 'Identifier' && (member.object as Identifier).name === 'target') {
+        const property = member.computed ? (member.property as Literal).value : (member.property as Identifier).name;
+        if (typeof property === 'string') result.push([activeField, property]);
+      }
+    } else if (node.type === 'BinaryExpression' || node.type === 'LogicalExpression') {
+      const binary = node as Expression & { left: Expression; right: Expression }; visit(binary.left, activeField); visit(binary.right, activeField);
+    } else if (node.type === 'UnaryExpression') visit((node as Expression & { argument: Expression }).argument, activeField);
+  };
+  visit(expression); return result;
 }
 
 /**
@@ -567,10 +686,32 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
     whereExpressions,
     effectiveKnownKeys
   );
-  const expressionPairs = normalizedExpressions.map((normalized, index) => ({
-    normalized,
-    original: whereExpressions[index] ?? normalized,
-  }));
+  const expressionPairs = normalizedExpressions.map((normalized, index) => {
+    const original = whereExpressions[index] ?? normalized;
+    try {
+      return { normalized, original, ast: parseExpression(normalized) };
+    } catch (error) {
+      throw new Error(`Expression error in "${original}": ${(error as Error).message}`);
+    }
+  });
+  const directExpressionAsts = expressionPairs.map(pair => pair.ast);
+  const schemaDerivedQuantifierAsts = schema
+    ? [...schema.types.values()].flatMap(type => {
+        const plan = getDerivedFieldPlan(schema, type.name);
+        return plan ? plan.order.map(field => plan.fields.get(field)!.expressionAst) : [];
+      })
+    : [];
+  const usesRelationQuantifiers = schema &&
+    [...directExpressionAsts, ...schemaDerivedQuantifierAsts].some(ast => collectRelationQuantifierFields(ast).length > 0);
+  // A quantifier needs every target frontmatter record, and hierarchy augmentation
+  // may need the same snapshot. Build it once for this command.
+  const vaultIndex = (schema && usesRelationQuantifiers)
+    ? await buildVaultNoteIndex(schema, vaultDir)
+    : undefined;
+  const vaultSnapshot = (schema && !usesRelationQuantifiers && expressionsNeedVaultAugmentation(normalizedExpressions))
+    ? await buildVaultNoteSnapshot(schema, vaultDir)
+    : vaultIndex?.snapshot;
+  const relationQuantifierIndex = vaultIndex ? createRelationQuantifierIndexContext(vaultIndex) : undefined;
 
   // Build hierarchy data if any expression uses hierarchy functions
   // This is done once before the loop for efficiency
@@ -595,6 +736,7 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
       await augmentHierarchyDataFromVault(hierarchyData, {
         schema,
         vaultDir,
+        ...(vaultSnapshot ? { snapshot: vaultSnapshot } : {}),
       });
     }
   }
@@ -602,7 +744,7 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
   const relationSourceCache = new Map<string, Map<string, string | string[] | undefined>>();
   const relativeDateFields =
     schema && expressionPairs.length > 0
-      ? await resolveRelativeDateFieldsForQuery(schema, vaultDir)
+      ? await resolveRelativeDateFieldsForQuery(schema, vaultDir, vaultIndex)
       : undefined;
   for (const file of files) {
     // Apply expression filters (--where style)
@@ -616,18 +758,37 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
         ...(schema ? { schema } : {}),
         ...(typePath ? { typePath } : {}),
       });
+      const relationSources = getRelationSourcesForType(schema, relationType, relationSourceCache);
+      const derivedExpressionAsts = schema && relationType
+        ? (getDerivedFieldPlan(schema, relationType)?.order.map(field => getDerivedFieldPlan(schema, relationType)!.fields.get(field)!.expressionAst) ?? [])
+        : [];
+      const quantifierExpressions = [...directExpressionAsts, ...derivedExpressionAsts];
+      const relationQuantifiers = usesRelationQuantifiers && schema && relationQuantifierIndex
+        ? buildRelationQuantifierContext(
+            baseFrontmatter,
+            relative(vaultDir, file.path),
+            quantifierExpressions,
+            schema,
+            relationQuantifierIndex,
+            relationSources ?? new Map()
+          )
+        : undefined;
       const evalFrontmatter = schema
         ? projectDerivedFields(
             relationType ? getDerivedFieldPlan(schema, relationType) : undefined,
             baseFrontmatter,
-            { asOf: effectiveAsOf, notePath: relative(vaultDir, file.path) }
+            {
+              asOf: effectiveAsOf,
+              notePath: relative(vaultDir, file.path),
+              ...(relationQuantifiers ? { relationQuantifiers } : {}),
+            }
           )
         : baseFrontmatter;
       const context = await buildEvalContext(file.path, vaultDir, evalFrontmatter, effectiveAsOf);
-      const relationSources = getRelationSourcesForType(schema, relationType, relationSourceCache);
       if (relationSources) {
         context.relationSourcesByField = relationSources;
       }
+      if (relationQuantifiers) context.relationQuantifiers = relationQuantifiers;
       // Add hierarchy data to context if available
       if (hierarchyData) {
         context.hierarchyData = hierarchyData;
@@ -658,9 +819,10 @@ export async function applyFrontmatterFilters<T extends FileWithFrontmatter>(
 
 async function resolveRelativeDateFieldsForQuery(
   schema: LoadedSchema,
-  vaultDir: string
+  vaultDir: string,
+  existingIndex?: VaultNoteIndex
 ): Promise<RelativeDateFieldMap> {
-  const index = await buildVaultNoteIndex(schema, vaultDir);
+  const index = existingIndex ?? await buildVaultNoteIndex(schema, vaultDir);
   const result = buildRelativeDateFieldMap(
     schema,
     vaultDir,

--- a/src/lib/targeting.ts
+++ b/src/lib/targeting.ts
@@ -24,6 +24,7 @@ import { parseNote } from './frontmatter.js';
 import { searchContent } from './content-search.js';
 import { getType, getTypeNames } from './schema.js';
 import { applyWhereExpressions } from './where-targeting.js';
+import type { QueryExecutionContext } from './query.js';
 
 // ============================================================================
 // Types
@@ -68,6 +69,8 @@ export interface TargetingResult {
   hasTargeting: boolean;
   /** Error message if targeting failed */
   error?: string;
+  /** Command-scoped immutable query resources reusable by rendering. */
+  queryContext?: QueryExecutionContext;
 }
 
 /**
@@ -219,6 +222,7 @@ export async function resolveTargets(
   const hasTargeting = !!(
     options.type || options.path || options.where?.length || options.id || bodyFilter
   );
+  const queryContext: QueryExecutionContext = {};
 
   try {
     // Step 1: Discover base files
@@ -334,6 +338,7 @@ export async function resolveTargets(
         ...(options.asOf ? { asOf: options.asOf } : {}),
         whereExpressions: options.where,
         vaultDir,
+        queryContext,
       });
 
       if (!filtered.ok) {
@@ -347,6 +352,7 @@ export async function resolveTargets(
       return {
         files: filtered.files as TargetedFile[],
         hasTargeting,
+        queryContext,
       };
     }
 

--- a/src/lib/where-targeting.ts
+++ b/src/lib/where-targeting.ts
@@ -1,5 +1,9 @@
 import type { LoadedSchema } from '../types/schema.js';
-import { applyFrontmatterFilters, type FileWithFrontmatter } from './query.js';
+import {
+  applyFrontmatterFilters,
+  type FileWithFrontmatter,
+  type QueryExecutionContext,
+} from './query.js';
 import { getAllFieldsForType } from './schema.js';
 import {
   formatWhereValidationErrors,
@@ -12,6 +16,7 @@ export interface WhereFilterOptions {
   schema: LoadedSchema;
   typePath?: string;
   asOf?: string;
+  queryContext?: QueryExecutionContext;
 }
 
 export type WhereFilterResult<T extends FileWithFrontmatter> =
@@ -22,7 +27,7 @@ export async function applyWhereExpressions<T extends FileWithFrontmatter>(
   files: T[],
   options: WhereFilterOptions
 ): Promise<WhereFilterResult<T>> {
-  const { whereExpressions, vaultDir, schema, typePath, asOf } = options;
+  const { whereExpressions, vaultDir, schema, typePath, asOf, queryContext } = options;
 
   if (whereExpressions.length === 0) {
     return { ok: true, files };
@@ -48,6 +53,7 @@ export async function applyWhereExpressions<T extends FileWithFrontmatter>(
       ...(asOf ? { asOf } : {}),
       ...(typePath ? { typePath } : {}),
       ...(knownKeys ? { knownKeys } : {}),
+      ...(queryContext ? { queryContext } : {}),
     });
 
     return { ok: true, files: filtered };

--- a/tests/ts/commands/derived-fields.test.ts
+++ b/tests/ts/commands/derived-fields.test.ts
@@ -1,7 +1,11 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { cleanupTestVault, createTestVault, runCLI } from '../fixtures/setup.js';
+import { loadSchema } from '../../../src/lib/schema.js';
+import { resolveTargets } from '../../../src/lib/targeting.js';
+import { listObjects } from '../../../src/commands/list.js';
+import * as discovery from '../../../src/lib/discovery.js';
 
 describe('schema-derived fields through the public CLI', () => {
   let vaultDir: string;
@@ -113,6 +117,34 @@ describe('schema-derived fields through the public CLI', () => {
     expect(dashboard.exitCode).toBe(0);
     expect(dashboard.stdout).toContain('Blocked');
     expect(dashboard.stdout).not.toContain('Waiting');
+  });
+
+  it('shares one relation index across filtering and list projection', async () => {
+    const schema = await loadSchema(vaultDir);
+    const indexSpy = vi.spyOn(discovery, 'buildVaultNoteIndex');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    try {
+      const targets = await resolveTargets(
+        { type: 'task', where: ['ready == true'] }, schema, vaultDir
+      );
+      expect(targets.error).toBeUndefined();
+      await listObjects(schema, vaultDir, 'task', targets.files, {
+        outputFormat: 'json',
+        queryContext: targets.queryContext,
+      });
+      expect(indexSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      indexSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+
+  it('rejects a non-relation quantifier field without an explicit type filter', async () => {
+    const result = await runCLI([
+      'list', '--where', "any(status, target.status == 'settled')", '--output', 'json',
+    ], vaultDir);
+    expect(result.exitCode).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toContain('is not a relation field');
   });
 
   it('fails closed when a relation target cannot be resolved', async () => {

--- a/tests/ts/commands/derived-fields.test.ts
+++ b/tests/ts/commands/derived-fields.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { cleanupTestVault, createTestVault, runCLI } from '../fixtures/setup.js';
 
@@ -12,13 +12,26 @@ describe('schema-derived fields through the public CLI', () => {
     vaultDir = await createTestVault();
     const schemaPath = join(vaultDir, '.bwrb', 'schema.json');
     const schema = JSON.parse(await readFile(schemaPath, 'utf8')) as {
-      types: { idea: { fields: Record<string, unknown> } };
+      types: {
+        idea: { fields: Record<string, unknown> };
+        task: { fields: Record<string, unknown> };
+      };
     };
     Object.assign(schema.types.idea.fields, {
       importance: { prompt: 'number' },
       excitement: { prompt: 'number' },
       score: { derived: { expression: 'importance * 4 + excitement', type: 'number' } },
       query_day: { derived: { expression: 'today()', type: 'date' } },
+      related: { prompt: 'relation', source: 'idea', multiple: true },
+      has_active_related: {
+        derived: { expression: "any(related, target.status == 'in-flight')", type: 'boolean' },
+      },
+    });
+    Object.assign(schema.types.task.fields, {
+      'depends-on': { prompt: 'relation', source: 'task', multiple: true },
+      ready: {
+        derived: { expression: "all(depends-on, target.status == 'settled')", type: 'boolean' },
+      },
     });
     await writeFile(schemaPath, JSON.stringify(schema, null, 2));
 
@@ -32,8 +45,17 @@ describe('schema-derived fields through the public CLI', () => {
     const anotherPath = join(vaultDir, 'Ideas', 'Another Idea.md');
     await writeFile(
       anotherPath,
-      (await readFile(anotherPath, 'utf8')).replace('status: backlog\n', 'status: backlog\nimportance: 2\n')
+      (await readFile(anotherPath, 'utf8')).replace('status: backlog\n', 'status: in-flight\nimportance: 2\n')
     );
+    await writeFile(samplePath, sampleBefore.replace('score: 999\n', 'score: 999\nrelated:\n  - "[[Another Idea]]"\n'));
+    sampleBefore = await readFile(samplePath, 'utf8');
+
+    const tasksDir = join(vaultDir, 'Objectives', 'Tasks');
+    await mkdir(tasksDir, { recursive: true });
+    await writeFile(join(tasksDir, 'Finished.md'), '---\ntype: task\nstatus: settled\n---\n');
+    await writeFile(join(tasksDir, 'Blocked.md'), '---\ntype: task\nstatus: in-flight\ndepends-on:\n  - "[[Finished]]"\n---\n');
+    await writeFile(join(tasksDir, 'Empty.md'), '---\ntype: task\nstatus: backlog\ndepends-on: []\n---\n');
+    await writeFile(join(tasksDir, 'Waiting.md'), '---\ntype: task\nstatus: backlog\ndepends-on:\n  - "[[Blocked]]"\n---\n');
   });
 
   afterAll(async () => cleanupTestVault(vaultDir));
@@ -66,6 +88,42 @@ describe('schema-derived fields through the public CLI', () => {
     expect(dashboard.stdout).toContain('Sample Idea');
     expect(dashboard.stdout).toContain('19');
     expect(dashboard.stdout).not.toContain('Another Idea');
+  });
+
+  it('supports direct and schema-derived one-hop relation quantifiers', async () => {
+    const ideas = await runCLI([
+      'list', '--type', 'idea', '--where', "any(related, target.status == 'in-flight')", '--output', 'json',
+    ], vaultDir);
+    expect(ideas.exitCode).toBe(0);
+    expect((JSON.parse(ideas.stdout) as Array<{ _name: string }>).map(row => row._name)).toEqual(['Sample Idea']);
+
+    const tasks = await runCLI([
+      'list', '--type', 'task', '--where', 'ready == true', '--sort', 'ready', '--fields', 'ready', '--output', 'json',
+    ], vaultDir);
+    expect(tasks.exitCode).toBe(0);
+    const rows = JSON.parse(tasks.stdout) as Array<Record<string, unknown>>;
+    expect(rows.map(row => row._name).sort()).toEqual(['Blocked', 'Empty', 'Finished', 'Sample Task']);
+    expect(rows.map(row => row._name)).not.toContain('Waiting');
+    expect(rows.every(row => row.ready === true)).toBe(true);
+
+    await writeFile(join(vaultDir, '.bwrb', 'dashboards.json'), JSON.stringify({
+      dashboards: { ready: { type: 'task', where: ['ready == true'], fields: ['ready'] } },
+    }, null, 2));
+    const dashboard = await runCLI(['dashboard', 'ready'], vaultDir);
+    expect(dashboard.exitCode).toBe(0);
+    expect(dashboard.stdout).toContain('Blocked');
+    expect(dashboard.stdout).not.toContain('Waiting');
+  });
+
+  it('fails closed when a relation target cannot be resolved', async () => {
+    const broken = join(vaultDir, 'Objectives', 'Tasks', 'Broken.md');
+    await writeFile(broken, '---\ntype: task\nstatus: backlog\ndepends-on:\n  - "[[Missing Task]]"\n---\n');
+    const result = await runCLI([
+      'list', '--type', 'task', '--where', 'ready == true', '--output', 'json',
+    ], vaultDir);
+    expect(result.exitCode).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toContain('Objectives/Tasks/Broken.md');
+    expect(`${result.stdout}${result.stderr}`).toContain('Missing Task');
   });
 
   it('rejects attempts to write or bulk-update a derived field', async () => {

--- a/tests/ts/lib/derived-fields.test.ts
+++ b/tests/ts/lib/derived-fields.test.ts
@@ -44,6 +44,23 @@ describe('derived fields', () => {
     expect(() => plan({ x: { derived: { expression: 'isRoot()', type: 'boolean' } } })).toThrow('isRoot() is not supported');
   });
 
+  it('normalizes hyphenated relation fields and requires boolean quantifier results', () => {
+    const derived = plan({
+      'depends-on': { prompt: 'relation', source: 'task', multiple: true },
+      ready: {
+        derived: {
+          expression: "all(depends-on, target.status == 'done')",
+          type: 'boolean',
+        },
+      },
+    });
+    expect(derived.fields.get('ready')?.dependencies).toEqual(['depends-on']);
+    expect(() => plan({
+      related: { prompt: 'relation', source: 'task' },
+      invalid: { derived: { expression: 'any(related, target.done)', type: 'string' } },
+    })).toThrow('must declare type "boolean"');
+  });
+
   it('enforces declared scalar result types and finite numbers', () => {
     const number = plan({ x: { derived: { expression: '1 / 0', type: 'number' } } });
     expect(() => projectDerivedFields(number, {}, { asOf: '2026-08-10' })).toThrow('expected number');

--- a/tests/ts/lib/expression-validation.test.ts
+++ b/tests/ts/lib/expression-validation.test.ts
@@ -119,6 +119,25 @@ describe('expression-validation', () => {
     });
   });
 
+  describe('relation quantifier validation', () => {
+    it('requires a direct relation and fields shared by its allowed target types', () => {
+      expect(validateWhereExpressions(
+        ["any(milestone, target.status == 'backlog')"], schema, 'task'
+      ).valid).toBe(true);
+      const invalid = validateWhereExpressions(
+        ["any(status, target.nope == 'x')"], schema, 'task'
+      );
+      expect(invalid.valid).toBe(false);
+      expect(invalid.errors.map(error => error.message).join('\n')).toContain('expects a relation field');
+
+      const invalidOption = validateWhereExpressions(
+        ["any(milestone, target.status == 'vanished')"], schema, 'task'
+      );
+      expect(invalidOption.valid).toBe(false);
+      expect(invalidOption.errors.map(error => error.message).join('\n')).toContain("target value 'vanished' is invalid");
+    });
+  });
+
   describe('validateWhereExpressions', () => {
     it('passes for valid select value', () => {
       // task.status has options: raw, backlog, in-flight, settled

--- a/tests/ts/lib/expression.test.ts
+++ b/tests/ts/lib/expression.test.ts
@@ -691,6 +691,33 @@ describe('expression', () => {
       });
     });
 
+    describe('relation quantifiers', () => {
+      const context: EvalContext = {
+        frontmatter: { milestone: ['[[One]]', '[[Two]]'] },
+        relationQuantifiers: {
+          targetsByField: new Map([['milestone', [
+            { path: 'Milestones/One.md', frontmatter: { status: 'done', 'due-date': '2026-08-01' } },
+            { path: 'Milestones/Two.md', frontmatter: { status: 'backlog', 'due-date': '2026-08-02' } },
+          ]]]),
+        },
+      };
+
+      it('evaluates target predicates with vacuous empty semantics', () => {
+        expect(matchesExpression("any(milestone, target.status == 'done')", context)).toBe(true);
+        expect(matchesExpression("all(milestone, target.status != 'done')", context)).toBe(false);
+        const empty: EvalContext = { frontmatter: { milestone: [] }, relationQuantifiers: { targetsByField: new Map([['milestone', []]]) } };
+        expect(matchesExpression("all(milestone, target.status == 'done')", empty)).toBe(true);
+        expect(matchesExpression("any(milestone, target.status == 'done')", empty)).toBe(false);
+      });
+
+      it('requires the target namespace and rejects nested or hierarchy predicates', () => {
+        expect(() => matchesExpression("any(milestone, status == 'done')", context)).toThrow('target.<field>');
+        expect(() => matchesExpression("any(milestone, all(milestone, target.status == 'done'))", context)).toThrow('nested all()/any()');
+        expect(() => matchesExpression("any(milestone, under(milestone, '[[X]]'))", context)).toThrow('does not permit under()');
+        expect(matchesExpression("any(milestone, target['due-date'] == '2026-08-01')", context)).toBe(true);
+      });
+    });
+
     describe('hierarchy functions composability', () => {
       it('should combine with other expressions using AND', () => {
         const ctx: EvalContext = {

--- a/tests/ts/lib/query.test.ts
+++ b/tests/ts/lib/query.test.ts
@@ -327,6 +327,56 @@ describe('query', () => {
         expect(result).toHaveLength(0);
       });
 
+      it('evaluates one-hop any()/all() predicates against the shared snapshot', async () => {
+        const files = makeFiles([
+          { path: 'Objectives/Tasks/Leaf.md', fm: { type: 'task', status: 'backlog', milestone: ['[[Active Milestone]]', '[[Settled Milestone]]'] } },
+        ]);
+
+        await expect(applyFrontmatterFilters(files, {
+          whereExpressions: ["any(milestone, target.status == 'settled')"],
+          vaultDir, schema, typePath: 'task',
+        })).resolves.toHaveLength(1);
+        await expect(applyFrontmatterFilters(files, {
+          whereExpressions: ["all(milestone, target.status != 'backlog')"],
+          vaultDir, schema, typePath: 'task',
+        })).resolves.toHaveLength(1);
+      });
+
+      it('fails closed when a quantifier relation target cannot resolve', async () => {
+        const files = makeFiles([
+          { path: 'Objectives/Tasks/Leaf.md', fm: { type: 'task', status: 'backlog', milestone: '[[Ghost]]' } },
+        ]);
+        await expect(applyFrontmatterFilters(files, {
+          whereExpressions: ["any(milestone, target.status == 'backlog')"],
+          vaultDir, schema, typePath: 'task',
+        })).rejects.toThrow('Relation quantifier resolution failed');
+      });
+
+      it('builds one vault index for quantifier evaluation and rejects malformed relation values', async () => {
+        const indexSpy = vi.spyOn(discovery, 'buildVaultNoteIndex');
+        try {
+          const files = makeFiles([
+            { path: 'Objectives/Tasks/Leaf.md', fm: { type: 'task', status: 'backlog', milestone: '[[Active Milestone]]' } },
+          ]);
+          await expect(applyFrontmatterFilters(files, {
+            whereExpressions: ["any(milestone, target.status == 'in-flight')"], vaultDir, schema, typePath: 'task',
+          })).resolves.toHaveLength(1);
+          expect(indexSpy).toHaveBeenCalledTimes(1);
+          await expect(applyFrontmatterFilters(makeFiles([
+            { path: 'Objectives/Tasks/Bad.md', fm: { type: 'task', milestone: { bad: true } } },
+          ]), {
+            whereExpressions: ["any(milestone, target.status == 'in-flight')"], vaultDir, schema, typePath: 'task',
+          })).rejects.toThrow('malformed relation value');
+          await expect(applyFrontmatterFilters(makeFiles([
+            { path: 'Objectives/Tasks/Bad.md', fm: { type: 'task', milestone: 'see [[Active Milestone]]' } },
+          ]), {
+            whereExpressions: ["any(milestone, target.status == 'in-flight')"], vaultDir, schema, typePath: 'task',
+          })).rejects.toThrow('expected one wikilink or Markdown link');
+        } finally {
+          indexSpy.mockRestore();
+        }
+      });
+
       it('resolves same-name relation targets by the field source type', async () => {
         const created: string[] = [];
         const writeNote = async (


### PR DESCRIPTION
## Problem

Bowerbird can validate and store relations, but queries can only ask whether a relation field is empty. A vault author who needs to know whether every dependency is finished—or whether any related edition is available—must load all note JSON and reimplement target resolution outside Bowerbird. That makes aliases, path qualification, source types, corrupt links, and derived fields easy to handle inconsistently.

## Approach

Add the smallest generic cross-record primitive: typed, read-only, one-hop `all(relation, target.predicate)` and `any(...)` expressions. Bowerbird resolves relation targets through its canonical source-aware name/path/alias index, validates the target namespace against the schema, then evaluates a boolean predicate over stored target fields.

Readiness remains vault policy rather than a built-in workflow concept. A task schema can declare `ready` as a derived boolean using `all(depends-on, ...)`; another schema can use the same primitive for books and editions. This PR deliberately does not add `ready()`, reverse edges, transitive closure, graph ordering, critical-path analysis, scheduling, or agent policy.

## What changed

- Add `all()` and `any()` to `--where` with explicit `target.field` / `target['hyphenated-field']` access, boolean predicate enforcement, and `all([]) = true` / `any([]) = false` semantics.
- Validate direct relation arguments, constrained target types, stored target fields, and select literals. Untyped queries perform the same relation-field check against each source note's resolved concrete type.
- Resolve every edge before predicate evaluation. Malformed, dangling, ambiguous, wrong-source, unreadable, or untyped targets fail with the source path, relation field, raw target, and candidate state.
- Permit quantifiers in schema-derived boolean fields, including hyphenated relations such as `depends-on`, and project the same value through filtering, sorting, JSON, selected fields, and dashboards.
- Share one immutable vault index across filtering and rendering for a command, avoiding inconsistent observations and per-note vault rebuilds.
- Document the grammar, failure model, task example, non-task example, automation guidance, and intentional one-hop boundary.

## Safety and compatibility

The feature is opt-in through query expressions or schema-derived fields. Existing schemas and Markdown remain unchanged. Evaluation is read-only, uses one command-scoped snapshot, and performs no migration, backfill, network operation, credential access, or live-vault mutation. Removing a derived declaration restores prior query behavior.

Corrupt edges become hard errors only when a quantifier actually traverses that relation; silently dropping one could invert `all()` or `any()`. PR #840 and its branch remain untouched and separately owned.

## Verification

Evidence on exact head `a4f23d3aa57288a7cfc875ed7d47dbbc388237dc`:

- Full local CI parity passed in repository order: build, packaged-install verification, typecheck, ESLint, Knip, and 3,046 non-PTY tests across 134 files (3 skipped).
- Focused public-CLI coverage proves direct non-task `any()`, schema-owned task readiness, empty-set semantics, list/filter/sort/fields/dashboard parity, one index across filtering and projection, untyped non-relation rejection, dangling-edge errors, and unchanged Markdown.
- Independent bounded review found two snapshot/type-safety defects; both were repaired, and the single allowed repair review reports a clean disposition on `a4f23d3`.
- Independent real-PTY QA passed H1-H6 against a packaged tarball: book/edition alias resolution, task readiness, dashboard rendering, JSON error purity, dangling-edge diagnostics, and byte-for-byte vault invariance. The disposable fixture was removed, and independent absence checks found no matching directory in `/tmp` or Trash.

GitHub CI passed on the exact head: Test, retry-zero reliability, PTY, Windows lock, Docs Relevance, Docs Site CI, and Vercel checks are green.

## Review focus

- Does the explicit target namespace and stored-field-only predicate grammar keep the first slice narrow enough?
- Are source-aware resolution and fail-closed corruption errors correct for scalar and multi-value relations?
- Does the command-scoped index preserve one coherent observation across filtering and rendering?
- Is schema-owned readiness the right boundary, with graph algorithms and workflow policy clearly deferred?

## Follow-ups

Reverse-edge queries, transitive closure, topological ordering, cycle reporting for graph walks, critical-path analysis, and any convenience `ready()` helper remain separate product decisions. None is required for this one-hop primitive.