### PR TITLE
Parallelize pull-request validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,14 +94,17 @@ jobs:
         if: steps.decision.outputs.run_docs_build == 'true'
         run: pnpm -C docs-site build
 
-  test:
-    name: Test
+  quality:
+    name: Quality, package, and static checks
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -109,21 +112,8 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - name: Cache ripgrep
-        id: cache-ripgrep
-        uses: actions/cache@v4
-        with:
-          path: /usr/bin/rg
-          key: ripgrep-${{ runner.os }}-14.1
-
-      - name: Install ripgrep
-        if: steps.cache-ripgrep.outputs.cache-hit != 'true'
-        run: |
-          curl -LO https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep_14.1.1-1_amd64.deb
-          sudo dpkg -i ripgrep_14.1.1-1_amd64.deb
-
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build
@@ -140,21 +130,10 @@ jobs:
       - name: Check for dead code (Knip)
         run: pnpm knip
 
-      - name: Run retrying feedback tests (excluding PTY)
-        run: pnpm test -- --exclude='**/*.pty.test.ts'
-
-      - name: Run retrying feedback tests (excluding PTY) with dist
-        run: pnpm test -- --exclude='**/*.pty.test.ts'
-        env:
-          BWRB_TEST_DIST: 1
-
-      - name: Verify deterministic benchmark fixtures
-        run: pnpm test:bench
-
-  test-retry-zero:
-    name: Retry-zero reliability (non-PTY)
+  test_source:
+    name: Source tests (non-PTY)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -180,48 +159,211 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Run retry-zero reliability tests (excluding PTY)
-        id: retry_zero
-        run: pnpm test:reliability
+      - name: Run retrying feedback tests (excluding PTY)
+        run: pnpm test -- --exclude='**/*.pty.test.ts'
 
-      - name: Summarize retry-zero JSON results
-        if: always()
+  test_dist:
+    name: Dist tests (non-PTY)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install ripgrep
         run: |
-          node <<'NODE'
-          const fs = require('fs');
-          const input = 'artifacts/health/retry-zero-results.json';
-          const output = 'artifacts/health/retry-zero-summary.json';
-          if (!fs.existsSync(input)) {
-            console.log('Retry-zero summary: results file not found; the run is unmeasured.');
-            process.exit(0);
-          }
-          const data = JSON.parse(fs.readFileSync(input, 'utf8'));
-          const assertions = (data.testResults || []).flatMap((suite) => suite.assertionResults || []);
-          const count = (statuses) => assertions.filter((test) => statuses.includes(test.status)).length;
-          const summary = {
-            passed: count(['passed']),
-            failed: count(['failed']),
-            skipped: count(['skipped']),
-            pending: count(['pending', 'todo']),
-            retried: 0,
-            ptySupported: 0,
-            ptySkipped: 0,
-            retryMode: 'retry-zero',
-            pty: 'skipped',
-          };
-          fs.writeFileSync(output, `${JSON.stringify(summary, null, 2)}\n`);
-          console.log('Retry-zero summary:', summary);
-          NODE
+          curl -LO https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep_14.1.1-1_amd64.deb
+          sudo dpkg -i ripgrep_14.1.1-1_amd64.deb
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run retrying feedback tests (excluding PTY) with dist
+        run: pnpm test -- --exclude='**/*.pty.test.ts'
+        env:
+          BWRB_TEST_DIST: 1
+
+  benchmarks:
+    name: Deterministic benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify deterministic benchmark fixtures
+        run: pnpm test:bench
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [quality, test_source, test_dist, benchmarks]
+    steps:
+      - name: Require every Test component
+        env:
+          BENCHMARKS_RESULT: ${{ needs.benchmarks.result }}
+          DIST_RESULT: ${{ needs.test_dist.result }}
+          QUALITY_RESULT: ${{ needs.quality.result }}
+          SOURCE_RESULT: ${{ needs.test_source.result }}
+        run: |
+          for result in "$QUALITY_RESULT" "$SOURCE_RESULT" "$DIST_RESULT" "$BENCHMARKS_RESULT"; do
+            if [ "$result" != "success" ]; then
+              echo "A required Test component did not succeed."
+              exit 1
+            fi
+          done
+
+  test_retry_zero_shard:
+    name: Retry-zero shard ${{ matrix.shard }}/2
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install ripgrep
+        run: |
+          curl -LO https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep_14.1.1-1_amd64.deb
+          sudo dpkg -i ripgrep_14.1.1-1_amd64.deb
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run retry-zero reliability shard (excluding PTY)
+        id: retry_zero
+        run: >-
+          pnpm test:reliability --
+          --shard=${{ matrix.shard }}/2
+          --reporter=default
+          --reporter=blob
+          --outputFile=artifacts/health/retry-zero-shard-${{ matrix.shard }}.blob
+
+      - name: Upload retry-zero shard report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: retry-zero-shard-${{ matrix.shard }}
+          path: artifacts/health/retry-zero-shard-${{ matrix.shard }}.blob
+          if-no-files-found: error
+          retention-days: 30
+
+  test-retry-zero:
+    name: Retry-zero reliability (non-PTY)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ always() }}
+    needs: [test_retry_zero_shard]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download retry-zero shard reports
+        id: download_shards
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          pattern: retry-zero-shard-*
+          path: artifacts/health/retry-zero-shards
+          merge-multiple: true
+
+      - name: Merge retry-zero shard results
+        id: merge_results
+        if: always()
+        continue-on-error: true
+        run: >-
+          pnpm exec vitest run
+          --merge-reports=artifacts/health/retry-zero-shards
+          --reporter=default
+          --reporter=json
+          --outputFile=artifacts/health/retry-zero-results.json
+
+      - name: Verify retry-zero coverage and summarize results
+        id: aggregate_results
+        if: always()
+        continue-on-error: true
+        run: >-
+          pnpm health:retry-zero-aggregate --
+          --results artifacts/health/retry-zero-results.json
+          --expected-root tests/ts
+          --shard-dir artifacts/health/retry-zero-shards
+          --expected-shards 2
+          --summary artifacts/health/retry-zero-summary.json
+          --manifest artifacts/health/retry-zero-manifest.json
 
       - name: Write retry-zero health report
         if: always()
         env:
