### PR TITLE
Make typed relation validation consistent

### DIFF
--- a/docs-site/src/content/docs/reference/commands/audit.md
+++ b/docs-site/src/content/docs/reference/commands/audit.md
@@ -123,6 +123,8 @@ Delete semantics in repair mode:
 | `fork-cycle` | Following immediate `forked-from` references forms a cycle (error; flag-only). Traversal is cycle-safe and always terminates |
 | `format-violation` | Field value doesn't match expected format (wikilink, etc.) |
 | `stale-reference` | Wikilink points to non-existent file |
+| `invalid-source-type` | Typed relation points to an existing note with the wrong type or no `type`. When a bare name matches multiple wrong-type notes, the issue lists every candidate so the reference can be path-qualified |
+| `ambiguous-link-target` | Relation target matches multiple allowed files; path-qualify the wikilink using one of the reported candidate paths |
 | `trailing-whitespace` | Trailing spaces/tabs on raw frontmatter `key: value` lines (warning; auto-fixable) |
 | `wrong-scalar-type` | Scalar value has wrong type for schema |
 | `illegal-aliases` | An [`alias`-role field](/reference/schema/#alias) violates the Obsidian aliases format (array of **non-empty, unique** strings): an empty/whitespace entry, a **duplicate** entry, or a non-string entry (**error** — matching what `bwrb new`/`bwrb edit` reject on write; empty/whitespace + duplicate cases are **auto-fixable**, a non-string entry is **flag-only** — see below) |

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -133,6 +133,7 @@ Issue Types:
   duplicate-note-id     Stable note id is used by multiple notes
   self-reference        Relation field references the same note
   ambiguous-link-target Relation target matches multiple files
+  invalid-source-type   Typed relation target has a wrong or missing note type
   invalid-list-element  List field contains non-string values
   wrong-scalar-type     Scalar value has wrong type for schema
   invalid-date-format   Date value too imprecise or malformed for field granularity

--- a/src/lib/audit/detection.ts
+++ b/src/lib/audit/detection.ts
@@ -1298,7 +1298,7 @@ function checkRelationFieldIssues(
         rawString,
         rawTarget,
         field.source,
-        resolvedTarget.candidates[0],
+        resolvedTarget.candidates,
         noteTargetIndex
       );
       if (wrongTypeIssue) {
@@ -1335,7 +1335,7 @@ function checkRelationFieldIssues(
       issues.push({
         severity: 'warning',
         code: 'ambiguous-link-target',
-        message: `Ambiguous link target for ${fieldName}: '${rawTarget}' matches multiple files`,
+        message: `Ambiguous link target for ${fieldName}: '${rawTarget}' matches multiple files; path-qualify one of ${filteredCandidates.join(', ')}`,
         field: fieldName,
         value: rawString,
         candidates: filteredCandidates,
@@ -1360,7 +1360,7 @@ function checkRelationFieldIssues(
         rawString,
         rawTarget,
         field.source,
-        resolvedPath,
+        [resolvedPath],
         noteTargetIndex
       );
       if (sourceIssue) {
@@ -1842,10 +1842,10 @@ function checkResolvedContextSource(
   value: string,
   target: string,
   source: string | string[],
-  resolvedPath: string | undefined,
+  resolvedPaths: string[],
   noteTargetIndex: NoteTargetIndex | undefined
 ): AuditIssue | null {
-  if (!resolvedPath || !noteTargetIndex) return null;
+  if (resolvedPaths.length === 0 || !noteTargetIndex) return null;
 
   // Normalize source to array
   const sources = Array.isArray(source) ? source : [source];
@@ -1860,14 +1860,38 @@ function checkResolvedContextSource(
     return null;
   }
 
-  const pathKey = resolvedPath.replace(/\.md$/, '');
-  const actualType =
-    noteTargetIndex.pathNoExtToType.get(pathKey) ??
-    noteTargetIndex.pathToType.get(resolvedPath);
-  if (!actualType) {
-    // Note doesn't exist or has no type - stale reference check handles this
-    return null;
+  const candidates = resolvedPaths.map((path) => ({
+    path,
+    type: noteTargetIndex.pathNoExtToType.get(path.replace(/\.md$/, '')) ??
+      noteTargetIndex.pathToType.get(path),
+  }));
+  const typedCandidates = candidates.filter(
+    (candidate): candidate is { path: string; type: string } => Boolean(candidate.type)
+  );
+
+  if (candidates.length > 1) {
+    const candidateSummary = candidates
+      .map((candidate) => `${candidate.path} (${candidate.type ?? 'no type'})`).join(', ');
+    return {
+      severity: 'error', code: 'invalid-source-type',
+      message: `Type mismatch: '${fieldName}' expects ${sources.join(' or ')}, but '${target}' matches only disallowed candidates: ${candidateSummary}; path-qualify the intended note`,
+      field: fieldName, value, expectedType: sources[0],
+      expected: validTypes.size > 1 ? Array.from(validTypes) : sources[0],
+      candidates: candidates.map((candidate) => candidate.path), autoFixable: false,
+    };
   }
+
+  if (typedCandidates.length === 0) {
+    return {
+      severity: 'error', code: 'invalid-source-type',
+      message: `Type mismatch: '${fieldName}' expects ${sources.join(' or ')}, but '${target}' exists without a type`,
+      field: fieldName, value, expectedType: sources[0],
+      expected: validTypes.size > 1 ? Array.from(validTypes) : sources[0],
+      candidates: resolvedPaths, autoFixable: false,
+    };
+  }
+
+  const actualType = typedCandidates[0]!.type;
   
   // Check if actual type is in the set of valid types
   if (validTypes.has(actualType)) {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -920,6 +920,8 @@ export interface ContextValidationError extends ValidationError {
   actualType?: string;
   /** The expected types based on the source constraint */
   expectedTypes?: string[];
+  /** Candidate paths when a target is ambiguous or has no allowed match */
+  candidates?: string[];
 }
 
 /**
@@ -1143,30 +1145,53 @@ async function validateSingleContextValue(
       targetName,
       expectedTypes: Array.from(validTypes),
       expected: Array.from(validTypes),
+      candidates: resolved.sourceCandidates,
     };
   }
 
-  const candidateTypes = resolved.candidates
-    .map((candidatePath) => {
+  const candidateDetails = resolved.candidates.map((candidatePath) => {
       const pathKey = candidatePath.replace(/\.md$/, '');
       return {
         path: candidatePath,
         type: noteTargetIndex.pathNoExtToType.get(pathKey),
       };
-    })
+    });
+  const candidateTypes = candidateDetails
     .filter((candidate): candidate is { path: string; type: string } => Boolean(candidate.type));
 
-  const wrongTypeCandidate = candidateTypes[0];
-  if (wrongTypeCandidate) {
+  if (candidateDetails.length > 1) {
+    const candidateSummary = candidateDetails
+      .map((candidate) => `${candidate.path} (${candidate.type ? `type "${candidate.type}"` : 'no type'})`)
+      .join(', ');
+    return {
+      type: 'invalid_context_source', field: fieldName, value,
+      message: `"${targetName}" matches only disallowed candidates: ${candidateSummary}; expected ${formatExpectedTypes(validTypes)}; path-qualify the intended note`,
+      targetName, expectedTypes: Array.from(validTypes), expected: Array.from(validTypes),
+      candidates: candidateDetails.map((candidate) => candidate.path),
+    };
+  }
+
+  if (candidateTypes.length === 1) {
+    const firstCandidate = candidateTypes[0]!;
     return {
       type: 'invalid_context_source',
       field: fieldName,
       value,
-      message: `"${targetName}" is type "${wrongTypeCandidate.type}", expected ${formatExpectedTypes(validTypes)}`,
+      message: `"${targetName}" is type "${firstCandidate.type}", expected ${formatExpectedTypes(validTypes)}`,
       targetName,
-      actualType: wrongTypeCandidate.type,
+      actualType: firstCandidate.type,
       expectedTypes: Array.from(validTypes),
       expected: Array.from(validTypes),
+      candidates: [firstCandidate.path],
+    };
+  }
+
+  if (resolved.candidates.length > 0) {
+    return {
+      type: 'invalid_context_source', field: fieldName, value,
+      message: `"${targetName}" exists but has no type; expected ${formatExpectedTypes(validTypes)}`,
+      targetName, expectedTypes: Array.from(validTypes), expected: Array.from(validTypes),
+      candidates: resolved.candidates,
     };
   }
 

--- a/tests/ts/commands/audit.test.ts
+++ b/tests/ts/commands/audit.test.ts
@@ -2088,6 +2088,10 @@ unknownField: should warn
               prompt: 'relation',
               source: 'any',
             },
+            idea_ref: {
+              prompt: 'relation',
+              source: 'idea',
+            },
           },
         },
         idea: {
@@ -2333,6 +2337,46 @@ milestone: "[[Only Wrong]]"
         actualType: 'idea',
         expected: 'milestone',
       });
+    });
+
+    it('reports an existing typeless note as an invalid typed relation target', async () => {
+      await writeFile(join(tempVaultDir, 'ideas', 'Untyped.md'), '---\ntitle: Untyped\n---\n');
+      await writeFile(
+        join(tempVaultDir, 'objectives/tasks', 'Typeless Ref.md'),
+        '---\ntype: task\nstatus: backlog\nidea_ref: "[[Untyped]]"\n---\n'
+      );
+
+      const result = await runCLI(['audit', 'task', '--output', 'json'], tempVaultDir);
+      expect(result.exitCode).toBe(1);
+      const output = JSON.parse(result.stdout);
+      const taskFile = output.files.find((f: { path: string }) => f.path.includes('Typeless Ref.md'));
+      const issue = taskFile.issues.find((i: { code: string }) => i.code === 'invalid-source-type');
+      expect(issue).toMatchObject({ field: 'idea_ref', expectedType: 'idea', autoFixable: false });
+      expect(issue).not.toHaveProperty('actualType');
+      expect(issue.message).toContain('exists without a type');
+      expect(issue.candidates).toEqual(['ideas/Untyped.md']);
+    });
+
+    it('lists every wrong-type candidate and tells the user to path-qualify', async () => {
+      await writeFile(join(tempVaultDir, 'ideas', 'Shared Wrong.md'), '---\ntype: idea\nstatus: raw\n---\n');
+      await writeFile(join(tempVaultDir, 'objectives/tasks', 'Shared Wrong.md'), '---\ntype: task\nstatus: backlog\n---\n');
+      await writeFile(
+        join(tempVaultDir, 'objectives/tasks', 'Multiple Wrong Ref.md'),
+        '---\ntype: task\nstatus: backlog\nmilestone: "[[Shared Wrong]]"\n---\n'
+      );
+
+      const result = await runCLI(['audit', 'task', '--output', 'json'], tempVaultDir);
+      expect(result.exitCode).toBe(1);
+      const output = JSON.parse(result.stdout);
+      const taskFile = output.files.find((f: { path: string }) => f.path.includes('Multiple Wrong Ref.md'));
+      const issue = taskFile.issues.find((i: { code: string }) => i.code === 'invalid-source-type');
+      expect(issue.candidates).toEqual(expect.arrayContaining([
+        'ideas/Shared Wrong.md',
+        'objectives/tasks/Shared Wrong.md',
+      ]));
+      expect(issue.message).toContain('path-qualify');
+      expect(issue.message).toContain('ideas/Shared Wrong.md (idea)');
+      expect(issue.message).toContain('objectives/tasks/Shared Wrong.md (task)');
     });
 
     it('should detect type mismatch when context field references wrong type', async () => {

--- a/tests/ts/commands/hierarchical-scope.test.ts
+++ b/tests/ts/commands/hierarchical-scope.test.ts
@@ -348,6 +348,12 @@ describe('#636 under() canonicalizes aliases', () => {
       'aliases:',
       '  - Dup',
     ]);
+    await writeNote('Contexts/Alias Carrier.md', [
+      'type: context',
+      'aliases:',
+      '  - Verse',
+    ]);
+    await writeNote('Contexts/Verse.md', ['type: context', 'parent: "[[Beta]]"']);
 
     // Task uses the ALIAS as its context value.
     await writeNote('Tasks/Aliased context task.md', [
@@ -366,6 +372,11 @@ describe('#636 under() canonicalizes aliases', () => {
       'type: task',
       'status: active',
       'context: "[[Dup]]"',
+    ]);
+    await writeNote('Tasks/Real name wins task.md', [
+      'type: task',
+      'status: active',
+      'context: "[[Verse]]"',
     ]);
   });
 
@@ -426,6 +437,22 @@ describe('#636 under() canonicalizes aliases', () => {
     );
     expect(viaBeta.exitCode).toBe(0);
     expect(viaBeta.stdout).not.toContain('Ambiguous alias task.md');
+  });
+
+  it('prefers a real note name over a colliding alias in under()', async () => {
+    const viaRealParent = await runCLI(
+      ['list', 'task', '--where', "under(context, '[[Beta]]')", '--output', 'paths'],
+      vaultDir
+    );
+    expect(viaRealParent.exitCode).toBe(0);
+    expect(viaRealParent.stdout).toContain('Real name wins task.md');
+
+    const viaAliasCarrier = await runCLI(
+      ['list', 'task', '--where', "under(context, '[[Alias Carrier]]')", '--output', 'paths'],
+      vaultDir
+    );
+    expect(viaAliasCarrier.exitCode).toBe(0);
+    expect(viaAliasCarrier.stdout).not.toContain('Real name wins task.md');
   });
 
   it('does not crash on a dangling alias', async () => {

--- a/tests/ts/lib/validation.test.ts
+++ b/tests/ts/lib/validation.test.ts
@@ -1187,6 +1187,7 @@ type: milestone
         ]);
         expect(result.errors[0].message).toContain('Ambiguous relation target');
         expect(result.errors[0].message).toContain('path-qualify');
+        expect(result.errors[0].candidates).toHaveLength(2);
       } finally {
         await rm(tempVaultDir, { recursive: true, force: true });
       }
@@ -1232,6 +1233,27 @@ type: milestone
       }
     });
 
+    it('lists every wrong-type candidate for a bare relation target', async () => {
+      const { relationSchema, tempVaultDir } = await buildRelationContractVault();
+      try {
+        await writeFile(join(tempVaultDir, 'Tasks', 'Only Wrong.md'), '---\ntype: task\n---\n');
+        const result = await validateContextFields(relationSchema, tempVaultDir, 'task', {
+          type: 'task', milestone: '[[Only Wrong]]',
+        });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors[0].candidates).toEqual(expect.arrayContaining([
+          'Ideas/Only Wrong.md', 'Tasks/Only Wrong.md',
+        ]));
+        expect(result.errors[0].message).toContain('Ideas/Only Wrong.md (type "idea")');
+        expect(result.errors[0].message).toContain('Tasks/Only Wrong.md (type "task")');
+        expect(result.errors[0].message).toContain('path-qualify');
+        expect(result.errors[0]).not.toHaveProperty('actualType');
+      } finally {
+        await rm(tempVaultDir, { recursive: true, force: true });
+      }
+    });
+
     it('does not accept a typeless note as a typed relation target based on directory', async () => {
       const { relationSchema, tempVaultDir } = await buildRelationContractVault();
       try {
@@ -1252,7 +1274,8 @@ type: milestone
           }),
         ]);
         expect(result.errors[0]).not.toHaveProperty('actualType');
-        expect(result.errors[0].message).toContain('Referenced note not found');
+        expect(result.errors[0].message).toContain('exists but has no type');
+        expect(result.errors[0].candidates).toEqual(['Ideas/Untyped.md']);
       } finally {
         await rm(tempVaultDir, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Problem

Bowerbird validates relation fields against schema-declared source types, but audit and write-time validation did not describe the same invalid targets consistently. Audit silently accepted an existing note with no type, while write-time validation called that same note missing. When a bare target matched several wrong-type notes, diagnostics reported only one candidate. Audit ambiguity errors also omitted the path-qualified recovery that write-time validation already offered.

These gaps make malformed vault relations appear valid in one workflow and invalid in another, and leave users guessing which path to put in a wikilink.

## Approach

Keep the existing shared relation target index and resolver as the single source of candidate truth, then make each consumer classify the resolver result consistently. Existing typeless targets are invalid for typed relations, every disallowed candidate is retained in diagnostics, and ambiguous targets explain how to path-qualify the intended note.

Real note names continue to outrank aliases. This PR adds an end-to-end `under()` regression for that contract rather than introducing another resolver or alias path.

The change deliberately leaves `source: any` behavior unchanged. It adds no fuzzy matching, directory-inferred type acceptance, automatic repair, or new audit issue code.

## What changed

- Report existing typeless typed-relation targets as `invalid-source-type` during audit and as explicit invalid context sources during writes.
- Include all disallowed candidate paths and their parsed types, including no-type candidates, when a bare name has no allowed match.
- Add path-qualification guidance and candidate metadata to ambiguity diagnostics.
- Add CLI and library regressions for audit, write-time validation, and real-name-over-alias precedence in `under()`.
- Document `invalid-source-type` and `ambiguous-link-target` in canonical audit documentation and command help.

## Safety and operations

This is validation and diagnostic behavior only. It performs no migration, backfill, automatic mutation, network operation, or persistent data rewrite. Existing valid relations are unchanged. Rollback is a code revert; vault content is unaffected.

## Verification

Evidence on exact commit `b92a15b`:

- Full local CI parity passed in repository order: build, packaged-install verification, typecheck, ESLint, Knip, and the complete non-PTY suite.
- The complete local suite passed 3,057 tests across 135 files, with 3 expected skips.
- Focused audit and write-time validation coverage passed 339 tests, proving typeless rejection, complete wrong-candidate reporting, and path-qualification guidance.
- Focused validation, alias-index, and hierarchical query coverage passed 148 tests, including the new `under()` real-name collision story.
- A packaged CLI installed into a disposable vault produced both explicit typeless and complete multi-candidate diagnostics with a nonzero audit exit. It also resolved `[[Verse]]` to the real note under `[[Parent]]`, not to the colliding alias carrier. The disposable install and vault were removed and absence verified.
- GitHub CI passed on the same head: source and dist suites, both retry-zero shards and aggregate, PTY, Windows lock, deterministic benchmarks, quality/package/static checks, docs checks, Vercel, and the required `Test` aggregate.

## Review focus

- Do audit and write-time validation now classify every resolver outcome consistently?
- Do multi-candidate diagnostics retain enough path and type information without choosing a silent winner?
- Does the implementation preserve `source: any` and real-name-over-alias behavior?

Closes #782