-          RETRY_ZERO_OUTCOME: ${{ steps.retry_zero.outcome }}
+          AGGREGATE_OUTCOME: ${{ steps.aggregate_results.outcome }}
+          DOWNLOAD_OUTCOME: ${{ steps.download_shards.outcome }}
+          MERGE_OUTCOME: ${{ steps.merge_results.outcome }}
+          SHARD_JOB_RESULT: ${{ needs.test_retry_zero_shard.result }}
         run: |
           if [ -f artifacts/health/retry-zero-results.json ]; then
             STATUS=failed
-            if [ "$RETRY_ZERO_OUTCOME" = "success" ]; then STATUS=passed; fi
             CLASSIFICATION=measured
+            if [ "$SHARD_JOB_RESULT" = "success" ] && \
+               [ "$DOWNLOAD_OUTCOME" = "success" ] && \
+               [ "$MERGE_OUTCOME" = "success" ] && \
+               [ "$AGGREGATE_OUTCOME" = "success" ]; then
+              STATUS=passed
+            fi
           else
             STATUS=not-run
             CLASSIFICATION=unmeasured
@@ -236,6 +378,7 @@ jobs:
             --pty skipped \
             --raw-artifact artifacts/health/retry-zero-results.json \
             --raw-artifact artifacts/health/retry-zero-summary.json \
+            --raw-artifact artifacts/health/retry-zero-manifest.json \
             --out artifacts/health/retry-zero-report.json
 
       - name: Upload health report artifacts
@@ -246,6 +389,22 @@ jobs:
           path: artifacts/health/
           if-no-files-found: warn
           retention-days: 30
+
+      - name: Enforce retry-zero outcome
+        if: always()
+        env:
+          AGGREGATE_OUTCOME: ${{ steps.aggregate_results.outcome }}
+          DOWNLOAD_OUTCOME: ${{ steps.download_shards.outcome }}
+          MERGE_OUTCOME: ${{ steps.merge_results.outcome }}
+          SHARD_JOB_RESULT: ${{ needs.test_retry_zero_shard.result }}
+        run: |
+          if [ "$SHARD_JOB_RESULT" != "success" ] || \
+             [ "$DOWNLOAD_OUTCOME" != "success" ] || \
+             [ "$MERGE_OUTCOME" != "success" ] || \
+             [ "$AGGREGATE_OUTCOME" != "success" ]; then
+            echo "Retry-zero reliability did not produce a complete successful aggregate."
+            exit 1
+          fi
 
   windows_lock_tests:
     name: Windows Lock Tests

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "knip": "knip",
     "knip:prod": "knip --production",
     "health:report": "tsx src/tools/health/report.ts",
+    "health:retry-zero-aggregate": "tsx src/tools/health/retry-zero-aggregate.ts",
     "postinstall": "chmod +x node_modules/.pnpm/node-pty@*/node_modules/node-pty/prebuilds/darwin-*/spawn-helper 2>/dev/null || true"
   },
   "keywords": [

--- a/src/tools/health/retry-zero-aggregate.ts
+++ b/src/tools/health/retry-zero-aggregate.ts
@@ -1,0 +1,213 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+type AssertionStatus = 'passed' | 'failed' | 'pending' | 'skipped' | 'todo';
+
+interface VitestAssertion {
+  retryCount?: number;
+  status: AssertionStatus;
+}
+
+interface VitestTestFile {
+  assertionResults?: VitestAssertion[];
+  name: string;
+}
+
+interface VitestJsonResult {
+  success?: boolean;
+  testResults?: VitestTestFile[];
+}
+
+interface Arguments {
+  expectedRoot: string;
+  expectedShards: number;
+  manifest: string;
+  results: string;
+  shardDir: string;
+  summary: string;
+}
+
+interface RetryZeroSummary {
+  complete: boolean;
+  expectedFiles: number;
+  failed: number;
+  observedFiles: number;
+  passed: number;
+  pending: number;
+  pty: 'skipped';
+  ptySkipped: 0;
+  ptySupported: 0;
+  retried: number;
+  retryMode: 'retry-zero';
+  shardReports: number;
+  skipped: number;
+}
+
+interface RetryZeroManifest {
+  duplicateFiles: string[];
+  expectedFiles: string[];
+  expectedShards: number;
+  missingFiles: string[];
+  observedFiles: string[];
+  ptyFiles: string[];
+  shardReports: string[];
+  unexpectedFiles: string[];
+  violations: string[];
+}
+
+const testFilePattern = /\.test\.[cm]?[jt]sx?$/;
+const ptyTestFilePattern = /\.pty\.test\.[cm]?[jt]sx?$/;
+
+function usage(): string {
+  return 'Usage: pnpm health:retry-zero-aggregate -- ' +
+    '--results <path> --expected-root <path> --shard-dir <path> --expected-shards <n> ' +
+    '--summary <path> --manifest <path>';
+}
+
+function readArguments(argv: string[]): Arguments {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (!flag) throw new Error(usage());
+    if (flag === '--') continue;
+    if (flag === '--help' || flag === '-h') throw new Error(usage());
+    const value = argv[++index];
+    if (!value || value.startsWith('--')) throw new Error(`Missing value for ${flag}`);
+    values.set(flag, value);
+  }
+
+  const required = (flag: string): string => {
+    const value = values.get(flag);
+    if (!value) throw new Error(`Missing required option: ${flag}`);
+    return value;
+  };
+  const expectedShards = Number.parseInt(required('--expected-shards'), 10);
+  if (!Number.isSafeInteger(expectedShards) || expectedShards < 1) {
+    throw new Error('--expected-shards must be a positive integer');
+  }
+
+  return {
+    results: required('--results'),
+    expectedRoot: required('--expected-root'),
+    shardDir: required('--shard-dir'),
+    expectedShards,
+    summary: required('--summary'),
+    manifest: required('--manifest'),
+  };
+}
+
+const portablePath = (path: string): string => path.split(sep).join('/');
+
+function resultPath(cwd: string, name: string): string {
+  const path = name.startsWith('file:') ? fileURLToPath(name) : name;
+  return portablePath(relative(cwd, isAbsolute(path) ? path : resolve(cwd, path)));
+}
+
+async function discoverTests(directory: string, cwd: string): Promise<string[]> {
+  const discovered: string[] = [];
+  const visit = async (current: string): Promise<void> => {
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const path = resolve(current, entry.name);
+      if (entry.isDirectory()) await visit(path);
+      else if (entry.isFile() && testFilePattern.test(entry.name) && !ptyTestFilePattern.test(entry.name)) {
+        discovered.push(portablePath(relative(cwd, path)));
+      }
+    }
+  };
+  await visit(resolve(cwd, directory));
+  return discovered.sort();
+}
+
+async function discoverShardReports(directory: string, cwd: string): Promise<string[]> {
+  const entries = await readdir(resolve(cwd, directory), { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.blob'))
+    .map((entry) => portablePath(relative(cwd, resolve(cwd, directory, entry.name))))
+    .sort();
+}
+
+const difference = (left: string[], right: Set<string>): string[] =>
+  left.filter((value) => !right.has(value));
+
+export async function aggregateRetryZero(args: Arguments, cwd = process.cwd()): Promise<{
+  manifest: RetryZeroManifest;
+  summary: RetryZeroSummary;
+}> {
+  const data = JSON.parse(await readFile(resolve(cwd, args.results), 'utf8')) as VitestJsonResult;
+  if (!Array.isArray(data.testResults)) throw new Error('Vitest JSON results do not contain testResults');
+
+  const expectedFiles = await discoverTests(args.expectedRoot, cwd);
+  const observed = data.testResults.map((file) => resultPath(cwd, file.name));
+  const observedFiles = [...new Set(observed)].sort();
+  const duplicateFiles = [...new Set(observed.filter((file, index) => observed.indexOf(file) !== index))].sort();
+  const expectedSet = new Set(expectedFiles);
+  const observedSet = new Set(observedFiles);
+  const missingFiles = difference(expectedFiles, observedSet);
+  const unexpectedFiles = difference(observedFiles, expectedSet);
+  const ptyFiles = observedFiles.filter((file) => ptyTestFilePattern.test(file));
+  const shardReports = await discoverShardReports(args.shardDir, cwd);
+
+  const assertions = data.testResults.flatMap((file) => file.assertionResults ?? []);
+  const count = (...statuses: AssertionStatus[]): number =>
+    assertions.filter((assertion) => statuses.includes(assertion.status)).length;
+  const retried = assertions.filter((assertion) => (assertion.retryCount ?? 0) > 0).length;
+  const violations: string[] = [];
+  if (shardReports.length !== args.expectedShards) {
+    violations.push(`expected ${args.expectedShards} shard reports, found ${shardReports.length}`);
+  }
+  if (duplicateFiles.length) violations.push(`duplicate test files: ${duplicateFiles.join(', ')}`);
+  if (missingFiles.length) violations.push(`missing test files: ${missingFiles.join(', ')}`);
+  if (unexpectedFiles.length) violations.push(`unexpected test files: ${unexpectedFiles.join(', ')}`);
+  if (ptyFiles.length) violations.push(`PTY files were executed: ${ptyFiles.join(', ')}`);
+  if (retried > 0) violations.push(`${retried} assertions recorded retries`);
+  if (count('failed') > 0 || data.success !== true) violations.push('merged retry-zero run failed');
+
+  const manifest: RetryZeroManifest = {
+    expectedShards: args.expectedShards,
+    shardReports,
+    expectedFiles,
+    observedFiles,
+    duplicateFiles,
+    missingFiles,
+    unexpectedFiles,
+    ptyFiles,
+    violations,
+  };
+  const summary: RetryZeroSummary = {
+    passed: count('passed'),
+    failed: count('failed'),
+    skipped: count('skipped'),
+    pending: count('pending', 'todo'),
+    retried,
+    ptySupported: 0,
+    ptySkipped: 0,
+    retryMode: 'retry-zero',
+    pty: 'skipped',
+    expectedFiles: expectedFiles.length,
+    observedFiles: observedFiles.length,
+    shardReports: shardReports.length,
+    complete: violations.length === 0,
+  };
+
+  await writeFile(resolve(cwd, args.summary), `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+  await writeFile(resolve(cwd, args.manifest), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  return { manifest, summary };
+}
+
+async function main(): Promise<void> {
+  const result = await aggregateRetryZero(readArguments(process.argv.slice(2)));
+  process.stdout.write(`Retry-zero summary: ${JSON.stringify(result.summary)}\n`);
+  if (result.manifest.violations.length) {
+    throw new Error(`Retry-zero aggregation failed:\n- ${result.manifest.violations.join('\n- ')}`);
+  }
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tests/ts/tools/retry-zero-aggregate.test.ts
+++ b/tests/ts/tools/retry-zero-aggregate.test.ts
@@ -1,0 +1,96 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { aggregateRetryZero } from '../../../src/tools/health/retry-zero-aggregate.js';
+
+const temporaryPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+async function fixture(options: {
+  duplicate?: boolean;
+  missing?: boolean;
+  pty?: boolean;
+  retried?: boolean;
+  shardReports?: number;
+  success?: boolean;
+} = {}) {
+  const root = await mkdtemp(join(tmpdir(), 'bwrb-retry-zero-aggregate-'));
+  temporaryPaths.push(root);
+  await mkdir(join(root, 'tests/ts/commands'), { recursive: true });
+  await mkdir(join(root, 'artifacts/shards'), { recursive: true });
+  await mkdir(join(root, 'artifacts/health'), { recursive: true });
+  await writeFile(join(root, 'tests/ts/commands/one.test.ts'), '');
+  await writeFile(join(root, 'tests/ts/commands/two.test.ts'), '');
+  await writeFile(join(root, 'tests/ts/commands/ignored.pty.test.ts'), '');
+  for (let shard = 1; shard <= (options.shardReports ?? 2); shard += 1) {
+    await writeFile(join(root, `artifacts/shards/retry-zero-${shard}.blob`), 'blob');
+  }
+  const first = {
+    name: join(root, 'tests/ts/commands/one.test.ts'),
+    assertionResults: [{ status: 'passed', retryCount: options.retried ? 1 : 0 }],
+  };
+  const second = {
+    name: join(root, 'tests/ts/commands/two.test.ts'),
+    assertionResults: [{ status: options.success === false ? 'failed' : 'passed' }],
+  };
+  await writeFile(join(root, 'artifacts/health/results.json'), JSON.stringify({
+    success: options.success ?? true,
+    testResults: [
+      first,
+      ...(options.missing ? [] : [second]),
+      ...(options.duplicate ? [first] : []),
+      ...(options.pty ? [{
+        name: join(root, 'tests/ts/commands/ignored.pty.test.ts'),
+        assertionResults: [{ status: 'passed' }],
+      }] : []),
+    ],
+  }));
+  return {
+    root,
+    args: {
+      results: 'artifacts/health/results.json',
+      expectedRoot: 'tests/ts',
+      shardDir: 'artifacts/shards',
+      expectedShards: 2,
+      summary: 'artifacts/health/summary.json',
+      manifest: 'artifacts/health/manifest.json',
+    },
+  };
+}
+
+describe('retry-zero result aggregation', () => {
+  it('proves the two shards cover every non-PTY file exactly once', async () => {
+    const { root, args } = await fixture();
+    const result = await aggregateRetryZero(args, root);
+
+    expect(result.summary).toMatchObject({
+      complete: true,
+      expectedFiles: 2,
+      observedFiles: 2,
+      passed: 2,
+      retried: 0,
+      shardReports: 2,
+    });
+    expect(result.manifest.violations).toEqual([]);
+    expect(JSON.parse(await readFile(join(root, args.summary), 'utf8'))).toEqual(result.summary);
+  });
+
+  it.each([
+    ['a missing shard report', { shardReports: 1 }, 'expected 2 shard reports, found 1'],
+    ['a missing test file', { missing: true }, 'missing test files: tests/ts/commands/two.test.ts'],
+    ['a duplicated test file', { duplicate: true }, 'duplicate test files: tests/ts/commands/one.test.ts'],
+    ['an executed PTY file', { pty: true }, 'PTY files were executed: tests/ts/commands/ignored.pty.test.ts'],
+    ['a recorded retry', { retried: true }, '1 assertions recorded retries'],
+    ['a failed merged run', { success: false }, 'merged retry-zero run failed'],
+  ])('records %s as a fail-closed violation', async (_name, options, violation) => {
+    const { root, args } = await fixture(options);
+    const result = await aggregateRetryZero(args, root);
+
+    expect(result.summary.complete).toBe(false);
+    expect(result.manifest.violations).toContain(violation);
+  });
+});


### PR DESCRIPTION
## Problem

Bowerbird's pull-request validation currently makes contributors wait for work that does not depend on itself. The ordinary `Test` job builds and checks the package, runs the source suite, reruns the same non-PTY corpus against `dist/`, and verifies benchmarks sequentially. PR #838 demonstrated the consequence: the required lane was on the critical path while those independent checks accumulated wall time.

The retry-zero reliability lane has a similar shape. It deliberately uses one worker and zero retries so first-attempt failures remain observable, but today one GitHub job walks the entire non-PTY corpus serially.

Recent successful `main` runs had a median workflow duration of about 18m34s. This PR aims to remove at least five minutes from that critical path without deleting or relaxing any validation.

## Approach

Run independent validation beside each other, then preserve the existing public check names with fail-closed aggregate jobs. The required `Test` context remains intact for branch protection; it succeeds only when quality/package/static checks, source tests, dist tests, and benchmarks all succeed.

Retry-zero becomes two deterministic Vitest shards in isolated GitHub jobs. Each shard retains one worker, one concurrent test, and zero retries. A final job keeps the existing `Retry-zero reliability (non-PTY)` name, merges both blob reports, and verifies that every expected non-PTY test file ran exactly once before publishing the familiar health artifacts.

This changes deterministic validation infrastructure only. It does not add agent, process, retry, deployment, scheduling, or execution policy to the Bowerbird product.

## What changed

- Split the former serial `Test` job into four parallel component jobs plus a required aggregate named `Test`.
- Split retry-zero into two fixed shards with `fail-fast: false`, so one failure does not suppress evidence from the other shard.
- Added a retry-zero aggregation tool that fails on missing or duplicate shard reports, missing or duplicate test files, unexpected or PTY files, recorded retries, or merged failures.
- Preserved health summaries, manifests, raw merged results, and final failure semantics even when an earlier retry-zero step fails.
- Left the PTY and Windows lock-test jobs unchanged.

## Safety and operations

The rollback is one workflow/tool revert; there are no migrations, persistent data writes, credentials, product-runtime changes, or compatibility concerns. The tradeoff is additional GitHub-hosted runner setup and build time in exchange for lower contributor wall time. The design favors the smallest two-shard retry-zero split rather than multiplying runner count further.

## Verification

Current commit `417b088` passed:

- build, package verification, typecheck, lint, and Knip;
- the complete source and dist corpora before the final test-only PTY guard assertion: 135 files, 3,052 passing tests, three expected skips in each mode;
- all 12 deterministic benchmark tests;
- a local two-process retry-zero execution and blob merge: 135 expected and observed files, 3,052 passes, three skips, two reports, zero retries, zero failures, no gaps or duplicates;
- after that final assertion, all seven focused fail-closed aggregation tests plus typecheck, lint, and Knip; and
- an independent read-only technical review with no findings.

Provider acceptance passed on three complete executions of [Actions run 31887431130](https://github.com/3mdistal/bwrb/actions/runs/31887431130) against the same head: 13m34s, 13m17s, and a queue-contention outlier at 14m29s. The 13m34s median is five minutes below the refreshed 18m34s baseline and below the frozen 13m55s ceiling. Every attempt kept `Test`, retry-zero, PTY, and Windows lock evidence green. The uploaded retry-zero report independently confirmed 135 expected and observed files, 3,053 passes, three skips, two shard reports, zero retries, and no coverage violations. A separate tester executed the frozen provider story through authenticated GitHub CLI/API access and passed all five steps, including the direct ripgrep-install cold-start path.

## Review focus

- Can any failed or cancelled component produce a misleading successful aggregate?
- Does retry-zero retain equivalent first-attempt observability and complete failure artifacts across both shards?
- Is two shards the right compute-cost boundary for the measured gain?
